### PR TITLE
Phase 6c: Global search across zones

### DIFF
--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -1,7 +1,9 @@
+import { useRef, useEffect, useCallback } from "react";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useProjectStore } from "@/stores/projectStore";
 import type { Tab, ConfigSubTab } from "@/types/project";
+import { useGlobalSearch, ENTITY_TYPE_LABELS } from "@/lib/useGlobalSearch";
 
 export function Sidebar() {
   const zones = useZoneStore((s) => s.zones);
@@ -10,14 +12,107 @@ export function Sidebar() {
   const setConfigSubTab = useProjectStore((s) => s.setConfigSubTab);
   const activeTabId = useProjectStore((s) => s.activeTabId);
 
+  const { query, setQuery, clearQuery, grouped, isSearching } =
+    useGlobalSearch();
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Ctrl+K to focus search
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key === "k") {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        clearQuery();
+        searchRef.current?.blur();
+      }
+    },
+    [clearQuery],
+  );
+
   const sortedZones = [...zones.entries()].sort(([a], [b]) =>
     a.localeCompare(b),
   );
 
   return (
     <div className="flex h-full w-56 shrink-0 flex-col border-r border-border-default bg-bg-secondary">
-      {/* Zones section */}
+      {/* Search */}
+      <div className="shrink-0 border-b border-border-default px-3 py-2">
+        <div className="relative">
+          <input
+            ref={searchRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleSearchKeyDown}
+            placeholder="Search... (Ctrl+K)"
+            className="h-7 w-full rounded border border-border-default bg-bg-primary px-2 pr-6 text-xs text-text-primary outline-none placeholder:text-text-muted focus:border-accent"
+          />
+          {query && (
+            <button
+              onClick={clearQuery}
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 text-xs text-text-muted hover:text-text-primary"
+            >
+              &times;
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Zones section (or search results) */}
       <div className="flex-1 overflow-y-auto">
+        {isSearching ? (
+          <div className="px-3 py-2">
+            {grouped.size === 0 ? (
+              <p className="text-xs text-text-muted">No results</p>
+            ) : (
+              [...grouped.entries()].map(([zoneId, entries]) => (
+                <div key={zoneId} className="mb-3">
+                  <h3 className="mb-1 text-xs font-semibold text-text-muted">
+                    {zoneId}
+                  </h3>
+                  <ul className="flex flex-col gap-0.5">
+                    {entries.map((entry) => (
+                      <li key={`${entry.entityType}:${entry.entityId}`}>
+                        <button
+                          onClick={() => {
+                            const tab: Tab = {
+                              id: `zone:${entry.zoneId}`,
+                              kind: "zone",
+                              label: entry.zoneId,
+                            };
+                            openTab(tab);
+                            clearQuery();
+                          }}
+                          className="flex w-full items-center gap-1.5 rounded px-2 py-1 text-left text-xs transition-colors text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+                        >
+                          <span className="shrink-0 rounded bg-bg-elevated px-1 py-0.5 font-mono text-[10px] text-text-muted">
+                            {ENTITY_TYPE_LABELS[entry.entityType]}
+                          </span>
+                          <span className="truncate">{entry.displayName}</span>
+                          {entry.entityId !== entry.displayName && (
+                            <span className="ml-auto shrink-0 text-[10px] text-text-muted">
+                              {entry.entityId}
+                            </span>
+                          )}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))
+            )}
+          </div>
+        ) : (
+        <>
         <div className="px-3 py-2">
           <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-text-muted">
             Zones
@@ -96,6 +191,8 @@ export function Sidebar() {
             ))}
           </ul>
         </div>
+        </>
+        )}
       </div>
 
       {/* Console shortcut at bottom */}

--- a/creator/src/lib/useGlobalSearch.ts
+++ b/creator/src/lib/useGlobalSearch.ts
@@ -1,0 +1,191 @@
+import { useMemo, useState, useRef, useCallback } from "react";
+import { useZoneStore } from "@/stores/zoneStore";
+
+export type EntityType =
+  | "zone"
+  | "room"
+  | "mob"
+  | "item"
+  | "shop"
+  | "quest"
+  | "gatheringNode"
+  | "recipe";
+
+export interface SearchEntry {
+  zoneId: string;
+  entityType: EntityType;
+  entityId: string;
+  displayName: string;
+  searchText: string;
+}
+
+function buildIndex(zones: Map<string, { data: import("@/types/world").WorldFile }>): SearchEntry[] {
+  const entries: SearchEntry[] = [];
+
+  for (const [zoneId, { data }] of zones) {
+    // Zone itself
+    entries.push({
+      zoneId,
+      entityType: "zone",
+      entityId: zoneId,
+      displayName: data.zone,
+      searchText: `${zoneId} ${data.zone}`.toLowerCase(),
+    });
+
+    // Rooms
+    for (const [roomId, room] of Object.entries(data.rooms)) {
+      entries.push({
+        zoneId,
+        entityType: "room",
+        entityId: roomId,
+        displayName: room.title,
+        searchText: `${roomId} ${room.title}`.toLowerCase(),
+      });
+    }
+
+    // Mobs
+    if (data.mobs) {
+      for (const [mobId, mob] of Object.entries(data.mobs)) {
+        entries.push({
+          zoneId,
+          entityType: "mob",
+          entityId: mobId,
+          displayName: mob.name,
+          searchText: `${mobId} ${mob.name}`.toLowerCase(),
+        });
+      }
+    }
+
+    // Items
+    if (data.items) {
+      for (const [itemId, item] of Object.entries(data.items)) {
+        entries.push({
+          zoneId,
+          entityType: "item",
+          entityId: itemId,
+          displayName: item.displayName,
+          searchText: `${itemId} ${item.displayName}`.toLowerCase(),
+        });
+      }
+    }
+
+    // Shops
+    if (data.shops) {
+      for (const [shopId, shop] of Object.entries(data.shops)) {
+        entries.push({
+          zoneId,
+          entityType: "shop",
+          entityId: shopId,
+          displayName: shop.name,
+          searchText: `${shopId} ${shop.name}`.toLowerCase(),
+        });
+      }
+    }
+
+    // Quests
+    if (data.quests) {
+      for (const [questId, quest] of Object.entries(data.quests)) {
+        entries.push({
+          zoneId,
+          entityType: "quest",
+          entityId: questId,
+          displayName: quest.name,
+          searchText: `${questId} ${quest.name}`.toLowerCase(),
+        });
+      }
+    }
+
+    // Gathering Nodes
+    if (data.gatheringNodes) {
+      for (const [nodeId, node] of Object.entries(data.gatheringNodes)) {
+        entries.push({
+          zoneId,
+          entityType: "gatheringNode",
+          entityId: nodeId,
+          displayName: node.displayName,
+          searchText: `${nodeId} ${node.displayName}`.toLowerCase(),
+        });
+      }
+    }
+
+    // Recipes
+    if (data.recipes) {
+      for (const [recipeId, recipe] of Object.entries(data.recipes)) {
+        entries.push({
+          zoneId,
+          entityType: "recipe",
+          entityId: recipeId,
+          displayName: recipe.displayName,
+          searchText: `${recipeId} ${recipe.displayName}`.toLowerCase(),
+        });
+      }
+    }
+  }
+
+  return entries;
+}
+
+const ENTITY_TYPE_LABELS: Record<EntityType, string> = {
+  zone: "Zone",
+  room: "Room",
+  mob: "Mob",
+  item: "Item",
+  shop: "Shop",
+  quest: "Quest",
+  gatheringNode: "Node",
+  recipe: "Recipe",
+};
+
+export { ENTITY_TYPE_LABELS };
+
+export function useGlobalSearch() {
+  const zones = useZoneStore((s) => s.zones);
+  const [query, setQuery] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  const index = useMemo(() => buildIndex(zones), [zones]);
+
+  const handleQueryChange = useCallback((value: string) => {
+    setQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedQuery(value);
+    }, 150);
+  }, []);
+
+  const clearQuery = useCallback(() => {
+    setQuery("");
+    setDebouncedQuery("");
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+  }, []);
+
+  const results = useMemo(() => {
+    const q = debouncedQuery.trim().toLowerCase();
+    if (!q) return [];
+    return index.filter((entry) => entry.searchText.includes(q));
+  }, [index, debouncedQuery]);
+
+  // Group results by zone
+  const grouped = useMemo(() => {
+    const map = new Map<string, SearchEntry[]>();
+    for (const entry of results) {
+      const list = map.get(entry.zoneId);
+      if (list) {
+        list.push(entry);
+      } else {
+        map.set(entry.zoneId, [entry]);
+      }
+    }
+    return map;
+  }, [results]);
+
+  return {
+    query,
+    setQuery: handleQueryChange,
+    clearQuery,
+    results,
+    grouped,
+    isSearching: debouncedQuery.trim().length > 0,
+  };
+}


### PR DESCRIPTION
## Summary
- Add search input to sidebar header with `Ctrl+K` focus shortcut
- Build flat search index from all zone data (rooms, mobs, items, shops, quests, gathering nodes, recipes)
- Case-insensitive substring matching with 150ms debounce
- Results grouped by zone with entity type badges, clicking opens the zone tab
- Escape clears search and returns focus to main area

## Test plan
- [ ] Verify search input appears at top of sidebar
- [ ] Verify typing filters results across all zones
- [ ] Verify results show entity type badge, display name, and ID
- [ ] Verify clicking a result opens the zone tab and clears search
- [ ] Verify "No results" shown for unmatched queries
- [ ] Verify clear button (x) resets search
- [ ] Verify Ctrl+K focuses the search input
- [ ] Verify Escape clears and blurs the search input
- [ ] Verify normal sidebar (zones + config) shown when not searching

Closes #26