### PR TITLE
Phase 3c: Zone-level validation engine

### DIFF
--- a/creator/src/components/StatusBar.tsx
+++ b/creator/src/components/StatusBar.tsx
@@ -1,16 +1,26 @@
 import { useServerStore } from "@/stores/serverStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useConfigStore } from "@/stores/configStore";
+import { useValidationStore } from "@/stores/validationStore";
 
 export function StatusBar() {
   const status = useServerStore((s) => s.status);
   const lastError = useServerStore((s) => s.lastError);
   const zones = useZoneStore((s) => s.zones);
   const configDirty = useConfigStore((s) => s.dirty);
+  const validationResults = useValidationStore((s) => s.results);
+  const openValidationPanel = useValidationStore((s) => s.openPanel);
 
   const dirtyZones = [...zones.values()].filter((z) => z.dirty).length;
   const totalZones = zones.size;
   const hasDirty = dirtyZones > 0 || configDirty;
+
+  // Validation summary
+  const allIssues = validationResults
+    ? [...validationResults.values()].flat()
+    : [];
+  const errorCount = allIssues.filter((i) => i.severity === "error").length;
+  const warningCount = allIssues.filter((i) => i.severity === "warning").length;
 
   return (
     <div className="flex h-6 shrink-0 items-center gap-4 border-t border-border-default bg-bg-secondary px-3 text-xs">
@@ -26,6 +36,32 @@ export function StatusBar() {
           {dirtyZones > 0 && configDirty && " | "}
           {configDirty && "Config modified"}
         </span>
+      )}
+
+      {/* Validation summary */}
+      {validationResults && (
+        <button
+          onClick={openValidationPanel}
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors hover:bg-bg-elevated"
+          title="Open validation results"
+        >
+          {errorCount > 0 && (
+            <span className="text-status-error">
+              {errorCount} error{errorCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {errorCount > 0 && warningCount > 0 && (
+            <span className="text-text-muted">/</span>
+          )}
+          {warningCount > 0 && (
+            <span className="text-status-warning">
+              {warningCount} warning{warningCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {errorCount === 0 && warningCount === 0 && (
+            <span className="text-status-success">&#x2713; valid</span>
+          )}
+        </button>
       )}
 
       <div className="flex-1" />

--- a/creator/src/components/Toolbar.tsx
+++ b/creator/src/components/Toolbar.tsx
@@ -2,9 +2,12 @@ import { useState } from "react";
 import { useProjectStore } from "@/stores/projectStore";
 import { useServerStore } from "@/stores/serverStore";
 import { useZoneStore } from "@/stores/zoneStore";
+import { useValidationStore } from "@/stores/validationStore";
 import { useServerManager } from "@/lib/useServerManager";
 import { saveAllZones } from "@/lib/saveZone";
+import { validateAllZones } from "@/lib/validateZone";
 import { ErrorDialog } from "./ErrorDialog";
+import { ValidationPanel } from "./ValidationPanel";
 
 const STATUS_COLORS: Record<string, string> = {
   stopped: "bg-server-stopped",
@@ -28,6 +31,9 @@ export function Toolbar() {
   const dirtyCount = useZoneStore(
     (s) => Array.from(s.zones.values()).filter((z) => z.dirty).length,
   );
+  const zones = useZoneStore((s) => s.zones);
+  const setValidationResults = useValidationStore((s) => s.setResults);
+  const openValidationPanel = useValidationStore((s) => s.openPanel);
   const { startServer, stopServer } = useServerManager();
   const [errors, setErrors] = useState<string[] | null>(null);
   const [saving, setSaving] = useState(false);
@@ -120,9 +126,19 @@ export function Toolbar() {
       >
         {saving ? "Saving..." : dirtyCount > 0 ? `Save All (${dirtyCount})` : "Save All"}
       </button>
-      <button className="rounded px-3 py-1 text-xs font-medium text-text-primary transition-colors hover:bg-bg-elevated">
+      <button
+        onClick={() => {
+          const results = validateAllZones(zones);
+          setValidationResults(results);
+          openValidationPanel();
+        }}
+        disabled={zones.size === 0}
+        className="rounded px-3 py-1 text-xs font-medium transition-colors enabled:text-text-primary enabled:hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-40"
+      >
         Validate
       </button>
+
+      <ValidationPanel />
 
       {errors && (
         <ErrorDialog

--- a/creator/src/components/ValidationPanel.tsx
+++ b/creator/src/components/ValidationPanel.tsx
@@ -1,0 +1,115 @@
+import { useValidationStore } from "@/stores/validationStore";
+import type { ValidationIssue } from "@/lib/validateZone";
+
+export function ValidationPanel() {
+  const results = useValidationStore((s) => s.results);
+  const panelOpen = useValidationStore((s) => s.panelOpen);
+  const closePanel = useValidationStore((s) => s.closePanel);
+
+  if (!panelOpen || !results) return null;
+
+  const totalErrors = [...results.values()]
+    .flat()
+    .filter((i) => i.severity === "error").length;
+  const totalWarnings = [...results.values()]
+    .flat()
+    .filter((i) => i.severity === "warning").length;
+  const isClean = totalErrors === 0 && totalWarnings === 0;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="mx-4 flex max-h-[80vh] w-full max-w-xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border-default px-5 py-3">
+          <h2 className="text-sm font-semibold text-text-primary">
+            Validation Results
+          </h2>
+          <div className="flex items-center gap-3 text-xs">
+            {totalErrors > 0 && (
+              <span className="text-status-error">
+                {totalErrors} error{totalErrors !== 1 ? "s" : ""}
+              </span>
+            )}
+            {totalWarnings > 0 && (
+              <span className="text-status-warning">
+                {totalWarnings} warning{totalWarnings !== 1 ? "s" : ""}
+              </span>
+            )}
+            {isClean && (
+              <span className="text-status-success">All zones valid</span>
+            )}
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-3">
+          {isClean ? (
+            <p className="py-4 text-center text-sm text-text-muted">
+              No issues found across all loaded zones.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {[...results.entries()].map(([zoneId, issues]) => (
+                <ZoneIssueGroup
+                  key={zoneId}
+                  zoneId={zoneId}
+                  issues={issues}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end border-t border-border-default px-5 py-3">
+          <button
+            onClick={closePanel}
+            className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ZoneIssueGroup({
+  zoneId,
+  issues,
+}: {
+  zoneId: string;
+  issues: ValidationIssue[];
+}) {
+  const errs = issues.filter((i) => i.severity === "error");
+  const warns = issues.filter((i) => i.severity === "warning");
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-2">
+        <h3 className="text-xs font-semibold text-text-primary">{zoneId}</h3>
+        <span className="text-[10px] text-text-muted">
+          {errs.length}E / {warns.length}W
+        </span>
+      </div>
+      <ul className="flex flex-col gap-0.5">
+        {/* Errors first, then warnings */}
+        {[...errs, ...warns].map((issue, i) => (
+          <li key={i} className="flex items-start gap-2 py-0.5 text-xs">
+            <span
+              className={`mt-0.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full ${
+                issue.severity === "error"
+                  ? "bg-status-error"
+                  : "bg-status-warning"
+              }`}
+            />
+            <span className="shrink-0 font-mono text-text-muted">
+              {issue.entity}
+            </span>
+            <span className="text-text-secondary">{issue.message}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+import { validateZone, type ValidationIssue } from "../validateZone";
+import type { WorldFile } from "@/types/world";
+
+function makeValidWorld(): WorldFile {
+  return {
+    zone: "test",
+    startRoom: "room1",
+    rooms: {
+      room1: {
+        title: "Room 1",
+        description: "First room",
+        exits: { n: "room2" },
+      },
+      room2: {
+        title: "Room 2",
+        description: "Second room",
+        exits: { s: "room1" },
+      },
+    },
+    mobs: {
+      rat: { name: "Rat", room: "room1" },
+    },
+    items: {
+      sword: { displayName: "Sword", room: "room1" },
+    },
+  };
+}
+
+function errors(issues: ValidationIssue[]) {
+  return issues.filter((i) => i.severity === "error");
+}
+
+function warnings(issues: ValidationIssue[]) {
+  return issues.filter((i) => i.severity === "warning");
+}
+
+describe("validateZone", () => {
+  it("returns no issues for a valid world", () => {
+    const issues = validateZone(makeValidWorld());
+    expect(issues).toHaveLength(0);
+  });
+
+  // ─── Zone-level ──────────────────────────────────────────────
+  it("errors if startRoom does not exist", () => {
+    const world = makeValidWorld();
+    world.startRoom = "nonexistent";
+    const issues = errors(validateZone(world));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("does not exist");
+  });
+
+  it("errors if zone has no rooms", () => {
+    const world = makeValidWorld();
+    world.rooms = {};
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.message.includes("no rooms"))).toBe(true);
+  });
+
+  // ─── Room exits ──────────────────────────────────────────────
+  it("errors on exit to non-existent room", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.exits = { n: "missing_room" };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.message.includes("missing_room"))).toBe(true);
+  });
+
+  it("does not error on cross-zone exits", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.exits = { n: "other_zone:room1" };
+    const issues = errors(validateZone(world));
+    expect(issues).toHaveLength(0);
+  });
+
+  it("warns on door key that is not a known item", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.exits = {
+      n: { to: "room2", door: { locked: true, key: "missing_key" } },
+    };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("missing_key"))).toBe(true);
+  });
+
+  // ─── Room content ────────────────────────────────────────────
+  it("warns on room with no title", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.title = "";
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("no title"))).toBe(true);
+  });
+
+  // ─── Mob checks ──────────────────────────────────────────────
+  it("errors if mob room does not exist", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.room = "missing";
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.entity === "mob:rat")).toBe(true);
+  });
+
+  it("warns on mob drop referencing unknown item", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.drops = [{ itemId: "missing_item", chance: 50 }];
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("missing_item"))).toBe(true);
+  });
+
+  it("warns on invalid drop chance", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.drops = [{ itemId: "sword", chance: 0 }];
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("invalid chance"))).toBe(true);
+  });
+
+  it("errors on patrol route with non-existent room", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.behavior = {
+      template: "PATROL",
+      params: { patrolRoute: ["room1", "missing"] },
+    };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.message.includes("missing"))).toBe(true);
+  });
+
+  it("errors on mob quest reference to non-existent quest", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.quests = ["no_quest"];
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.message.includes("no_quest"))).toBe(true);
+  });
+
+  // ─── Dialogue checks ────────────────────────────────────────
+  it("errors on dialogue choice pointing to non-existent node", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.dialogue = {
+      root: {
+        text: "Hello",
+        choices: [{ text: "Go", next: "missing_node" }],
+      },
+    };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.message.includes("missing_node"))).toBe(true);
+  });
+
+  it("warns on dialogue node with empty text", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.dialogue = {
+      root: { text: "" },
+    };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("empty text"))).toBe(true);
+  });
+
+  // ─── Item checks ────────────────────────────────────────────
+  it("errors if item room does not exist", () => {
+    const world = makeValidWorld();
+    world.items!.sword.room = "missing";
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.entity === "item:sword")).toBe(true);
+  });
+
+  // ─── Shop checks ───────────────────────────────────────────
+  it("errors if shop room does not exist", () => {
+    const world = makeValidWorld();
+    world.shops = { vendor: { name: "Vendor", room: "missing" } };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.entity === "shop:vendor")).toBe(true);
+  });
+
+  it("warns on shop inventory item not in zone", () => {
+    const world = makeValidWorld();
+    world.shops = {
+      vendor: { name: "Vendor", room: "room1", items: ["missing_item"] },
+    };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("missing_item"))).toBe(true);
+  });
+
+  // ─── Quest checks ──────────────────────────────────────────
+  it("warns if quest giver mob does not exist", () => {
+    const world = makeValidWorld();
+    world.quests = {
+      q1: {
+        name: "Quest",
+        giver: "missing_mob",
+        objectives: [{ type: "KILL", targetKey: "rat" }],
+      },
+    };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("missing_mob"))).toBe(true);
+  });
+
+  it("warns if quest has no objectives", () => {
+    const world = makeValidWorld();
+    world.quests = {
+      q1: { name: "Quest", giver: "rat" },
+    };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("no objectives"))).toBe(true);
+  });
+
+  // ─── Gathering node checks ────────────────────────────────
+  it("errors if gathering node room does not exist", () => {
+    const world = makeValidWorld();
+    world.gatheringNodes = {
+      ore: {
+        displayName: "Ore",
+        skill: "MINING",
+        yields: [{ itemId: "sword" }],
+        room: "missing",
+      },
+    };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.entity === "gatheringNode:ore")).toBe(true);
+  });
+
+  it("warns on gathering yield referencing unknown item", () => {
+    const world = makeValidWorld();
+    world.gatheringNodes = {
+      ore: {
+        displayName: "Ore",
+        skill: "MINING",
+        yields: [{ itemId: "missing_item" }],
+        room: "room1",
+      },
+    };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("missing_item"))).toBe(true);
+  });
+
+  // ─── Recipe checks ────────────────────────────────────────
+  it("warns on recipe output item not in zone", () => {
+    const world = makeValidWorld();
+    world.recipes = {
+      r1: {
+        displayName: "Recipe",
+        skill: "SMITHING",
+        materials: [{ itemId: "sword", quantity: 1 }],
+        outputItemId: "missing_output",
+      },
+    };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("missing_output"))).toBe(
+      true,
+    );
+  });
+
+  it("warns on recipe material item not in zone", () => {
+    const world = makeValidWorld();
+    world.recipes = {
+      r1: {
+        displayName: "Recipe",
+        skill: "SMITHING",
+        materials: [{ itemId: "missing_mat", quantity: 1 }],
+        outputItemId: "sword",
+      },
+    };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("missing_mat"))).toBe(true);
+  });
+});

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -1,0 +1,380 @@
+import type { WorldFile } from "@/types/world";
+import { exitTarget } from "./zoneEdits";
+
+export type Severity = "error" | "warning";
+
+export interface ValidationIssue {
+  severity: Severity;
+  /** e.g. "room:tavern", "mob:rat", "quest:fetch_sword" */
+  entity: string;
+  message: string;
+}
+
+/**
+ * Validate a single zone's WorldFile for referential integrity and
+ * common mistakes. Returns an array of issues (empty = valid).
+ */
+export function validateZone(world: WorldFile): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const roomIds = new Set(Object.keys(world.rooms));
+  const mobIds = new Set(Object.keys(world.mobs ?? {}));
+  const itemIds = new Set(Object.keys(world.items ?? {}));
+
+  // ─── Zone-level checks ──────────────────────────────────────────
+  if (!world.startRoom) {
+    issues.push({
+      severity: "error",
+      entity: "zone",
+      message: "No start room defined",
+    });
+  } else if (!roomIds.has(world.startRoom)) {
+    issues.push({
+      severity: "error",
+      entity: "zone",
+      message: `Start room "${world.startRoom}" does not exist`,
+    });
+  }
+
+  if (roomIds.size === 0) {
+    issues.push({
+      severity: "error",
+      entity: "zone",
+      message: "Zone has no rooms",
+    });
+  }
+
+  // ─── Room checks ────────────────────────────────────────────────
+  for (const [roomId, room] of Object.entries(world.rooms)) {
+    if (!room.title?.trim()) {
+      issues.push({
+        severity: "warning",
+        entity: `room:${roomId}`,
+        message: "Room has no title",
+      });
+    }
+    if (!room.description?.trim()) {
+      issues.push({
+        severity: "warning",
+        entity: `room:${roomId}`,
+        message: "Room has no description",
+      });
+    }
+
+    // Exit targets
+    for (const [dir, exit] of Object.entries(room.exits ?? {})) {
+      const target = exitTarget(exit);
+      // Cross-zone exits (contain ":") are not validated here
+      if (!target.includes(":") && !roomIds.has(target)) {
+        issues.push({
+          severity: "error",
+          entity: `room:${roomId}`,
+          message: `Exit "${dir}" points to non-existent room "${target}"`,
+        });
+      }
+
+      // Door key validation
+      if (typeof exit !== "string" && exit.door?.key) {
+        if (!itemIds.has(exit.door.key)) {
+          issues.push({
+            severity: "warning",
+            entity: `room:${roomId}`,
+            message: `Exit "${dir}" door key "${exit.door.key}" is not a known item in this zone`,
+          });
+        }
+      }
+    }
+  }
+
+  // ─── Mob checks ─────────────────────────────────────────────────
+  for (const [mobId, mob] of Object.entries(world.mobs ?? {})) {
+    if (!mob.name?.trim()) {
+      issues.push({
+        severity: "warning",
+        entity: `mob:${mobId}`,
+        message: "Mob has no name",
+      });
+    }
+    if (!roomIds.has(mob.room)) {
+      issues.push({
+        severity: "error",
+        entity: `mob:${mobId}`,
+        message: `Room "${mob.room}" does not exist`,
+      });
+    }
+
+    // Drop references
+    for (const drop of mob.drops ?? []) {
+      if (!drop.itemId) {
+        issues.push({
+          severity: "warning",
+          entity: `mob:${mobId}`,
+          message: "Drop has empty item ID",
+        });
+      } else if (!itemIds.has(drop.itemId)) {
+        issues.push({
+          severity: "warning",
+          entity: `mob:${mobId}`,
+          message: `Drop item "${drop.itemId}" is not a known item in this zone`,
+        });
+      }
+      if (drop.chance <= 0 || drop.chance > 100) {
+        issues.push({
+          severity: "warning",
+          entity: `mob:${mobId}`,
+          message: `Drop "${drop.itemId}" has invalid chance ${drop.chance}`,
+        });
+      }
+    }
+
+    // Behavior patrol route
+    if (mob.behavior?.params?.patrolRoute) {
+      for (const routeRoom of mob.behavior.params.patrolRoute) {
+        if (!roomIds.has(routeRoom)) {
+          issues.push({
+            severity: "error",
+            entity: `mob:${mobId}`,
+            message: `Patrol route room "${routeRoom}" does not exist`,
+          });
+        }
+      }
+    }
+
+    // Quest references
+    for (const questId of mob.quests ?? []) {
+      if (!world.quests?.[questId]) {
+        issues.push({
+          severity: "error",
+          entity: `mob:${mobId}`,
+          message: `Quest "${questId}" does not exist`,
+        });
+      }
+    }
+
+    // Dialogue node references
+    if (mob.dialogue) {
+      const dialogueIds = new Set(Object.keys(mob.dialogue));
+      for (const [nodeId, node] of Object.entries(mob.dialogue)) {
+        if (!node.text?.trim()) {
+          issues.push({
+            severity: "warning",
+            entity: `mob:${mobId}`,
+            message: `Dialogue node "${nodeId}" has empty text`,
+          });
+        }
+        for (const choice of node.choices ?? []) {
+          if (!choice.text?.trim()) {
+            issues.push({
+              severity: "warning",
+              entity: `mob:${mobId}`,
+              message: `Dialogue node "${nodeId}" has a choice with empty text`,
+            });
+          }
+          if (choice.next && !dialogueIds.has(choice.next)) {
+            issues.push({
+              severity: "error",
+              entity: `mob:${mobId}`,
+              message: `Dialogue choice in "${nodeId}" points to non-existent node "${choice.next}"`,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // ─── Item checks ────────────────────────────────────────────────
+  for (const [itemId, item] of Object.entries(world.items ?? {})) {
+    if (!item.displayName?.trim()) {
+      issues.push({
+        severity: "warning",
+        entity: `item:${itemId}`,
+        message: "Item has no display name",
+      });
+    }
+    if (item.room && !roomIds.has(item.room)) {
+      issues.push({
+        severity: "error",
+        entity: `item:${itemId}`,
+        message: `Room "${item.room}" does not exist`,
+      });
+    }
+  }
+
+  // ─── Shop checks ───────────────────────────────────────────────
+  for (const [shopId, shop] of Object.entries(world.shops ?? {})) {
+    if (!shop.name?.trim()) {
+      issues.push({
+        severity: "warning",
+        entity: `shop:${shopId}`,
+        message: "Shop has no name",
+      });
+    }
+    if (!roomIds.has(shop.room)) {
+      issues.push({
+        severity: "error",
+        entity: `shop:${shopId}`,
+        message: `Room "${shop.room}" does not exist`,
+      });
+    }
+    for (const itemId of shop.items ?? []) {
+      if (!itemIds.has(itemId)) {
+        issues.push({
+          severity: "warning",
+          entity: `shop:${shopId}`,
+          message: `Inventory item "${itemId}" is not a known item in this zone`,
+        });
+      }
+    }
+  }
+
+  // ─── Quest checks ──────────────────────────────────────────────
+  for (const [questId, quest] of Object.entries(world.quests ?? {})) {
+    if (!quest.name?.trim()) {
+      issues.push({
+        severity: "warning",
+        entity: `quest:${questId}`,
+        message: "Quest has no name",
+      });
+    }
+    if (!quest.giver) {
+      issues.push({
+        severity: "warning",
+        entity: `quest:${questId}`,
+        message: "Quest has no giver",
+      });
+    } else if (!mobIds.has(quest.giver)) {
+      issues.push({
+        severity: "warning",
+        entity: `quest:${questId}`,
+        message: `Giver mob "${quest.giver}" is not a known mob in this zone`,
+      });
+    }
+    if (!quest.objectives || quest.objectives.length === 0) {
+      issues.push({
+        severity: "warning",
+        entity: `quest:${questId}`,
+        message: "Quest has no objectives",
+      });
+    } else {
+      for (const obj of quest.objectives) {
+        if (!obj.type) {
+          issues.push({
+            severity: "warning",
+            entity: `quest:${questId}`,
+            message: "Objective has no type",
+          });
+        }
+        if (!obj.targetKey) {
+          issues.push({
+            severity: "warning",
+            entity: `quest:${questId}`,
+            message: "Objective has no target key",
+          });
+        }
+      }
+    }
+  }
+
+  // ─── Gathering node checks ─────────────────────────────────────
+  for (const [nodeId, node] of Object.entries(world.gatheringNodes ?? {})) {
+    if (!node.displayName?.trim()) {
+      issues.push({
+        severity: "warning",
+        entity: `gatheringNode:${nodeId}`,
+        message: "Gathering node has no display name",
+      });
+    }
+    if (!roomIds.has(node.room)) {
+      issues.push({
+        severity: "error",
+        entity: `gatheringNode:${nodeId}`,
+        message: `Room "${node.room}" does not exist`,
+      });
+    }
+    if (!node.yields || node.yields.length === 0) {
+      issues.push({
+        severity: "warning",
+        entity: `gatheringNode:${nodeId}`,
+        message: "Gathering node has no yields",
+      });
+    } else {
+      for (const y of node.yields) {
+        if (!y.itemId) {
+          issues.push({
+            severity: "warning",
+            entity: `gatheringNode:${nodeId}`,
+            message: "Yield has empty item ID",
+          });
+        } else if (!itemIds.has(y.itemId)) {
+          issues.push({
+            severity: "warning",
+            entity: `gatheringNode:${nodeId}`,
+            message: `Yield item "${y.itemId}" is not a known item in this zone`,
+          });
+        }
+      }
+    }
+  }
+
+  // ─── Recipe checks ─────────────────────────────────────────────
+  for (const [recipeId, recipe] of Object.entries(world.recipes ?? {})) {
+    if (!recipe.displayName?.trim()) {
+      issues.push({
+        severity: "warning",
+        entity: `recipe:${recipeId}`,
+        message: "Recipe has no display name",
+      });
+    }
+    if (!recipe.outputItemId) {
+      issues.push({
+        severity: "warning",
+        entity: `recipe:${recipeId}`,
+        message: "Recipe has no output item",
+      });
+    } else if (!itemIds.has(recipe.outputItemId)) {
+      issues.push({
+        severity: "warning",
+        entity: `recipe:${recipeId}`,
+        message: `Output item "${recipe.outputItemId}" is not a known item in this zone`,
+      });
+    }
+    if (!recipe.materials || recipe.materials.length === 0) {
+      issues.push({
+        severity: "warning",
+        entity: `recipe:${recipeId}`,
+        message: "Recipe has no materials",
+      });
+    } else {
+      for (const mat of recipe.materials) {
+        if (!mat.itemId) {
+          issues.push({
+            severity: "warning",
+            entity: `recipe:${recipeId}`,
+            message: "Material has empty item ID",
+          });
+        } else if (!itemIds.has(mat.itemId)) {
+          issues.push({
+            severity: "warning",
+            entity: `recipe:${recipeId}`,
+            message: `Material item "${mat.itemId}" is not a known item in this zone`,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+/** Validate all zones and return a map of zoneId -> issues. */
+export function validateAllZones(
+  zones: Map<string, { data: WorldFile }>,
+): Map<string, ValidationIssue[]> {
+  const results = new Map<string, ValidationIssue[]>();
+  for (const [zoneId, zone] of zones) {
+    const issues = validateZone(zone.data);
+    if (issues.length > 0) {
+      results.set(zoneId, issues);
+    }
+  }
+  return results;
+}

--- a/creator/src/stores/validationStore.ts
+++ b/creator/src/stores/validationStore.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+import type { ValidationIssue } from "@/lib/validateZone";
+
+interface ValidationStore {
+  /** Map of zoneId -> issues from last validation run. null = never run. */
+  results: Map<string, ValidationIssue[]> | null;
+  /** Whether the validation panel is open */
+  panelOpen: boolean;
+
+  setResults: (results: Map<string, ValidationIssue[]>) => void;
+  openPanel: () => void;
+  closePanel: () => void;
+  clear: () => void;
+}
+
+export const useValidationStore = create<ValidationStore>((set) => ({
+  results: null,
+  panelOpen: false,
+
+  setResults: (results) => set({ results }),
+  openPanel: () => set({ panelOpen: true }),
+  closePanel: () => set({ panelOpen: false }),
+  clear: () => set({ results: null, panelOpen: false }),
+}));


### PR DESCRIPTION
## Summary
- Pure `validateZone(world)` function checks referential integrity across the entire WorldFile — exits, room references, item references, quest givers, dialogue links, patrol routes, door keys, and required fields
- `validateAllZones()` runs validation across all loaded zones
- Toolbar **Validate** button (previously noop) now runs validation and opens results panel
- **ValidationPanel** dialog groups issues by zone, sorted errors-first, with colored severity dots
- **StatusBar** shows clickable validation summary: `N errors / M warnings` or `✓ valid`
- Small `validationStore` (Zustand) shares results between Toolbar and StatusBar

## Test plan
- [ ] Load zones and click Validate — panel shows issues grouped by zone
- [ ] Load a clean zone — panel shows "No issues found"
- [ ] Click the status bar validation summary to reopen the panel
- [ ] Validate button disabled when no zones loaded
- [ ] `bunx tsc --noEmit` passes, `bun test` — 134 tests pass (23 new)