### PR TITLE
Fix stale Phase 5 placeholders, unify config tab routing

### DIFF
--- a/creator/src/components/MainArea.tsx
+++ b/creator/src/components/MainArea.tsx
@@ -25,18 +25,6 @@ export function MainArea() {
     }
     case "config":
       return <ConfigEditor />;
-    case "classes":
-      return (
-        <div className="flex flex-1 items-center justify-center text-text-muted">
-          Class designer (Phase 5)
-        </div>
-      );
-    case "races":
-      return (
-        <div className="flex flex-1 items-center justify-center text-text-muted">
-          Race designer (Phase 5)
-        </div>
-      );
     default:
       return null;
   }

--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -1,12 +1,13 @@
 import { useZoneStore } from "@/stores/zoneStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useProjectStore } from "@/stores/projectStore";
-import type { Tab } from "@/types/project";
+import type { Tab, ConfigSubTab } from "@/types/project";
 
 export function Sidebar() {
   const zones = useZoneStore((s) => s.zones);
   const configDirty = useConfigStore((s) => s.dirty);
   const openTab = useProjectStore((s) => s.openTab);
+  const setConfigSubTab = useProjectStore((s) => s.setConfigSubTab);
   const activeTabId = useProjectStore((s) => s.activeTabId);
 
   const sortedZones = [...zones.entries()].sort(([a], [b]) =>
@@ -69,22 +70,25 @@ export function Sidebar() {
           <ul className="flex flex-col gap-0.5">
             {(
               [
-                { id: "config", kind: "config" as const, label: "Game Config" },
-                { id: "classes", kind: "classes" as const, label: "Classes" },
-                { id: "races", kind: "races" as const, label: "Races" },
-              ] as Tab[]
-            ).map((tab) => (
-              <li key={tab.id}>
+                { label: "Game Config", subTab: "server" as ConfigSubTab },
+                { label: "Classes", subTab: "classes" as ConfigSubTab },
+                { label: "Races", subTab: "races" as ConfigSubTab },
+              ]
+            ).map((entry) => (
+              <li key={entry.subTab}>
                 <button
-                  onClick={() => openTab(tab)}
+                  onClick={() => {
+                    setConfigSubTab(entry.subTab);
+                    openTab({ id: "config", kind: "config", label: "Config" });
+                  }}
                   className={`w-full rounded px-2 py-1 text-left text-sm transition-colors ${
-                    activeTabId === tab.id
+                    activeTabId === "config"
                       ? "bg-bg-hover text-text-primary"
                       : "text-text-secondary hover:bg-bg-hover hover:text-text-primary"
                   }`}
                 >
-                  {tab.label}
-                  {tab.id === "config" && configDirty && (
+                  {entry.label}
+                  {entry.subTab === "server" && configDirty && (
                     <span className="ml-1 text-accent">*</span>
                   )}
                 </button>

--- a/creator/src/components/config/ConfigEditor.tsx
+++ b/creator/src/components/config/ConfigEditor.tsx
@@ -37,14 +37,13 @@ const CONFIG_TABS = [
   { id: "rawYaml", label: "Raw YAML" },
 ] as const;
 
-type ConfigTabId = (typeof CONFIG_TABS)[number]["id"];
-
 export function ConfigEditor() {
   const config = useConfigStore((s) => s.config);
   const dirty = useConfigStore((s) => s.dirty);
   const updateConfig = useConfigStore((s) => s.updateConfig);
   const mudDir = useProjectStore((s) => s.project?.mudDir);
-  const [activeTab, setActiveTab] = useState<ConfigTabId>("server");
+  const activeTab = useProjectStore((s) => s.configSubTab);
+  const setActiveTab = useProjectStore((s) => s.setConfigSubTab);
   const [saving, setSaving] = useState(false);
 
   const handleChange = useCallback(

--- a/creator/src/stores/projectStore.ts
+++ b/creator/src/stores/projectStore.ts
@@ -1,10 +1,11 @@
 import { create } from "zustand";
-import type { Project, Tab } from "@/types/project";
+import type { Project, Tab, ConfigSubTab } from "@/types/project";
 
 interface ProjectStore {
   project: Project | null;
   tabs: Tab[];
   activeTabId: string | null;
+  configSubTab: ConfigSubTab;
 
   setProject: (project: Project) => void;
   closeProject: () => void;
@@ -12,12 +13,14 @@ interface ProjectStore {
   openTab: (tab: Tab) => void;
   closeTab: (tabId: string) => void;
   setActiveTab: (tabId: string) => void;
+  setConfigSubTab: (subTab: ConfigSubTab) => void;
 }
 
 export const useProjectStore = create<ProjectStore>((set, get) => ({
   project: null,
   tabs: [],
   activeTabId: null,
+  configSubTab: "server" as ConfigSubTab,
 
   setProject: (project) =>
     set({
@@ -50,4 +53,6 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   },
 
   setActiveTab: (tabId) => set({ activeTabId: tabId }),
+
+  setConfigSubTab: (subTab) => set({ configSubTab: subTab }),
 }));

--- a/creator/src/types/project.ts
+++ b/creator/src/types/project.ts
@@ -19,7 +19,12 @@ export interface ServerState {
   lastError?: string;
 }
 
-export type TabKind = "zone" | "config" | "classes" | "races" | "console";
+export type TabKind = "zone" | "config" | "console";
+
+export type ConfigSubTab =
+  | "server" | "stats" | "classes" | "races" | "abilities"
+  | "statusEffects" | "combat" | "mobTiers" | "progression"
+  | "economy" | "regen" | "crafting" | "group" | "charCreate" | "rawYaml";
 
 export interface Tab {
   id: string;


### PR DESCRIPTION
## Summary
- Remove `classes` and `races` tab kinds that showed Phase 5 placeholder text
- Add `configSubTab` to projectStore so Sidebar can navigate directly to any config sub-tab (Classes, Races, etc.)
- ConfigEditor uses store-driven sub-tab state instead of local useState

Closes #30

## Test plan
- [ ] Click "Classes" in sidebar → opens Config tab on Classes sub-tab
- [ ] Click "Races" in sidebar → opens Config tab on Races sub-tab
- [ ] Click "Game Config" in sidebar → opens Config tab on Server sub-tab
- [ ] Switching between config sub-tabs via the internal tab bar still works
- [ ] All 148 tests pass