### PR TITLE
Phase 7: Art generation, asset gallery, and new zones

### DIFF
--- a/ARCANUM_STYLE_GUIDE.md
+++ b/ARCANUM_STYLE_GUIDE.md
@@ -1,0 +1,749 @@
+# AmbonMUD Design System: Ambon Arcanum Style
+
+**Version:** arcanum_v1
+**Last Updated:** March 7, 2026
+**Scope:** Unified aesthetic for the Ambon Arcanum creator tool — server management, world building, zone editing, and configuration
+**Product:** Ambon Arcanum (standalone creator tool, separate from the AmbonMUD game client)
+
+---
+
+## Table of Contents
+
+1. [Core Philosophy](#core-philosophy)
+2. [Visual Language](#visual-language)
+3. [Color System](#color-system)
+4. [Typography](#typography)
+5. [Motion & Animation](#motion--animation)
+6. [Component Design Language](#component-design-language)
+7. [World Art Prompts](#world-art-prompts)
+8. [Validation Checklist](#validation-checklist)
+9. [Versioning Strategy](#versioning-strategy)
+
+---
+
+## Core Philosophy
+
+The Arcanum is the Creator's own instrument — the same cosmic machinery used to bring Ambon into existence before the Creator departed. The person operating the Arcanum is not a player inside the world. They are above it, looking down with the same perspective the Creator once held. Every design decision should reinforce that position: vast in scale, precise in intent, ornate because creation is abundant, never sparse.
+
+This style is:
+
+- **Cosmological, not intimate** — Scale is always implied. The user is working at the level of worlds.
+- **Baroque in detail, cosmic in composition** — Ornamentation is present and deliberate, but it serves the grandeur rather than decorating for decoration's sake.
+- **Gold against the void** — Warm aurum light is the primary creative accent. It appears only where something is alive, active, or important. Against deep cosmic indigo, a single gold highlight carries enormous weight.
+- **Unhurried** — The cosmos does not rush. Animations are slow, deliberate, and inevitable. Nothing snaps; everything unfurls.
+
+**Key Principle:** This is not a modern SaaS dashboard dressed up with a dark theme. It is a window into the architecture of a world. Every panel, button, and indicator should feel like it was carved into existence by the same force that shaped the land.
+
+---
+
+## Visual Language
+
+### Shape Vocabulary
+
+**Baroque/Rococo Principles Applied to UI:**
+
+The baroque tradition is defined by movement, abundance, and the refusal to let any surface rest passively. Applied cosmologically, this means:
+
+- **C-curves and S-curves** — The primary unit of ornamentation. Borders, dividers, and decorative elements terminate in curls rather than hard stops.
+- **Acanthus light scrollwork** — Panel borders and section dividers may incorporate subtle curling flourishes rendered as faint gold or violet lines, as if traced by the Creator's hand.
+- **Spiral arms** — Active or highlighted elements trail gentle spiraling light threads, tightening toward a center as they dissipate.
+- **Gradual dissolution** — Nothing abruptly ends. Decorative elements fade to transparency at their extremities. Hard termination is forbidden.
+
+**Preferred:**
+- Rounded terminals on all lines and dividers (ends curl or dissolve)
+- Panel corners: large radius with optional subtle scrollwork overlay
+- Connectors in tree views: gentle arcs, never right-angle bends
+- Active/focus states expressed as an encircling glow, not a hard border change
+
+**Forbidden:**
+- Flat corporate geometry (perfect rectangles without treatment)
+- Right-angle tree/graph connectors
+- Neon or saturated primary colors
+- Anything that reads as a modern SaaS product (no sharp shadows, no heavy card grids, no flat color fills)
+- Pure black backgrounds — use the deep indigo palette
+
+### Light Behavior
+
+This is deep-space luminosity, not ambient diffusion.
+
+**The two light modes:**
+
+1. **Concentrated Aurum** — Warm gold-amber light emanating from active, important, or alive elements. It has a clear source. It pools and fades outward. The server is running; this is what that looks like.
+
+2. **Nebula-violet ambient fill** — A cool blue-violet glow that fills the darkness without illuminating it. It gives the deep background depth and dimension without competing with the Aurum.
+
+**Rules:**
+- Gold light only appears where something demands attention or represents the active creative force.
+- Blue-violet light is the atmosphere, the medium through which the tool exists.
+- Stars and pinpoint lights (tiny, pure white) live in background art, not in UI chrome.
+- Glow should bloom softly — a 20-40px feathered spread on important elements.
+- No hard drop shadows. All shadows use the deep indigo base color and spread widely.
+
+---
+
+## Color System
+
+### Palette
+
+#### Deep Space (Backgrounds)
+
+| Name | Hex | Use |
+|------|-----|-----|
+| Abyssal Navy | `#080c1c` | Deepest background, outermost shell |
+| Cosmic Indigo | `#0f1428` | Primary panel base |
+| Deep Nebula | `#161b38` | Elevated panel surfaces |
+| Celestial Slate | `#1e2748` | Highest surfaces, focused panels |
+| Void Edge | `#2a3460` | Borders, dividers, structural lines |
+
+#### Cool Accents (Structure & Information)
+
+| Name | Hex | Use |
+|------|-----|-----|
+| Nebula Violet | `#7a5fc0` | Secondary accent, tree connectors, structural chrome |
+| Stellar Blue | `#4e7fd4` | Info states, links, selected items, cool highlights |
+| Arcane Teal | `#3aa8b8` | Data/schema elements, optional third accent |
+
+#### Warm Accents (The Creative Force)
+
+| Name | Hex | Use |
+|------|-----|-----|
+| Aurum | `#c8972e` | Primary creative accent — active states, primary buttons, running server |
+| Pale Aurum | `#e2bc6a` | Gold highlights, glow centers, hover states |
+| Amber Thread | `#a07820` | Pressed/active button fill, gold border variant |
+
+#### Text & Neutrals
+
+| Name | Hex | Use |
+|------|-----|-----|
+| Stardust | `#c2cef0` | Primary text |
+| Cosmic Haze | `#6a7aac` | Secondary text, captions, disabled labels |
+| Faint Starlight | `#3a4880` | Placeholder text, very subtle separators |
+
+#### Semantic States
+
+| State | Color | Hex | Notes |
+|-------|-------|-----|-------|
+| Server Running | Aurum | `#c8972e` | Pulsing gold, rotation in background |
+| Server Stopped | Cosmic Haze | `#6a7aac` | Still, cool, no animation |
+| Server Error | Void Crimson | `#8a2a3c` | Deep desaturated red — the void has been disturbed |
+| Success | Nebula Green | `#3a8a6a` | Muted teal-green |
+| Warning | Pale Aurum | `#e2bc6a` | Gold-adjacent, urgent but not alarming |
+| Info | Stellar Blue | `#4e7fd4` | Informational, structural |
+| Destructive | Void Crimson | `#8a2a3c` | Delete, force-stop, irreversible |
+
+### Design Tokens (CSS)
+
+```css
+/* Backgrounds */
+--bg-abyss:         #080c1c;
+--bg-primary:       #0f1428;
+--bg-elevated:      #161b38;
+--bg-surface:       #1e2748;
+
+/* Accents */
+--accent-aurum:     #c8972e;
+--accent-aurum-pale:#e2bc6a;
+--accent-aurum-deep:#a07820;
+--accent-violet:    #7a5fc0;
+--accent-blue:      #4e7fd4;
+--accent-teal:      #3aa8b8;
+
+/* Borders */
+--border-void:      #2a3460;
+--border-aurum:     rgba(200, 151, 46, 0.4);
+--border-violet:    rgba(122, 95, 192, 0.35);
+
+/* Text */
+--text-primary:     #c2cef0;
+--text-secondary:   #6a7aac;
+--text-disabled:    #3a4880;
+
+/* Glows */
+--glow-aurum:       0 0 32px rgba(200, 151, 46, 0.35);
+--glow-aurum-strong:0 0 48px rgba(226, 188, 106, 0.5);
+--glow-violet:      0 0 28px rgba(122, 95, 192, 0.3);
+--glow-blue:        0 0 24px rgba(78, 127, 212, 0.25);
+
+/* Shadows */
+--shadow-deep:      0 8px 32px rgba(4, 6, 18, 0.7);
+--shadow-panel:     0 16px 56px rgba(4, 6, 18, 0.8);
+
+/* Semantic */
+--state-running:    #c8972e;
+--state-stopped:    #6a7aac;
+--state-error:      #8a2a3c;
+--state-success:    #3a8a6a;
+--state-warning:    #e2bc6a;
+```
+
+### Opacity Guidelines
+
+- **100%** — Primary text, primary UI elements, server status indicators
+- **80%** — Overlay backgrounds, hover state fills
+- **50%** — Secondary text, inactive tabs
+- **35%** — Glow borders, baroque scrollwork overlays, structural decorative lines
+- **15%** — Barely-visible background texture, depth separation
+
+---
+
+## Typography
+
+The typeface must evoke age, authority, and the weight of cosmological inscription — while remaining legible in a dense creator tool.
+
+### Typefaces
+
+| Context | Font | Weights | Size | Use |
+|---------|------|---------|------|-----|
+| Display / Titles | `Cinzel` | 400, 600, 700 | 20–36px | App title, section headings, zone names, major labels |
+| UI Body | `Crimson Pro` | 400, 500, 600 | 14–16px | Panel text, descriptions, config labels, list items |
+| UI Small | `Crimson Pro` | 400 | 12–13px | Captions, metadata, tree node labels |
+| Code / YAML / Config | `JetBrains Mono` | 400, 500 | 13–15px | All config editing, YAML, command output, server logs |
+| Fallbacks | `Palatino`, `serif` (titles); `Georgia`, `serif` (body); `Consolas`, `monospace` (code) | — | — | System fallbacks |
+
+**Notes:**
+- `Cinzel` is derived from Roman inscriptional lettering — it carries the weight of ancient authority without feeling decorative.
+- `Crimson Pro` has an old-book warmth that complements Cinzel without competing. It is readable at small sizes.
+- Never use a sans-serif for display or body text in this style. Sans-serif feels modern and corporate. This is neither.
+
+### Typography Hierarchy
+
+**App Title / Zone Name**
+- Font: `Cinzel`
+- Size: 28–36px
+- Weight: 600
+- Color: Pale Aurum (`#e2bc6a`)
+- Letter spacing: 2px
+- Usage: top-level titles only
+
+**Section Heading**
+- Font: `Cinzel`
+- Size: 18–22px
+- Weight: 400
+- Color: Stardust (`#c2cef0`)
+- Letter spacing: 1px
+
+**Panel Heading**
+- Font: `Cinzel`
+- Size: 14–16px
+- Weight: 400
+- Color: Cosmic Haze (`#6a7aac`)
+- Letter spacing: 0.5px
+- Uppercase: yes
+
+**Body Text**
+- Font: `Crimson Pro`
+- Size: 15px
+- Weight: 400
+- Color: Stardust (`#c2cef0`)
+- Line height: 1.6
+
+**Caption / Metadata**
+- Font: `Crimson Pro`
+- Size: 12–13px
+- Weight: 400
+- Color: Cosmic Haze (`#6a7aac`)
+- Line height: 1.4
+
+**Code / Config**
+- Font: `JetBrains Mono`
+- Size: 13px
+- Weight: 400
+- Color: Stardust (`#c2cef0`)
+- Line height: 1.7
+
+### Special Treatments
+
+- **Emphasis:** Italic Crimson Pro, no bold for body
+- **Key values / entity names:** Pale Aurum, normal weight
+- **Error messages:** Void Crimson, italic
+- **Links:** Stellar Blue, no underline by default, Pale Aurum on hover
+- **Section dividers:** A thin centered horizontal rule with a small baroque diamond or circle glyph at the midpoint, rendered in Void Edge color (`#2a3460`), 35% opacity
+
+---
+
+## Motion & Animation
+
+### Principles
+
+Motion in the Arcanum is the motion of the cosmos: inevitable, unhurried, operating at scales that make haste irrelevant. Nothing snaps. Nothing bounces. Things come into being as if they were always going to be there.
+
+- **Slow and gravitational** — Background elements rotate on cycles of 30–90 seconds. The user almost cannot perceive the motion; they feel it rather than see it.
+- **Weaving and threading** — Light and energy move in flowing curved paths, tracing the baroque scrollwork forms. They do not travel in straight lines.
+- **Unfurling** — Panels and elements enter by opening outward from a center point, or by fading in while gently expanding. They do not slide from edges.
+- **No sudden starts** — All animations use easing that begins gently. Even fast interactions (hover: 200ms) feel considered.
+
+### Easing Functions
+
+```css
+/* Standard entry — element comes into being */
+--ease-unfurl:    cubic-bezier(0.16, 1, 0.3, 1);
+
+/* Standard exit — element dissolves */
+--ease-dissolve:  cubic-bezier(0.7, 0, 0.84, 0);
+
+/* Smooth bidirectional — hover states, continuous transitions */
+--ease-cosmic:    cubic-bezier(0.4, 0, 0.2, 1);
+
+/* Cosmic rotation — ambient background elements */
+/* Use: animation-timing-function: linear (constant angular velocity) */
+```
+
+### Duration Guidelines
+
+| Category | Duration | Easing | Notes |
+|----------|----------|--------|-------|
+| Hover state | 180ms | `ease-cosmic` | Color and glow shift |
+| Focus ring appear | 200ms | `ease-unfurl` | Gold ring unfurls around element |
+| Button press | 120ms | `ease-cosmic` | Scale 0.97, darken |
+| Panel open | 400ms | `ease-unfurl` | Fade + scale from 0.96 |
+| Panel close | 280ms | `ease-dissolve` | Fade + scale to 0.96 |
+| Modal appear | 500ms | `ease-unfurl` | Backdrop fade + content unfurl |
+| Tree node expand | 300ms | `ease-unfurl` | Height expand + child fade in |
+| Server status change | 800ms | `ease-cosmic` | Smooth state transition with glow shift |
+| Tooltip | 200ms in, 120ms out | `ease-unfurl`/`ease-dissolve` | |
+| Toast notification | 400ms in, 300ms out | `ease-unfurl`/`ease-dissolve` | |
+| Gold pulse (running) | 3s loop | `ease-cosmic` | Breathing aurum glow |
+| Background rotation | 60s loop | `linear` | Full 360° cosmic backdrop |
+| Light thread drift | 12–20s loop | `ease-cosmic` | Slow baroque swirl in bg layers |
+
+### Animation Categories
+
+#### 1. Ambient (Always On — Cosmic Backdrop)
+
+The background of the Arcanum is never fully still. At the lowest z-index, slow-moving elements imply the cosmos continuing its work:
+
+- A very faint, extremely slow (60–90s) rotation of a large cosmic spiral or mandala shape — barely visible, 8–12% opacity.
+- Subtle blue-violet nebula wisps drifting across deep backgrounds on 15–20s cycles.
+- For the running server state: a slow gold pulse (3s breathe cycle) on the status indicator, and the background rotation gains a faint warm tint.
+
+**Intensity:** Never distracting. If the user notices the background moving, it is too fast or too bright.
+
+#### 2. Interaction Animations (User-Triggered)
+
+- **Button hover:** Gold glow blooms (var(--glow-aurum)), text shifts to Pale Aurum, 180ms.
+- **Button press:** Scale to 0.97, glow briefly intensifies, 120ms.
+- **Panel focus:** A baroque-curved focus ring in Aurum unfurls around the focused element, 200ms.
+- **Tree node expand:** Children unfurl downward with a 300ms height animation.
+- **Tab switch:** Active tab gets Aurum underline, content cross-fades, 250ms.
+
+#### 3. System State Animations (Server Lifecycle)
+
+- **Running state entered:** Status indicator transitions from cool-blue to warm gold over 800ms. Background rotation becomes slightly visible. Aurum pulse begins.
+- **Server stopped:** Gold fades, everything cools to Cosmic Haze. Background motion slows and fades. The interface becomes still.
+- **Error state:** A slow, low-frequency crimson pulse (4s cycle) replaces the gold. The background rotation stops entirely. The stillness communicates wrongness.
+- **Build/reload in progress:** A threading animation — a thin gold line traces a flowing path along the border of the active panel, completing its circuit every 2s.
+
+#### 4. Data Change Animations
+
+- **YAML saved / written to disk:** A brief gold ripple emanates from the save button, fading outward across the panel, 600ms.
+- **Validation error:** Affected field border shifts to Void Crimson with a single 300ms pulse.
+- **Zone reload:** Active zone panel's content cross-fades with a 500ms dissolve.
+
+---
+
+## Component Design Language
+
+### Panels and Surfaces
+
+**Primary panel:**
+- Background: Deep Nebula (`#161b38`)
+- Border: 1px solid Void Edge (`#2a3460`), with optional baroque corner accent at 35% opacity
+- Border radius: 14–18px
+- Box shadow: `var(--shadow-panel)`
+- Optional: a very faint inner blue-violet glow (`var(--glow-violet)`) at 40% intensity on active/focused panels
+
+**Elevated panel (modal, popover, flyout):**
+- Background: Celestial Slate (`#1e2748`)
+- Border: 1px solid, 50% Nebula Violet
+- Box shadow: `var(--shadow-panel)`, `var(--glow-violet)` combined
+- Backdrop blur: 12px (if supported) over underlying content
+
+**Panel header:**
+- Cinzel, 14px, uppercase, letter-spacing 0.5px, Cosmic Haze color
+- Bottom border: 1px Void Edge, with a centered subtle flourish (thin horizontal rule with a small circle or diamond glyph at center)
+
+### Buttons
+
+**Primary (creative action — create zone, add mob, apply config):**
+- Background: linear-gradient from Amber Thread (`#a07820`) to Aurum (`#c8972e`)
+- Text: Pale Aurum (`#e2bc6a`), Cinzel, 13px, letter-spacing 0.5px
+- Border: 1px solid Pale Aurum at 50% opacity
+- Box shadow: `var(--glow-aurum)`
+- Border radius: 8px
+- Hover: gradient brightens toward Pale Aurum, glow intensifies, 180ms
+- Press: scale 0.97, gradient darkens
+
+**Secondary (structural actions — open editor, view log, navigate):**
+- Background: Deep Nebula (`#161b38`)
+- Text: Stardust (`#c2cef0`), Crimson Pro, 14px
+- Border: 1px solid Nebula Violet at 50% opacity
+- Box shadow: `var(--glow-violet)` at 50% intensity
+- Hover: border brightens, subtle violet glow increase, text shifts to white
+
+**Destructive (delete zone, force-kill server, irreversible ops):**
+- Background: `#1a0d12` (very dark crimson-void)
+- Text: `#e8a0aa` (desaturated rose-red)
+- Border: 1px solid Void Crimson (`#8a2a3c`) at 60% opacity
+- Hover: border and text brighten toward pure Void Crimson, slow pulse
+- Never uses a gold accent
+
+**Ghost / subtle (secondary navigation, inline actions):**
+- Background: transparent
+- Text: Cosmic Haze (`#6a7aac`)
+- Border: none
+- Hover: text shifts to Stardust, very faint aurum underline appears
+
+### Input Fields
+
+**Default:**
+- Background: Cosmic Indigo (`#0f1428`)
+- Border: 1px solid Void Edge (`#2a3460`)
+- Text: Stardust (`#c2cef0`), Crimson Pro, 14px
+- Placeholder: Faint Starlight (`#3a4880`)
+- Border radius: 8px
+
+**Focus:**
+- Border: 1px solid Aurum at 60% opacity
+- Box shadow: `0 0 0 2px rgba(200, 151, 46, 0.18)` (soft gold ring)
+- Transition: 200ms `ease-unfurl`
+
+**Error:**
+- Border: 1px solid Void Crimson
+- Box shadow: `0 0 0 2px rgba(138, 42, 60, 0.2)`
+
+**YAML / Code Editor:**
+- Background: Abyssal Navy (`#080c1c`)
+- Font: JetBrains Mono, 13px
+- Line numbers: Faint Starlight color
+- Syntax highlighting palette (token colors):
+  - Keys: Pale Aurum (`#e2bc6a`)
+  - String values: Stardust (`#c2cef0`)
+  - Numeric values: Stellar Blue (`#4e7fd4`)
+  - Booleans: Nebula Violet (`#7a5fc0`)
+  - Comments: Cosmic Haze (`#6a7aac`), italic
+  - Errors/markers: Void Crimson (`#8a2a3c`)
+
+### Tree Views (Zone Hierarchy, Config Tree)
+
+- Connector lines: gentle arcs (SVG curves, not right-angle bends), Void Edge color, 50% opacity
+- Expand/collapse icon: a small baroque-inspired chevron or spiral glyph in Cosmic Haze
+- Node text: Crimson Pro, 14px, Stardust
+- Selected node: Pale Aurum text, Aurum left-border accent (3px), very faint aurum background tint
+- Hover: Stardust text, subtle background highlight
+- Expand animation: 300ms `ease-unfurl` height reveal
+
+### Data Tables (Mob Lists, Item Lists, Ability Tables)
+
+- Header row: Cinzel, 12px, uppercase, letter-spacing 0.5px, Cosmic Haze
+- Header bottom border: 1px Void Edge + a faint baroque line decoration at center
+- Row background: alternating Cosmic Indigo / Deep Nebula (very subtle, 3% brightness delta)
+- Row hover: Celestial Slate background, left border 2px Aurum
+- Selected row: Deep Nebula background, left border 3px Aurum, Pale Aurum text
+- Row dividers: 1px Void Edge at 40% opacity
+
+### Server Status Indicator
+
+The server status indicator is the most emotionally expressive component in the tool. It communicates the state of the world the Creator has built.
+
+**Running:**
+- Large gold orb or sigil with a breathing pulse animation (3s cycle, opacity 70%→100%)
+- Text: "RUNNING", Cinzel, Pale Aurum
+- Background area: faint warm tint, cosmic rotation visible in backdrop
+- Subtle gold threading animation around the panel border (2s circuit)
+
+**Stopped:**
+- Cool blue-grey orb, no animation, still
+- Text: "STOPPED", Cinzel, Cosmic Haze
+- Background area: fully still, no ambient motion
+- The stillness is the message
+
+**Error:**
+- Deep crimson orb with a slow, low-frequency pulse (4s, menacing rather than urgent)
+- Text: "ERROR", Cinzel, Void Crimson
+- Background area: still (motion has stopped), very faint crimson tint
+- Error message below in Crimson Pro, italic, desaturated rose text
+
+**Starting / Reloading:**
+- Gold threading animation traces the panel border on loop (2s circuit)
+- Orb fades between stopped-cool and running-warm
+- Text: "STARTING..." or "RELOADING...", Cinzel, Pale Aurum at 70% opacity
+
+### Tabs
+
+- Inactive tab: Crimson Pro, 14px, Cosmic Haze, no border
+- Active tab: Crimson Pro, 14px, Stardust, Aurum underline (2px, full tab width)
+- Hover: Stardust text, Void Edge underline
+- Transition: 180ms `ease-cosmic`
+
+### Toggles / Checkboxes
+
+- Track (off): Void Edge background, 1px Cosmic Haze border, border radius 999px
+- Track (on): Aurum gradient, 1px Pale Aurum border, soft gold glow
+- Thumb: Stardust circle, `var(--shadow-deep)` drop shadow
+- Transition: 220ms `ease-cosmic`
+
+### Tooltips
+
+- Background: Celestial Slate, 95% opacity, backdrop blur 8px
+- Border: 1px Void Edge
+- Text: Crimson Pro, 13px, Stardust
+- Box shadow: `var(--shadow-deep)`
+- Arrow: matches background
+- Border radius: 8px
+
+---
+
+## World Art Prompts
+
+These prompts target **Flux Dev** and **Flux Schnell** for still images. Video prompts target **LTX 2.0** and **Hunyuan Mini**.
+
+### Prompt System Preamble (include in all prompts)
+
+Add this to any Arcanum art prompt as a style anchor:
+
+```
+Ambon Arcanum style (arcanum_v1): deep cosmic indigo and abyssal navy backgrounds,
+baroque rococo light scrollwork rendered as glowing energy threads, warm aurum-gold
+as the primary accent color against cool blue-violet atmospheric fill, sweeping
+spiral arms of light, fractaline structures, slow cosmological scale, no runes or
+text, no humanoid figures, no neon colors, no harsh edges
+```
+
+---
+
+### Still Image Prompts (Flux Dev / Flux Schnell)
+
+#### Main Background — The Creator's Observatory
+
+Use as the primary backdrop for the Arcanum tool's main screen or loading screen.
+
+```
+Prompt:
+Vast cosmic observatory floating in deep space, baroque architectural elements
+rendered in flowing light — sweeping rococo scrollwork of glowing blue-violet and
+gold energy forming grand archways and spiral colonnades, a colossal golden spiral
+galaxy visible through open arched windows, deep indigo and abyssal navy void
+beyond, fractaline structures branching into the distance like crystalline trees
+made of light, warm aurum-amber luminescence pooling at architectural nodes, cool
+nebula-violet atmospheric mist drifting between pillars, ultra-wide panoramic
+composition, painterly oil technique, extremely detailed
+
+Negative:
+humanoid figures, faces, text, runes, glyphs, logos, neon colors, bright white
+backgrounds, modern technology, computers, flat design, cartoon style, anime,
+hard shadows, sharp edges, photorealism
+```
+
+#### Zone Map Background — The Cartography of Creation
+
+For use behind world map and zone layout visualizations.
+
+```
+Prompt:
+Celestial cartography from above, a glowing world map rendered in baroque light
+threads on a deep cosmic indigo void, landmasses formed from swirling aurum-gold
+energy lines that curl and flourish at coastlines and mountain ranges in rococo
+scrollwork style, rivers traced as flowing silver-blue light, zone boundaries
+marked by gentle violet-glowing arcs, concentric circles of faint stardust
+suggesting scale and depth, fractal detail increasing toward the edges, bird's-eye
+perspective, painterly, luminous
+
+Negative:
+modern map symbols, text labels, legends, compass roses, grid lines, flat colors,
+cartoon style, humanoid figures, photorealism
+```
+
+#### Panel Ornament — Baroque Energy Border
+
+For use as decorative border elements, panel header art, or section dividers.
+
+```
+Prompt:
+Intricate baroque energy scrollwork border, symmetrical horizontal composition,
+glowing aurum-gold rococo flourishes and acanthus-leaf spirals rendered as threads
+of light against deep cosmic indigo, cool blue-violet glow fills the spaces between
+curls, the scrollwork dissolves to transparency at both horizontal ends, extremely
+detailed filigree of light, jewelry-like precision, wide aspect ratio banner format
+
+Negative:
+text, runes, faces, animals, modern design, flat colors, harsh edges, neon
+```
+
+#### Empty State — The Unwritten World
+
+For use when no project or zone is loaded.
+
+```
+Prompt:
+An empty cosmic void beginning to stir — deep abyssal navy space with the faint
+suggestion of energy not yet shaped into form, a single point of warm aurum-gold
+light at the center casting the first illumination into darkness, baroque energy
+tendrils beginning to curl outward from that center point as if the act of creation
+is just beginning, blue-violet nebula mist drifting at the periphery, vast and
+serene, the moment before the world exists, painterly, luminous
+
+Negative:
+humanoid figures, text, runes, modern elements, harsh light, neon, flat design
+```
+
+#### Server Status — The Engine Running
+
+For use as artwork in the server control panel when the server is running.
+
+```
+Prompt:
+A cosmic engine in full operation — a grand mechanical orrery made entirely of
+light, baroque golden rings and spiral armatures rotating slowly in deep indigo
+space, warm aurum energy flowing along the curved spokes like luminous oil, smaller
+fractal orreries visible in the distance like satellites, blue-violet atmospheric
+fill between components, a sense of vast power operating at perfect equilibrium,
+painterly, glowing, majestic
+
+Negative:
+text, runes, humanoid figures, modern machinery, computer hardware, neon, flat
+design, photorealism, harsh shadows
+```
+
+#### Server Status — The Engine Stopped
+
+For use when the server is stopped or not yet started.
+
+```
+Prompt:
+A dormant cosmic mechanism in deep stillness — baroque golden rings and spiral
+armatures at rest, faintly visible in cool blue-grey light, deep abyssal navy
+void surrounds everything, a single cool blue-violet ember at the center barely
+glowing, the scrollwork and ornamental curves still beautiful but inert, a sense
+of vast potential waiting to be awakened, muted palette, painterly, quiet,
+mysterious
+
+Negative:
+warm colors, gold glow, motion blur, text, runes, humanoid figures, neon,
+harsh light, photorealism
+```
+
+---
+
+### Video / Motion Prompts (LTX 2.0 / Hunyuan Mini)
+
+These prompts describe looping ambient animations for backgrounds and loading screens.
+
+#### Ambient Background Loop — Cosmic Rotation
+
+Use as a looping background for the main Arcanum screen.
+
+```
+Prompt:
+Slow rotation of a vast baroque cosmic structure in deep indigo space — ornate
+rococo scrollwork of blue-violet and aurum-gold light turning at a stately,
+gravitational pace, spiral arms curling outward then dissolving at their tips,
+the entire composition completing one rotation every thirty seconds, cool nebula
+mist drifting across the foreground in gentle cross-currents, tiny stars fixed
+in the background, warm gold brightens and dims in a slow breathing rhythm,
+no cuts, seamless loop, painterly
+
+Negative:
+fast motion, sudden cuts, camera movement, text, humanoid figures, neon colors,
+modern technology
+```
+
+#### Loading Screen Loop — Creation Begins
+
+For use on initial load / project open.
+
+```
+Prompt:
+A single point of aurum-gold light at the center of deep cosmic void beginning
+to expand outward — baroque energy threads curl and spiral away from the center
+like a flower blooming in slow motion, each thread tracing rococo scrollwork
+curves as it extends into the dark, blue-violet atmospheric mist parts where
+the gold passes through it, the entire sequence takes eight seconds and then
+gently reverses, soft and inevitable, no sharp edges, no sudden motion, seamless
+
+Negative:
+fast motion, explosions, flash effects, text, humanoid figures, neon, modern
+design, photorealism
+```
+
+#### Server Running Loop — The Engine Breathes
+
+A subtle looping animation for the server status area when the server is running.
+
+```
+Prompt:
+Close view of a slowly rotating baroque golden orrery made of light —
+warm aurum rings turning at different rates in layered depth, energy flowing
+along the curved armatures in smooth continuous streams, blue-violet glow
+fills the space between rings, the whole assembly breathing gently with a
+three-second luminosity pulse, seamless loop, depth of field soft on distant
+elements, stately and powerful
+
+Negative:
+fast motion, flickering, text, humanoid figures, neon, harsh light, modern
+machinery, photorealism
+```
+
+---
+
+### Negative Prompt (Universal — Add to All Generations)
+
+```
+text, words, letters, runes, glyphs, watermarks, logos, signatures, humanoid
+figures, faces, bodies, animals, modern technology, computers, user interfaces,
+neon colors, hot pink, electric blue, lime green, harsh shadows, hard edges,
+flat design, cartoon, anime, photorealism, studio lighting, stock photo aesthetic,
+horror elements, gore
+```
+
+---
+
+## Validation Checklist
+
+When reviewing any component, screen, or artwork against this style:
+
+**Scale & Weight**
+- [ ] Does this feel like it operates at cosmological scale?
+- [ ] Is the gold accent used sparingly — only where something is alive or important?
+- [ ] Does the deep indigo background give a sense of infinite depth?
+
+**Ornamentation**
+- [ ] Are curves baroque — do they terminate in scrollwork, dissolve, or curl?
+- [ ] Are there any abrupt hard edges where there should be a flourish or fade?
+- [ ] Is decorative detail present but not cluttered?
+
+**Light Behavior**
+- [ ] Does gold light have a clear source and bloom softly?
+- [ ] Is the blue-violet ambient fill present without competing with the gold?
+- [ ] Are glows feathered (no hard-edged halos)?
+
+**Motion**
+- [ ] Is all animation unhurried — does nothing snap or bounce?
+- [ ] Does the server's running/stopped state feel emotionally distinct?
+- [ ] Would the background motion be invisible if the user stopped looking for it?
+
+**Typography**
+- [ ] Does all display text use Cinzel?
+- [ ] Is Crimson Pro used for body/UI — no sans-serif in those roles?
+- [ ] Is code/YAML always in JetBrains Mono?
+
+**Emotional Check**
+- [ ] Does this feel like the Creator's instrument?
+- [ ] Does the gold feel earned?
+- [ ] Is this unmistakably different from a modern SaaS dashboard?
+- [ ] Would someone opening this tool for the first time feel the weight of what they're about to do?
+
+**If it feels like a modern productivity tool — it has drifted. Revise.**
+
+---
+
+## Versioning Strategy
+
+- `arcanum_v1` — **Current** (deep cosmic, baroque gold, Cinzel/Crimson Pro)
+- `arcanum_dawn_v1` — Lighter variant: rose-gold and pale violet at dawn, for onboarding/welcome screens
+- `arcanum_void_v1` — Deeper, darker, more minimal: the Creator has been gone a long time
+- `arcanum_active_v1` — Higher contrast, brighter gold: for power-user/high-density layouts
+
+---
+
+**Last Updated:** March 7, 2026
+**Next Review:** June 1, 2026

--- a/creator/bun.lock
+++ b/creator/bun.lock
@@ -6,6 +6,9 @@
       "name": "ambon-creator",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
+        "@fontsource/cinzel": "^5.2.8",
+        "@fontsource/crimson-pro": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-fs": "^2",
@@ -130,6 +133,12 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@fontsource/cinzel": ["@fontsource/cinzel@5.2.8", "", {}, "sha512-B9WeF/jPlOJOrcXfX96cy4KfM+s1QcU2C9W2hE3azBOBzPvzFkNpBovT5JmhAeicE/s4HZWKF9LF5hmEcqlbsw=="],
+
+    "@fontsource/crimson-pro": ["@fontsource/crimson-pro@5.2.8", "", {}, "sha512-t+cAoAswUKEReDPqDNWWSyAp7baZkKrtF6Ry0KrDZQHJCldS9pIbRH0n2hm1u4+SbIUI7c+nUS9yfK6rEhycTw=="],
+
+    "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.2.8", "", {}, "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 

--- a/creator/index.html
+++ b/creator/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AmbonMUD Creator</title>
+    <title>Ambon Arcanum</title>
   </head>
   <body>
     <div id="root"></div>

--- a/creator/package.json
+++ b/creator/package.json
@@ -13,6 +13,9 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^2.0.4",
+    "@fontsource/cinzel": "^5.2.8",
+    "@fontsource/crimson-pro": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-fs": "^2",

--- a/creator/src-tauri/Cargo.lock
+++ b/creator/src-tauri/Cargo.lock
@@ -36,13 +36,19 @@ dependencies = [
 name = "ambon-creator"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-shell",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -299,14 +305,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -338,6 +352,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -359,9 +383,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -372,7 +396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -684,6 +708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,12 +762,21 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -750,6 +789,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -983,8 +1028,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -994,9 +1041,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1161,6 +1210,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1328,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1269,6 +1338,39 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1289,9 +1391,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1671,6 +1775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1800,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -1789,6 +1905,23 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2009,6 +2142,50 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2383,6 +2560,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,6 +2661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,6 +2691,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +2716,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2561,6 +2822,50 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -2618,6 +2923,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,10 +2952,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2639,6 +3018,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2697,6 +3085,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -2819,6 +3230,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3069,6 +3492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3122,6 +3551,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,7 +3592,7 @@ checksum = "6e06d52c379e63da659a483a958110bbde891695a0ecb53e48cc7786d5eda7bb"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -3219,7 +3669,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3482,6 +3932,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tendril"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3574,6 +4037,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,6 +4063,26 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3869,6 +4367,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,6 +4420,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -4115,6 +4625,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,6 +4676,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4344,6 +4873,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,6 +4926,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4870,6 +5419,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/creator/src-tauri/Cargo.toml
+++ b/creator/src-tauri/Cargo.toml
@@ -19,3 +19,9 @@ tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+uuid = { version = "1", features = ["v4"] }
+sha2 = "0.10"
+base64 = "0.22"
+chrono = { version = "0.4", features = ["serde"] }
+tokio = { version = "1", features = ["fs"] }

--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -1,0 +1,151 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+const MANIFEST_FILE: &str = "manifest.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssetEntry {
+    pub id: String,
+    pub hash: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub enhanced_prompt: String,
+    pub model: String,
+    pub asset_type: String,
+    #[serde(default)]
+    pub context: AssetContext,
+    pub created_at: DateTime<Utc>,
+    pub file_name: String,
+    pub width: u32,
+    pub height: u32,
+    #[serde(default = "default_sync_status")]
+    pub sync_status: String,
+}
+
+fn default_sync_status() -> String {
+    "local".to_string()
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AssetContext {
+    #[serde(default)]
+    pub zone: String,
+    #[serde(default)]
+    pub entity_type: String,
+    #[serde(default)]
+    pub entity_id: String,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Manifest {
+    assets: Vec<AssetEntry>,
+}
+
+fn assets_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    Ok(dir.join("assets"))
+}
+
+fn manifest_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(assets_dir(app)?.join(MANIFEST_FILE))
+}
+
+async fn load_manifest(app: &AppHandle) -> Result<Manifest, String> {
+    let path = manifest_path(app)?;
+    if !path.exists() {
+        return Ok(Manifest::default());
+    }
+    let data = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| format!("Failed to read manifest: {e}"))?;
+    serde_json::from_str(&data).map_err(|e| format!("Failed to parse manifest: {e}"))
+}
+
+async fn save_manifest(app: &AppHandle, manifest: &Manifest) -> Result<(), String> {
+    let path = manifest_path(app)?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Failed to create assets dir: {e}"))?;
+    }
+    let json = serde_json::to_string_pretty(manifest)
+        .map_err(|e| format!("Failed to serialize manifest: {e}"))?;
+    tokio::fs::write(&path, json)
+        .await
+        .map_err(|e| format!("Failed to write manifest: {e}"))
+}
+
+#[tauri::command]
+pub async fn accept_asset(
+    app: AppHandle,
+    id: String,
+    hash: String,
+    prompt: String,
+    enhanced_prompt: Option<String>,
+    model: String,
+    asset_type: String,
+    context: Option<AssetContext>,
+    file_name: String,
+    width: u32,
+    height: u32,
+) -> Result<AssetEntry, String> {
+    let entry = AssetEntry {
+        id,
+        hash,
+        prompt,
+        enhanced_prompt: enhanced_prompt.unwrap_or_default(),
+        model,
+        asset_type,
+        context: context.unwrap_or_default(),
+        created_at: Utc::now(),
+        file_name,
+        width,
+        height,
+        sync_status: "local".to_string(),
+    };
+
+    let mut manifest = load_manifest(&app).await?;
+    // Avoid duplicates by hash
+    manifest.assets.retain(|a| a.hash != entry.hash);
+    manifest.assets.push(entry.clone());
+    save_manifest(&app, &manifest).await?;
+
+    Ok(entry)
+}
+
+#[tauri::command]
+pub async fn list_assets(app: AppHandle) -> Result<Vec<AssetEntry>, String> {
+    let manifest = load_manifest(&app).await?;
+    Ok(manifest.assets)
+}
+
+#[tauri::command]
+pub async fn delete_asset(app: AppHandle, id: String) -> Result<(), String> {
+    let mut manifest = load_manifest(&app).await?;
+    let entry = manifest.assets.iter().find(|a| a.id == id).cloned();
+
+    if let Some(entry) = &entry {
+        // Delete the file
+        let file_path = assets_dir(&app)?.join("images").join(&entry.file_name);
+        if file_path.exists() {
+            tokio::fs::remove_file(&file_path)
+                .await
+                .map_err(|e| format!("Failed to delete file: {e}"))?;
+        }
+    }
+
+    manifest.assets.retain(|a| a.id != id);
+    save_manifest(&app, &manifest).await?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_assets_dir(app: AppHandle) -> Result<String, String> {
+    let dir = assets_dir(&app)?;
+    Ok(dir.to_string_lossy().to_string())
+}

--- a/creator/src-tauri/src/deepinfra.rs
+++ b/creator/src-tauri/src/deepinfra.rs
@@ -1,0 +1,292 @@
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+use crate::settings;
+
+const INFERENCE_URL: &str = "https://api.deepinfra.com/v1/inference";
+const CHAT_URL: &str = "https://api.deepinfra.com/v1/openai/chat/completions";
+
+// ─── Image Generation ────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+struct ImageRequest {
+    prompt: String,
+    width: u32,
+    height: u32,
+    num_inference_steps: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    guidance_scale: Option<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImageResponse {
+    images: Vec<ImageEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ImageEntry {
+    UrlObject { url: String },
+    Base64String(String),
+}
+
+impl ImageEntry {
+    fn to_base64(&self) -> Result<String, String> {
+        match self {
+            ImageEntry::UrlObject { url } => {
+                // Strip data URI prefix if present
+                if let Some(data) = url.strip_prefix("data:image/png;base64,")
+                    .or_else(|| url.strip_prefix("data:image/jpeg;base64,"))
+                    .or_else(|| url.strip_prefix("data:image/webp;base64,"))
+                {
+                    Ok(data.to_string())
+                } else {
+                    Err("Unsupported image URL format".to_string())
+                }
+            }
+            ImageEntry::Base64String(s) => {
+                // Strip data URI prefix if present, otherwise return as-is
+                if let Some(data) = s.strip_prefix("data:image/png;base64,")
+                    .or_else(|| s.strip_prefix("data:image/jpeg;base64,"))
+                    .or_else(|| s.strip_prefix("data:image/webp;base64,"))
+                {
+                    Ok(data.to_string())
+                } else {
+                    Ok(s.clone())
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneratedImage {
+    pub id: String,
+    pub hash: String,
+    pub file_path: String,
+    pub data_url: String,
+    pub width: u32,
+    pub height: u32,
+    pub prompt: String,
+    pub model: String,
+}
+
+fn assets_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    Ok(dir.join("assets").join("images"))
+}
+
+#[tauri::command]
+pub async fn generate_image(
+    app: AppHandle,
+    prompt: String,
+    model: Option<String>,
+    width: Option<u32>,
+    height: Option<u32>,
+    steps: Option<u32>,
+    guidance: Option<f32>,
+) -> Result<GeneratedImage, String> {
+    let settings = settings::get_settings(app.clone()).await?;
+    if settings.deepinfra_api_key.is_empty() {
+        return Err("DeepInfra API key not configured. Set it in Settings.".to_string());
+    }
+
+    let model = model.unwrap_or(settings.image_model);
+    let w = width.unwrap_or(1024);
+    let h = height.unwrap_or(1024);
+
+    let is_schnell = model.contains("schnell");
+    let default_steps = if is_schnell { 4 } else { 28 };
+    let default_guidance = if is_schnell { None } else { Some(3.5) };
+
+    let body = ImageRequest {
+        prompt: prompt.clone(),
+        width: w,
+        height: h,
+        num_inference_steps: steps.unwrap_or(default_steps),
+        guidance_scale: guidance.or(default_guidance),
+    };
+
+    let url = format!("{INFERENCE_URL}/{model}");
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", settings.deepinfra_api_key))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("API request failed: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("API error ({status}): {text}"));
+    }
+
+    let resp: ImageResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse API response: {e}"))?;
+
+    let entry = resp.images.first().ok_or("No images in response")?;
+    let b64 = entry.to_base64()?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(&b64)
+        .map_err(|e| format!("Failed to decode base64 image: {e}"))?;
+
+    // Content-addressed filename
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let hash = format!("{:x}", hasher.finalize());
+
+    // Save to assets dir
+    let dir = assets_dir(&app)?;
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| format!("Failed to create assets dir: {e}"))?;
+
+    let ext = detect_extension(&bytes);
+    let mime = detect_mime(ext);
+    let filename = format!("{hash}.{ext}");
+    let file_path = dir.join(&filename);
+    tokio::fs::write(&file_path, &bytes)
+        .await
+        .map_err(|e| format!("Failed to save image: {e}"))?;
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let data_url = format!("data:{mime};base64,{b64}");
+
+    Ok(GeneratedImage {
+        id,
+        hash,
+        file_path: file_path.to_string_lossy().to_string(),
+        data_url,
+        width: w,
+        height: h,
+        prompt,
+        model,
+    })
+}
+
+fn detect_extension(bytes: &[u8]) -> &'static str {
+    if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
+        "png"
+    } else if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        "jpg"
+    } else if bytes.starts_with(b"RIFF") && bytes.len() > 12 && &bytes[8..12] == b"WEBP" {
+        "webp"
+    } else {
+        "png" // default
+    }
+}
+
+fn detect_mime(ext: &str) -> &'static str {
+    match ext {
+        "jpg" => "image/jpeg",
+        "webp" => "image/webp",
+        _ => "image/png",
+    }
+}
+
+/// Read a saved image from disk and return it as a data URL.
+#[tauri::command]
+pub async fn read_image_data_url(path: String) -> Result<String, String> {
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|e| format!("Failed to read image: {e}"))?;
+
+    let ext = detect_extension(&bytes);
+    let mime = detect_mime(ext);
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Ok(format!("data:{mime};base64,{b64}"))
+}
+
+// ─── Prompt Enhancement ──────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+struct ChatRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    max_tokens: u32,
+    temperature: f32,
+}
+
+#[derive(Debug, Serialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatResponse {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatChoice {
+    message: ChatResponseMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatResponseMessage {
+    content: String,
+}
+
+#[tauri::command]
+pub async fn enhance_prompt(
+    app: AppHandle,
+    prompt: String,
+    system_prompt: String,
+) -> Result<String, String> {
+    let settings = settings::get_settings(app).await?;
+    if settings.deepinfra_api_key.is_empty() {
+        return Err("DeepInfra API key not configured. Set it in Settings.".to_string());
+    }
+
+    let body = ChatRequest {
+        model: settings.enhance_model,
+        messages: vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: system_prompt,
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: prompt,
+            },
+        ],
+        max_tokens: 512,
+        temperature: 0.7,
+    };
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(CHAT_URL)
+        .header("Authorization", format!("Bearer {}", settings.deepinfra_api_key))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("API request failed: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("API error ({status}): {text}"));
+    }
+
+    let resp: ChatResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse API response: {e}"))?;
+
+    resp.choices
+        .first()
+        .map(|c| c.message.content.trim().to_string())
+        .ok_or_else(|| "No response from model".to_string())
+}

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -1,4 +1,7 @@
+mod assets;
+mod deepinfra;
 mod project;
+mod settings;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -6,7 +9,18 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_shell::init())
-        .invoke_handler(tauri::generate_handler![project::validate_mud_dir])
+        .invoke_handler(tauri::generate_handler![
+            project::validate_mud_dir,
+            settings::get_settings,
+            settings::save_settings,
+            deepinfra::generate_image,
+            deepinfra::enhance_prompt,
+            deepinfra::read_image_data_url,
+            assets::accept_asset,
+            assets::list_assets,
+            assets::delete_asset,
+            assets::get_assets_dir,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/creator/src-tauri/src/settings.rs
+++ b/creator/src-tauri/src/settings.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+const SETTINGS_FILE: &str = "settings.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Settings {
+    #[serde(default)]
+    pub deepinfra_api_key: String,
+    #[serde(default = "default_image_model")]
+    pub image_model: String,
+    #[serde(default = "default_enhance_model")]
+    pub enhance_model: String,
+}
+
+fn default_image_model() -> String {
+    "black-forest-labs/FLUX-1-schnell".to_string()
+}
+
+fn default_enhance_model() -> String {
+    "Qwen/Qwen2.5-7B-Instruct".to_string()
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            deepinfra_api_key: String::new(),
+            image_model: default_image_model(),
+            enhance_model: default_enhance_model(),
+        }
+    }
+}
+
+fn settings_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    Ok(dir.join(SETTINGS_FILE))
+}
+
+#[tauri::command]
+pub async fn get_settings(app: AppHandle) -> Result<Settings, String> {
+    let path = settings_path(&app)?;
+    if !path.exists() {
+        return Ok(Settings::default());
+    }
+    let data = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| format!("Failed to read settings: {e}"))?;
+    serde_json::from_str(&data).map_err(|e| format!("Failed to parse settings: {e}"))
+}
+
+#[tauri::command]
+pub async fn save_settings(app: AppHandle, settings: Settings) -> Result<(), String> {
+    let path = settings_path(&app)?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Failed to create settings dir: {e}"))?;
+    }
+    let json = serde_json::to_string_pretty(&settings)
+        .map_err(|e| format!("Failed to serialize settings: {e}"))?;
+    tokio::fs::write(&path, json)
+        .await
+        .map_err(|e| format!("Failed to write settings: {e}"))
+}

--- a/creator/src-tauri/tauri.conf.json
+++ b/creator/src-tauri/tauri.conf.json
@@ -22,7 +22,13 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "scope": {
+          "allow": ["$APPDATA/**"],
+          "deny": []
+        }
+      }
     }
   },
   "plugins": {

--- a/creator/src/App.tsx
+++ b/creator/src/App.tsx
@@ -1,9 +1,16 @@
+import { useEffect } from "react";
 import { useProjectStore } from "@/stores/projectStore";
+import { useAssetStore } from "@/stores/assetStore";
 import { AppShell } from "@/components/AppShell";
 import { WelcomeScreen } from "@/components/WelcomeScreen";
 
 export function App() {
   const project = useProjectStore((s) => s.project);
+  const loadSettings = useAssetStore((s) => s.loadSettings);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
 
   if (!project) {
     return <WelcomeScreen />;

--- a/creator/src/components/AppShell.tsx
+++ b/creator/src/components/AppShell.tsx
@@ -4,13 +4,19 @@ import { TabBar } from "./TabBar";
 import { MainArea } from "./MainArea";
 import { StatusBar } from "./StatusBar";
 import { ShortcutsHelp } from "./ui/ShortcutsHelp";
+import { AssetGenerator } from "./AssetGenerator";
+import { AssetGallery } from "./AssetGallery";
 import { useKeyboardShortcuts } from "@/lib/useKeyboardShortcuts";
+import { useAssetStore } from "@/stores/assetStore";
 
 export function AppShell() {
   const { showHelp, setShowHelp } = useKeyboardShortcuts();
+  const generatorOpen = useAssetStore((s) => s.generatorOpen);
+  const galleryOpen = useAssetStore((s) => s.galleryOpen);
+  const closeGallery = useAssetStore((s) => s.closeGallery);
 
   return (
-    <div className="flex h-screen flex-col bg-bg-primary">
+    <div className="flex h-screen flex-col bg-bg-abyss">
       <Toolbar />
       <div className="flex min-h-0 flex-1">
         <Sidebar />
@@ -21,6 +27,8 @@ export function AppShell() {
       </div>
       <StatusBar />
       {showHelp && <ShortcutsHelp onClose={() => setShowHelp(false)} />}
+      {generatorOpen && <AssetGenerator />}
+      {galleryOpen && <AssetGallery onClose={closeGallery} />}
     </div>
   );
 }

--- a/creator/src/components/AssetGallery.tsx
+++ b/creator/src/components/AssetGallery.tsx
@@ -1,0 +1,322 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useAssetStore } from "@/stores/assetStore";
+import type { AssetEntry } from "@/types/assets";
+
+/** Triggers image loading when the element scrolls into view. */
+function LazyImage({
+  asset,
+  onVisible,
+}: {
+  asset: AssetEntry;
+  onVisible: (entry: AssetEntry) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          onVisible(asset);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [asset, onVisible]);
+
+  return (
+    <div ref={ref} className="flex h-full w-full items-center justify-center">
+      <div className="h-4 w-4 rounded-full border border-border-default border-t-accent animate-spin" />
+    </div>
+  );
+}
+
+type SortKey = "newest" | "oldest" | "type";
+
+export function AssetGallery({ onClose }: { onClose: () => void }) {
+  const assets = useAssetStore((s) => s.assets);
+  const assetsDir = useAssetStore((s) => s.assetsDir);
+  const loadAssets = useAssetStore((s) => s.loadAssets);
+  const deleteAsset = useAssetStore((s) => s.deleteAsset);
+
+  const [selected, setSelected] = useState<AssetEntry | null>(null);
+  const [filter, setFilter] = useState<string>("all");
+  const [sort, setSort] = useState<SortKey>("newest");
+  const [deleting, setDeleting] = useState(false);
+  const [imageCache, setImageCache] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    loadAssets();
+  }, [loadAssets]);
+
+  const types = Array.from(new Set(assets.map((a) => a.asset_type)));
+
+  const filtered = assets.filter(
+    (a) => filter === "all" || a.asset_type === filter,
+  );
+
+  const sorted = [...filtered].sort((a, b) => {
+    if (sort === "newest") return b.created_at.localeCompare(a.created_at);
+    if (sort === "oldest") return a.created_at.localeCompare(b.created_at);
+    return a.asset_type.localeCompare(b.asset_type);
+  });
+
+  const loadImage = useCallback(
+    (entry: AssetEntry) => {
+      if (imageCache[entry.id]) return;
+      const path = `${assetsDir}\\images\\${entry.file_name}`;
+      invoke<string>("read_image_data_url", { path }).then((dataUrl) => {
+        setImageCache((prev) => ({ ...prev, [entry.id]: dataUrl }));
+      }).catch(() => {});
+    },
+    [assetsDir, imageCache],
+  );
+
+  const handleDelete = async (entry: AssetEntry) => {
+    setDeleting(true);
+    try {
+      await deleteAsset(entry.id);
+      if (selected?.id === entry.id) setSelected(null);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const formatDate = (iso: string) => {
+    try {
+      return new Date(iso).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    } catch {
+      return iso;
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="mx-4 flex max-h-[90vh] w-full max-w-5xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl">
+        {/* Header */}
+        <div className="flex shrink-0 items-center justify-between border-b border-border-default px-5 py-3">
+          <div className="flex items-center gap-3">
+            <h2 className="font-display text-sm tracking-wide text-text-primary">
+              Asset Gallery
+            </h2>
+            <span className="text-xs text-text-muted">
+              {sorted.length} asset{sorted.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-xs text-text-muted hover:text-text-primary"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Filters */}
+        <div className="flex shrink-0 items-center gap-3 border-b border-border-default px-5 py-2">
+          <div className="flex gap-1">
+            <button
+              onClick={() => setFilter("all")}
+              className={`rounded px-2 py-0.5 text-[10px] transition-colors ${
+                filter === "all"
+                  ? "bg-accent/20 text-accent"
+                  : "text-text-muted hover:text-text-secondary"
+              }`}
+            >
+              All
+            </button>
+            {types.map((type) => (
+              <button
+                key={type}
+                onClick={() => setFilter(type)}
+                className={`rounded px-2 py-0.5 text-[10px] transition-colors ${
+                  filter === type
+                    ? "bg-accent/20 text-accent"
+                    : "text-text-muted hover:text-text-secondary"
+                }`}
+              >
+                {type.replace(/_/g, " ")}
+              </button>
+            ))}
+          </div>
+          <div className="ml-auto flex gap-1">
+            {(["newest", "oldest", "type"] as SortKey[]).map((key) => (
+              <button
+                key={key}
+                onClick={() => setSort(key)}
+                className={`rounded px-2 py-0.5 text-[10px] transition-colors ${
+                  sort === key
+                    ? "bg-accent/20 text-accent"
+                    : "text-text-muted hover:text-text-secondary"
+                }`}
+              >
+                {key}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex min-h-0 flex-1">
+          {/* Grid */}
+          <div className="flex-1 overflow-y-auto p-4">
+            {sorted.length === 0 ? (
+              <div className="flex h-full items-center justify-center">
+                <p className="text-sm text-text-muted">
+                  No assets yet. Generate some art to see them here.
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-5">
+                {sorted.map((asset) => (
+                  <button
+                    key={asset.id}
+                    onClick={() => setSelected(asset)}
+                    className={`group overflow-hidden rounded-lg border transition-all ${
+                      selected?.id === asset.id
+                        ? "border-accent shadow-[var(--glow-aurum)]"
+                        : "border-border-default hover:border-border-hover"
+                    }`}
+                  >
+                    <div className="aspect-square bg-bg-primary">
+                      {imageCache[asset.id] ? (
+                        <img
+                          src={imageCache[asset.id]}
+                          alt={asset.prompt.slice(0, 60)}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <LazyImage asset={asset} onVisible={loadImage} />
+                      )}
+                    </div>
+                    <div className="px-2 py-1.5">
+                      <p className="truncate text-[10px] text-text-secondary">
+                        {asset.asset_type.replace(/_/g, " ")}
+                      </p>
+                      <p className="truncate text-[9px] text-text-muted">
+                        {asset.model.split("/").pop()}
+                      </p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Detail panel */}
+          {selected && (
+            <div className="flex w-72 shrink-0 flex-col border-l border-border-default bg-bg-primary">
+              {/* Preview */}
+              <div className="shrink-0 border-b border-border-default p-3">
+                <div className="overflow-hidden rounded border border-border-default">
+                  {imageCache[selected.id] && (
+                    <img
+                      src={imageCache[selected.id]}
+                      alt="Selected asset"
+                      className="w-full"
+                    />
+                  )}
+                </div>
+              </div>
+
+              {/* Metadata */}
+              <div className="min-h-0 flex-1 overflow-y-auto p-3">
+                <div className="flex flex-col gap-2">
+                  <div>
+                    <p className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Type
+                    </p>
+                    <p className="text-xs text-text-secondary">
+                      {selected.asset_type.replace(/_/g, " ")}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Model
+                    </p>
+                    <p className="text-xs text-text-secondary">
+                      {selected.model.split("/").pop()}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Size
+                    </p>
+                    <p className="text-xs text-text-secondary">
+                      {selected.width}x{selected.height}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Created
+                    </p>
+                    <p className="text-xs text-text-secondary">
+                      {formatDate(selected.created_at)}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Hash
+                    </p>
+                    <p className="truncate font-mono text-[10px] text-text-muted">
+                      {selected.hash.slice(0, 16)}...
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Prompt
+                    </p>
+                    <p className="text-[10px] leading-relaxed text-text-secondary">
+                      {selected.prompt.length > 300
+                        ? `${selected.prompt.slice(0, 300)}...`
+                        : selected.prompt}
+                    </p>
+                  </div>
+
+                  {selected.enhanced_prompt && (
+                    <div>
+                      <p className="text-[10px] uppercase tracking-wider text-text-muted">
+                        Enhanced Prompt
+                      </p>
+                      <p className="text-[10px] leading-relaxed text-text-secondary">
+                        {selected.enhanced_prompt.length > 300
+                          ? `${selected.enhanced_prompt.slice(0, 300)}...`
+                          : selected.enhanced_prompt}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Actions */}
+              <div className="shrink-0 border-t border-border-default p-3">
+                <button
+                  onClick={() => handleDelete(selected)}
+                  disabled={deleting}
+                  className="w-full rounded border border-status-danger/40 px-2 py-1.5 text-xs text-status-danger transition-colors hover:bg-status-danger/10 disabled:opacity-50"
+                >
+                  {deleting ? "Deleting..." : "Delete Asset"}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/AssetGenerator.tsx
+++ b/creator/src/components/AssetGenerator.tsx
@@ -1,0 +1,344 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useAssetStore } from "@/stores/assetStore";
+import {
+  ASSET_TEMPLATES,
+  ARCANUM_PREAMBLE,
+  ENHANCE_SYSTEM_PROMPT,
+  composePrompt,
+} from "@/lib/arcanumPrompts";
+import { IMAGE_MODELS } from "@/types/assets";
+import type { AssetType, GeneratedImage } from "@/types/assets";
+
+type Stage = "compose" | "generating" | "preview";
+
+export function AssetGenerator() {
+  const settings = useAssetStore((s) => s.settings);
+  const closeGenerator = useAssetStore((s) => s.closeGenerator);
+  const acceptAsset = useAssetStore((s) => s.acceptAsset);
+
+  const [stage, setStage] = useState<Stage>("compose");
+  const [assetType, setAssetType] = useState<AssetType>("background");
+  const [modelId, setModelId] = useState<string>(IMAGE_MODELS[0].id);
+  const [customization, setCustomization] = useState("");
+  const [prompt, setPrompt] = useState(() => composePrompt("background"));
+  const [enhancedPrompt, setEnhancedPrompt] = useState("");
+  const [useEnhanced, setUseEnhanced] = useState(false);
+  const [enhancing, setEnhancing] = useState(false);
+  const [result, setResult] = useState<GeneratedImage | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [accepting, setAccepting] = useState(false);
+
+  const hasApiKey = settings && settings.deepinfra_api_key.length > 0;
+
+  const handleTypeChange = (type: AssetType) => {
+    setAssetType(type);
+    setPrompt(composePrompt(type, customization || undefined));
+    setEnhancedPrompt("");
+    setUseEnhanced(false);
+  };
+
+  const handleCustomizationChange = (value: string) => {
+    setCustomization(value);
+    setPrompt(composePrompt(assetType, value || undefined));
+  };
+
+  const handleEnhance = async () => {
+    setEnhancing(true);
+    setError(null);
+    try {
+      const result = await invoke<string>("enhance_prompt", {
+        prompt: `${ARCANUM_PREAMBLE}\n\n${prompt}`,
+        systemPrompt: ENHANCE_SYSTEM_PROMPT,
+      });
+      setEnhancedPrompt(result);
+      setUseEnhanced(true);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setEnhancing(false);
+    }
+  };
+
+  const handleGenerate = async () => {
+    setStage("generating");
+    setError(null);
+    try {
+      const finalPrompt = useEnhanced && enhancedPrompt
+        ? enhancedPrompt
+        : `${ARCANUM_PREAMBLE}\n\n${prompt}`;
+
+      const model = IMAGE_MODELS.find((m) => m.id === modelId);
+      const guidance = model && "defaultGuidance" in model
+        ? (model as { defaultGuidance: number }).defaultGuidance
+        : null;
+
+      const image = await invoke<GeneratedImage>("generate_image", {
+        prompt: finalPrompt,
+        model: modelId,
+        width: 1024,
+        height: 1024,
+        steps: model?.defaultSteps ?? null,
+        guidance,
+      });
+      setResult(image);
+      setStage("preview");
+    } catch (e) {
+      setError(String(e));
+      setStage("compose");
+    }
+  };
+
+  const handleAccept = async () => {
+    if (!result) return;
+    setAccepting(true);
+    try {
+      await acceptAsset(
+        result,
+        assetType,
+        useEnhanced ? enhancedPrompt : undefined,
+      );
+      closeGenerator();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setAccepting(false);
+    }
+  };
+
+  const handleReject = () => {
+    setResult(null);
+    setStage("compose");
+  };
+
+  if (!hasApiKey) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+        <div className="mx-4 w-96 rounded-lg border border-border-default bg-bg-secondary shadow-xl">
+          <div className="border-b border-border-default px-5 py-3">
+            <h2 className="font-display text-sm tracking-wide text-text-primary">
+              API Key Required
+            </h2>
+          </div>
+          <div className="px-5 py-4">
+            <p className="text-sm text-text-secondary">
+              Set your DeepInfra API key in Config &rarr; API Settings before generating assets.
+            </p>
+          </div>
+          <div className="flex justify-end border-t border-border-default px-5 py-3">
+            <button
+              onClick={closeGenerator}
+              className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="mx-4 flex max-h-[90vh] w-full max-w-2xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border-default px-5 py-3">
+          <h2 className="font-display text-sm tracking-wide text-text-primary">
+            Generate Arcanum Art
+          </h2>
+          <button
+            onClick={closeGenerator}
+            className="text-xs text-text-muted hover:text-text-primary"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {stage === "compose" && (
+            <div className="flex flex-col gap-4">
+              {/* Asset type */}
+              <div>
+                <label className="mb-1 block font-display text-[10px] uppercase tracking-widest text-text-muted">
+                  Asset Type
+                </label>
+                <div className="flex flex-wrap gap-1.5">
+                  {(Object.entries(ASSET_TEMPLATES) as [AssetType, { label: string }][]).map(
+                    ([key, { label }]) => (
+                      <button
+                        key={key}
+                        onClick={() => handleTypeChange(key)}
+                        className={`rounded px-2.5 py-1 text-xs transition-colors ${
+                          assetType === key
+                            ? "bg-accent/20 text-accent"
+                            : "bg-bg-elevated text-text-secondary hover:text-text-primary"
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    ),
+                  )}
+                </div>
+              </div>
+
+              {/* Model */}
+              <div>
+                <label className="mb-1 block font-display text-[10px] uppercase tracking-widest text-text-muted">
+                  Model
+                </label>
+                <div className="flex gap-2">
+                  {IMAGE_MODELS.map((model) => (
+                    <button
+                      key={model.id}
+                      onClick={() => setModelId(model.id)}
+                      className={`flex-1 rounded px-3 py-1.5 text-left text-xs transition-colors ${
+                        modelId === model.id
+                          ? "bg-accent/20 text-accent"
+                          : "bg-bg-elevated text-text-secondary hover:text-text-primary"
+                      }`}
+                    >
+                      <div className="font-medium">{model.label}</div>
+                      <div className="text-[10px] opacity-70">{model.description}</div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Customization */}
+              <div>
+                <label className="mb-1 block font-display text-[10px] uppercase tracking-widest text-text-muted">
+                  Customization (optional)
+                </label>
+                <input
+                  type="text"
+                  value={customization}
+                  onChange={(e) => handleCustomizationChange(e.target.value)}
+                  placeholder="Add specific details, e.g. 'forest clearing with ancient ruins'"
+                  className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50"
+                />
+              </div>
+
+              {/* Prompt preview */}
+              <div>
+                <div className="mb-1 flex items-center gap-2">
+                  <label className="font-display text-[10px] uppercase tracking-widest text-text-muted">
+                    Prompt
+                  </label>
+                  <button
+                    onClick={handleEnhance}
+                    disabled={enhancing}
+                    className="ml-auto rounded px-2 py-0.5 text-[10px] text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
+                  >
+                    {enhancing ? "Enhancing..." : "Enhance with AI"}
+                  </button>
+                </div>
+                <textarea
+                  value={useEnhanced && enhancedPrompt ? enhancedPrompt : prompt}
+                  onChange={(e) => {
+                    if (useEnhanced) {
+                      setEnhancedPrompt(e.target.value);
+                    } else {
+                      setPrompt(e.target.value);
+                    }
+                  }}
+                  rows={5}
+                  className="w-full resize-y rounded border border-border-default bg-bg-primary px-3 py-2 font-mono text-xs leading-relaxed text-text-secondary outline-none focus:border-accent/50"
+                />
+                {enhancedPrompt && (
+                  <div className="mt-1 flex gap-2">
+                    <button
+                      onClick={() => setUseEnhanced(true)}
+                      className={`text-[10px] ${useEnhanced ? "text-accent" : "text-text-muted hover:text-text-secondary"}`}
+                    >
+                      Enhanced
+                    </button>
+                    <button
+                      onClick={() => setUseEnhanced(false)}
+                      className={`text-[10px] ${!useEnhanced ? "text-accent" : "text-text-muted hover:text-text-secondary"}`}
+                    >
+                      Original
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              {error && (
+                <p className="text-xs italic text-status-error">{error}</p>
+              )}
+            </div>
+          )}
+
+          {stage === "generating" && (
+            <div className="flex flex-col items-center justify-center gap-4 py-12">
+              <div className="h-8 w-8 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+              <p className="font-display text-sm tracking-wide text-text-secondary">
+                Generating...
+              </p>
+              <p className="text-xs text-text-muted">
+                This may take a few seconds
+              </p>
+            </div>
+          )}
+
+          {stage === "preview" && result && (
+            <div className="flex flex-col gap-4">
+              <div className="overflow-hidden rounded-lg border border-border-default">
+                <img
+                  src={result.data_url}
+                  alt="Generated art"
+                  className="w-full"
+                />
+              </div>
+              <div className="flex items-center gap-2 text-xs text-text-muted">
+                <span>{result.width}x{result.height}</span>
+                <span>&middot;</span>
+                <span>{result.model.split("/").pop()}</span>
+              </div>
+              {error && (
+                <p className="text-xs italic text-status-error">{error}</p>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 border-t border-border-default px-5 py-3">
+          {stage === "compose" && (
+            <>
+              <button
+                onClick={closeGenerator}
+                className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleGenerate}
+                className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110"
+              >
+                Generate
+              </button>
+            </>
+          )}
+          {stage === "preview" && (
+            <>
+              <button
+                onClick={handleReject}
+                className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+              >
+                Reject &amp; Retry
+              </button>
+              <button
+                onClick={handleAccept}
+                disabled={accepting}
+                className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:opacity-50"
+              >
+                {accepting ? "Saving..." : "Accept"}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/Console.tsx
+++ b/creator/src/components/Console.tsx
@@ -85,7 +85,7 @@ export function Console() {
           placeholder="Filter logs..."
           value={searchText}
           onChange={(e) => setSearchText(e.target.value)}
-          className="rounded border border-border-default bg-bg-primary px-2 py-0.5 text-xs text-text-primary placeholder-text-muted outline-none focus:border-border-focus"
+          className="rounded border border-border-default bg-bg-primary px-2 py-0.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-border-focus"
         />
 
         <div className="flex-1" />

--- a/creator/src/components/ErrorDialog.tsx
+++ b/creator/src/components/ErrorDialog.tsx
@@ -9,7 +9,7 @@ export function ErrorDialog({ title, messages, onClose }: ErrorDialogProps) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
       <div className="mx-4 max-w-lg rounded-lg border border-border-default bg-bg-secondary shadow-xl">
         <div className="border-b border-border-default px-5 py-3">
-          <h2 className="text-sm font-semibold text-status-error">{title}</h2>
+          <h2 className="font-display text-sm tracking-wide text-status-error">{title}</h2>
         </div>
         <div className="px-5 py-4">
           <ul className="flex flex-col gap-2">

--- a/creator/src/components/MainArea.tsx
+++ b/creator/src/components/MainArea.tsx
@@ -10,22 +10,32 @@ export function MainArea() {
 
   if (!activeTab) {
     return (
-      <div className="flex flex-1 items-center justify-center text-text-muted">
+      <div className="flex min-h-0 flex-1 items-center justify-center text-text-muted">
         Open a zone or config tab from the sidebar
       </div>
     );
   }
 
+  let content: React.ReactNode;
   switch (activeTab.kind) {
     case "console":
-      return <Console />;
+      content = <Console />;
+      break;
     case "zone": {
       const zoneId = activeTab.id.replace(/^zone:/, "");
-      return <ZoneEditor key={zoneId} zoneId={zoneId} />;
+      content = <ZoneEditor key={zoneId} zoneId={zoneId} />;
+      break;
     }
     case "config":
-      return <ConfigEditor />;
+      content = <ConfigEditor />;
+      break;
     default:
-      return null;
+      content = null;
   }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {content}
+    </div>
+  );
 }

--- a/creator/src/components/NewZoneDialog.tsx
+++ b/creator/src/components/NewZoneDialog.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import { stringify } from "yaml";
+import { useProjectStore } from "@/stores/projectStore";
+import { useZoneStore } from "@/stores/zoneStore";
+import type { WorldFile } from "@/types/world";
+
+const YAML_OPTS = {
+  lineWidth: 120,
+  defaultKeyType: "PLAIN" as const,
+  defaultStringType: "PLAIN" as const,
+};
+
+interface NewZoneDialogProps {
+  onClose: () => void;
+}
+
+export function NewZoneDialog({ onClose }: NewZoneDialogProps) {
+  const mudDir = useProjectStore((s) => s.project?.mudDir);
+  const loadZone = useZoneStore((s) => s.loadZone);
+  const zones = useZoneStore((s) => s.zones);
+  const openTab = useProjectStore((s) => s.openTab);
+
+  const [zoneId, setZoneId] = useState("");
+  const [startRoom, setStartRoom] = useState("entrance");
+  const [roomTitle, setRoomTitle] = useState("Entrance");
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const trimmedId = zoneId.trim().toLowerCase().replace(/\s+/g, "_");
+  const idValid = /^[a-z][a-z0-9_]*$/.test(trimmedId);
+  const idTaken = zones.has(trimmedId);
+
+  const handleCreate = async () => {
+    if (!mudDir || !idValid || idTaken) return;
+
+    setCreating(true);
+    setError(null);
+
+    try {
+      const world: WorldFile = {
+        zone: trimmedId,
+        startRoom: startRoom.trim() || "entrance",
+        rooms: {
+          [startRoom.trim() || "entrance"]: {
+            title: roomTitle.trim() || "Entrance",
+            description: "A new room.",
+          },
+        },
+      };
+
+      const filePath = `${mudDir}/src/main/resources/world/${trimmedId}.yaml`;
+      const yaml = stringify(world, YAML_OPTS);
+      await writeTextFile(filePath, yaml);
+
+      loadZone(trimmedId, filePath, world);
+      openTab({ id: `zone:${trimmedId}`, kind: "zone", label: trimmedId });
+      onClose();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="mx-4 w-96 rounded-lg border border-border-default bg-bg-secondary shadow-xl">
+        <div className="border-b border-border-default px-5 py-3">
+          <h2 className="font-display text-sm tracking-wide text-text-primary">
+            New Zone
+          </h2>
+        </div>
+
+        <div className="flex flex-col gap-3 px-5 py-4">
+          {/* Zone ID */}
+          <div>
+            <label className="mb-1 block text-[10px] uppercase tracking-wider text-text-muted">
+              Zone ID
+            </label>
+            <input
+              type="text"
+              value={zoneId}
+              onChange={(e) => setZoneId(e.target.value)}
+              placeholder="e.g. dark_forest"
+              autoFocus
+              className="h-8 w-full rounded border border-border-default bg-bg-primary px-2 text-xs text-text-primary outline-none placeholder:text-text-muted focus:border-accent"
+            />
+            {zoneId && !idValid && (
+              <p className="mt-1 text-[10px] text-status-error">
+                Must start with a letter, only lowercase letters, numbers, and underscores.
+              </p>
+            )}
+            {idTaken && (
+              <p className="mt-1 text-[10px] text-status-error">
+                Zone "{trimmedId}" already exists.
+              </p>
+            )}
+          </div>
+
+          {/* Start Room ID */}
+          <div>
+            <label className="mb-1 block text-[10px] uppercase tracking-wider text-text-muted">
+              Start Room ID
+            </label>
+            <input
+              type="text"
+              value={startRoom}
+              onChange={(e) => setStartRoom(e.target.value)}
+              placeholder="entrance"
+              className="h-8 w-full rounded border border-border-default bg-bg-primary px-2 text-xs text-text-primary outline-none placeholder:text-text-muted focus:border-accent"
+            />
+          </div>
+
+          {/* Room Title */}
+          <div>
+            <label className="mb-1 block text-[10px] uppercase tracking-wider text-text-muted">
+              Room Title
+            </label>
+            <input
+              type="text"
+              value={roomTitle}
+              onChange={(e) => setRoomTitle(e.target.value)}
+              placeholder="Entrance"
+              className="h-8 w-full rounded border border-border-default bg-bg-primary px-2 text-xs text-text-primary outline-none placeholder:text-text-muted focus:border-accent"
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs text-status-error">{error}</p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-border-default px-5 py-3">
+          <button
+            onClick={onClose}
+            className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleCreate}
+            disabled={!idValid || idTaken || creating || !mudDir}
+            className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {creating ? "Creating..." : "Create Zone"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -1,9 +1,10 @@
-import { useRef, useEffect, useCallback } from "react";
+import { useRef, useState, useEffect, useCallback } from "react";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useProjectStore } from "@/stores/projectStore";
 import type { Tab, ConfigSubTab } from "@/types/project";
 import { useGlobalSearch, ENTITY_TYPE_LABELS } from "@/lib/useGlobalSearch";
+import { NewZoneDialog } from "./NewZoneDialog";
 
 export function Sidebar() {
   const zones = useZoneStore((s) => s.zones);
@@ -15,6 +16,8 @@ export function Sidebar() {
   const { query, setQuery, clearQuery, grouped, isSearching } =
     useGlobalSearch();
   const searchRef = useRef<HTMLInputElement>(null);
+  const [showNewZone, setShowNewZone] = useState(false);
+  const hasProject = !!useProjectStore((s) => s.project);
 
   // Ctrl+K to focus search
   useEffect(() => {
@@ -76,7 +79,7 @@ export function Sidebar() {
             ) : (
               [...grouped.entries()].map(([zoneId, entries]) => (
                 <div key={zoneId} className="mb-3">
-                  <h3 className="mb-1 text-xs font-semibold text-text-muted">
+                  <h3 className="mb-1 font-display text-xs text-text-muted">
                     {zoneId}
                   </h3>
                   <ul className="flex flex-col gap-0.5">
@@ -114,9 +117,20 @@ export function Sidebar() {
         ) : (
         <>
         <div className="px-3 py-2">
-          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-text-muted">
-            Zones
-          </h2>
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="font-display text-xs uppercase tracking-widest text-text-muted">
+              Zones
+            </h2>
+            {hasProject && (
+              <button
+                onClick={() => setShowNewZone(true)}
+                className="rounded px-1.5 py-0.5 text-xs text-text-muted transition-colors hover:bg-bg-elevated hover:text-text-primary"
+                title="New Zone"
+              >
+                +
+              </button>
+            )}
+          </div>
           {sortedZones.length === 0 ? (
             <p className="text-xs text-text-muted">No zones loaded</p>
           ) : (
@@ -159,7 +173,7 @@ export function Sidebar() {
 
         {/* Config section */}
         <div className="px-3 py-2">
-          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-text-muted">
+          <h2 className="mb-2 font-display text-xs uppercase tracking-widest text-text-muted">
             Config
           </h2>
           <ul className="flex flex-col gap-0.5">
@@ -210,6 +224,8 @@ export function Sidebar() {
           Console
         </button>
       </div>
+
+      {showNewZone && <NewZoneDialog onClose={() => setShowNewZone(false)} />}
     </div>
   );
 }

--- a/creator/src/components/Toolbar.tsx
+++ b/creator/src/components/Toolbar.tsx
@@ -12,6 +12,7 @@ import { useConfigStore } from "@/stores/configStore";
 import { ErrorDialog } from "./ErrorDialog";
 import { ValidationPanel } from "./ValidationPanel";
 import { DiffModal } from "./ui/DiffModal";
+import { useAssetStore } from "@/stores/assetStore";
 
 const STATUS_COLORS: Record<string, string> = {
   stopped: "bg-server-stopped",
@@ -44,6 +45,8 @@ export function Toolbar() {
   const [errors, setErrors] = useState<string[] | null>(null);
   const [saving, setSaving] = useState(false);
   const [showDiff, setShowDiff] = useState(false);
+  const openGenerator = useAssetStore((s) => s.openGenerator);
+  const openGallery = useAssetStore((s) => s.openGallery);
 
   const handleStart = async () => {
     const result = await startServer();
@@ -75,7 +78,7 @@ export function Toolbar() {
   return (
     <div className="flex h-11 shrink-0 items-center gap-3 border-b border-border-default bg-bg-secondary px-4">
       {/* Project name */}
-      <span className="text-sm font-medium text-text-primary">
+      <span className="font-display text-sm font-semibold tracking-wide text-accent-emphasis">
         {project?.name ?? "AmbonMUD Creator"}
       </span>
 
@@ -108,8 +111,8 @@ export function Toolbar() {
 
       {/* Server status badge */}
       <div className="flex items-center gap-2">
-        <div className={`h-2 w-2 rounded-full ${STATUS_COLORS[status]}`} />
-        <span className="text-xs text-text-secondary">
+        <div className={`h-2 w-2 rounded-full ${STATUS_COLORS[status]} ${status === "running" ? "animate-aurum-pulse" : ""} ${status === "error" ? "animate-crimson-pulse" : ""}`} />
+        <span className="font-display text-xs tracking-wide text-text-secondary uppercase">
           {STATUS_LABELS[status]}
         </span>
       </div>
@@ -117,6 +120,19 @@ export function Toolbar() {
       <div className="flex-1" />
 
       {/* Right side actions */}
+      <button
+        onClick={openGallery}
+        className="rounded px-3 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-bg-elevated hover:text-text-primary"
+      >
+        Gallery
+      </button>
+      <button
+        onClick={openGenerator}
+        className="rounded px-3 py-1 text-xs font-medium text-accent transition-colors hover:bg-accent/10"
+      >
+        Generate Art
+      </button>
+      <div className="mx-1 h-4 w-px bg-border-default" />
       <button
         onClick={() => setShowDiff(true)}
         disabled={(dirtyCount === 0 && !configDirty) || saving}

--- a/creator/src/components/ValidationPanel.tsx
+++ b/creator/src/components/ValidationPanel.tsx
@@ -21,7 +21,7 @@ export function ValidationPanel() {
       <div className="mx-4 flex max-h-[80vh] w-full max-w-xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border-default px-5 py-3">
-          <h2 className="text-sm font-semibold text-text-primary">
+          <h2 className="font-display text-sm tracking-wide text-text-primary">
             Validation Results
           </h2>
           <div className="flex items-center gap-3 text-xs">
@@ -87,7 +87,7 @@ function ZoneIssueGroup({
   return (
     <div>
       <div className="mb-1 flex items-center gap-2">
-        <h3 className="text-xs font-semibold text-text-primary">{zoneId}</h3>
+        <h3 className="font-display text-xs text-text-primary">{zoneId}</h3>
         <span className="text-[10px] text-text-muted">
           {errs.length}E / {warns.length}W
         </span>

--- a/creator/src/components/WelcomeScreen.tsx
+++ b/creator/src/components/WelcomeScreen.tsx
@@ -35,20 +35,20 @@ export function WelcomeScreen() {
   };
 
   return (
-    <div className="flex h-screen items-center justify-center bg-bg-primary">
+    <div className="flex h-screen items-center justify-center bg-bg-abyss">
       <div className="flex flex-col items-center gap-8">
         <div className="flex flex-col items-center gap-2">
-          <h1 className="text-3xl font-bold text-text-primary">
+          <h1 className="font-display text-4xl font-semibold tracking-wide text-accent-emphasis">
             AmbonMUD Creator
           </h1>
-          <p className="text-text-secondary">
+          <p className="text-lg text-text-secondary">
             World building and server management tool
           </p>
         </div>
         <div className="flex flex-col items-center gap-3">
           <button
             onClick={handleOpen}
-            className="rounded-lg bg-accent px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-accent-emphasis"
+            className="rounded-lg bg-gradient-to-r from-accent-muted to-accent px-6 py-3 font-display text-sm font-medium tracking-wide text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110"
           >
             Open AmbonMUD Project
           </button>

--- a/creator/src/components/config/ConfigEditor.tsx
+++ b/creator/src/components/config/ConfigEditor.tsx
@@ -18,6 +18,7 @@ import { RawYamlPanel } from "./panels/RawYamlPanel";
 import { ClassesPanel } from "./panels/ClassesPanel";
 import { RacesPanel } from "./panels/RacesPanel";
 import { CharacterCreationPanel } from "./panels/CharacterCreationPanel";
+import { ApiSettingsPanel } from "./panels/ApiSettingsPanel";
 
 const CONFIG_TABS = [
   { id: "server", label: "Server" },
@@ -35,6 +36,7 @@ const CONFIG_TABS = [
   { id: "group", label: "Group" },
   { id: "charCreate", label: "Char Create" },
   { id: "rawYaml", label: "Raw YAML" },
+  { id: "apiSettings", label: "API Settings" },
 ] as const;
 
 export function ConfigEditor() {
@@ -155,6 +157,7 @@ export function ConfigEditor() {
           {activeTab === "rawYaml" && (
             <RawYamlPanel config={config} onChange={handleChange} />
           )}
+          {activeTab === "apiSettings" && <ApiSettingsPanel />}
         </div>
       </div>
     </div>

--- a/creator/src/components/config/panels/AbilitiesPanel.tsx
+++ b/creator/src/components/config/panels/AbilitiesPanel.tsx
@@ -130,7 +130,7 @@ export function AbilitiesPanel({ config, onChange }: ConfigPanelProps) {
 
           {/* Effect sub-section */}
           <div className="mt-1 border-t border-border-muted pt-1.5">
-            <h5 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+            <h5 className="mb-1 text-[10px] font-display uppercase tracking-widest text-text-muted">
               Effect
             </h5>
             <div className="flex flex-col gap-1.5">

--- a/creator/src/components/config/panels/ApiSettingsPanel.tsx
+++ b/creator/src/components/config/panels/ApiSettingsPanel.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect } from "react";
+import { useAssetStore } from "@/stores/assetStore";
+import { IMAGE_MODELS } from "@/types/assets";
+import type { Settings } from "@/types/assets";
+
+export function ApiSettingsPanel() {
+  const settings = useAssetStore((s) => s.settings);
+  const loadSettings = useAssetStore((s) => s.loadSettings);
+  const saveSettings = useAssetStore((s) => s.saveSettings);
+
+  const [draft, setDraft] = useState<Settings | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  useEffect(() => {
+    if (settings) setDraft({ ...settings });
+  }, [settings]);
+
+  if (!draft) {
+    return (
+      <div className="text-xs text-text-muted">Loading settings...</div>
+    );
+  }
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await saveSettings(draft);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isDirty = JSON.stringify(draft) !== JSON.stringify(settings);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* API Key */}
+      <div>
+        <label className="mb-1 block font-display text-[10px] uppercase tracking-widest text-text-muted">
+          DeepInfra API Key
+        </label>
+        <input
+          type="password"
+          value={draft.deepinfra_api_key}
+          onChange={(e) =>
+            setDraft({ ...draft, deepinfra_api_key: e.target.value })
+          }
+          placeholder="Enter your DeepInfra API key"
+          className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50"
+        />
+        <p className="mt-1 text-[10px] text-text-muted">
+          Get your key at deepinfra.com/dash/api_keys
+        </p>
+      </div>
+
+      {/* Default Image Model */}
+      <div>
+        <label className="mb-1 block font-display text-[10px] uppercase tracking-widest text-text-muted">
+          Default Image Model
+        </label>
+        <div className="flex flex-col gap-1.5">
+          {IMAGE_MODELS.map((model) => (
+            <label
+              key={model.id}
+              className={`flex cursor-pointer items-center gap-2 rounded px-3 py-2 text-xs transition-colors ${
+                draft.image_model === model.id
+                  ? "bg-accent/10 text-text-primary"
+                  : "text-text-secondary hover:bg-bg-elevated"
+              }`}
+            >
+              <input
+                type="radio"
+                name="image_model"
+                value={model.id}
+                checked={draft.image_model === model.id}
+                onChange={() =>
+                  setDraft({ ...draft, image_model: model.id })
+                }
+                className="accent-accent"
+              />
+              <div>
+                <span className="font-medium">{model.label}</span>
+                <span className="ml-2 text-text-muted">{model.description}</span>
+              </div>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Enhance Model */}
+      <div>
+        <label className="mb-1 block font-display text-[10px] uppercase tracking-widest text-text-muted">
+          Prompt Enhancement Model
+        </label>
+        <input
+          type="text"
+          value={draft.enhance_model}
+          onChange={(e) =>
+            setDraft({ ...draft, enhance_model: e.target.value })
+          }
+          className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50"
+        />
+      </div>
+
+      {/* Save */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleSave}
+          disabled={!isDirty || saving}
+          className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:opacity-50"
+        >
+          {saving ? "Saving..." : "Save Settings"}
+        </button>
+        {saved && (
+          <span className="text-xs text-status-success">Saved</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/config/panels/ClassesPanel.tsx
+++ b/creator/src/components/config/panels/ClassesPanel.tsx
@@ -179,7 +179,7 @@ function HpManaCurve({
 
   return (
     <div className="mt-1 border-t border-border-muted pt-1.5">
-      <h5 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+      <h5 className="mb-1 text-[10px] font-display uppercase tracking-widest text-text-muted">
         HP / Mana Growth (Levels 1-{levels})
       </h5>
       <svg
@@ -230,20 +230,20 @@ function HpManaCurve({
         <path
           d={buildPath(hpAt)}
           fill="none"
-          stroke="#ef4444"
+          stroke="#c05060"
           strokeWidth={1.5}
         />
         <path
           d={buildPath(manaAt)}
           fill="none"
-          stroke="#3b82f6"
+          stroke="#4e7fd4"
           strokeWidth={1.5}
         />
-        <line x1={pad.left} y1={pad.top - 2} x2={pad.left + 14} y2={pad.top - 2} stroke="#ef4444" strokeWidth={1.5} />
+        <line x1={pad.left} y1={pad.top - 2} x2={pad.left + 14} y2={pad.top - 2} stroke="#c05060" strokeWidth={1.5} />
         <text x={pad.left + 17} y={pad.top + 1} className="fill-text-secondary" fontSize={8}>
           HP ({hpAt(levels)})
         </text>
-        <line x1={pad.left + 80} y1={pad.top - 2} x2={pad.left + 94} y2={pad.top - 2} stroke="#3b82f6" strokeWidth={1.5} />
+        <line x1={pad.left + 80} y1={pad.top - 2} x2={pad.left + 94} y2={pad.top - 2} stroke="#4e7fd4" strokeWidth={1.5} />
         <text x={pad.left + 97} y={pad.top + 1} className="fill-text-secondary" fontSize={8}>
           Mana ({manaAt(levels)})
         </text>

--- a/creator/src/components/config/panels/RacesPanel.tsx
+++ b/creator/src/components/config/panels/RacesPanel.tsx
@@ -88,7 +88,7 @@ function RaceStatMods({
   return (
     <div className="mt-1 border-t border-border-muted pt-1.5">
       <div className="mb-1 flex items-center gap-2">
-        <h5 className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+        <h5 className="text-[10px] font-display uppercase tracking-widest text-text-muted">
           Stat Modifiers
         </h5>
         <span

--- a/creator/src/components/config/panels/StatusEffectsPanel.tsx
+++ b/creator/src/components/config/panels/StatusEffectsPanel.tsx
@@ -160,7 +160,7 @@ function StatModsEditor({
   return (
     <div className="mt-1 border-t border-border-muted pt-1.5">
       <div className="mb-1 flex items-center gap-2">
-        <h5 className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+        <h5 className="text-[10px] font-display uppercase tracking-widest text-text-muted">
           Stat Modifiers
         </h5>
         {available.length > 0 && (

--- a/creator/src/components/editors/EditorShared.tsx
+++ b/creator/src/components/editors/EditorShared.tsx
@@ -1,4 +1,6 @@
 import { Section, FieldRow, TextInput } from "@/components/ui/FormWidgets";
+import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import type { ArtStyle } from "@/lib/arcanumPrompts";
 
 export function DeleteEntityButton({
   onClick,
@@ -22,9 +24,11 @@ export function DeleteEntityButton({
 export function MediaSection({
   image,
   onImageChange,
+  getPrompt,
 }: {
   image: string | undefined;
   onImageChange: (v: string | undefined) => void;
+  getPrompt?: (style: ArtStyle) => string;
 }) {
   return (
     <Section title="Media">
@@ -36,6 +40,13 @@ export function MediaSection({
             placeholder="none"
           />
         </FieldRow>
+        {getPrompt && (
+          <EntityArtGenerator
+            getPrompt={getPrompt}
+            currentImage={image}
+            onAccept={(filePath) => onImageChange(filePath)}
+          />
+        )}
       </div>
     </Section>
   );

--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -11,6 +11,7 @@ import {
   CheckboxInput,
 } from "@/components/ui/FormWidgets";
 import { DeleteEntityButton, MediaSection } from "./EditorShared";
+import { itemPrompt } from "@/lib/entityPrompts";
 
 interface ItemEditorProps {
   itemId: string;
@@ -213,7 +214,7 @@ export function ItemEditor({
         </div>
       </Section>
 
-      <MediaSection image={item.image} onImageChange={(v) => patch({ image: v })} />
+      <MediaSection image={item.image} onImageChange={(v) => patch({ image: v })} getPrompt={(style) => itemPrompt(itemId, item, style)} />
       <DeleteEntityButton onClick={handleDelete} label="Delete Item" />
     </>
   );

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/FormWidgets";
 import { DialogueEditor } from "./DialogueEditor";
 import { DeleteEntityButton, MediaSection } from "./EditorShared";
+import { mobPrompt } from "@/lib/entityPrompts";
 
 interface MobEditorProps {
   mobId: string;
@@ -378,7 +379,7 @@ export function MobEditor({
         onWorldChange={onWorldChange}
       />
 
-      <MediaSection image={mob.image} onImageChange={(v) => patch({ image: v })} />
+      <MediaSection image={mob.image} onImageChange={(v) => patch({ image: v })} getPrompt={(style) => mobPrompt(mobId, mob, style)} />
       <DeleteEntityButton onClick={handleDelete} label="Delete Mob" />
     </>
   );

--- a/creator/src/components/editors/RecipeEditor.tsx
+++ b/creator/src/components/editors/RecipeEditor.tsx
@@ -11,6 +11,7 @@ import {
   IconButton,
 } from "@/components/ui/FormWidgets";
 import { DeleteEntityButton, MediaSection } from "./EditorShared";
+import { getPreamble, type ArtStyle } from "@/lib/arcanumPrompts";
 
 interface RecipeEditorProps {
   recipeId: string;
@@ -183,7 +184,12 @@ export function RecipeEditor({
         )}
       </Section>
 
-      <MediaSection image={recipe.image} onImageChange={(v) => patch({ image: v })} />
+      <MediaSection image={recipe.image} onImageChange={(v) => patch({ image: v })} getPrompt={(style: ArtStyle) => {
+        const preamble = getPreamble(style);
+        return style === "gentle_magic"
+          ? `${preamble}\n\nStill life of a crafted creation called "${recipe.displayName}" — a warmly glowing artifact resting on a soft surface, gentle ambient light diffusing around it, floating motes of gold, lavender and pale blue tones, dreamlike quality, painterly, centered composition`
+          : `${preamble}\n\nStill life of a crafted creation called "${recipe.displayName}" — a luminous artifact emerging from baroque scrollwork, aurum-gold energy threads weaving through its form, deep indigo background, painterly, centered composition`;
+      }} />
       <DeleteEntityButton onClick={handleDelete} label="Delete Recipe" />
     </>
   );

--- a/creator/src/components/editors/ShopEditor.tsx
+++ b/creator/src/components/editors/ShopEditor.tsx
@@ -9,7 +9,8 @@ import {
   SelectInput,
   IconButton,
 } from "@/components/ui/FormWidgets";
-import { DeleteEntityButton } from "./EditorShared";
+import { DeleteEntityButton, MediaSection } from "./EditorShared";
+import { shopPrompt } from "@/lib/entityPrompts";
 
 interface ShopEditorProps {
   shopId: string;
@@ -113,6 +114,7 @@ export function ShopEditor({
         )}
       </Section>
 
+      <MediaSection image={shop.image} onImageChange={(v) => patch({ image: v })} getPrompt={(style) => shopPrompt(shopId, shop, style)} />
       <DeleteEntityButton onClick={handleDelete} label="Delete Shop" />
     </>
   );

--- a/creator/src/components/ui/DiffModal.tsx
+++ b/creator/src/components/ui/DiffModal.tsx
@@ -29,7 +29,7 @@ export function DiffModal({ onConfirm, onCancel }: DiffModalProps) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
       <div className="mx-4 flex max-h-[80vh] w-full max-w-3xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl">
         <div className="flex items-center justify-between border-b border-border-default px-5 py-3">
-          <h2 className="text-sm font-semibold text-text-primary">
+          <h2 className="font-display text-sm tracking-wide text-text-primary">
             Review Changes
           </h2>
           <span className="text-xs text-text-muted">
@@ -60,9 +60,9 @@ export function DiffModal({ onConfirm, onCancel }: DiffModalProps) {
                     key={i}
                     className={
                       line.kind === "add"
-                        ? "bg-[#1a3a2a] text-[#7ee787]"
+                        ? "bg-[#0a2a2a] text-[#4aaa7a]"
                         : line.kind === "del"
-                          ? "bg-[#3a1a1a] text-[#f47067]"
+                          ? "bg-[#2a0a14] text-[#c05060]"
                           : "text-text-muted"
                     }
                   >
@@ -87,7 +87,7 @@ export function DiffModal({ onConfirm, onCancel }: DiffModalProps) {
           <button
             onClick={onConfirm}
             disabled={!diffs}
-            className="rounded bg-accent px-4 py-1.5 text-xs font-medium text-white transition-colors hover:bg-accent-emphasis disabled:opacity-50"
+            className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:opacity-50"
           >
             Save All
           </button>

--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -1,0 +1,224 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useAssetStore } from "@/stores/assetStore";
+import { useImageSrc } from "@/lib/useImageSrc";
+import { getEnhanceSystemPrompt, ART_STYLE_LABELS, type ArtStyle } from "@/lib/arcanumPrompts";
+import { IMAGE_MODELS } from "@/types/assets";
+import type { GeneratedImage } from "@/types/assets";
+
+type Stage = "idle" | "generating" | "preview";
+
+interface EntityArtGeneratorProps {
+  /** Returns the composed prompt for the given art style */
+  getPrompt: (style: ArtStyle) => string;
+  /** Current image value (path or URL) */
+  currentImage?: string;
+  /** Called when user accepts a generated image */
+  onAccept: (filePath: string) => void;
+}
+
+export function EntityArtGenerator({
+  getPrompt,
+  currentImage,
+  onAccept,
+}: EntityArtGeneratorProps) {
+  const settings = useAssetStore((s) => s.settings);
+  const artStyle = useAssetStore((s) => s.artStyle);
+  const setArtStyle = useAssetStore((s) => s.setArtStyle);
+  const [stage, setStage] = useState<Stage>("idle");
+  const [result, setResult] = useState<GeneratedImage | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [editedPrompt, setEditedPrompt] = useState<string | null>(null);
+  const [showPrompt, setShowPrompt] = useState(false);
+  const [enhancing, setEnhancing] = useState(false);
+
+  const hasApiKey = settings && settings.deepinfra_api_key.length > 0;
+  const basePrompt = getPrompt(artStyle);
+  const activePrompt = editedPrompt ?? basePrompt;
+
+  // Reset edited prompt when style changes
+  const handleStyleChange = (style: ArtStyle) => {
+    setArtStyle(style);
+    setEditedPrompt(null);
+  };
+
+  const handleGenerate = async () => {
+    setStage("generating");
+    setError(null);
+    try {
+      const model = IMAGE_MODELS[0]; // FLUX Schnell for fast iteration
+      const image = await invoke<GeneratedImage>("generate_image", {
+        prompt: activePrompt,
+        model: model.id,
+        width: 1024,
+        height: 1024,
+        steps: model.defaultSteps,
+        guidance: null,
+      });
+      setResult(image);
+      setStage("preview");
+    } catch (e) {
+      setError(String(e));
+      setStage("idle");
+    }
+  };
+
+  const handleEnhance = async () => {
+    setEnhancing(true);
+    setError(null);
+    try {
+      const enhanced = await invoke<string>("enhance_prompt", {
+        prompt: activePrompt,
+        systemPrompt: getEnhanceSystemPrompt(artStyle),
+      });
+      setEditedPrompt(enhanced);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setEnhancing(false);
+    }
+  };
+
+  const handleAccept = () => {
+    if (!result) return;
+    onAccept(result.file_path);
+    setStage("idle");
+    setResult(null);
+  };
+
+  const handleReject = () => {
+    setResult(null);
+    setStage("idle");
+  };
+
+  // Load saved image from disk via IPC
+  const savedImageSrc = useImageSrc(currentImage);
+
+  // Show generated preview (data_url) or saved image
+  const previewSrc = stage === "preview" && result
+    ? result.data_url
+    : savedImageSrc;
+
+  if (!hasApiKey) {
+    return (
+      <div className="mt-1">
+        <p className="text-[10px] text-text-muted">
+          Set API key in Config &rarr; API Settings to generate art
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Current / preview image */}
+      {previewSrc && (
+        <div className="overflow-hidden rounded border border-border-default">
+          <img
+            src={previewSrc}
+            alt="Entity art"
+            className="w-full"
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = "none";
+            }}
+          />
+        </div>
+      )}
+
+      {/* Controls */}
+      {stage === "idle" && (
+        <div className="flex flex-col gap-1">
+          {/* Style toggle */}
+          <div className="flex gap-0.5 rounded bg-bg-primary p-0.5">
+            {(Object.entries(ART_STYLE_LABELS) as [ArtStyle, string][]).map(
+              ([key, label]) => (
+                <button
+                  key={key}
+                  onClick={() => handleStyleChange(key)}
+                  className={`flex-1 rounded px-1.5 py-0.5 text-[10px] transition-colors ${
+                    artStyle === key
+                      ? "bg-accent/20 text-accent"
+                      : "text-text-muted hover:text-text-secondary"
+                  }`}
+                >
+                  {label}
+                </button>
+              ),
+            )}
+          </div>
+
+          <div className="flex gap-1">
+            <button
+              onClick={handleGenerate}
+              className="flex-1 rounded bg-accent/15 px-2 py-1 text-[10px] font-medium text-accent transition-colors hover:bg-accent/25"
+            >
+              Generate Art
+            </button>
+            <button
+              onClick={() => setShowPrompt((v) => !v)}
+              className="rounded px-1.5 py-1 text-[10px] text-text-muted transition-colors hover:text-text-secondary"
+            >
+              {showPrompt ? "Hide" : "Prompt"}
+            </button>
+          </div>
+
+          {showPrompt && (
+            <div className="flex flex-col gap-1">
+              <textarea
+                value={activePrompt}
+                onChange={(e) => setEditedPrompt(e.target.value)}
+                rows={4}
+                className="w-full resize-y rounded border border-border-default bg-bg-primary px-2 py-1 font-mono text-[10px] leading-relaxed text-text-secondary outline-none focus:border-accent/50"
+              />
+              <div className="flex gap-1">
+                <button
+                  onClick={handleEnhance}
+                  disabled={enhancing}
+                  className="rounded px-1.5 py-0.5 text-[10px] text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
+                >
+                  {enhancing ? "..." : "Enhance"}
+                </button>
+                {editedPrompt && (
+                  <button
+                    onClick={() => setEditedPrompt(null)}
+                    className="rounded px-1.5 py-0.5 text-[10px] text-text-muted transition-colors hover:text-text-secondary"
+                  >
+                    Reset
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {stage === "generating" && (
+        <div className="flex items-center gap-2 py-2">
+          <div className="h-4 w-4 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+          <span className="text-[10px] text-text-secondary">Generating...</span>
+        </div>
+      )}
+
+      {stage === "preview" && (
+        <div className="flex gap-1">
+          <button
+            onClick={handleAccept}
+            className="flex-1 rounded bg-accent/15 px-2 py-1 text-[10px] font-medium text-accent transition-colors hover:bg-accent/25"
+          >
+            Accept
+          </button>
+          <button
+            onClick={handleReject}
+            className="flex-1 rounded px-2 py-1 text-[10px] text-text-muted transition-colors hover:text-text-secondary"
+          >
+            Reject
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <p className="text-[10px] italic text-status-error">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/ui/FormWidgets.tsx
+++ b/creator/src/components/ui/FormWidgets.tsx
@@ -118,7 +118,7 @@ export function Section({
   return (
     <div className="border-b border-border-muted px-4 py-3">
       <div className="mb-1.5 flex items-center gap-2">
-        <h4 className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+        <h4 className="font-display text-[10px] uppercase tracking-widest text-text-muted">
           {title}
         </h4>
         {actions && <div className="ml-auto flex items-center gap-1">{actions}</div>}

--- a/creator/src/components/ui/ShortcutsHelp.tsx
+++ b/creator/src/components/ui/ShortcutsHelp.tsx
@@ -25,7 +25,7 @@ export function ShortcutsHelp({ onClose }: ShortcutsHelpProps) {
         onClick={(e) => e.stopPropagation()}
       >
         <div className="border-b border-border-default px-5 py-3">
-          <h2 className="text-sm font-semibold text-text-primary">
+          <h2 className="font-display text-sm tracking-wide text-text-primary">
             Keyboard Shortcuts
           </h2>
         </div>

--- a/creator/src/components/ui/YamlPreview.tsx
+++ b/creator/src/components/ui/YamlPreview.tsx
@@ -16,7 +16,7 @@ export function YamlPreview({ data, label }: YamlPreviewProps) {
     <div className="flex flex-1 flex-col">
       {label && (
         <div className="border-b border-border-default px-4 py-1.5">
-          <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+          <span className="font-display text-[10px] uppercase tracking-widest text-text-muted">
             {label}
           </span>
         </div>

--- a/creator/src/components/zone/BatchArtGenerator.tsx
+++ b/creator/src/components/zone/BatchArtGenerator.tsx
@@ -1,0 +1,307 @@
+import { useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { WorldFile } from "@/types/world";
+import { entityPrompt, roomPrompt } from "@/lib/entityPrompts";
+import { ART_STYLE_LABELS, type ArtStyle } from "@/lib/arcanumPrompts";
+import { useAssetStore } from "@/stores/assetStore";
+import type { GeneratedImage } from "@/types/assets";
+import { IMAGE_MODELS } from "@/types/assets";
+
+interface BatchTarget {
+  kind: string;
+  id: string;
+  label: string;
+  status: "pending" | "generating" | "done" | "error";
+  result?: GeneratedImage;
+  error?: string;
+}
+
+interface BatchArtGeneratorProps {
+  zoneId: string;
+  world: WorldFile;
+  onWorldChange: (world: WorldFile) => void;
+  onClose: () => void;
+}
+
+function collectTargets(world: WorldFile): BatchTarget[] {
+  const targets: BatchTarget[] = [];
+
+  // Rooms without images
+  for (const [id, room] of Object.entries(world.rooms)) {
+    if (!room.image) {
+      targets.push({
+        kind: "room",
+        id,
+        label: `Room: ${room.title}`,
+        status: "pending",
+      });
+    }
+  }
+
+  // Mobs without images
+  for (const [id, mob] of Object.entries(world.mobs ?? {})) {
+    if (!mob.image) {
+      targets.push({
+        kind: "mob",
+        id,
+        label: `Mob: ${mob.name}`,
+        status: "pending",
+      });
+    }
+  }
+
+  // Items without images
+  for (const [id, item] of Object.entries(world.items ?? {})) {
+    if (!item.image) {
+      targets.push({
+        kind: "item",
+        id,
+        label: `Item: ${item.displayName}`,
+        status: "pending",
+      });
+    }
+  }
+
+  // Shops without images
+  for (const [id, shop] of Object.entries(world.shops ?? {})) {
+    if (!shop.image) {
+      targets.push({
+        kind: "shop",
+        id,
+        label: `Shop: ${shop.name}`,
+        status: "pending",
+      });
+    }
+  }
+
+  return targets;
+}
+
+/** Get the prompt for a target using current world data and art style. */
+function getTargetPrompt(target: BatchTarget, world: WorldFile, style: ArtStyle): string {
+  const { kind, id } = target;
+  if (kind === "room") {
+    return roomPrompt(id, world.rooms[id]!, style);
+  }
+  const collection = kind === "mob" ? "mobs" : kind === "item" ? "items" : "shops";
+  const entity = (world as unknown as Record<string, Record<string, unknown> | undefined>)[collection]?.[id];
+  return entityPrompt(kind, id, entity, style);
+}
+
+export function BatchArtGenerator({
+  zoneId,
+  world,
+  onWorldChange,
+  onClose,
+}: BatchArtGeneratorProps) {
+  const artStyle = useAssetStore((s) => s.artStyle);
+  const setArtStyle = useAssetStore((s) => s.setArtStyle);
+  const [targets, setTargets] = useState(() => collectTargets(world));
+  const [running, setRunning] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const doneCount = targets.filter((t) => t.status === "done").length;
+  const errorCount = targets.filter((t) => t.status === "error").length;
+
+  const handleRun = useCallback(async () => {
+    setRunning(true);
+    const model = IMAGE_MODELS[0]; // FLUX Schnell for batch
+    let updatedWorld = { ...world };
+
+    for (let i = 0; i < targets.length; i++) {
+      setCurrentIndex(i);
+      setTargets((prev) =>
+        prev.map((t, j) => (j === i ? { ...t, status: "generating" } : t)),
+      );
+
+      try {
+        const target = targets[i];
+        if (!target) continue;
+        const prompt = getTargetPrompt(target, updatedWorld, artStyle);
+        const image = await invoke<GeneratedImage>("generate_image", {
+          prompt,
+          model: model.id,
+          width: 1024,
+          height: 1024,
+          steps: model.defaultSteps,
+          guidance: null,
+        });
+
+        setTargets((prev) =>
+          prev.map((t, j) =>
+            j === i ? { ...t, status: "done", result: image } : t,
+          ),
+        );
+
+        // Update world with image path
+        const { kind, id } = target;
+        if (kind === "room") {
+          updatedWorld = {
+            ...updatedWorld,
+            rooms: {
+              ...updatedWorld.rooms,
+              [id]: { ...updatedWorld.rooms[id]!, image: image.file_path },
+            },
+          };
+        } else {
+          const collection = kind === "mob" ? "mobs" : kind === "item" ? "items" : "shops";
+          const entities = (updatedWorld as Record<string, unknown>)[collection] as Record<string, Record<string, unknown>> | undefined;
+          if (entities?.[id]) {
+            (updatedWorld as Record<string, unknown>)[collection] = {
+              ...entities,
+              [id]: { ...entities[id], image: image.file_path },
+            };
+          }
+        }
+      } catch (e) {
+        setTargets((prev) =>
+          prev.map((t, j) =>
+            j === i ? { ...t, status: "error", error: String(e) } : t,
+          ),
+        );
+      }
+    }
+
+    onWorldChange(updatedWorld);
+    setRunning(false);
+  }, [targets, world, onWorldChange, artStyle]);
+
+  if (targets.length === 0) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+        <div className="mx-4 w-96 rounded-lg border border-border-default bg-bg-secondary shadow-xl">
+          <div className="border-b border-border-default px-5 py-3">
+            <h2 className="font-display text-sm tracking-wide text-text-primary">
+              Batch Art Generation
+            </h2>
+          </div>
+          <div className="px-5 py-4">
+            <p className="text-sm text-text-secondary">
+              All entities in this zone already have images.
+            </p>
+          </div>
+          <div className="flex justify-end border-t border-border-default px-5 py-3">
+            <button
+              onClick={onClose}
+              className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="mx-4 flex max-h-[80vh] w-full max-w-lg flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border-default px-5 py-3">
+          <h2 className="font-display text-sm tracking-wide text-text-primary">
+            Batch Art — {zoneId}
+          </h2>
+          <span className="text-xs text-text-muted">
+            {targets.length} entities without art
+          </span>
+        </div>
+
+        {/* Style selector */}
+        {!running && doneCount === 0 && (
+          <div className="border-b border-border-default px-5 py-2">
+            <div className="flex gap-1 rounded bg-bg-primary p-0.5">
+              {(Object.entries(ART_STYLE_LABELS) as [ArtStyle, string][]).map(
+                ([key, label]) => (
+                  <button
+                    key={key}
+                    onClick={() => setArtStyle(key)}
+                    className={`flex-1 rounded px-2 py-1 text-xs transition-colors ${
+                      artStyle === key
+                        ? "bg-accent/20 text-accent"
+                        : "text-text-muted hover:text-text-secondary"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ),
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Progress */}
+        {running && (
+          <div className="border-b border-border-default px-5 py-2">
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="text-text-secondary">
+                Generating {currentIndex + 1} of {targets.length}...
+              </span>
+              <span className="text-text-muted">
+                {doneCount} done{errorCount > 0 ? `, ${errorCount} errors` : ""}
+              </span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-bg-primary">
+              <div
+                className="h-full rounded-full bg-accent transition-all"
+                style={{ width: `${((doneCount + errorCount) / targets.length) * 100}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Target list */}
+        <div className="flex-1 overflow-y-auto px-5 py-3">
+          <div className="flex flex-col gap-1">
+            {targets.map((target) => (
+              <div
+                key={`${target.kind}:${target.id}`}
+                className="flex items-center gap-2 rounded px-2 py-1 text-xs"
+              >
+                <span className="w-4 shrink-0 text-center">
+                  {target.status === "pending" && (
+                    <span className="text-text-muted">&middot;</span>
+                  )}
+                  {target.status === "generating" && (
+                    <span className="inline-block h-3 w-3 rounded-full border border-accent border-t-transparent animate-spin" />
+                  )}
+                  {target.status === "done" && (
+                    <span className="text-status-success">&#x2713;</span>
+                  )}
+                  {target.status === "error" && (
+                    <span className="text-status-error">&#x2717;</span>
+                  )}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-text-secondary">
+                  {target.label}
+                </span>
+                {target.error && (
+                  <span className="truncate text-[10px] text-status-error" title={target.error}>
+                    {target.error.slice(0, 40)}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 border-t border-border-default px-5 py-3">
+          <button
+            onClick={onClose}
+            className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+          >
+            {running ? "Running..." : doneCount > 0 ? "Done" : "Cancel"}
+          </button>
+          {!running && doneCount === 0 && (
+            <button
+              onClick={handleRun}
+              className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110"
+            >
+              Generate {targets.length} Images
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/zone/DirectionPicker.tsx
+++ b/creator/src/components/zone/DirectionPicker.tsx
@@ -62,7 +62,7 @@ export function DirectionPicker({
         ref={panelRef}
         className="rounded-lg border border-border-default bg-bg-secondary p-4 shadow-xl"
       >
-        <p className="mb-1 text-xs font-medium text-text-primary">
+        <p className="mb-1 font-display text-xs tracking-wide text-text-primary">
           New exit direction
         </p>
         <p className="mb-3 text-[10px] text-text-muted">

--- a/creator/src/components/zone/EntityPanel.tsx
+++ b/creator/src/components/zone/EntityPanel.tsx
@@ -44,9 +44,9 @@ export function EntityPanel({
   }, [world, selection]);
 
   return (
-    <div className="flex w-80 shrink-0 flex-col overflow-y-auto border-l border-border-default bg-bg-secondary">
+    <div className="flex w-80 shrink-0 flex-col border-l border-border-default bg-bg-secondary">
       {/* Header with back button */}
-      <div className="flex items-center gap-2 border-b border-border-default px-4 py-2">
+      <div className="shrink-0 flex items-center gap-2 border-b border-border-default px-4 py-2">
         <button
           onClick={onClose}
           className="h-5 w-5 rounded text-xs text-text-muted transition-colors hover:bg-bg-elevated hover:text-text-primary"
@@ -54,7 +54,7 @@ export function EntityPanel({
         >
           &#x2190;
         </button>
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+        <span className="font-display text-[10px] uppercase tracking-widest text-text-muted">
           {selection.kind}
         </span>
         <span className="text-xs font-medium text-text-primary">
@@ -74,6 +74,7 @@ export function EntityPanel({
       </div>
 
       {/* YAML preview or editor */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
       {showYaml ? (
         <YamlPreview
           data={entityData ? { [selection.id]: entityData } : null}
@@ -131,6 +132,7 @@ export function EntityPanel({
       )}
       </>
       )}
+      </div>
     </div>
   );
 }

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/lib/zoneEdits";
 import { EditableField, EditableTextArea, Section, IconButton } from "@/components/ui/FormWidgets";
 import { YamlPreview } from "@/components/ui/YamlPreview";
+import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import { roomPrompt } from "@/lib/entityPrompts";
 
 export type EntityKind = "mob" | "item" | "shop" | "quest" | "gatheringNode" | "recipe";
 
@@ -149,9 +151,9 @@ export function RoomPanel({
   }, [world, roomId, onWorldChange, onSelectEntity]);
 
   return (
-    <div className="flex w-72 shrink-0 flex-col overflow-y-auto border-l border-border-default bg-bg-secondary">
+    <div className="flex w-72 shrink-0 flex-col border-l border-border-default bg-bg-secondary">
       {/* Header */}
-      <div className="border-b border-border-default px-4 py-3">
+      <div className="shrink-0 border-b border-border-default px-4 py-3">
         <div className="flex items-start justify-between">
           <div>
             <EditableField
@@ -180,6 +182,7 @@ export function RoomPanel({
         </div>
       </div>
 
+      <div className="min-h-0 flex-1 overflow-y-auto">
       {showYaml ? (
         <YamlPreview data={{ [roomId]: room }} label={`room: ${roomId}`} />
       ) : (
@@ -372,21 +375,26 @@ export function RoomPanel({
 
       {/* Media */}
       <Section title="Media">
-        {room.image && (
-          <p className="text-xs text-text-muted">Image: {room.image}</p>
-        )}
-        {room.music && (
-          <p className="text-xs text-text-muted">Music: {room.music}</p>
-        )}
-        {room.ambient && (
-          <p className="text-xs text-text-muted">Ambient: {room.ambient}</p>
-        )}
-        {room.audio && (
-          <p className="text-xs text-text-muted">Audio: {room.audio}</p>
-        )}
-        {!room.image && !room.music && !room.ambient && !room.audio && (
-          <p className="text-xs text-text-muted">None</p>
-        )}
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-1 text-xs">
+            <span className="w-12 shrink-0 text-text-muted">Image</span>
+            <span className="truncate text-text-secondary">{room.image || "none"}</span>
+          </div>
+          <EntityArtGenerator
+            getPrompt={(style) => roomPrompt(roomId, room, style)}
+            currentImage={room.image}
+            onAccept={(filePath) => onWorldChange(updateRoom(world, roomId, { image: filePath }))}
+          />
+          {room.music && (
+            <p className="text-xs text-text-muted">Music: {room.music}</p>
+          )}
+          {room.ambient && (
+            <p className="text-xs text-text-muted">Ambient: {room.ambient}</p>
+          )}
+          {room.audio && (
+            <p className="text-xs text-text-muted">Audio: {room.audio}</p>
+          )}
+        </div>
       </Section>
 
       {/* Delete Room */}
@@ -402,6 +410,7 @@ export function RoomPanel({
       )}
       </>
       )}
+      </div>
     </div>
   );
 }

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -25,6 +25,7 @@ import { CrossZoneNode } from "./CrossZoneNode";
 import { RoomPanel, type EntitySelection } from "./RoomPanel";
 import { EntityPanel } from "./EntityPanel";
 import { DirectionPicker } from "./DirectionPicker";
+import { BatchArtGenerator } from "./BatchArtGenerator";
 
 const nodeTypes = {
   room: RoomNode,
@@ -56,6 +57,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
   const [pendingConnection, setPendingConnection] =
     useState<PendingConnection | null>(null);
   const [saving, setSaving] = useState(false);
+  const [showBatchArt, setShowBatchArt] = useState(false);
 
   // Auto-close entity panel if the selected entity was removed (e.g. by undo)
   useEffect(() => {
@@ -217,7 +219,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
     <div className="flex flex-1 flex-col">
       {/* Zone toolbar */}
       <div className="flex shrink-0 items-center gap-3 border-b border-border-default bg-bg-secondary px-3 py-1.5">
-        <span className="text-xs font-medium text-text-primary">
+        <span className="font-display text-xs font-medium tracking-wide text-text-primary">
           {zoneState.data.zone}
         </span>
         <span className="text-xs text-text-muted">
@@ -258,6 +260,13 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
         </button>
 
         <div className="ml-auto flex items-center gap-2">
+          <button
+            onClick={() => setShowBatchArt(true)}
+            className="h-6 rounded px-2 text-xs text-accent transition-colors hover:bg-accent/10"
+            title="Generate art for all entities"
+          >
+            Batch Art
+          </button>
           {showAddRoom ? (
             <form
               onSubmit={(e) => {
@@ -318,26 +327,34 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
             minZoom={0.1}
             maxZoom={2}
             proOptions={{ hideAttribution: true }}
-            style={{ background: "#0d1117" }}
+            style={{ background: "#080c1c" }}
           >
             <Background
               variant={BackgroundVariant.Dots}
               gap={20}
               size={1}
-              color="#21262d"
+              color="#1e2748"
             />
             <Controls
               showInteractive={false}
-              style={{ background: "#161b22", border: "1px solid #30363d" }}
             />
             <MiniMap
               nodeColor={(node) =>
-                node.type === "crossZone" ? "#a371f7" : "#30363d"
+                node.type === "crossZone" ? "#c8972e" : "#2a3460"
               }
-              maskColor="rgba(13, 17, 23, 0.8)"
-              style={{ background: "#161b22", border: "1px solid #30363d" }}
+              maskColor="rgba(8, 12, 28, 0.8)"
             />
           </ReactFlow>
+
+          {/* Batch art generator */}
+          {showBatchArt && zoneState && (
+            <BatchArtGenerator
+              zoneId={zoneId}
+              world={zoneState.data}
+              onWorldChange={applyWorldChange}
+              onClose={() => setShowBatchArt(false)}
+            />
+          )}
 
           {/* Direction picker overlay */}
           {pendingConnection && (

--- a/creator/src/index.css
+++ b/creator/src/index.css
@@ -1,63 +1,96 @@
 @import "tailwindcss";
 
 @theme {
-  /* Core palette - dark arcane theme */
-  --color-bg-primary: #0d1117;
-  --color-bg-secondary: #161b22;
-  --color-bg-tertiary: #1c2128;
-  --color-bg-elevated: #21262d;
-  --color-bg-hover: #292e36;
+  /* ─── Typography ─── */
+  --font-sans: 'Crimson Pro', Georgia, serif;
+  --font-display: 'Cinzel', Palatino, serif;
+  --font-mono: 'JetBrains Mono', Consolas, monospace;
 
-  /* Borders */
-  --color-border-default: #30363d;
-  --color-border-muted: #21262d;
-  --color-border-focus: #58a6ff;
+  /* ─── Deep Space (Backgrounds) ─── */
+  --color-bg-abyss:     #080c1c;
+  --color-bg-primary:   #0f1428;
+  --color-bg-secondary: #161b38;
+  --color-bg-tertiary:  #1e2748;
+  --color-bg-elevated:  #1e2748;
+  --color-bg-hover:     #2a3460;
 
-  /* Text */
-  --color-text-primary: #e6edf3;
-  --color-text-secondary: #8b949e;
-  --color-text-muted: #6e7681;
-  --color-text-link: #58a6ff;
+  /* ─── Borders ─── */
+  --color-border-default: #2a3460;
+  --color-border-muted:   #1e2748;
+  --color-border-focus:   #c8972e;
 
-  /* Accent - arcane purple */
-  --color-accent: #a371f7;
-  --color-accent-muted: #8957e5;
-  --color-accent-emphasis: #bc8cff;
+  /* ─── Text ─── */
+  --color-text-primary:   #c2cef0;
+  --color-text-secondary: #6a7aac;
+  --color-text-muted:     #3a4880;
+  --color-text-link:      #4e7fd4;
 
-  /* Status colors */
-  --color-status-success: #3fb950;
-  --color-status-warning: #d29922;
-  --color-status-error: #f85149;
-  --color-status-info: #58a6ff;
+  /* ─── Accent — Aurum (the creative force) ─── */
+  --color-accent:          #c8972e;
+  --color-accent-muted:    #a07820;
+  --color-accent-emphasis: #e2bc6a;
 
-  /* Server status */
-  --color-server-stopped: #6e7681;
-  --color-server-starting: #d29922;
-  --color-server-running: #3fb950;
-  --color-server-error: #f85149;
+  /* ─── Cool Accents ─── */
+  --color-violet:       #7a5fc0;
+  --color-stellar-blue: #4e7fd4;
+  --color-arcane-teal:  #3aa8b8;
+
+  /* ─── Status Colors ─── */
+  --color-status-success: #3a8a6a;
+  --color-status-warning: #e2bc6a;
+  --color-status-error:   #8a2a3c;
+  --color-status-info:    #4e7fd4;
+  --color-status-danger:  #8a2a3c;
+
+  /* ─── Server Status ─── */
+  --color-server-stopped:  #6a7aac;
+  --color-server-starting: #e2bc6a;
+  --color-server-running:  #c8972e;
+  --color-server-error:    #8a2a3c;
+}
+
+/* ─── Arcanum Design Tokens ─── */
+:root {
+  /* Glows */
+  --glow-aurum:        0 0 32px rgba(200, 151, 46, 0.35);
+  --glow-aurum-strong: 0 0 48px rgba(226, 188, 106, 0.5);
+  --glow-violet:       0 0 28px rgba(122, 95, 192, 0.3);
+  --glow-blue:         0 0 24px rgba(78, 127, 212, 0.25);
+
+  /* Shadows */
+  --shadow-deep:  0 8px 32px rgba(4, 6, 18, 0.7);
+  --shadow-panel: 0 16px 56px rgba(4, 6, 18, 0.8);
+
+  /* Easing */
+  --ease-unfurl:   cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-dissolve: cubic-bezier(0.7, 0, 0.84, 0);
+  --ease-cosmic:   cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Border accents (semi-transparent) */
+  --border-aurum:  rgba(200, 151, 46, 0.4);
+  --border-violet: rgba(122, 95, 192, 0.35);
 }
 
 body {
   margin: 0;
   padding: 0;
-  background-color: var(--color-bg-primary);
+  background-color: var(--color-bg-abyss);
   color: var(--color-text-primary);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial,
-    sans-serif;
-  font-size: 14px;
-  line-height: 1.5;
+  font-family: 'Crimson Pro', Georgia, serif;
+  font-size: 15px;
+  line-height: 1.6;
   overflow: hidden;
   user-select: none;
 }
 
-/* Scrollbar styling */
+/* ─── Scrollbar ─── */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--color-bg-secondary);
+  background: var(--color-bg-primary);
 }
 
 ::-webkit-scrollbar-thumb {
@@ -75,4 +108,72 @@ textarea,
 select,
 [contenteditable] {
   user-select: text;
+}
+
+/* ─── Animation Keyframes ─── */
+@keyframes aurum-pulse {
+  0%, 100% { opacity: 0.7; box-shadow: 0 0 8px rgba(200, 151, 46, 0.3); }
+  50%      { opacity: 1;   box-shadow: 0 0 20px rgba(200, 151, 46, 0.6); }
+}
+
+@keyframes crimson-pulse {
+  0%, 100% { opacity: 0.7; box-shadow: 0 0 6px rgba(138, 42, 60, 0.2); }
+  50%      { opacity: 1;   box-shadow: 0 0 16px rgba(138, 42, 60, 0.5); }
+}
+
+@keyframes slow-rotate {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+@keyframes thread-trace {
+  0%   { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
+}
+
+/* ─── Utility Classes ─── */
+.animate-aurum-pulse {
+  animation: aurum-pulse 3s var(--ease-cosmic) infinite;
+}
+
+.animate-crimson-pulse {
+  animation: crimson-pulse 4s var(--ease-cosmic) infinite;
+}
+
+.animate-slow-rotate {
+  animation: slow-rotate 60s linear infinite;
+}
+
+/* ─── Focus ring (Aurum unfurl) ─── */
+*:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(200, 151, 46, 0.3);
+  transition: box-shadow 200ms var(--ease-unfurl);
+}
+
+/* ─── ReactFlow Overrides ─── */
+.react-flow__controls button {
+  background-color: var(--color-bg-secondary) !important;
+  border-color: var(--color-border-default) !important;
+  color: var(--color-text-secondary) !important;
+  fill: var(--color-text-secondary) !important;
+}
+
+.react-flow__controls button:hover {
+  background-color: var(--color-bg-elevated) !important;
+  color: var(--color-text-primary) !important;
+  fill: var(--color-text-primary) !important;
+}
+
+.react-flow__edge-path {
+  stroke: var(--color-border-default) !important;
+}
+
+.react-flow__edge.selected .react-flow__edge-path {
+  stroke: var(--color-accent) !important;
+}
+
+.react-flow__minimap {
+  background-color: var(--color-bg-secondary) !important;
+  border-color: var(--color-border-default) !important;
 }

--- a/creator/src/lib/arcanumPrompts.ts
+++ b/creator/src/lib/arcanumPrompts.ts
@@ -1,0 +1,178 @@
+import type { AssetType } from "@/types/assets";
+
+// ─── Art Style System ─────────────────────────────────────────────
+
+export type ArtStyle = "arcanum" | "gentle_magic";
+
+export const ART_STYLE_LABELS: Record<ArtStyle, string> = {
+  arcanum: "Arcanum",
+  gentle_magic: "Gentle Magic",
+};
+
+export const ART_STYLE_DESCRIPTIONS: Record<ArtStyle, string> = {
+  arcanum: "Baroque cosmic gold-and-indigo — the Creator's instrument",
+  gentle_magic: "Surreal soft magic — dreamlike, enchanted, emotionally safe",
+};
+
+// ─── Arcanum v1 ───────────────────────────────────────────────────
+
+/** Arcanum v1 style preamble — prepended to all art prompts */
+export const ARCANUM_PREAMBLE = `Ambon Arcanum style (arcanum_v1): deep cosmic indigo and abyssal navy backgrounds, baroque rococo light scrollwork rendered as glowing energy threads, warm aurum-gold as the primary accent color against cool blue-violet atmospheric fill, sweeping spiral arms of light, fractaline structures, slow cosmological scale, no runes or text, no humanoid figures, no neon colors, no harsh edges`;
+
+// ─── Surreal Gentle Magic v1 ──────────────────────────────────────
+
+/** Gentle Magic style preamble — for MUD world assets */
+export const GENTLE_MAGIC_PREAMBLE = `Surreal Gentle Magic style (surreal_softmagic_v1): soft lavender and pale blue undertones, ambient diffused lighting with no harsh shadows or spotlighting, gentle atmospheric haze with floating motes of light, subtle magical glow integrated naturally into the environment, slightly elongated organic forms, dreamy breathable emotionally safe aesthetic, no neon colors, no high contrast, no harsh edges, painterly and luminous`;
+
+/** Universal negative prompt — appended to all generations */
+export const UNIVERSAL_NEGATIVE = `text, words, letters, runes, glyphs, watermarks, logos, signatures, humanoid figures, faces, bodies, animals, modern technology, computers, user interfaces, neon colors, hot pink, electric blue, lime green, harsh shadows, hard edges, flat design, cartoon, anime, photorealism, studio lighting, stock photo aesthetic, horror elements, gore`;
+
+/** Get the preamble for a given art style */
+export function getPreamble(style: ArtStyle): string {
+  return style === "arcanum" ? ARCANUM_PREAMBLE : GENTLE_MAGIC_PREAMBLE;
+}
+
+/** Per-asset-type prompt templates */
+export const ASSET_TEMPLATES: Record<AssetType, { label: string; template: string }> = {
+  background: {
+    label: "Background",
+    template: `Vast cosmic observatory floating in deep space, baroque architectural elements rendered in flowing light — sweeping rococo scrollwork of glowing blue-violet and gold energy forming grand archways and spiral colonnades, a colossal golden spiral galaxy visible through open arched windows, deep indigo and abyssal navy void beyond, fractaline structures branching into the distance like crystalline trees made of light, warm aurum-amber luminescence pooling at architectural nodes, cool nebula-violet atmospheric mist drifting between pillars, ultra-wide panoramic composition, painterly oil technique, extremely detailed`,
+  },
+  ornament: {
+    label: "Panel Ornament",
+    template: `Intricate baroque energy scrollwork border, symmetrical horizontal composition, glowing aurum-gold rococo flourishes and acanthus-leaf spirals rendered as threads of light against deep cosmic indigo, cool blue-violet glow fills the spaces between curls, the scrollwork dissolves to transparency at both horizontal ends, extremely detailed filigree of light, jewelry-like precision, wide aspect ratio banner format`,
+  },
+  status_art: {
+    label: "Server Status Art",
+    template: `A cosmic engine in full operation — a grand mechanical orrery made entirely of light, baroque golden rings and spiral armatures rotating slowly in deep indigo space, warm aurum energy flowing along the curved spokes like luminous oil, smaller fractal orreries visible in the distance like satellites, blue-violet atmospheric fill between components, a sense of vast power operating at perfect equilibrium, painterly, glowing, majestic`,
+  },
+  empty_state: {
+    label: "Empty State",
+    template: `An empty cosmic void beginning to stir — deep abyssal navy space with the faint suggestion of energy not yet shaped into form, a single point of warm aurum-gold light at the center casting the first illumination into darkness, baroque energy tendrils beginning to curl outward from that center point as if the act of creation is just beginning, blue-violet nebula mist drifting at the periphery, vast and serene, the moment before the world exists, painterly, luminous`,
+  },
+  entity_portrait: {
+    label: "Entity Portrait",
+    template: `Baroque cosmic portrait frame rendered in glowing aurum-gold scrollwork, deep indigo background with blue-violet nebula wisps, the subject depicted as an archetypal symbol rendered in flowing light rather than literal form, ornate frame edges curl and dissolve into darkness, warm golden light emanates from the center, painterly, luminous`,
+  },
+  zone_map: {
+    label: "Zone Map",
+    template: `Celestial cartography from above, a glowing world map rendered in baroque light threads on a deep cosmic indigo void, landmasses formed from swirling aurum-gold energy lines that curl and flourish at coastlines and mountain ranges in rococo scrollwork style, rivers traced as flowing silver-blue light, zone boundaries marked by gentle violet-glowing arcs, concentric circles of faint stardust suggesting scale and depth, fractal detail increasing toward the edges, bird's-eye perspective, painterly, luminous`,
+  },
+};
+
+// ─── Enhance System Prompts ───────────────────────────────────────
+
+const ENHANCE_SYSTEM_PROMPT_ARCANUM = `You are a prompt engineer specializing in FLUX image generation models. Your task is to enhance user prompts for the Ambon Arcanum art style (arcanum_v1).
+
+## The Arcanum Visual Language
+
+The Arcanum is the Creator's instrument — a cosmic machine used to shape worlds. Art should feel vast, baroque, and luminous, like looking into the architecture of creation itself.
+
+### Core Palette
+- **Backgrounds:** Deep cosmic indigo (#080c1c), abyssal navy (#0f1428) — never pure black
+- **Primary accent:** Warm aurum-gold (#c8972e) and pale aurum (#e2bc6a) — only where something is alive, active, or important
+- **Atmospheric fill:** Cool blue-violet and nebula-violet — the medium through which everything exists
+- **Forbidden:** Neon colors, hot pink, electric blue, lime green, harsh white backgrounds
+
+### Shape & Ornamentation
+- Baroque/rococo scrollwork rendered as glowing energy threads, not solid matter
+- C-curves and S-curves — borders and ornaments terminate in curls, never hard stops
+- Acanthus-leaf spirals, flowing filigree of light
+- Gradual dissolution — nothing abruptly ends, decorative elements fade to transparency at extremities
+- Sweeping spiral arms of light, fractaline crystalline structures
+
+### Light Behavior
+- **Concentrated Aurum:** Warm gold-amber light emanating from active/important elements. It pools and fades outward with a 20-40px feathered bloom.
+- **Nebula-violet ambient fill:** Cool blue-violet glow that fills darkness without illuminating it. Gives depth without competing with the Aurum.
+- No hard drop shadows — all shadows use deep indigo base and spread widely
+- Stars and pinpoint lights only in background art, not UI chrome
+
+### Composition Rules
+- Cosmological scale — always implied, even for small objects
+- Painterly oil technique, luminous, extremely detailed
+- Objects float in void or are framed by baroque energy architecture
+- Portraits use archetypal/symbolic forms rendered in flowing energy, not literal anatomy
+- Wide compositions for environments, centered compositions for items/icons, vertical for portraits
+
+### Absolute Negatives (never include)
+Text, words, letters, runes, glyphs, watermarks, logos, signatures, humanoid figures, faces, bodies, animals, modern technology, computers, user interfaces, neon colors, harsh shadows, hard edges, flat design, cartoon, anime, photorealism, studio lighting, stock photo aesthetic, horror elements, gore
+
+## Your Task
+
+When enhancing a prompt:
+1. Preserve the core subject/concept from the original prompt
+2. Add specific Arcanum palette colors (deep indigo, aurum-gold, blue-violet)
+3. Add baroque ornamentation details (scrollwork, energy threads, fractaline structures)
+4. Add light behavior (aurum pooling, nebula mist, soft bloom)
+5. Add composition and quality terms (painterly, luminous, extremely detailed)
+6. Ensure the prompt avoids all absolute negatives
+7. Output ONLY the enhanced prompt text — no explanation, no preamble, no formatting`;
+
+const ENHANCE_SYSTEM_PROMPT_GENTLE_MAGIC = `You are a prompt engineer specializing in FLUX image generation models. Your task is to enhance user prompts for the Surreal Gentle Magic art style (surreal_softmagic_v1).
+
+## The Gentle Magic Visual Language
+
+This world feels enchanted, dreamlike, and emotionally safe. Magic is ambient and inevitable, never aggressive. Light is a character, not a weapon. Nothing feels industrial or sharp unless narratively intentional.
+
+### Core Palette
+- **Backgrounds:** Deep Mist (#22293c) — never pure black
+- **Primary accents:** Lavender (#a897d2), Pale Blue (#8caec9), Dusty Rose (#b88faa), Moss Green (#8da97b), Soft Gold (#bea873)
+- **Neutrals:** Soft Fog (#6f7da1), Cloud (#d8def1)
+- **Forbidden:** Neon colors, saturated primaries, pure black, high-contrast chiaroscuro
+
+### Shape & Form
+- Gentle curves over hard angles, organic lived-in quality
+- Slight vertical elongation (trees, towers, figures)
+- Micro-warping allowed — nothing perfectly straight
+- No harsh geometric symmetry, no brutalist silhouettes, no mechanical rigidity
+
+### Light Behavior
+- **Ambient and diffused** — no clear source point, edges fade softly
+- **Source-ambiguous** — viewer unsure where glow originates
+- Ground-level glow (magical plants, glowing moss), halos around magical beings
+- Soft bloom around windows and light sources, atmospheric diffusion creating depth
+- Light threads connecting magical objects
+- No sharp rim lights, no hard shadows, no spotlight effects
+
+### Composition Rules
+- Dreamlike and breathable — space between elements matters
+- Environments feel lived-in and gentle, not grand or imposing
+- Items depicted as warm objects with subtle magical glow
+- Portraits feel intimate and kind, not commanding
+- Floating motes of light in atmospheric haze
+
+### Absolute Negatives (never include)
+Text, words, letters, runes, watermarks, logos, neon colors, harsh shadows, hard edges, sharp rim lights, spotlight effects, high-contrast chiaroscuro, brutalist shapes, mechanical rigidity, flat design, cartoon, anime, photorealism, studio lighting, stock photo aesthetic, horror elements, gore
+
+## Your Task
+
+When enhancing a prompt:
+1. Preserve the core subject/concept from the original prompt
+2. Add Gentle Magic palette colors (lavender, pale blue, dusty rose, moss green, soft gold)
+3. Add organic softness (gentle curves, atmospheric haze, floating motes)
+4. Add light behavior (ambient diffusion, soft bloom, source-ambiguous glow)
+5. Add quality terms (painterly, luminous, dreamlike, breathable)
+6. Ensure the prompt avoids all absolute negatives
+7. Output ONLY the enhanced prompt text — no explanation, no preamble, no formatting`;
+
+/** System prompt for the prompt enhancement LLM — kept for backward compat */
+export const ENHANCE_SYSTEM_PROMPT = ENHANCE_SYSTEM_PROMPT_ARCANUM;
+
+/** Get the style-aware system prompt for prompt enhancement */
+export function getEnhanceSystemPrompt(style: ArtStyle): string {
+  return style === "arcanum"
+    ? ENHANCE_SYSTEM_PROMPT_ARCANUM
+    : ENHANCE_SYSTEM_PROMPT_GENTLE_MAGIC;
+}
+
+/** Compose a full prompt from template + context */
+export function composePrompt(
+  assetType: AssetType,
+  customization?: string,
+): string {
+  const template = ASSET_TEMPLATES[assetType].template;
+  if (customization) {
+    return `${template}, ${customization}`;
+  }
+  return template;
+}

--- a/creator/src/lib/entityPrompts.ts
+++ b/creator/src/lib/entityPrompts.ts
@@ -1,0 +1,133 @@
+import type { RoomFile, MobFile, ItemFile, ShopFile } from "@/types/world";
+import { type ArtStyle, getPreamble } from "./arcanumPrompts";
+
+/** Build a full prompt for a room image. */
+export function roomPrompt(_roomId: string, room: RoomFile, style: ArtStyle = "gentle_magic"): string {
+  const preamble = getPreamble(style);
+  const setting = room.description
+    ? `A place called "${room.title}": ${room.description}.`
+    : `A chamber known as "${room.title}".`;
+
+  const station = room.station
+    ? ` A ${room.station.toLowerCase()} crafting station is present.`
+    : "";
+
+  if (style === "gentle_magic") {
+    return `${preamble}
+
+${setting}${station} Rendered as a dreamlike interior space — soft lavender and pale blue ambient light diffusing through gentle atmospheric haze, floating motes of warm light drifting lazily, organic curves and lived-in details, moss green and dusty rose accents on natural surfaces, soft gold highlights on magical elements, painterly, luminous, breathable, wide composition suitable for a game room background`;
+  }
+
+  return `${preamble}
+
+${setting}${station} Rendered as a baroque cosmic interior — deep indigo shadows, aurum-gold light pooling at architectural details, rococo scrollwork framing the space, blue-violet atmospheric mist, painterly, luminous, extremely detailed, wide composition suitable for a game room background`;
+}
+
+/** Build a full prompt for a mob portrait. */
+export function mobPrompt(_mobId: string, mob: MobFile, style: ArtStyle = "gentle_magic"): string {
+  const preamble = getPreamble(style);
+  const tier = mob.tier ?? "standard";
+  const level = mob.level ?? 1;
+
+  if (style === "gentle_magic") {
+    const tierDesc: Record<string, string> = {
+      weak: "a small, gentle creature",
+      standard: "a quietly formidable creature",
+      elite: "a powerful creature surrounded by softly swirling magical energy",
+      boss: "an immense ancient being radiating gentle but overwhelming power",
+    };
+    const desc = tierDesc[tier] ?? tierDesc.standard;
+
+    return `${preamble}
+
+Portrait of ${desc} known as "${mob.name}", level ${level}. Depicted with soft organic forms and gentle curves, ambient lavender and pale blue light diffusing around its silhouette, floating motes of warm gold light, subtle magical glow emanating naturally from within, dreamlike atmospheric haze, dusty rose and moss green accents, painterly, luminous, vertical portrait composition`;
+  }
+
+  const tierDesc: Record<string, string> = {
+    weak: "a minor, diminished creature",
+    standard: "a formidable creature",
+    elite: "a powerful, commanding creature surrounded by crackling energy",
+    boss: "a vast, terrifying entity of immense power, dominating the composition",
+  };
+  const desc = tierDesc[tier] ?? tierDesc.standard;
+
+  return `${preamble}
+
+Archetypal portrait of ${desc} known as "${mob.name}", level ${level}. Depicted as a symbolic form rendered in flowing energy rather than literal anatomy — the essence of the creature expressed through baroque light scrollwork, aurum-gold highlights on key features, deep indigo background with blue-violet nebula wisps, ornate frame edges dissolving into darkness, painterly, luminous, vertical portrait composition`;
+}
+
+/** Build a full prompt for an item image. */
+export function itemPrompt(_itemId: string, item: ItemFile, style: ArtStyle = "gentle_magic"): string {
+  const preamble = getPreamble(style);
+  const slotDesc = item.slot
+    ? ` worn in the ${item.slot.toLowerCase()} slot`
+    : "";
+  const desc = item.description
+    ? ` ${item.description}.`
+    : "";
+
+  const isWeapon = item.damage && item.damage > 0;
+  const isArmor = item.armor && item.armor > 0;
+
+  if (style === "gentle_magic") {
+    const typeHint = isWeapon
+      ? "a weapon with a soft magical glow"
+      : isArmor
+        ? "protective armor with gentle enchantment traces"
+        : "a warmly glowing magical artifact";
+
+    return `${preamble}
+
+Still life of ${typeHint} called "${item.displayName}"${slotDesc}.${desc} Rendered as a gently luminous object resting on a soft surface, ambient lavender and pale blue light diffusing around it, subtle floating motes of warm gold, soft atmospheric haze, organic gentle forms, dreamlike quality, painterly, centered composition suitable for an inventory icon`;
+  }
+
+  const typeHint = isWeapon
+    ? "a weapon radiating aurum energy"
+    : isArmor
+      ? "protective armor traced with baroque scrollwork"
+      : "a luminous artifact";
+
+  return `${preamble}
+
+Still life of ${typeHint} called "${item.displayName}"${slotDesc}.${desc} Rendered as a glowing object floating in deep cosmic indigo void, baroque energy threads curling around it, aurum-gold light emanating from its core, blue-violet ambient fill, ornate and detailed, painterly, centered composition suitable for an inventory icon`;
+}
+
+/** Build a full prompt for a shop image. */
+export function shopPrompt(_shopId: string, shop: ShopFile, style: ArtStyle = "gentle_magic"): string {
+  const preamble = getPreamble(style);
+
+  if (style === "gentle_magic") {
+    return `${preamble}
+
+A gentle magical marketplace called "${shop.name}" — cozy shelves and display cases holding softly glowing artifacts, warm ambient light filtering through atmospheric haze, floating motes of gold drifting between items, lavender and pale blue tones in the shadows, dusty rose accents on wooden surfaces, a sense of wonder and quiet abundance, organic curves and lived-in warmth, painterly, luminous, wide composition`;
+  }
+
+  return `${preamble}
+
+An arcane marketplace called "${shop.name}" — baroque display cases of glowing energy holding luminous artifacts, aurum-gold light pooling on shelves traced with rococo scrollwork, deep indigo shadows between alcoves, blue-violet atmospheric mist, a sense of abundance and ancient commerce, painterly, luminous, wide composition`;
+}
+
+/** Dispatch to the right prompt builder by entity kind. */
+export function entityPrompt(
+  kind: string,
+  id: string,
+  entity: unknown,
+  style: ArtStyle = "gentle_magic",
+): string {
+  switch (kind) {
+    case "room":
+      return roomPrompt(id, entity as RoomFile, style);
+    case "mob":
+      return mobPrompt(id, entity as MobFile, style);
+    case "item":
+      return itemPrompt(id, entity as ItemFile, style);
+    case "shop":
+      return shopPrompt(id, entity as ShopFile, style);
+    default: {
+      const preamble = getPreamble(style);
+      return style === "gentle_magic"
+        ? `${preamble}\n\nDreamlike portrait of a ${kind} entity called "${id}", rendered in soft magical style, lavender and pale blue tones, gentle ambient glow, floating motes of warm light, painterly, luminous`
+        : `${preamble}\n\nArcane portrait of a ${kind} entity called "${id}", rendered in baroque cosmic style, aurum-gold highlights, deep indigo background, painterly, luminous`;
+    }
+  }
+}

--- a/creator/src/lib/useImageSrc.ts
+++ b/creator/src/lib/useImageSrc.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Load an image from a local file path via IPC, returning a data URL.
+ * Returns null while loading or if the path is undefined.
+ */
+export function useImageSrc(filePath: string | undefined): string | null {
+  const [src, setSrc] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!filePath) {
+      setSrc(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    invoke<string>("read_image_data_url", { path: filePath })
+      .then((dataUrl) => {
+        if (!cancelled) setSrc(dataUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setSrc(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filePath]);
+
+  return src;
+}

--- a/creator/src/lib/zoneToGraph.ts
+++ b/creator/src/lib/zoneToGraph.ts
@@ -172,19 +172,19 @@ export function zoneToGraph(
       animated: isCrossZone,
       markerEnd: isBidirectional
         ? undefined
-        : { type: MarkerType.ArrowClosed, color: "#8b949e" },
+        : { type: MarkerType.ArrowClosed, color: "#6a7aac" },
       style: {
-        stroke: isCrossZone ? "#a371f7" : exit.hasDoor ? "#e3b341" : "#8b949e",
+        stroke: isCrossZone ? "#c8972e" : exit.hasDoor ? "#e2bc6a" : "#6a7aac",
         strokeDasharray: exit.hasDoor ? "6 3" : undefined,
         strokeWidth: 1.5,
       },
       labelStyle: {
-        fill: "#8b949e",
+        fill: "#6a7aac",
         fontSize: 10,
         fontWeight: 500,
       },
       labelBgStyle: {
-        fill: "#0d1117",
+        fill: "#080c1c",
         fillOpacity: 0.9,
       },
     });

--- a/creator/src/main.tsx
+++ b/creator/src/main.tsx
@@ -1,5 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+
+// Fontsource bundles (local, no CDN)
+import "@fontsource/cinzel/400.css";
+import "@fontsource/cinzel/600.css";
+import "@fontsource/cinzel/700.css";
+import "@fontsource/crimson-pro/400.css";
+import "@fontsource/crimson-pro/400-italic.css";
+import "@fontsource/crimson-pro/500.css";
+import "@fontsource/crimson-pro/600.css";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/500.css";
+
 import { App } from "./App";
 import "./index.css";
 

--- a/creator/src/stores/assetStore.ts
+++ b/creator/src/stores/assetStore.ts
@@ -1,0 +1,81 @@
+import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
+import type { AssetEntry, GeneratedImage, Settings } from "@/types/assets";
+import type { ArtStyle } from "@/lib/arcanumPrompts";
+
+interface AssetState {
+  assets: AssetEntry[];
+  assetsDir: string;
+  settings: Settings | null;
+  generatorOpen: boolean;
+  galleryOpen: boolean;
+  artStyle: ArtStyle;
+
+  loadSettings: () => Promise<void>;
+  saveSettings: (settings: Settings) => Promise<void>;
+
+  loadAssets: () => Promise<void>;
+  acceptAsset: (image: GeneratedImage, assetType: string, enhancedPrompt?: string) => Promise<void>;
+  deleteAsset: (id: string) => Promise<void>;
+
+  setArtStyle: (style: ArtStyle) => void;
+  openGenerator: () => void;
+  closeGenerator: () => void;
+  openGallery: () => void;
+  closeGallery: () => void;
+}
+
+export const useAssetStore = create<AssetState>((set, get) => ({
+  assets: [],
+  assetsDir: "",
+  settings: null,
+  generatorOpen: false,
+  galleryOpen: false,
+  artStyle: "gentle_magic" as ArtStyle,
+
+  loadSettings: async () => {
+    const settings = await invoke<Settings>("get_settings");
+    const assetsDir = await invoke<string>("get_assets_dir");
+    set({ settings, assetsDir });
+  },
+
+  saveSettings: async (settings: Settings) => {
+    await invoke("save_settings", { settings });
+    set({ settings });
+  },
+
+  loadAssets: async () => {
+    const assets = await invoke<AssetEntry[]>("list_assets");
+    set({ assets });
+  },
+
+  acceptAsset: async (image, assetType, enhancedPrompt) => {
+    // Extract just the filename from the full path
+    const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
+
+    await invoke<AssetEntry>("accept_asset", {
+      id: image.id,
+      hash: image.hash,
+      prompt: image.prompt,
+      enhancedPrompt: enhancedPrompt ?? null,
+      model: image.model,
+      assetType,
+      context: null,
+      fileName,
+      width: image.width,
+      height: image.height,
+    });
+    await get().loadAssets();
+  },
+
+  deleteAsset: async (id: string) => {
+    await invoke("delete_asset", { id });
+    await get().loadAssets();
+  },
+
+  setArtStyle: (artStyle) => set({ artStyle }),
+  openGenerator: () => set({ generatorOpen: true }),
+  closeGenerator: () => set({ generatorOpen: false }),
+  openGallery: () => set({ galleryOpen: true }),
+  closeGallery: () => set({ galleryOpen: false }),
+}));

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -1,0 +1,64 @@
+/** Mirrors the Rust GeneratedImage struct returned by generate_image command */
+export interface GeneratedImage {
+  id: string;
+  hash: string;
+  file_path: string;
+  data_url: string;
+  width: number;
+  height: number;
+  prompt: string;
+  model: string;
+}
+
+/** Mirrors the Rust AssetEntry struct */
+export interface AssetEntry {
+  id: string;
+  hash: string;
+  prompt: string;
+  enhanced_prompt: string;
+  model: string;
+  asset_type: AssetType;
+  context: AssetContext;
+  created_at: string;
+  file_name: string;
+  width: number;
+  height: number;
+  sync_status: string;
+}
+
+export interface AssetContext {
+  zone: string;
+  entity_type: string;
+  entity_id: string;
+}
+
+export type AssetType =
+  | "background"
+  | "ornament"
+  | "status_art"
+  | "empty_state"
+  | "entity_portrait"
+  | "zone_map";
+
+/** Mirrors the Rust Settings struct */
+export interface Settings {
+  deepinfra_api_key: string;
+  image_model: string;
+  enhance_model: string;
+}
+
+export const IMAGE_MODELS = [
+  {
+    id: "black-forest-labs/FLUX-1-schnell",
+    label: "FLUX Schnell",
+    description: "Fast, ~$0.0005/image",
+    defaultSteps: 4,
+  },
+  {
+    id: "black-forest-labs/FLUX-1-dev",
+    label: "FLUX Dev",
+    description: "Quality, ~$0.012/image",
+    defaultSteps: 28,
+    defaultGuidance: 3.5,
+  },
+] as const;

--- a/creator/src/types/project.ts
+++ b/creator/src/types/project.ts
@@ -24,7 +24,8 @@ export type TabKind = "zone" | "config" | "console";
 export type ConfigSubTab =
   | "server" | "stats" | "classes" | "races" | "abilities"
   | "statusEffects" | "combat" | "mobTiers" | "progression"
-  | "economy" | "regen" | "crafting" | "group" | "charCreate" | "rawYaml";
+  | "economy" | "regen" | "crafting" | "group" | "charCreate" | "rawYaml"
+  | "apiSettings";
 
 export interface Tab {
   id: string;

--- a/reference/GENTLE_MAGIC.md
+++ b/reference/GENTLE_MAGIC.md
@@ -1,0 +1,637 @@
+# AmbonMUD Design System: Surreal Gentle Magic
+
+**Version:** surreal_softmagic_v1
+**Last Updated:** February 26, 2026
+**Scope:** Unified aesthetic for UI components, world rendering, and interactive experiences
+**Implementation:** Dark-mode theme implemented in `web-v3/src/styles.css` (design tokens + component styles). Canvas/SVG decorative elements and world rendering are planned (Phase 5 of the roadmap).
+
+---
+
+## 📖 Table of Contents
+
+1. [Core Philosophy](#core-philosophy)
+2. [Visual Language](#visual-language)
+3. [Color System](#color-system)
+4. [Typography](#typography)
+5. [Motion & Animation](#motion--animation)
+6. [Interactive States](#interactive-states)
+7. [Component Library Architecture](#component-library-architecture)
+8. [Design Tokens](#design-tokens)
+9. [Implementation Roadmap](#implementation-roadmap)
+10. [Validation Checklist](#validation-checklist)
+
+---
+
+## 🌿 Core Philosophy
+
+This style is:
+- ✨ **Enchanted, not explosive** — Magic feels ambient and inevitable, never aggressive
+- 🌫 **Dreamlike, not chaotic** — Softness enables focus and contemplation
+- 🌸 **Softly luminous, never harsh** — Light is a character, not a weapon
+- 🌙 **Otherworldly, but emotionally safe** — Players feel welcomed, not threatened
+
+**Key Principle:** Nothing feels industrial. Nothing feels sharp unless narratively intentional.
+
+---
+
+## 🎨 Visual Language
+
+### Shapes
+
+**Preferred:**
+- Slight vertical elongation (trees, UI elements, characters)
+- Gentle curves over hard angles
+- Organic, lived-in quality
+- Micro-warping allowed (nothing perfectly straight)
+
+**Forbidden:**
+- Harsh geometric symmetry
+- Perfect 90° realism
+- Brutalist silhouettes
+- Mechanical rigidity
+
+### Color Palette
+
+#### Primary Tones
+| Color | Hex | Use Case | Undertone |
+|-------|-----|----------|-----------|
+| Lavender | `#a897d2` | Accents, magic aura, highlights | Cool |
+| Pale Blue | `#8caec9` | Borders, depth, info states | Cool |
+| Dusty Rose | `#b88faa` | Accents, warmth, warning states | Warm |
+| Moss Green | `#8da97b` | Navigation, success states | Neutral |
+| Soft Gold | `#bea873` | Highlights, important elements, glow | Warm |
+
+#### Neutrals (Dark Theme)
+| Color | Hex | Use Case |
+|-------|-----|----------|
+| Deep Mist | `#22293c` | Darkest backgrounds, base color |
+| Soft Fog | `#6f7da1` | Secondary text, subtle UI |
+| Cloud | `#d8def1` | Light text, UI highlights |
+
+#### Rules
+- ❌ No neon
+- ❌ No saturated primaries (RGB 255, 0, 0)
+- ❌ No pure black (#000000) — use Deep Mist (`#22293c`) or a dark gradient instead
+- ✅ Contrast should be moderate (WCAG AA minimum: 4.5:1 for `--text-primary` on panel surfaces)
+- ✅ Cool undertones dominate, warm accents balance
+- ✅ Theme is dark mode — light text on dark surfaces throughout
+
+### Light Behavior
+
+Light sources should feel:
+- **Ambient** — No clear source point
+- **Diffused** — Edges fade softly
+- **Source-ambiguous** — Player unsure where glow originates
+
+#### Treatments
+- Ground-level glow (magical plants, glowing moss)
+- Halos around magical beings and important UI elements
+- Soft bloom around windows and light sources
+- Light threads connecting magical objects
+- Atmospheric diffusion creating depth
+
+#### Forbidden
+- ❌ Sharp rim lights
+- ❌ Hard shadows (use soft shadows only)
+- ❌ Spotlight effect
+- ❌ High-contrast chiaroscuro
+
+---
+
+## 🌈 Color System
+
+### Design Tokens
+
+```css
+/* Primary — dark-mode palette */
+--color-primary-lavender: #a897d2;
+--color-primary-pale-blue: #8caec9;
+--color-primary-dusty-rose: #b88faa;
+--color-primary-moss-green: #8da97b;
+--color-primary-soft-gold: #bea873;
+
+/* Neutrals */
+--color-neutral-deep-mist: #22293c;
+--color-neutral-soft-fog: #6f7da1;
+--color-neutral-cloud: #d8def1;
+
+/* Semantic */
+--color-success: var(--color-primary-moss-green);
+--color-warning: var(--color-primary-dusty-rose);
+--color-error: #C5A8A8; /* desaturated red */
+--color-info: var(--color-primary-pale-blue);
+
+/* Backgrounds (dark) */
+--bg-primary: #2a3149;
+--bg-secondary: #262f47;
+--bg-elevated: #313a56;
+
+/* Surfaces (glassmorphism panels) */
+--surface-panel-a: rgb(54 63 90 / 95%);
+--surface-panel-b: rgb(43 53 79 / 92%);
+--surface-subpanel: rgb(50 60 88 / 94%);
+--surface-chip: rgb(62 74 108 / 90%);
+--surface-input: rgb(45 56 84 / 96%);
+
+/* Lines & edges */
+--line-soft: rgb(151 166 204 / 36%);
+--line-faint: rgb(140 154 193 / 24%);
+--glass-edge: rgb(236 242 255 / 18%);
+
+/* Text */
+--text-primary: #dbe3f8;
+--text-secondary: #aebada;
+--text-disabled: #7f89a8;
+```
+
+### Opacity Guidelines
+
+- **100%** — Primary text, primary UI elements
+- **85%** — Overlay backgrounds, hover states
+- **60%** — Secondary text, disabled elements
+- **30%** — Subtle separation lines, light decorative elements
+- **15%** — Barely visible texture or depth cues
+
+---
+
+## 🔤 Typography
+
+### Font Strategy
+
+The typeface should evoke:
+- Elegance without formality
+- Organic warmth
+- Readability at small sizes (UI) and large sizes (world rendering)
+
+#### Typefaces (loaded via Google Fonts)
+
+| Context | Font | Weight | Size | Line Height | Use |
+|---------|------|--------|------|-------------|-----|
+| Display / Titles | `Cormorant Garamond` | 500–700 | clamp(1.8rem, 2.45vw, 2.45rem) | 1.2 | App banner, section headings |
+| UI Body | `Nunito Sans` | 400–800 | 14px | 1.5 | Buttons, descriptions, labels, chat |
+| UI Small | `Nunito Sans` | 400 | 12px | 1.4 | Metadata, captions |
+| Terminal / Code | `JetBrains Mono` | 400–600 | 16–18px | 1.6 | MUD text output, combat log |
+| Fallbacks | `Georgia` (titles), `Segoe UI` / `sans-serif` (UI) | — | — | — | System fallbacks when Google Fonts unavailable |
+
+### Hierarchy
+
+**Display (Large Titles)**
+- Size: 32px
+- Weight: 600
+- Color: `--color-neutral-deep-mist`
+- Letter spacing: 0.5px
+- All caps: optional, rarely
+
+**Heading (Section)**
+- Size: 24px
+- Weight: 600
+- Color: `--color-neutral-deep-mist`
+
+**Subheading**
+- Size: 18px
+- Weight: 500
+- Color: `--color-neutral-deep-mist`
+
+**Body**
+- Size: 14px
+- Weight: 400
+- Color: `--color-neutral-deep-mist`
+- Line height: 1.5
+
+**Caption**
+- Size: 12px
+- Weight: 400
+- Color: `--color-neutral-soft-fog`
+
+### Special Treatments
+
+- **Emphasis:** Italics (never bold body text for emphasis)
+- **Code/System:** `Courier New`, size 12px, background `--bg-secondary`
+- **Quotes:** Italic, pale blue accent border left
+- **Links:** `--color-primary-dusty-rose`, underline on hover
+
+---
+
+## ✨ Motion & Animation
+
+### Principles
+
+Motion should feel:
+- **Gentle** — Curves over linear
+- **Inevitable** — Not sudden
+- **Breathing** — Rhythm suggests life
+- **Responsive** — User action always gets immediate visual feedback
+
+### Easing Functions
+
+```css
+/* Gentle entry */
+--ease-in-soft: cubic-bezier(0.25, 0.46, 0.45, 0.94);
+
+/* Gentle exit */
+--ease-out-soft: cubic-bezier(0.33, 0.66, 0.66, 1);
+
+/* Smooth return */
+--ease-in-out-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+
+/* Bounce (for magic / spell cast) — planned, not yet defined in styles.css */
+/* --ease-bounce-soft: cubic-bezier(0.34, 1.56, 0.64, 1); */
+```
+
+### Duration Guidelines
+
+| Interaction | Duration | Easing | Purpose |
+|-------------|----------|--------|---------|
+| Hover state | 200ms | `ease-out-soft` | Button/UI element highlight |
+| Menu slide | 300ms | `ease-out-soft` | Panel entrance |
+| Fade transition | 300ms | `ease-in-out-smooth` | Screen transitions |
+| Particle drift | 3–8s | `ease-out-soft` | Ambient magic motes |
+| Pulse (magical glow) | 2–4s | `ease-in-out-smooth` | Breathing highlights |
+| Text appear | 600ms | `ease-out-soft` | NPC dialogue, quest text |
+| Spell cast | 1–2s | `ease-bounce-soft` | Ability activation visual |
+
+### Animation Categories
+
+#### 1. **Ambient Animations** (Always On)
+- Floating motes in backgrounds
+- Subtle plant sway
+- Slow color pulse on magical elements
+- Breathing glow on UI focus indicators
+
+**Intensity:** 2–3% scale shift, ±10% opacity
+
+#### 2. **Interaction Animations** (User-Triggered)
+- Button hover: 10% scale growth, color shift to dusty rose
+- Menu slide: Enter from edge, 300ms
+- Checkbox toggle: 200ms smooth transition
+- Slider handle: Follow cursor smoothly
+
+#### 3. **Feedback Animations** (System Response)
+- Success toast: Slide in, dwell 4s, fade out
+- Error flash: Red tint overlay, 600ms pulse
+- Level up sparkle: Particle burst upward, 1.5s
+- Spell cast: Character aura intensifies, then fades
+
+#### 4. **Transition Animations** (Page Changes)
+- Fade in/out: 300ms
+- Slide left/right: 400ms (for page nav)
+- Dissolve: 500ms (for modal open)
+
+---
+
+## 🎯 Interactive States
+
+### Button States
+
+Primary button class: `.soft-button`.
+
+#### Default
+- Background: dark blue-violet gradient (blue-slate tones)
+- Text: `--text-primary`
+- Box shadow: `--shadow-sm`
+- Border: 1px solid `--line-soft`
+
+#### Hover
+- Background: shift toward purple-rose (lavender/dusty-rose blend)
+- Transform: `translateY(-1px)`
+- Box shadow: `--shadow-md, --shadow-glow`
+- Border color: lightened `--line-soft`
+- Transition: 180ms `ease-out-soft`
+
+#### Active (Pressed)
+- Background: shift toward blue-slate
+- Transform: `translateY(0) scale(0.98)`
+
+#### Disabled
+- Background: muted dark gradient
+- Opacity: 62%
+- Box shadow: none
+- Cursor: not-allowed
+
+#### Focus (Keyboard)
+- Box shadow: `0 0 0 3px rgba(168, 151, 210, 0.4)` (lavender soft glow)
+- No color change
+
+### Input Fields
+
+#### Default
+- Background: `--surface-input`
+- Border: 1px solid `--line-soft`
+- Text: `--text-primary`
+- Placeholder: `--text-disabled`
+
+#### Focus
+- Border: 1px solid `--color-primary-dusty-rose`
+- Box shadow: `0 0 0 2px rgba(184, 143, 170, 0.2)`
+
+#### Error
+- Border: 1px solid `#C5A8A8`
+- Box shadow: `0 0 0 2px rgba(197, 168, 168, 0.15)`
+- Helper text: Color `#C5A8A8`
+
+### Checkbox / Toggle
+
+#### Default
+- Background: `--bg-elevated`
+- Border: 1px solid `--color-primary-pale-blue`
+- Size: 18x18px
+- Rounded: 4px
+
+#### Checked
+- Background: `--color-primary-moss-green`
+- Checkmark: `--color-neutral-cloud` (white)
+- Animation: 200ms `ease-out-soft` scale + fade
+
+#### Hover (Unchecked)
+- Background: lighten by 5%
+- Border: `--color-primary-dusty-rose`
+
+### Links
+
+#### Default
+- Color: `--color-primary-dusty-rose`
+- Text decoration: none
+
+#### Hover
+- Color: Darken by 10%
+- Text decoration: underline
+- Animation: 150ms
+
+#### Visited
+- Color: `--color-primary-pale-blue`
+
+#### Disabled
+- Color: `--color-text-disabled`
+- Cursor: not-allowed
+
+---
+
+## 🏗 Component Library Architecture
+
+### Folder Structure
+
+The v3 client is a React + TypeScript + Vite application built with Bun. All design tokens and component styles live in a single CSS file.
+
+```
+web-v3/
+├── src/
+│   ├── styles.css               # All design tokens + component styles
+│   ├── App.tsx                  # Composition root; owns all app state
+│   ├── main.tsx                 # Vite entry point
+│   ├── components/
+│   │   ├── panels/
+│   │   │   ├── PlayPanel.tsx    # Terminal + input bar
+│   │   │   ├── WorldPanel.tsx   # Room info, mobs, skills combat panel
+│   │   │   ├── ChatPanel.tsx    # Social channels, who list
+│   │   │   └── CharacterPanel.tsx # Stats, inventory, equipment
+│   │   ├── PopoutLayer.tsx      # Floating overlay panels
+│   │   ├── MobileTabBar.tsx     # Mobile tab navigation
+│   │   ├── Icons.tsx            # Shared SVG icons
+│   │   └── isDirection.ts       # Direction type helper
+│   ├── hooks/
+│   │   ├── useMudSocket.ts      # WebSocket lifecycle
+│   │   ├── useCommandHistory.ts # Command history & tab completion
+│   │   └── useMiniMap.ts        # Visited-room graph & canvas rendering
+│   └── gmcp/
+│       └── applyGmcpPackage.ts  # GMCP package handler map
+└── bun.lock                     # Dependency lockfile (Bun)
+```
+
+Canvas-based decorative elements (particle effects, glow auras, light threads, world renderer) are planned for Phase 5.
+
+### Component Checklist
+
+**Phase 1: Foundations (CSS Design System)**
+- [ ] Design tokens CSS file
+- [ ] Reset/normalization
+- [ ] Typography hierarchy
+- [ ] Spacing scale
+- [ ] Animations & easing
+
+**Phase 2: Core Components**
+- [ ] Button (all states)
+- [ ] Text input
+- [ ] Select dropdown
+- [ ] Checkbox / toggle
+- [ ] Panel / card
+
+**Phase 3: Layout Components**
+- [ ] Sidebar
+- [ ] Modal
+- [ ] Tabs
+- [ ] Breadcrumb
+- [ ] Status bar
+
+**Phase 4: Indicators & Feedback**
+- [ ] Badge
+- [ ] Progress bar
+- [ ] Spinner/loader
+- [ ] Toast notification
+- [ ] Tooltip
+
+**Phase 5: Decorative & Canvas**
+- [ ] Particle effect system (floating motes)
+- [ ] Glow aura halos
+- [ ] Light thread connections
+- [ ] Ambient animation layer
+- [ ] World renderer integration
+
+---
+
+## 🎨 Design Tokens
+
+### Spacing Scale
+
+```css
+--space-1: 4px;   /* xs */
+--space-2: 8px;   /* sm */
+--space-3: 12px;
+--space-4: 16px;  /* md */
+--space-5: 24px;  /* lg */
+--space-6: 32px;  /* xl */
+```
+
+### Border Radius
+
+```css
+--radius-md: 10px;    /* Standard buttons, inputs */
+--radius-lg: 16px;    /* Cards, panels */
+--radius-xl: 24px;    /* Large decorative, app banner */
+/* Pills (connection pills, some buttons): border-radius: 999px (inline) */
+```
+
+### Shadows
+
+```css
+/* Drop shadows (dark theme — stronger than light-mode equivalents) */
+--shadow-sm: 0 2px 7px rgb(8 10 18 / 30%);
+--shadow-md: 0 10px 26px rgb(8 10 18 / 36%);
+--shadow-lg: 0 16px 40px rgb(8 10 18 / 44%);
+
+/* Magic glow (soft, diffused — blue-violet ambient) */
+--shadow-glow: 0 0 22px rgb(103 116 170 / 28%);
+```
+
+### Z-Index Scale
+
+```css
+--z-hidden: -1;
+--z-base: 0;
+--z-dropdown: 10;
+--z-sticky: 20;
+--z-fixed: 30;
+--z-modal-backdrop: 40;
+--z-modal: 50;
+--z-tooltip: 60;
+--z-notification: 70;
+```
+
+---
+
+## 🗺 Implementation Roadmap
+
+### Phase 1: Design System Foundation ✅ Complete
+**Goal:** Establish CSS tokens and component library structure
+
+- [x] Design tokens, spacing, shadows, easing — all in `web-v3/src/styles.css`
+- [x] Easing functions and @keyframes (`drift` animation) in `styles.css`
+- [x] Component folder structure set up under `web-v3/src/`
+- [x] Documented in `STYLE_GUIDE.md` (this file)
+- [ ] Visual regression test templates
+
+**Deliverable:** Usable CSS foundation ✅
+
+### Phase 2: Admin Console Redesign
+**Goal:** Retrofit admin dashboard to Surreal Gentle Magic aesthetic
+
+- [ ] Audit current admin UI components (served by `AdminHttpServer.kt`)
+- [ ] Redesign panels, buttons, inputs using design tokens
+- [ ] Add hover/active/focus states to all interactive elements
+- [ ] Integrate ambient animations (background particle drift)
+- [ ] Test on desktop (1920x1080, 1440x900)
+
+**Deliverable:** Functional admin console with full style compliance
+
+### Phase 3: Web Client ✅ Largely Complete
+**Goal:** Player-facing web client with immersive aesthetic
+
+- [x] Chat, inventory, spell bar, character sheet panels built
+- [x] Ambient orbs and background radial gradients implemented
+- [x] Dark-mode Surreal Gentle Magic theme applied throughout
+- [x] Tested on desktop + mobile (responsive layout)
+- [ ] Canvas-based world-space rendering (ambient motes, glows) — see Phase 5
+- [ ] Decorative elements (light threads, halos) — see Phase 5
+
+**Deliverable:** Full player-facing client ✅ (canvas decorative elements planned)
+
+### Phase 4: World Rendering Integration (Weeks 9–10)
+**Goal:** Apply style to in-game room/mob/item visuals
+
+- [ ] Extend world-space canvas renderer
+- [ ] Integrate ambient particle system
+- [ ] Apply lighting rules to mob/NPC renders
+- [ ] Test room descriptions with Canvas backdrop
+
+**Deliverable:** Cohesive world rendering experience
+
+### Phase 5: Iteration & Polish (Week 11+)
+**Goal:** Refine based on user feedback
+
+- [ ] Collect player feedback on new aesthetic
+- [ ] Refine easing/animation timings
+- [ ] Create style variants (e.g., `surreal_softmagic_night_v1`)
+- [ ] Performance optimization
+
+**Deliverable:** Production-ready design system
+
+---
+
+## ✅ Validation Checklist
+
+### For Every Component
+
+When reviewing a new component or render, verify:
+
+**Visual Harmony**
+- [ ] Uses only approved colors (no neon, no pure primaries)
+- [ ] Soft shadows (not hard/sharp)
+- [ ] Gentle curves where possible
+- [ ] Consistent spacing from design tokens
+- [ ] Typography follows hierarchy
+
+**Light & Glow**
+- [ ] Magical elements have ambient glow
+- [ ] Light sources feel diffused (not spotlit)
+- [ ] Bloom/halo around important UI (subtle, <5px)
+- [ ] No harsh rim lights or chiaroscuro
+
+**Motion**
+- [ ] Animations use approved easing functions
+- [ ] Duration matches category guidelines
+- [ ] No jarring transitions
+- [ ] Transitions feel inevitable, not sudden
+
+**Emotional Check**
+- [ ] Does this feel gentle?
+- [ ] Does this feel slow / breathable?
+- [ ] Does this feel enchanted but safe?
+- [ ] Would a new player feel welcomed?
+
+**If it feels intense, loud, or sharp — it's drifting. Revise.**
+
+### For Rendered Assets (World, NPCs, Items)
+
+Add to every generative prompt:
+
+```
+Rendered in the Surreal Gentle Magic style (surreal_softmagic_v1), featuring:
+- Soft lavender and pale blue undertones
+- Ambient diffused lighting (no harsh shadows, no spotlighting)
+- Gentle atmospheric haze with floating motes of light
+- Subtle magical glow integrated naturally into the environment
+- Slightly elongated organic forms (trees, towers, figures)
+- NO neon colors, NO high contrast, NO harsh edges
+- Dreamy, breathable, emotionally safe aesthetic
+```
+
+---
+
+## 🔮 Versioning Strategy
+
+You may eventually evolve this. Treat like shader versioning:
+
+- `surreal_softmagic_v1` — **Balanced** (current)
+- `surreal_softmagic_v2` — Slightly brighter, more vibrant
+- `surreal_softmagic_night_v1` — Moonlit variant (deeper blues, softer purples)
+- `surreal_softmagic_feycourt_v1` — More regal (golds, jewel tones, sharper accents)
+- `surreal_softmagic_ritual_v1` — Ritual/ceremony feel (more geometric, crystalline elements)
+
+When creating new variants, document the differences from v1 and update this section.
+
+---
+
+## 📝 Notes for Designers & Developers
+
+### For Designers
+- Test all components at 100% zoom and 120% zoom
+- Use a color picker to verify hex values match tokens in `web-v3/src/styles.css`
+- The theme is dark mode — verify contrast ratios for light text on dark surfaces (WCAG AA: 4.5:1)
+- Get feedback from accessibility checkers (WebAIM, WAVE)
+
+### For Developers
+- All design tokens live in `web-v3/src/styles.css` — edit that file for token changes; it is the single source of truth
+- Never hardcode colors — always use CSS variables
+- Use `calc()` for spacing combinations (e.g., `calc(var(--space-4) + var(--space-2))`)
+- Animate only `transform` and `opacity` for performance
+- Test on both desktop and mobile breakpoints
+
+### For Contributors
+- Always reference this guide when creating new components
+- Submit visual regression tests for new elements
+- Ask questions in pull request reviews if the style is unclear
+- Update this guide if you discover ambiguities or edge cases
+
+---
+
+**Last Updated:** February 26, 2026
+**Next Review:** April 30, 2026


### PR DESCRIPTION
## Summary

- **Art generation**: DeepInfra-powered image generation with FLUX Schnell/Dev models, LLM prompt enhancement, and content-addressed asset storage (SHA-256 hashed images in `app_data_dir/assets/`)
- **Dual art styles**: Arcanum (dark/ornate) and Gentle Magic (soft/dreamlike) with full style guides baked into prompt enhancement; per-entity and batch generation for entire zones
- **Asset gallery**: Browse, filter, sort, and delete all generated assets with lazy-loaded thumbnails and detail panel
- **New zones**: Create new zones from the sidebar with zone ID validation, start room scaffolding, and auto-open
- **Bug fixes**: Panel scrolling (Delete Room / Generate Art now reachable), image previews (IPC data URLs instead of broken asset protocol), settings persistence (API key loads at startup)

## Test plan

- [ ] Set API key in Config → API Settings, close and reopen app, verify key persists
- [ ] Generate art from a room panel (both Arcanum and Gentle Magic styles)
- [ ] Generate art from toolbar "Generate Art" button, verify preview renders
- [ ] Run batch art generation on a zone
- [ ] Open asset gallery, verify thumbnails load, filter/sort works, delete works
- [ ] Create a new zone from sidebar "+", verify it appears and opens
- [ ] Select a room with many entities, verify panel scrolls to Delete Room button