### PR TITLE
Extract useArrayField hook for array CRUD boilerplate

### DIFF
--- a/creator/src/components/editors/GatheringNodeEditor.tsx
+++ b/creator/src/components/editors/GatheringNodeEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import type { WorldFile, GatheringNodeFile, GatheringYieldFile } from "@/types/world";
 import { updateGatheringNode, deleteGatheringNode } from "@/lib/zoneEdits";
+import { useArrayField } from "@/lib/useArrayField";
 import {
   Section,
   FieldRow,
@@ -50,30 +51,14 @@ export function GatheringNodeEditor({
   }, [world, nodeId, onWorldChange, onDelete]);
 
   // ─── Yield helpers ────────────────────────────────────────────
-  const yields = node.yields ?? [];
-
-  const handleAddYield = useCallback(() => {
-    const next: GatheringYieldFile[] = [
-      ...yields,
-      { itemId: "", minQuantity: 1, maxQuantity: 1 },
-    ];
-    patch({ yields: next });
-  }, [yields, patch]);
-
-  const handleUpdateYield = useCallback(
-    (index: number, field: keyof GatheringYieldFile, value: string | number) => {
-      const next = [...yields];
-      next[index] = { ...next[index], [field]: value } as GatheringYieldFile;
-      patch({ yields: next });
-    },
-    [yields, patch],
-  );
-
-  const handleDeleteYield = useCallback(
-    (index: number) => {
-      patch({ yields: yields.filter((_, i) => i !== index) });
-    },
-    [yields, patch],
+  const {
+    add: handleAddYield,
+    update: handleUpdateYield,
+    remove: handleDeleteYield,
+  } = useArrayField<GatheringYieldFile>(
+    node.yields,
+    (yields) => patch({ yields }),
+    { itemId: "", minQuantity: 1, maxQuantity: 1 },
   );
 
   return (

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import type { WorldFile, MobFile, MobDropFile } from "@/types/world";
 import { updateMob, deleteMob } from "@/lib/zoneEdits";
+import { useArrayField } from "@/lib/useArrayField";
 import {
   Section,
   FieldRow,
@@ -66,26 +67,14 @@ export function MobEditor({
   }, [world, mobId, onWorldChange, onDelete]);
 
   // ─── Drop helpers ──────────────────────────────────────────────
-  const handleAddDrop = useCallback(() => {
-    const drops: MobDropFile[] = [...(mob.drops ?? []), { itemId: "", chance: 100 }];
-    patch({ drops });
-  }, [mob.drops, patch]);
-
-  const handleUpdateDrop = useCallback(
-    (index: number, field: keyof MobDropFile, value: string | number) => {
-      const drops = [...(mob.drops ?? [])];
-      drops[index] = { ...drops[index], [field]: value } as MobDropFile;
-      patch({ drops });
-    },
-    [mob.drops, patch],
-  );
-
-  const handleDeleteDrop = useCallback(
-    (index: number) => {
-      const drops = (mob.drops ?? []).filter((_, i) => i !== index);
-      patch({ drops });
-    },
-    [mob.drops, patch],
+  const {
+    add: handleAddDrop,
+    update: handleUpdateDrop,
+    remove: handleDeleteDrop,
+  } = useArrayField<MobDropFile>(
+    mob.drops,
+    (drops) => patch({ drops }),
+    { itemId: "", chance: 100 },
   );
 
   // ─── Behavior helpers ─────────────────────────────────────────

--- a/creator/src/components/editors/QuestEditor.tsx
+++ b/creator/src/components/editors/QuestEditor.tsx
@@ -6,6 +6,7 @@ import type {
   QuestRewardsFile,
 } from "@/types/world";
 import { updateQuest, deleteQuest } from "@/lib/zoneEdits";
+import { useArrayField } from "@/lib/useArrayField";
 import {
   Section,
   FieldRow,
@@ -59,31 +60,15 @@ export function QuestEditor({
   }, [world, questId, onWorldChange, onDelete]);
 
   // ─── Objective helpers ────────────────────────────────────────
-  const objectives = quest.objectives ?? [];
-
-  const handleAddObjective = useCallback(() => {
-    const next: QuestObjectiveFile[] = [
-      ...objectives,
-      { type: "KILL", targetKey: "", count: 1 },
-    ];
-    patch({ objectives: next });
-  }, [objectives, patch]);
-
-  const handleUpdateObjective = useCallback(
-    (index: number, field: keyof QuestObjectiveFile, value: string | number) => {
-      const next = [...objectives];
-      next[index] = { ...next[index], [field]: value } as QuestObjectiveFile;
-      patch({ objectives: next });
-    },
-    [objectives, patch],
-  );
-
-  const handleDeleteObjective = useCallback(
-    (index: number) => {
-      const next = objectives.filter((_, i) => i !== index);
-      patch({ objectives: next.length > 0 ? next : undefined });
-    },
-    [objectives, patch],
+  const {
+    add: handleAddObjective,
+    update: handleUpdateObjective,
+    remove: handleDeleteObjective,
+  } = useArrayField<QuestObjectiveFile>(
+    quest.objectives,
+    (objectives) => patch({ objectives }),
+    { type: "KILL", targetKey: "", count: 1 },
+    true, // clear to undefined when empty
   );
 
   // ─── Rewards helpers ──────────────────────────────────────────

--- a/creator/src/components/editors/RecipeEditor.tsx
+++ b/creator/src/components/editors/RecipeEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import type { WorldFile, RecipeFile, RecipeMaterialFile } from "@/types/world";
 import { updateRecipe, deleteRecipe } from "@/lib/zoneEdits";
+import { useArrayField } from "@/lib/useArrayField";
 import {
   Section,
   FieldRow,
@@ -51,30 +52,14 @@ export function RecipeEditor({
   }, [world, recipeId, onWorldChange, onDelete]);
 
   // ─── Material helpers ─────────────────────────────────────────
-  const materials = recipe.materials ?? [];
-
-  const handleAddMaterial = useCallback(() => {
-    const next: RecipeMaterialFile[] = [
-      ...materials,
-      { itemId: "", quantity: 1 },
-    ];
-    patch({ materials: next });
-  }, [materials, patch]);
-
-  const handleUpdateMaterial = useCallback(
-    (index: number, field: keyof RecipeMaterialFile, value: string | number) => {
-      const next = [...materials];
-      next[index] = { ...next[index], [field]: value } as RecipeMaterialFile;
-      patch({ materials: next });
-    },
-    [materials, patch],
-  );
-
-  const handleDeleteMaterial = useCallback(
-    (index: number) => {
-      patch({ materials: materials.filter((_, i) => i !== index) });
-    },
-    [materials, patch],
+  const {
+    add: handleAddMaterial,
+    update: handleUpdateMaterial,
+    remove: handleDeleteMaterial,
+  } = useArrayField<RecipeMaterialFile>(
+    recipe.materials,
+    (materials) => patch({ materials }),
+    { itemId: "", quantity: 1 },
   );
 
   return (

--- a/creator/src/lib/useArrayField.ts
+++ b/creator/src/lib/useArrayField.ts
@@ -1,0 +1,43 @@
+import { useCallback } from "react";
+
+/**
+ * Provides add / update / remove helpers for an array field on a parent entity.
+ *
+ * @param items     The current array (may be undefined).
+ * @param onUpdate  Callback to persist the updated array. Receives `undefined`
+ *                  when the array becomes empty and `clearOnEmpty` is true.
+ * @param defaultItem The item appended by `add()`.
+ * @param clearOnEmpty When true, calls `onUpdate(undefined)` instead of an
+ *                     empty array on the last removal. Default: false.
+ */
+export function useArrayField<T>(
+  items: T[] | undefined,
+  onUpdate: (next: T[] | undefined) => void,
+  defaultItem: T,
+  clearOnEmpty = false,
+) {
+  const arr = items ?? [];
+
+  const add = useCallback(() => {
+    onUpdate([...arr, defaultItem]);
+  }, [arr, onUpdate, defaultItem]);
+
+  const update = useCallback(
+    (index: number, field: keyof T, value: T[keyof T]) => {
+      const next = [...arr];
+      next[index] = { ...next[index], [field]: value } as T;
+      onUpdate(next);
+    },
+    [arr, onUpdate],
+  );
+
+  const remove = useCallback(
+    (index: number) => {
+      const next = arr.filter((_, i) => i !== index);
+      onUpdate(clearOnEmpty && next.length === 0 ? undefined : next);
+    },
+    [arr, onUpdate, clearOnEmpty],
+  );
+
+  return { add, update, remove } as const;
+}


### PR DESCRIPTION
## Summary
- Introduces a generic `useArrayField<T>` hook providing `add`/`update`/`remove` helpers for array fields
- Replaces ~80 lines of near-identical `useCallback` boilerplate across 4 zone entity editors
- Supports optional `clearOnEmpty` flag for editors that set the array to `undefined` when empty (QuestEditor)
- ShopEditor excluded — its `string[]` pattern uses a different update signature

### Editors updated
- `MobEditor` (drops)
- `GatheringNodeEditor` (yields)
- `RecipeEditor` (materials)
- `QuestEditor` (objectives)

Closes #14

## Test plan
- [x] All 148 existing tests pass
- [x] Vite production build succeeds
- [ ] Manual: verify add/edit/delete operations on drops, yields, materials, and objectives in each editor