### PR TITLE
Phase 6a: YAML preview toggle for panels

### DIFF
--- a/creator/src/components/ui/YamlPreview.tsx
+++ b/creator/src/components/ui/YamlPreview.tsx
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+import yaml from "yaml";
+
+interface YamlPreviewProps {
+  data: unknown;
+  label?: string;
+}
+
+export function YamlPreview({ data, label }: YamlPreviewProps) {
+  const text = useMemo(
+    () => yaml.stringify(data, { indent: 2, lineWidth: 120 }),
+    [data],
+  );
+
+  return (
+    <div className="flex flex-1 flex-col">
+      {label && (
+        <div className="border-b border-border-default px-4 py-1.5">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+            {label}
+          </span>
+        </div>
+      )}
+      <pre className="flex-1 overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-relaxed text-text-secondary">
+        {text}
+      </pre>
+    </div>
+  );
+}

--- a/creator/src/components/zone/EntityPanel.tsx
+++ b/creator/src/components/zone/EntityPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState, useMemo } from "react";
 import type { WorldFile } from "@/types/world";
 import type { EntitySelection } from "./RoomPanel";
 import { MobEditor } from "@/components/editors/MobEditor";
@@ -7,6 +7,16 @@ import { ShopEditor } from "@/components/editors/ShopEditor";
 import { QuestEditor } from "@/components/editors/QuestEditor";
 import { GatheringNodeEditor } from "@/components/editors/GatheringNodeEditor";
 import { RecipeEditor } from "@/components/editors/RecipeEditor";
+import { YamlPreview } from "@/components/ui/YamlPreview";
+
+const COLLECTION_MAP: Record<string, string> = {
+  mob: "mobs",
+  item: "items",
+  shop: "shops",
+  quest: "quests",
+  gatheringNode: "gatheringNodes",
+  recipe: "recipes",
+};
 
 interface EntityPanelProps {
   selection: EntitySelection;
@@ -21,9 +31,17 @@ export function EntityPanel({
   onWorldChange,
   onClose,
 }: EntityPanelProps) {
+  const [showYaml, setShowYaml] = useState(false);
+
   const handleDelete = useCallback(() => {
     onClose();
   }, [onClose]);
+
+  const entityData = useMemo(() => {
+    const collection = COLLECTION_MAP[selection.kind];
+    if (!collection) return null;
+    return (world as unknown as Record<string, Record<string, unknown>>)[collection]?.[selection.id] ?? null;
+  }, [world, selection]);
 
   return (
     <div className="flex w-80 shrink-0 flex-col overflow-y-auto border-l border-border-default bg-bg-secondary">
@@ -42,9 +60,27 @@ export function EntityPanel({
         <span className="text-xs font-medium text-text-primary">
           {selection.id}
         </span>
+        <button
+          onClick={() => setShowYaml((v) => !v)}
+          className={`ml-auto rounded px-1.5 py-0.5 font-mono text-[10px] transition-colors ${
+            showYaml
+              ? "bg-accent/20 text-accent"
+              : "text-text-muted hover:bg-bg-elevated hover:text-text-primary"
+          }`}
+          title="Toggle YAML preview"
+        >
+          YAML
+        </button>
       </div>
 
-      {/* Delegate to specific editor */}
+      {/* YAML preview or editor */}
+      {showYaml ? (
+        <YamlPreview
+          data={entityData ? { [selection.id]: entityData } : null}
+          label={`${selection.kind}: ${selection.id}`}
+        />
+      ) : (
+      <>
       {selection.kind === "mob" && (
         <MobEditor
           mobId={selection.id}
@@ -92,6 +128,8 @@ export function EntityPanel({
           onWorldChange={onWorldChange}
           onDelete={handleDelete}
         />
+      )}
+      </>
       )}
     </div>
   );

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import type { WorldFile, ExitValue } from "@/types/world";
 import {
   updateRoom,
@@ -11,6 +11,7 @@ import {
   generateEntityId,
 } from "@/lib/zoneEdits";
 import { EditableField, EditableTextArea, Section, IconButton } from "@/components/ui/FormWidgets";
+import { YamlPreview } from "@/components/ui/YamlPreview";
 
 export type EntityKind = "mob" | "item" | "shop" | "quest" | "gatheringNode" | "recipe";
 
@@ -53,6 +54,7 @@ export function RoomPanel({
   onRoomDeleted,
   onSelectEntity,
 }: RoomPanelProps) {
+  const [showYaml, setShowYaml] = useState(false);
   const room = world.rooms[roomId];
   if (!room) return null;
 
@@ -150,19 +152,38 @@ export function RoomPanel({
     <div className="flex w-72 shrink-0 flex-col overflow-y-auto border-l border-border-default bg-bg-secondary">
       {/* Header */}
       <div className="border-b border-border-default px-4 py-3">
-        <EditableField
-          value={room.title}
-          onCommit={(v) => handleFieldChange("title", v)}
-          className="text-sm font-semibold text-text-primary"
-        />
-        <p className="mt-0.5 text-xs text-text-muted">{roomId}</p>
-        {isStartRoom && (
-          <span className="mt-1 inline-block rounded bg-accent/20 px-1.5 py-0.5 text-[10px] font-medium text-accent">
-            Start Room
-          </span>
-        )}
+        <div className="flex items-start justify-between">
+          <div>
+            <EditableField
+              value={room.title}
+              onCommit={(v) => handleFieldChange("title", v)}
+              className="text-sm font-semibold text-text-primary"
+            />
+            <p className="mt-0.5 text-xs text-text-muted">{roomId}</p>
+            {isStartRoom && (
+              <span className="mt-1 inline-block rounded bg-accent/20 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+                Start Room
+              </span>
+            )}
+          </div>
+          <button
+            onClick={() => setShowYaml((v) => !v)}
+            className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] transition-colors ${
+              showYaml
+                ? "bg-accent/20 text-accent"
+                : "text-text-muted hover:bg-bg-elevated hover:text-text-primary"
+            }`}
+            title="Toggle YAML preview"
+          >
+            YAML
+          </button>
+        </div>
       </div>
 
+      {showYaml ? (
+        <YamlPreview data={{ [roomId]: room }} label={`room: ${roomId}`} />
+      ) : (
+      <>
       {/* Description */}
       <Section title="Description">
         <EditableTextArea
@@ -378,6 +399,8 @@ export function RoomPanel({
             Delete Room
           </button>
         </div>
+      )}
+      </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Add shared `YamlPreview` component using `yaml.stringify()` for read-only display
- Add YAML toggle button to `RoomPanel` header — shows room data as YAML
- Add YAML toggle button to `EntityPanel` header — shows entity data as YAML
- Toggle state is per-panel instance, not persisted

## Test plan
- [ ] Verify YAML button appears in RoomPanel header
- [ ] Verify clicking YAML replaces the form editor with YAML text
- [ ] Verify clicking YAML again returns to the form editor
- [ ] Verify YAML button appears in EntityPanel header (mob, item, shop, etc.)
- [ ] Verify YAML output matches the entity data structure
- [ ] Verify YAML button highlight indicates active state

Closes #24