### PR TITLE
Phase 6d: Bulk rename / refactor IDs

### DIFF
--- a/creator/src/components/config/panels/AbilitiesPanel.tsx
+++ b/creator/src/components/config/panels/AbilitiesPanel.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { ConfigPanelProps } from "./types";
 import type { AbilityDefinitionConfig, AbilityEffectConfig } from "@/types/config";
 import {
@@ -28,6 +29,17 @@ export function AbilitiesPanel({ config, onChange }: ConfigPanelProps) {
     label: config.statusEffects[id]!.displayName,
   }));
 
+  const handleRename = useCallback(
+    (oldId: string, newId: string) => {
+      const abilities: Record<string, AbilityDefinitionConfig> = {};
+      for (const [k, v] of Object.entries(config.abilities)) {
+        abilities[k === oldId ? newId : k] = v;
+      }
+      onChange({ abilities });
+    },
+    [config.abilities, onChange],
+  );
+
   const classOptions = Object.keys(config.classes).map((id) => ({
     value: id,
     label: config.classes[id]!.displayName,
@@ -50,6 +62,7 @@ export function AbilitiesPanel({ config, onChange }: ConfigPanelProps) {
       title="Abilities"
       items={config.abilities}
       onItemsChange={(abilities) => onChange({ abilities })}
+      onRenameId={handleRename}
       placeholder="New ability"
       idTransform={(raw) => raw.trim().toLowerCase().replace(/\s+/g, "_")}
       getDisplayName={(a) => a.displayName}

--- a/creator/src/components/config/panels/ClassesPanel.tsx
+++ b/creator/src/components/config/panels/ClassesPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import type { ConfigPanelProps } from "./types";
 import type { ClassDefinitionConfig } from "@/types/config";
 import {
@@ -9,6 +9,7 @@ import {
   CheckboxInput,
 } from "@/components/ui/FormWidgets";
 import { RegistryPanel } from "./RegistryPanel";
+import { renameClassInConfig } from "@/lib/refactorId";
 
 export function ClassesPanel({ config, onChange }: ConfigPanelProps) {
   const statOptions = useMemo(
@@ -22,11 +23,20 @@ export function ClassesPanel({ config, onChange }: ConfigPanelProps) {
 
   const maxLevel = config.progression.maxLevel;
 
+  const handleRenameClass = useCallback(
+    (oldId: string, newId: string) => {
+      const updated = renameClassInConfig(config, oldId, newId);
+      onChange({ classes: updated.classes, abilities: updated.abilities });
+    },
+    [config, onChange],
+  );
+
   return (
     <RegistryPanel<ClassDefinitionConfig>
       title="Classes"
       items={config.classes}
       onItemsChange={(classes) => onChange({ classes })}
+      onRenameId={handleRenameClass}
       placeholder="New class"
       idTransform={(raw) => raw.trim().toUpperCase().replace(/\s+/g, "_")}
       getDisplayName={(cls) => cls.displayName}

--- a/creator/src/components/config/panels/RacesPanel.tsx
+++ b/creator/src/components/config/panels/RacesPanel.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { ConfigPanelProps } from "./types";
 import type { RaceDefinitionConfig } from "@/types/config";
 import type { StatMap } from "@/types/world";
@@ -9,11 +10,23 @@ export function RacesPanel({ config, onChange }: ConfigPanelProps) {
   const statDefs = config.stats.definitions;
   const statIds = Object.keys(statDefs);
 
+  const handleRename = useCallback(
+    (oldId: string, newId: string) => {
+      const races: Record<string, RaceDefinitionConfig> = {};
+      for (const [k, v] of Object.entries(config.races)) {
+        races[k === oldId ? newId : k] = v;
+      }
+      onChange({ races });
+    },
+    [config.races, onChange],
+  );
+
   return (
     <RegistryPanel<RaceDefinitionConfig>
       title="Races"
       items={config.races}
       onItemsChange={(races) => onChange({ races })}
+      onRenameId={handleRename}
       placeholder="New race"
       idTransform={(raw) => raw.trim().toUpperCase().replace(/\s+/g, "_")}
       getDisplayName={(r) => r.displayName}

--- a/creator/src/components/config/panels/RegistryPanel.tsx
+++ b/creator/src/components/config/panels/RegistryPanel.tsx
@@ -23,6 +23,8 @@ export interface RegistryPanelProps<T> {
   searchThreshold?: number;
   /** Return the display name from an item for search matching. */
   getDisplayName?: (item: T) => string;
+  /** Called when user renames an ID. If provided, shows rename UI. */
+  onRenameId?: (oldId: string, newId: string) => void;
 }
 
 export function RegistryPanel<T>({
@@ -36,11 +38,14 @@ export function RegistryPanel<T>({
   placeholder = "New item",
   searchThreshold = 3,
   getDisplayName,
+  onRenameId,
 }: RegistryPanelProps<T>) {
   const allIds = Object.keys(items);
   const [expanded, setExpanded] = useState<string | null>(null);
   const [newId, setNewId] = useState("");
   const [search, setSearch] = useState("");
+  const [renaming, setRenaming] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
 
   const filteredIds = useMemo(() => {
     if (!search.trim() || !getDisplayName) return allIds;
@@ -156,6 +161,58 @@ export function RegistryPanel<T>({
                     <div className="flex flex-col gap-1.5">
                       {renderDetail(id, item, (p) => patch(id, p))}
                     </div>
+                    {onRenameId && (
+                      <div className="mt-2 border-t border-border-muted pt-2">
+                        {renaming === id ? (
+                          <div className="flex items-center gap-1">
+                            <input
+                              className="w-32 rounded border border-border-default bg-bg-primary px-1.5 py-0.5 text-xs text-text-primary outline-none focus:border-accent/50"
+                              value={renameValue}
+                              onChange={(e) => setRenameValue(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" && renameValue.trim() && renameValue.trim() !== id && !items[renameValue.trim()]) {
+                                  onRenameId(id, renameValue.trim());
+                                  setExpanded(renameValue.trim());
+                                  setRenaming(null);
+                                }
+                                if (e.key === "Escape") setRenaming(null);
+                              }}
+                              placeholder="new_id"
+                              autoFocus
+                            />
+                            <button
+                              onClick={() => {
+                                const nid = renameValue.trim();
+                                if (nid && nid !== id && !items[nid]) {
+                                  onRenameId(id, nid);
+                                  setExpanded(nid);
+                                  setRenaming(null);
+                                }
+                              }}
+                              className="rounded bg-accent/20 px-1.5 py-0.5 text-[10px] text-accent hover:bg-accent/30"
+                            >
+                              Rename
+                            </button>
+                            <button
+                              onClick={() => setRenaming(null)}
+                              className="rounded px-1.5 py-0.5 text-[10px] text-text-muted hover:text-text-primary"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            onClick={() => {
+                              setRenaming(id);
+                              setRenameValue(id);
+                            }}
+                            className="text-[10px] text-text-muted hover:text-text-primary"
+                          >
+                            Rename ID...
+                          </button>
+                        )}
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/creator/src/components/config/panels/StatusEffectsPanel.tsx
+++ b/creator/src/components/config/panels/StatusEffectsPanel.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { ConfigPanelProps } from "./types";
 import type { StatusEffectDefinitionConfig } from "@/types/config";
 import type { StatMap } from "@/types/world";
@@ -10,6 +11,7 @@ import {
   IconButton,
 } from "@/components/ui/FormWidgets";
 import { RegistryPanel } from "./RegistryPanel";
+import { renameStatusEffectInConfig } from "@/lib/refactorId";
 
 const EFFECT_TYPES = [
   { value: "DOT", label: "Damage Over Time" },
@@ -30,11 +32,20 @@ const STACK_BEHAVIORS = [
 export function StatusEffectsPanel({ config, onChange }: ConfigPanelProps) {
   const statIds = Object.keys(config.stats.definitions);
 
+  const handleRename = useCallback(
+    (oldId: string, newId: string) => {
+      const updated = renameStatusEffectInConfig(config, oldId, newId);
+      onChange({ statusEffects: updated.statusEffects, abilities: updated.abilities });
+    },
+    [config, onChange],
+  );
+
   return (
     <RegistryPanel<StatusEffectDefinitionConfig>
       title="Status Effects"
       items={config.statusEffects}
       onItemsChange={(statusEffects) => onChange({ statusEffects })}
+      onRenameId={handleRename}
       placeholder="New effect"
       idTransform={(raw) => raw.trim().toLowerCase().replace(/\s+/g, "_")}
       getDisplayName={(e) => e.displayName}

--- a/creator/src/lib/__tests__/refactorId.test.ts
+++ b/creator/src/lib/__tests__/refactorId.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { renameRoom, renameMob, renameItem, renameQuest, countReferences } from "../refactorId";
+import type { WorldFile } from "@/types/world";
+
+function makeWorld(overrides?: Partial<WorldFile>): WorldFile {
+  return {
+    zone: "test",
+    startRoom: "room1",
+    rooms: {
+      room1: {
+        title: "Room 1",
+        description: "First room",
+        exits: { n: "room2" },
+      },
+      room2: {
+        title: "Room 2",
+        description: "Second room",
+        exits: { s: "room1" },
+      },
+    },
+    mobs: {
+      rat: { name: "Rat", room: "room1" },
+    },
+    items: {
+      sword: { displayName: "Sword", room: "room1" },
+    },
+    shops: {
+      vendor: { name: "Vendor", room: "room2", items: ["sword"] },
+    },
+    quests: {
+      fetch: { name: "Fetch", giver: "rat", objectives: [] },
+    },
+    ...overrides,
+  };
+}
+
+describe("renameRoom", () => {
+  it("renames a room key and updates all references", () => {
+    const world = makeWorld();
+    const result = renameRoom(world, "room1", "tavern");
+
+    expect(result.rooms["tavern"]).toBeDefined();
+    expect(result.rooms["room1"]).toBeUndefined();
+    expect(result.startRoom).toBe("tavern");
+    expect(result.rooms["room2"]!.exits!["s"]).toBe("tavern");
+    expect(result.mobs!["rat"]!.room).toBe("tavern");
+    expect(result.items!["sword"]!.room).toBe("tavern");
+  });
+
+  it("updates patrol route references", () => {
+    const world = makeWorld({
+      mobs: {
+        guard: {
+          name: "Guard",
+          room: "room1",
+          behavior: {
+            template: "patrol",
+            params: { patrolRoute: ["room1", "room2", "room1"] },
+          },
+        },
+      },
+    });
+    const result = renameRoom(world, "room1", "hall");
+    expect(result.mobs!["guard"]!.behavior!.params!.patrolRoute).toEqual([
+      "hall", "room2", "hall",
+    ]);
+  });
+
+  it("returns unchanged world if IDs are the same", () => {
+    const world = makeWorld();
+    expect(renameRoom(world, "room1", "room1")).toBe(world);
+  });
+});
+
+describe("renameMob", () => {
+  it("renames a mob key and updates quest giver", () => {
+    const world = makeWorld();
+    const result = renameMob(world, "rat", "giant_rat");
+
+    expect(result.mobs!["giant_rat"]).toBeDefined();
+    expect(result.mobs!["rat"]).toBeUndefined();
+    expect(result.quests!["fetch"]!.giver).toBe("giant_rat");
+  });
+});
+
+describe("renameItem", () => {
+  it("renames an item key and updates shop inventory", () => {
+    const world = makeWorld();
+    const result = renameItem(world, "sword", "iron_sword");
+
+    expect(result.items!["iron_sword"]).toBeDefined();
+    expect(result.items!["sword"]).toBeUndefined();
+    expect(result.shops!["vendor"]!.items).toEqual(["iron_sword"]);
+  });
+
+  it("updates mob drops", () => {
+    const world = makeWorld({
+      mobs: {
+        rat: {
+          name: "Rat",
+          room: "room1",
+          drops: [{ itemId: "sword", chance: 50 }],
+        },
+      },
+    });
+    const result = renameItem(world, "sword", "rusty_sword");
+    expect(result.mobs!["rat"]!.drops![0]!.itemId).toBe("rusty_sword");
+  });
+
+  it("updates door key references", () => {
+    const world = makeWorld({
+      rooms: {
+        room1: {
+          title: "Room 1",
+          description: "",
+          exits: {
+            n: { to: "room2", door: { locked: true, key: "sword" } },
+          },
+        },
+        room2: { title: "Room 2", description: "" },
+      },
+    });
+    const result = renameItem(world, "sword", "gold_key");
+    const exit = result.rooms["room1"]!.exits!["n"];
+    expect(typeof exit !== "string" && exit.door?.key).toBe("gold_key");
+  });
+});
+
+describe("renameQuest", () => {
+  it("renames a quest key and updates mob.quests", () => {
+    const world = makeWorld({
+      mobs: {
+        rat: { name: "Rat", room: "room1", quests: ["fetch"] },
+      },
+    });
+    const result = renameQuest(world, "fetch", "retrieve");
+
+    expect(result.quests!["retrieve"]).toBeDefined();
+    expect(result.quests!["fetch"]).toBeUndefined();
+    expect(result.mobs!["rat"]!.quests).toEqual(["retrieve"]);
+  });
+});
+
+describe("countReferences", () => {
+  it("counts room references", () => {
+    const world = makeWorld();
+    // room1 is: startRoom + exit target from room2 + mob.room + item.room = 4
+    expect(countReferences(world, "room", "room1")).toBe(4);
+  });
+
+  it("counts item references", () => {
+    const world = makeWorld();
+    // sword is in shop inventory = 1
+    expect(countReferences(world, "item", "sword")).toBe(1);
+  });
+
+  it("counts mob references", () => {
+    const world = makeWorld();
+    // rat is quest giver = 1
+    expect(countReferences(world, "mob", "rat")).toBe(1);
+  });
+});

--- a/creator/src/lib/refactorId.ts
+++ b/creator/src/lib/refactorId.ts
@@ -1,0 +1,427 @@
+import type { WorldFile } from "@/types/world";
+import type { AppConfig, StatBindings } from "@/types/config";
+
+// ─── Zone-level renames ────────────────────────────────────────────
+
+/** Rename a room ID and cascade to all references. */
+export function renameRoom(world: WorldFile, oldId: string, newId: string): WorldFile {
+  if (oldId === newId || !world.rooms[oldId]) return world;
+
+  const rooms = { ...world.rooms };
+  rooms[newId] = rooms[oldId]!;
+  delete rooms[oldId];
+
+  // Update exit targets in all rooms
+  for (const [roomId, room] of Object.entries(rooms)) {
+    if (!room.exits) continue;
+    let changed = false;
+    const exits = { ...room.exits };
+    for (const [dir, exit] of Object.entries(exits)) {
+      if (typeof exit === "string") {
+        if (exit === oldId) {
+          exits[dir] = newId;
+          changed = true;
+        }
+      } else if (exit.to === oldId) {
+        exits[dir] = { ...exit, to: newId };
+        changed = true;
+      }
+    }
+    if (changed) rooms[roomId] = { ...room, exits };
+  }
+
+  // Update mob.room
+  const mobs = world.mobs ? { ...world.mobs } : undefined;
+  if (mobs) {
+    for (const [mobId, mob] of Object.entries(mobs)) {
+      if (mob.room === oldId) mobs[mobId] = { ...mob, room: newId };
+      if (mob.behavior?.params?.patrolRoute) {
+        const route = mob.behavior.params.patrolRoute;
+        if (route.includes(oldId)) {
+          mobs[mobId] = {
+            ...mobs[mobId]!,
+            behavior: {
+              ...mobs[mobId]!.behavior!,
+              params: {
+                ...mobs[mobId]!.behavior!.params,
+                patrolRoute: route.map((r) => (r === oldId ? newId : r)),
+              },
+            },
+          };
+        }
+      }
+    }
+  }
+
+  // Update item.room
+  const items = world.items ? { ...world.items } : undefined;
+  if (items) {
+    for (const [itemId, item] of Object.entries(items)) {
+      if (item.room === oldId) items[itemId] = { ...item, room: newId };
+    }
+  }
+
+  // Update shop.room
+  const shops = world.shops ? { ...world.shops } : undefined;
+  if (shops) {
+    for (const [shopId, shop] of Object.entries(shops)) {
+      if (shop.room === oldId) shops[shopId] = { ...shop, room: newId };
+    }
+  }
+
+  // Update gatheringNode.room
+  const gatheringNodes = world.gatheringNodes ? { ...world.gatheringNodes } : undefined;
+  if (gatheringNodes) {
+    for (const [nodeId, node] of Object.entries(gatheringNodes)) {
+      if (node.room === oldId) gatheringNodes[nodeId] = { ...node, room: newId };
+    }
+  }
+
+  return {
+    ...world,
+    rooms,
+    startRoom: world.startRoom === oldId ? newId : world.startRoom,
+    ...(mobs && { mobs }),
+    ...(items && { items }),
+    ...(shops && { shops }),
+    ...(gatheringNodes && { gatheringNodes }),
+  };
+}
+
+/** Rename a mob ID and cascade to quest.giver refs. */
+export function renameMob(world: WorldFile, oldId: string, newId: string): WorldFile {
+  if (oldId === newId || !world.mobs?.[oldId]) return world;
+
+  const mobs = { ...world.mobs };
+  mobs[newId] = mobs[oldId]!;
+  delete mobs[oldId];
+
+  // Update quest.giver
+  const quests = world.quests ? { ...world.quests } : undefined;
+  if (quests) {
+    for (const [questId, quest] of Object.entries(quests)) {
+      if (quest.giver === oldId) quests[questId] = { ...quest, giver: newId };
+    }
+  }
+
+  return { ...world, mobs, ...(quests && { quests }) };
+}
+
+/** Rename an item ID and cascade to all references. */
+export function renameItem(world: WorldFile, oldId: string, newId: string): WorldFile {
+  if (oldId === newId || !world.items?.[oldId]) return world;
+
+  const items = { ...world.items };
+  items[newId] = items[oldId]!;
+  delete items[oldId];
+
+  // Update mob drops
+  const mobs = world.mobs ? { ...world.mobs } : undefined;
+  if (mobs) {
+    for (const [mobId, mob] of Object.entries(mobs)) {
+      if (mob.drops?.some((d) => d.itemId === oldId)) {
+        mobs[mobId] = {
+          ...mob,
+          drops: mob.drops!.map((d) =>
+            d.itemId === oldId ? { ...d, itemId: newId } : d,
+          ),
+        };
+      }
+    }
+  }
+
+  // Update shop inventory
+  const shops = world.shops ? { ...world.shops } : undefined;
+  if (shops) {
+    for (const [shopId, shop] of Object.entries(shops)) {
+      if (shop.items?.includes(oldId)) {
+        shops[shopId] = {
+          ...shop,
+          items: shop.items.map((i) => (i === oldId ? newId : i)),
+        };
+      }
+    }
+  }
+
+  // Update recipe materials and output
+  const recipes = world.recipes ? { ...world.recipes } : undefined;
+  if (recipes) {
+    for (const [recipeId, recipe] of Object.entries(recipes)) {
+      let changed = false;
+      let outputItemId = recipe.outputItemId;
+      if (outputItemId === oldId) {
+        outputItemId = newId;
+        changed = true;
+      }
+      const materials = recipe.materials.map((m) => {
+        if (m.itemId === oldId) {
+          changed = true;
+          return { ...m, itemId: newId };
+        }
+        return m;
+      });
+      if (changed) {
+        recipes[recipeId] = { ...recipe, outputItemId, materials };
+      }
+    }
+  }
+
+  // Update gathering node yields
+  const gatheringNodes = world.gatheringNodes ? { ...world.gatheringNodes } : undefined;
+  if (gatheringNodes) {
+    for (const [nodeId, node] of Object.entries(gatheringNodes)) {
+      if (node.yields.some((y) => y.itemId === oldId)) {
+        gatheringNodes[nodeId] = {
+          ...node,
+          yields: node.yields.map((y) =>
+            y.itemId === oldId ? { ...y, itemId: newId } : y,
+          ),
+        };
+      }
+    }
+  }
+
+  // Update door keys in room exits
+  const rooms = { ...world.rooms };
+  for (const [roomId, room] of Object.entries(rooms)) {
+    if (!room.exits) continue;
+    let changed = false;
+    const exits = { ...room.exits };
+    for (const [dir, exit] of Object.entries(exits)) {
+      if (typeof exit !== "string" && exit.door?.key === oldId) {
+        exits[dir] = { ...exit, door: { ...exit.door, key: newId } };
+        changed = true;
+      }
+    }
+    if (changed) rooms[roomId] = { ...room, exits };
+  }
+
+  return {
+    ...world,
+    rooms,
+    items,
+    ...(mobs && { mobs }),
+    ...(shops && { shops }),
+    ...(recipes && { recipes }),
+    ...(gatheringNodes && { gatheringNodes }),
+  };
+}
+
+/** Rename a quest ID and cascade to mob.quests arrays. */
+export function renameQuest(world: WorldFile, oldId: string, newId: string): WorldFile {
+  if (oldId === newId || !world.quests?.[oldId]) return world;
+
+  const quests = { ...world.quests };
+  quests[newId] = quests[oldId]!;
+  delete quests[oldId];
+
+  const mobs = world.mobs ? { ...world.mobs } : undefined;
+  if (mobs) {
+    for (const [mobId, mob] of Object.entries(mobs)) {
+      if (mob.quests?.includes(oldId)) {
+        mobs[mobId] = {
+          ...mob,
+          quests: mob.quests.map((q) => (q === oldId ? newId : q)),
+        };
+      }
+    }
+  }
+
+  return { ...world, quests, ...(mobs && { mobs }) };
+}
+
+/** Rename a shop ID (no inbound references currently). */
+export function renameShop(world: WorldFile, oldId: string, newId: string): WorldFile {
+  if (oldId === newId || !world.shops?.[oldId]) return world;
+  const shops = { ...world.shops };
+  shops[newId] = shops[oldId]!;
+  delete shops[oldId];
+  return { ...world, shops };
+}
+
+/** Rename a gathering node ID (no inbound references currently). */
+export function renameGatheringNode(world: WorldFile, oldId: string, newId: string): WorldFile {
+  if (oldId === newId || !world.gatheringNodes?.[oldId]) return world;
+  const gatheringNodes = { ...world.gatheringNodes };
+  gatheringNodes[newId] = gatheringNodes[oldId]!;
+  delete gatheringNodes[oldId];
+  return { ...world, gatheringNodes };
+}
+
+/** Rename a recipe ID (no inbound references currently). */
+export function renameRecipe(world: WorldFile, oldId: string, newId: string): WorldFile {
+  if (oldId === newId || !world.recipes?.[oldId]) return world;
+  const recipes = { ...world.recipes };
+  recipes[newId] = recipes[oldId]!;
+  delete recipes[oldId];
+  return { ...world, recipes };
+}
+
+// ─── Count references (for confirmation dialog) ───────────────────
+
+export type EntityCategory = "room" | "mob" | "item" | "quest" | "shop" | "gatheringNode" | "recipe";
+
+export function countReferences(world: WorldFile, category: EntityCategory, entityId: string): number {
+  let count = 0;
+
+  if (category === "room") {
+    if (world.startRoom === entityId) count++;
+    for (const room of Object.values(world.rooms)) {
+      for (const exit of Object.values(room.exits ?? {})) {
+        const target = typeof exit === "string" ? exit : exit.to;
+        if (target === entityId) count++;
+      }
+    }
+    for (const mob of Object.values(world.mobs ?? {})) {
+      if (mob.room === entityId) count++;
+      if (mob.behavior?.params?.patrolRoute?.includes(entityId)) count++;
+    }
+    for (const item of Object.values(world.items ?? {})) {
+      if (item.room === entityId) count++;
+    }
+    for (const shop of Object.values(world.shops ?? {})) {
+      if (shop.room === entityId) count++;
+    }
+    for (const node of Object.values(world.gatheringNodes ?? {})) {
+      if (node.room === entityId) count++;
+    }
+  } else if (category === "mob") {
+    for (const quest of Object.values(world.quests ?? {})) {
+      if (quest.giver === entityId) count++;
+    }
+  } else if (category === "item") {
+    for (const mob of Object.values(world.mobs ?? {})) {
+      count += (mob.drops ?? []).filter((d) => d.itemId === entityId).length;
+    }
+    for (const shop of Object.values(world.shops ?? {})) {
+      count += (shop.items ?? []).filter((i) => i === entityId).length;
+    }
+    for (const recipe of Object.values(world.recipes ?? {})) {
+      if (recipe.outputItemId === entityId) count++;
+      count += recipe.materials.filter((m) => m.itemId === entityId).length;
+    }
+    for (const node of Object.values(world.gatheringNodes ?? {})) {
+      count += node.yields.filter((y) => y.itemId === entityId).length;
+    }
+    for (const room of Object.values(world.rooms)) {
+      for (const exit of Object.values(room.exits ?? {})) {
+        if (typeof exit !== "string" && exit.door?.key === entityId) count++;
+      }
+    }
+  } else if (category === "quest") {
+    for (const mob of Object.values(world.mobs ?? {})) {
+      count += (mob.quests ?? []).filter((q) => q === entityId).length;
+    }
+  }
+
+  return count;
+}
+
+// ─── Config-level renames ─────────────────────────────────────────
+
+/** Rename a key in a Record, preserving all other entries. */
+function renameKey<T>(record: Record<string, T>, oldKey: string, newKey: string): Record<string, T> {
+  const result: Record<string, T> = {};
+  for (const [k, v] of Object.entries(record)) {
+    result[k === oldKey ? newKey : k] = v;
+  }
+  return result;
+}
+
+/** Rename a stat ID across the entire config. */
+export function renameStatInConfig(config: AppConfig, oldId: string, newId: string): AppConfig {
+  if (oldId === newId) return config;
+
+  const oldBindings = config.stats.bindings;
+  const bindings: StatBindings = { ...oldBindings };
+  // Rename stat references in bindings (string fields that reference stat IDs)
+  const statKeys = [
+    "meleeDamageStat", "dodgeStat", "spellDamageStat",
+    "hpScalingStat", "manaScalingStat", "hpRegenStat",
+    "manaRegenStat", "xpBonusStat",
+  ] as const;
+  for (const key of statKeys) {
+    if (bindings[key] === oldId) {
+      (bindings as unknown as Record<string, unknown>)[key] = newId;
+    }
+  }
+
+  const stats = {
+    ...config.stats,
+    definitions: renameKey(config.stats.definitions, oldId, newId),
+    bindings,
+  };
+
+  // Race statMods
+  const races: typeof config.races = {};
+  for (const [raceId, race] of Object.entries(config.races)) {
+    if (race.statMods && oldId in race.statMods) {
+      races[raceId] = { ...race, statMods: renameKey(race.statMods, oldId, newId) };
+    } else {
+      races[raceId] = race;
+    }
+  }
+
+  // Status effect statMods
+  const statusEffects: typeof config.statusEffects = {};
+  for (const [seId, se] of Object.entries(config.statusEffects)) {
+    if (se.statMods && oldId in se.statMods) {
+      statusEffects[seId] = { ...se, statMods: renameKey(se.statMods, oldId, newId) };
+    } else {
+      statusEffects[seId] = se;
+    }
+  }
+
+  // Class primaryStat
+  const classes: typeof config.classes = {};
+  for (const [classId, cls] of Object.entries(config.classes)) {
+    if (cls.primaryStat === oldId) {
+      classes[classId] = { ...cls, primaryStat: newId };
+    } else {
+      classes[classId] = cls;
+    }
+  }
+
+  return { ...config, stats, races, statusEffects, classes };
+}
+
+/** Rename a class ID across the config. */
+export function renameClassInConfig(config: AppConfig, oldId: string, newId: string): AppConfig {
+  if (oldId === newId) return config;
+
+  const classes = renameKey(config.classes, oldId, newId);
+
+  // Ability classRestriction
+  const abilities: typeof config.abilities = {};
+  for (const [abilityId, ability] of Object.entries(config.abilities)) {
+    if (ability.classRestriction === oldId) {
+      abilities[abilityId] = { ...ability, classRestriction: newId };
+    } else {
+      abilities[abilityId] = ability;
+    }
+  }
+
+  return { ...config, classes, abilities };
+}
+
+/** Rename a status effect ID across the config. */
+export function renameStatusEffectInConfig(config: AppConfig, oldId: string, newId: string): AppConfig {
+  if (oldId === newId) return config;
+
+  const statusEffects = renameKey(config.statusEffects, oldId, newId);
+
+  // Ability statusEffectId
+  const abilities: typeof config.abilities = {};
+  for (const [abilityId, ability] of Object.entries(config.abilities)) {
+    if (ability.effect.statusEffectId === oldId) {
+      abilities[abilityId] = {
+        ...ability,
+        effect: { ...ability.effect, statusEffectId: newId },
+      };
+    } else {
+      abilities[abilityId] = ability;
+    }
+  }
+
+  return { ...config, statusEffects, abilities };
+}


### PR DESCRIPTION
## Summary
- Add `refactorId.ts` with zone-level rename functions that cascade references:
  - `renameRoom` — updates exits, mob/item/shop/gatheringNode rooms, startRoom, patrol routes
  - `renameMob` — updates quest.giver refs
  - `renameItem` — updates mob drops, shop inventory, recipe materials/output, gathering yields, door keys
  - `renameQuest` — updates mob.quests arrays
  - `renameShop`, `renameGatheringNode`, `renameRecipe` — simple key rename (no inbound refs)
  - `countReferences` — counts how many places reference a given entity ID
- Add config-level rename functions:
  - `renameStatInConfig` — updates bindings, race statMods, statusEffect statMods, class primaryStat
  - `renameClassInConfig` — updates ability classRestriction
  - `renameStatusEffectInConfig` — updates ability effect.statusEffectId
- Add `onRenameId` prop to `RegistryPanel` with inline rename UI
- Wire up cascading renames in ClassesPanel, StatusEffectsPanel, RacesPanel, AbilitiesPanel
- 11 new tests covering zone rename operations

## Test plan
- [ ] Verify "Rename ID..." button appears in expanded registry items
- [ ] Verify renaming a class ID updates ability classRestriction references
- [ ] Verify renaming a status effect ID updates ability statusEffectId references
- [ ] Verify Enter commits rename, Escape cancels
- [ ] Verify duplicate ID is rejected (can't rename to existing ID)
- [ ] Run `vitest` — 159 tests pass

Closes #27