### PR TITLE
Phase 6e: Centralize keyboard shortcuts with help modal

### DIFF
--- a/creator/src/components/AppShell.tsx
+++ b/creator/src/components/AppShell.tsx
@@ -3,8 +3,12 @@ import { Sidebar } from "./Sidebar";
 import { TabBar } from "./TabBar";
 import { MainArea } from "./MainArea";
 import { StatusBar } from "./StatusBar";
+import { ShortcutsHelp } from "./ui/ShortcutsHelp";
+import { useKeyboardShortcuts } from "@/lib/useKeyboardShortcuts";
 
 export function AppShell() {
+  const { showHelp, setShowHelp } = useKeyboardShortcuts();
+
   return (
     <div className="flex h-screen flex-col bg-bg-primary">
       <Toolbar />
@@ -16,6 +20,7 @@ export function AppShell() {
         </div>
       </div>
       <StatusBar />
+      {showHelp && <ShortcutsHelp onClose={() => setShowHelp(false)} />}
     </div>
   );
 }

--- a/creator/src/components/config/ConfigEditor.tsx
+++ b/creator/src/components/config/ConfigEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import { useConfigStore } from "@/stores/configStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { saveConfig } from "@/lib/saveConfig";
@@ -66,17 +66,6 @@ export function ConfigEditor() {
       setSaving(false);
     }
   }, [mudDir, saving]);
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === "s") {
-        e.preventDefault();
-        handleSave();
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [handleSave]);
 
   if (!config) {
     return (

--- a/creator/src/components/ui/ShortcutsHelp.tsx
+++ b/creator/src/components/ui/ShortcutsHelp.tsx
@@ -1,0 +1,61 @@
+interface ShortcutsHelpProps {
+  onClose: () => void;
+}
+
+const shortcuts = [
+  { keys: "Ctrl+S", desc: "Save all zones and config" },
+  { keys: "Ctrl+Z", desc: "Undo (active zone)" },
+  { keys: "Ctrl+Shift+Z / Ctrl+Y", desc: "Redo (active zone)" },
+  { keys: "Ctrl+W", desc: "Close active tab" },
+  { keys: "Ctrl+Tab", desc: "Next tab" },
+  { keys: "Ctrl+Shift+Tab", desc: "Previous tab" },
+  { keys: "Ctrl+1-9", desc: "Jump to tab N" },
+  { keys: "?", desc: "Toggle this help" },
+  { keys: "Escape", desc: "Close this help" },
+];
+
+export function ShortcutsHelp({ onClose }: ShortcutsHelpProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="mx-4 w-96 rounded-lg border border-border-default bg-bg-secondary shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="border-b border-border-default px-5 py-3">
+          <h2 className="text-sm font-semibold text-text-primary">
+            Keyboard Shortcuts
+          </h2>
+        </div>
+        <div className="px-5 py-3">
+          <table className="w-full">
+            <tbody>
+              {shortcuts.map((s) => (
+                <tr key={s.keys} className="border-b border-border-default last:border-0">
+                  <td className="py-2 pr-4">
+                    <kbd className="rounded bg-bg-elevated px-1.5 py-0.5 font-mono text-xs text-text-primary">
+                      {s.keys}
+                    </kbd>
+                  </td>
+                  <td className="py-2 text-xs text-text-secondary">
+                    {s.desc}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="flex justify-end border-t border-border-default px-5 py-3">
+          <button
+            onClick={onClose}
+            className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -57,39 +57,6 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
     useState<PendingConnection | null>(null);
   const [saving, setSaving] = useState(false);
 
-  // ─── Keyboard shortcuts ──────────────────────────────────────────
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      const mod = e.ctrlKey || e.metaKey;
-      if (!mod) return;
-
-      if (e.key === "s") {
-        e.preventDefault();
-        if (zoneState?.dirty && !saving) {
-          setSaving(true);
-          saveZone(zoneId)
-            .catch((err) => console.error("Save failed:", err))
-            .finally(() => setSaving(false));
-        }
-        return;
-      }
-
-      // Skip undo/redo when typing in an input or textarea
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA") return;
-
-      if (e.key === "z" && !e.shiftKey) {
-        e.preventDefault();
-        undo(zoneId);
-      } else if ((e.key === "z" && e.shiftKey) || e.key === "y") {
-        e.preventDefault();
-        redo(zoneId);
-      }
-    }
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [zoneId, zoneState?.dirty, saving, undo, redo]);
-
   // Auto-close entity panel if the selected entity was removed (e.g. by undo)
   useEffect(() => {
     if (!selectedEntity || !zoneState) return;

--- a/creator/src/lib/useKeyboardShortcuts.ts
+++ b/creator/src/lib/useKeyboardShortcuts.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import { useProjectStore } from "@/stores/projectStore";
+import { useZoneStore } from "@/stores/zoneStore";
+import { saveAllZones } from "@/lib/saveZone";
+import { saveConfig } from "@/lib/saveConfig";
+import { useConfigStore } from "@/stores/configStore";
+
+export function useKeyboardShortcuts() {
+  const [showHelp, setShowHelp] = useState(false);
+
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      const mod = e.ctrlKey || e.metaKey;
+      const tag = (e.target as HTMLElement)?.tagName;
+      const inInput = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+
+      // ─── ? → show help (only when not typing) ────────────────
+      if (e.key === "?" && !mod && !inInput) {
+        e.preventDefault();
+        setShowHelp((v) => !v);
+        return;
+      }
+
+      // ─── Escape → close help ─────────────────────────────────
+      if (e.key === "Escape") {
+        setShowHelp(false);
+        return;
+      }
+
+      if (!mod) return;
+
+      // ─── Ctrl+S → save all ───────────────────────────────────
+      if (e.key === "s") {
+        e.preventDefault();
+        saveAllZones().catch((err) =>
+          console.error("Zone save failed:", err),
+        );
+        const mudDir = useProjectStore.getState().project?.mudDir;
+        if (mudDir && useConfigStore.getState().dirty) {
+          saveConfig(mudDir).catch((err) =>
+            console.error("Config save failed:", err),
+          );
+        }
+        return;
+      }
+
+      // Skip remaining shortcuts when typing in inputs
+      if (inInput) return;
+
+      // ─── Ctrl+Z → undo active zone ──────────────────────────
+      if (e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        const activeZoneId = getActiveZoneId();
+        if (activeZoneId) {
+          useZoneStore.getState().undo(activeZoneId);
+        }
+        return;
+      }
+
+      // ─── Ctrl+Shift+Z / Ctrl+Y → redo active zone ───────────
+      if ((e.key === "z" && e.shiftKey) || e.key === "y") {
+        e.preventDefault();
+        const activeZoneId = getActiveZoneId();
+        if (activeZoneId) {
+          useZoneStore.getState().redo(activeZoneId);
+        }
+        return;
+      }
+
+      // ─── Ctrl+W → close active tab ──────────────────────────
+      if (e.key === "w") {
+        e.preventDefault();
+        const { activeTabId, closeTab } = useProjectStore.getState();
+        if (activeTabId) closeTab(activeTabId);
+        return;
+      }
+
+      // ─── Ctrl+Tab / Ctrl+Shift+Tab → cycle tabs ─────────────
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const { tabs, activeTabId, setActiveTab } =
+          useProjectStore.getState();
+        if (tabs.length < 2) return;
+        const idx = tabs.findIndex((t) => t.id === activeTabId);
+        const next = e.shiftKey
+          ? (idx - 1 + tabs.length) % tabs.length
+          : (idx + 1) % tabs.length;
+        setActiveTab(tabs[next]!.id);
+        return;
+      }
+
+      // ─── Ctrl+1-9 → jump to tab N ───────────────────────────
+      const num = parseInt(e.key, 10);
+      if (num >= 1 && num <= 9) {
+        e.preventDefault();
+        const { tabs, setActiveTab } = useProjectStore.getState();
+        const tab = tabs[num - 1];
+        if (tab) setActiveTab(tab.id);
+        return;
+      }
+    }
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  return { showHelp, setShowHelp };
+}
+
+function getActiveZoneId(): string | null {
+  const { activeTabId } = useProjectStore.getState();
+  if (!activeTabId?.startsWith("zone:")) return null;
+  return activeTabId.replace(/^zone:/, "");
+}


### PR DESCRIPTION
## Summary
- Extract inline keyboard handlers from `ZoneEditor` and `ConfigEditor` into a single `useKeyboardShortcuts` hook mounted in `AppShell`
- Add `ShortcutsHelp` modal (press `?` to toggle) showing all available shortcuts
- Shortcuts: Ctrl+S (save all), Ctrl+Z/Y (undo/redo active zone), Ctrl+W (close tab), Ctrl+Tab (cycle tabs), Ctrl+1-9 (jump to tab), Escape (close help)

## Test plan
- [ ] Verify `?` key toggles shortcuts help modal (not triggered while typing in inputs)
- [ ] Verify Escape closes the help modal
- [ ] Verify Ctrl+S saves all dirty zones and config
- [ ] Verify Ctrl+Z / Ctrl+Shift+Z undo/redo on active zone tab
- [ ] Verify Ctrl+W closes the active tab
- [ ] Verify Ctrl+Tab / Ctrl+Shift+Tab cycles through tabs
- [ ] Verify Ctrl+1-9 jumps to the Nth tab
- [ ] Verify no duplicate save/undo/redo behavior (old inline handlers removed)

Closes #28