### PR TITLE
Phase 6b: Diff view before save

### DIFF
--- a/creator/src/components/Toolbar.tsx
+++ b/creator/src/components/Toolbar.tsx
@@ -5,11 +5,13 @@ import { useZoneStore } from "@/stores/zoneStore";
 import { useValidationStore } from "@/stores/validationStore";
 import { useServerManager } from "@/lib/useServerManager";
 import { saveAllZones } from "@/lib/saveZone";
+import { saveConfig } from "@/lib/saveConfig";
 import { validateAllZones } from "@/lib/validateZone";
 import { validateConfig } from "@/lib/validateConfig";
 import { useConfigStore } from "@/stores/configStore";
 import { ErrorDialog } from "./ErrorDialog";
 import { ValidationPanel } from "./ValidationPanel";
+import { DiffModal } from "./ui/DiffModal";
 
 const STATUS_COLORS: Record<string, string> = {
   stopped: "bg-server-stopped",
@@ -38,8 +40,10 @@ export function Toolbar() {
   const openValidationPanel = useValidationStore((s) => s.openPanel);
   const hasConfig = useConfigStore((s) => !!s.config);
   const { startServer, stopServer } = useServerManager();
+  const configDirty = useConfigStore((s) => s.dirty);
   const [errors, setErrors] = useState<string[] | null>(null);
   const [saving, setSaving] = useState(false);
+  const [showDiff, setShowDiff] = useState(false);
 
   const handleStart = async () => {
     const result = await startServer();
@@ -114,20 +118,11 @@ export function Toolbar() {
 
       {/* Right side actions */}
       <button
-        onClick={async () => {
-          setSaving(true);
-          try {
-            await saveAllZones();
-          } catch (err) {
-            console.error("Save failed:", err);
-          } finally {
-            setSaving(false);
-          }
-        }}
-        disabled={dirtyCount === 0 || saving}
+        onClick={() => setShowDiff(true)}
+        disabled={(dirtyCount === 0 && !configDirty) || saving}
         className="rounded px-3 py-1 text-xs font-medium transition-colors enabled:bg-bg-elevated enabled:text-text-primary enabled:hover:bg-bg-hover disabled:cursor-not-allowed disabled:opacity-40"
       >
-        {saving ? "Saving..." : dirtyCount > 0 ? `Save All (${dirtyCount})` : "Save All"}
+        {saving ? "Saving..." : dirtyCount > 0 || configDirty ? `Save All (${dirtyCount + (configDirty ? 1 : 0)})` : "Save All"}
       </button>
       <button
         onClick={() => {
@@ -149,6 +144,27 @@ export function Toolbar() {
       </button>
 
       <ValidationPanel />
+
+      {showDiff && (
+        <DiffModal
+          onCancel={() => setShowDiff(false)}
+          onConfirm={async () => {
+            setShowDiff(false);
+            setSaving(true);
+            try {
+              await saveAllZones();
+              const mudDir = useProjectStore.getState().project?.mudDir;
+              if (mudDir && useConfigStore.getState().dirty) {
+                await saveConfig(mudDir);
+              }
+            } catch (err) {
+              console.error("Save failed:", err);
+            } finally {
+              setSaving(false);
+            }
+          }}
+        />
+      )}
 
       {errors && (
         <ErrorDialog

--- a/creator/src/components/ui/DiffModal.tsx
+++ b/creator/src/components/ui/DiffModal.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import { readTextFile } from "@tauri-apps/plugin-fs";
+import { useZoneStore } from "@/stores/zoneStore";
+import { useConfigStore } from "@/stores/configStore";
+import { useProjectStore } from "@/stores/projectStore";
+import { serializeZone } from "@/lib/saveZone";
+import { diffLines, type DiffLine } from "@/lib/diff";
+
+interface FileDiff {
+  label: string;
+  lines: DiffLine[];
+  changeCount: number;
+}
+
+interface DiffModalProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function DiffModal({ onConfirm, onCancel }: DiffModalProps) {
+  const [diffs, setDiffs] = useState<FileDiff[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    computeDiffs().then(setDiffs).catch((e) => setError(String(e)));
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="mx-4 flex max-h-[80vh] w-full max-w-3xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl">
+        <div className="flex items-center justify-between border-b border-border-default px-5 py-3">
+          <h2 className="text-sm font-semibold text-text-primary">
+            Review Changes
+          </h2>
+          <span className="text-xs text-text-muted">
+            {diffs ? `${diffs.length} file${diffs.length !== 1 ? "s" : ""}` : "Loading..."}
+          </span>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-3">
+          {error && (
+            <p className="text-xs text-status-error">{error}</p>
+          )}
+          {!diffs && !error && (
+            <p className="text-xs text-text-muted">Computing diffs...</p>
+          )}
+          {diffs?.map((diff) => (
+            <div key={diff.label} className="mb-4">
+              <div className="mb-1 flex items-center gap-2">
+                <span className="text-xs font-semibold text-text-primary">
+                  {diff.label}
+                </span>
+                <span className="text-[10px] text-text-muted">
+                  {diff.changeCount} change{diff.changeCount !== 1 ? "s" : ""}
+                </span>
+              </div>
+              <div className="max-h-64 overflow-auto rounded border border-border-default bg-bg-primary font-mono text-[11px] leading-5">
+                {diff.lines.map((line, i) => (
+                  <div
+                    key={i}
+                    className={
+                      line.kind === "add"
+                        ? "bg-[#1a3a2a] text-[#7ee787]"
+                        : line.kind === "del"
+                          ? "bg-[#3a1a1a] text-[#f47067]"
+                          : "text-text-muted"
+                    }
+                  >
+                    <span className="inline-block w-5 select-none text-right opacity-50">
+                      {line.kind === "add" ? "+" : line.kind === "del" ? "-" : " "}
+                    </span>
+                    {" "}{line.text}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-border-default px-5 py-3">
+          <button
+            onClick={onCancel}
+            className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={!diffs}
+            className="rounded bg-accent px-4 py-1.5 text-xs font-medium text-white transition-colors hover:bg-accent-emphasis disabled:opacity-50"
+          >
+            Save All
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+async function computeDiffs(): Promise<FileDiff[]> {
+  const result: FileDiff[] = [];
+  const zones = useZoneStore.getState().zones;
+
+  // Dirty zones
+  for (const [zoneId, zone] of zones) {
+    if (!zone.dirty) continue;
+    let oldText = "";
+    try {
+      oldText = await readTextFile(zone.filePath);
+    } catch {
+      // New file, no old content
+    }
+    const newText = serializeZone(zoneId);
+    if (oldText === newText) continue;
+    const lines = diffLines(oldText, newText);
+    const changeCount = lines.filter((l) => l.kind !== "same").length;
+    result.push({ label: `zone: ${zoneId}`, lines, changeCount });
+  }
+
+  // Dirty config
+  const configStore = useConfigStore.getState();
+  if (configStore.dirty && configStore.config) {
+    const mudDir = useProjectStore.getState().project?.mudDir;
+    if (mudDir) {
+      result.push({
+        label: "config: application.yaml",
+        lines: [{ kind: "same", text: "(Config uses CST-preserving save — full diff not available)" }],
+        changeCount: 1,
+      });
+    }
+  }
+
+  return result;
+}

--- a/creator/src/lib/diff.ts
+++ b/creator/src/lib/diff.ts
@@ -1,0 +1,53 @@
+export type DiffLineKind = "same" | "add" | "del";
+
+export interface DiffLine {
+  kind: DiffLineKind;
+  text: string;
+}
+
+/**
+ * Simple line-based diff using longest common subsequence.
+ * Returns an array of DiffLine entries.
+ */
+export function diffLines(oldText: string, newText: string): DiffLine[] {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+
+  // Build LCS table
+  const m = oldLines.length;
+  const n = newLines.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array<number>(n + 1).fill(0),
+  );
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (oldLines[i - 1] === newLines[j - 1]) {
+        dp[i]![j] = dp[i - 1]![j - 1]! + 1;
+      } else {
+        dp[i]![j] = Math.max(dp[i - 1]![j]!, dp[i]![j - 1]!);
+      }
+    }
+  }
+
+  // Backtrack to produce diff
+  const result: DiffLine[] = [];
+  let i = m;
+  let j = n;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      result.push({ kind: "same", text: oldLines[i - 1]! });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i]![j - 1]! >= dp[i - 1]![j]!)) {
+      result.push({ kind: "add", text: newLines[j - 1]! });
+      j--;
+    } else {
+      result.push({ kind: "del", text: oldLines[i - 1]! });
+      i--;
+    }
+  }
+
+  return result.reverse();
+}

--- a/creator/src/lib/saveZone.ts
+++ b/creator/src/lib/saveZone.ts
@@ -2,6 +2,21 @@ import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { stringify } from "yaml";
 import { useZoneStore } from "@/stores/zoneStore";
 
+const YAML_OPTS = {
+  lineWidth: 120,
+  defaultKeyType: "PLAIN" as const,
+  defaultStringType: "PLAIN" as const,
+};
+
+/**
+ * Serialize a zone's data to YAML without writing to disk.
+ */
+export function serializeZone(zoneId: string): string {
+  const zone = useZoneStore.getState().zones.get(zoneId);
+  if (!zone) throw new Error(`Zone "${zoneId}" not found`);
+  return stringify(zone.data, YAML_OPTS);
+}
+
 /**
  * Save a single zone to its YAML file.
  * Uses yaml stringify for clean output.
@@ -11,12 +26,7 @@ export async function saveZone(zoneId: string): Promise<void> {
   const zone = state.zones.get(zoneId);
   if (!zone) throw new Error(`Zone "${zoneId}" not found`);
 
-  const yaml = stringify(zone.data, {
-    lineWidth: 120,
-    defaultKeyType: "PLAIN",
-    defaultStringType: "PLAIN",
-  });
-
+  const yaml = serializeZone(zoneId);
   await writeTextFile(zone.filePath, yaml);
   state.markClean(zoneId);
 }


### PR DESCRIPTION
## Summary
- Add `DiffModal` that shows a unified line diff of all pending changes before saving
- Implement LCS-based `diffLines` utility for line-level diff computation
- Extract `serializeZone` from `saveZone` for diffing without writing to disk
- "Save All" toolbar button now opens the diff review modal instead of saving immediately
- Zone diffs show added (green) / removed (red) / unchanged lines
- Config changes are listed but not diffed (CST-preserving save makes pre-serialization complex)

## Test plan
- [ ] Verify clicking "Save All" shows the diff review modal
- [ ] Verify zone diffs show green/red coloring for changes
- [ ] Verify "Save All" in the modal actually saves all dirty files
- [ ] Verify "Cancel" closes the modal without saving
- [ ] Verify config is listed when dirty
- [ ] Verify modal shows correct file count
- [ ] Verify Ctrl+S still saves directly (via keyboard shortcuts hook)

Closes #25