### PR TITLE
Phase 7c: R2 sync with content-addressed dedup

### DIFF
--- a/creator/src-tauri/Cargo.lock
+++ b/creator/src-tauri/Cargo.lock
@@ -38,6 +38,8 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "hex",
+ "hmac",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -546,6 +548,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1266,6 +1269,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"

--- a/creator/src-tauri/Cargo.toml
+++ b/creator/src-tauri/Cargo.toml
@@ -22,6 +22,8 @@ serde_json = "1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 uuid = { version = "1", features = ["v4"] }
 sha2 = "0.10"
+hmac = "0.12"
+hex = "0.4"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["fs"] }

--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -149,3 +149,12 @@ pub async fn get_assets_dir(app: AppHandle) -> Result<String, String> {
     let dir = assets_dir(&app)?;
     Ok(dir.to_string_lossy().to_string())
 }
+
+/// Update the sync_status of an asset by ID. Called from r2 module.
+pub async fn update_sync_status(app: AppHandle, id: &str, status: &str) -> Result<(), String> {
+    let mut manifest = load_manifest(&app).await?;
+    if let Some(entry) = manifest.assets.iter_mut().find(|a| a.id == id) {
+        entry.sync_status = status.to_string();
+    }
+    save_manifest(&app, &manifest).await
+}

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod assets;
 mod deepinfra;
 mod project;
+mod r2;
 mod settings;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -20,6 +21,9 @@ pub fn run() {
             assets::list_assets,
             assets::delete_asset,
             assets::get_assets_dir,
+            r2::sync_assets,
+            r2::get_sync_status,
+            r2::resolve_asset_url,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -1,0 +1,317 @@
+use chrono::Utc;
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use tauri::{AppHandle, Manager};
+
+use crate::assets::{self, AssetEntry};
+use crate::settings;
+
+type HmacSha256 = Hmac<Sha256>;
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SyncProgress {
+    pub total: usize,
+    pub uploaded: usize,
+    pub skipped: usize,
+    pub failed: usize,
+    pub errors: Vec<String>,
+}
+
+// ─── AWS Signature V4 (minimal, for S3-compatible R2) ───────────────
+
+fn sign_key(key: &[u8], date: &str, region: &str, service: &str) -> Vec<u8> {
+    let k_date = hmac_sha256(&format!("AWS4{}", String::from_utf8_lossy(key)).into_bytes(), date.as_bytes());
+    let k_region = hmac_sha256(&k_date, region.as_bytes());
+    let k_service = hmac_sha256(&k_region, service.as_bytes());
+    hmac_sha256(&k_service, b"aws4_request")
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("{:x}", hasher.finalize())
+}
+
+/// Build a signed PUT request for R2 (S3-compatible).
+fn build_signed_put(
+    account_id: &str,
+    bucket: &str,
+    access_key: &str,
+    secret_key: &str,
+    object_key: &str,
+    body: &[u8],
+    content_type: &str,
+) -> Result<(String, Vec<(String, String)>), String> {
+    let host = format!("{bucket}.{account_id}.r2.cloudflarestorage.com");
+    let url = format!("https://{host}/{object_key}");
+    let now = Utc::now();
+    let date_stamp = now.format("%Y%m%d").to_string();
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let region = "auto";
+    let service = "s3";
+
+    let payload_hash = sha256_hex(body);
+
+    // Canonical request
+    let canonical_headers = format!(
+        "content-type:{content_type}\nhost:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n"
+    );
+    let signed_headers = "content-type;host;x-amz-content-sha256;x-amz-date";
+    let canonical_request = format!(
+        "PUT\n/{object_key}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+    );
+
+    let credential_scope = format!("{date_stamp}/{region}/{service}/aws4_request");
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n{}",
+        sha256_hex(canonical_request.as_bytes())
+    );
+
+    let signing_key = sign_key(secret_key.as_bytes(), &date_stamp, region, service);
+    let signature = hex::encode(hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={access_key}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}"
+    );
+
+    let headers = vec![
+        ("Content-Type".to_string(), content_type.to_string()),
+        ("Host".to_string(), host),
+        ("x-amz-date".to_string(), amz_date),
+        ("x-amz-content-sha256".to_string(), payload_hash),
+        ("Authorization".to_string(), authorization),
+    ];
+
+    Ok((url, headers))
+}
+
+/// Build a signed HEAD request for R2.
+fn build_signed_head(
+    account_id: &str,
+    bucket: &str,
+    access_key: &str,
+    secret_key: &str,
+    object_key: &str,
+) -> Result<(String, Vec<(String, String)>), String> {
+    let host = format!("{bucket}.{account_id}.r2.cloudflarestorage.com");
+    let url = format!("https://{host}/{object_key}");
+    let now = Utc::now();
+    let date_stamp = now.format("%Y%m%d").to_string();
+    let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+    let region = "auto";
+    let service = "s3";
+
+    let payload_hash = sha256_hex(b""); // empty body for HEAD
+
+    let canonical_headers = format!(
+        "host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n"
+    );
+    let signed_headers = "host;x-amz-content-sha256;x-amz-date";
+    let canonical_request = format!(
+        "HEAD\n/{object_key}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+    );
+
+    let credential_scope = format!("{date_stamp}/{region}/{service}/aws4_request");
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n{}",
+        sha256_hex(canonical_request.as_bytes())
+    );
+
+    let signing_key = sign_key(secret_key.as_bytes(), &date_stamp, region, service);
+    let signature = hex::encode(hmac_sha256(&signing_key, string_to_sign.as_bytes()));
+
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={access_key}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}"
+    );
+
+    let headers = vec![
+        ("Host".to_string(), host),
+        ("x-amz-date".to_string(), amz_date),
+        ("x-amz-content-sha256".to_string(), payload_hash),
+        ("Authorization".to_string(), authorization),
+    ];
+
+    Ok((url, headers))
+}
+
+// ─── R2 operations ──────────────────────────────────────────────────
+
+fn detect_content_type(file_name: &str) -> &'static str {
+    if file_name.ends_with(".jpg") || file_name.ends_with(".jpeg") {
+        "image/jpeg"
+    } else if file_name.ends_with(".webp") {
+        "image/webp"
+    } else {
+        "image/png"
+    }
+}
+
+/// Check if an object already exists in R2.
+async fn object_exists(
+    client: &reqwest::Client,
+    account_id: &str,
+    bucket: &str,
+    access_key: &str,
+    secret_key: &str,
+    object_key: &str,
+) -> Result<bool, String> {
+    let (url, headers) = build_signed_head(account_id, bucket, access_key, secret_key, object_key)?;
+
+    let mut req = client.head(&url);
+    for (k, v) in headers {
+        req = req.header(&k, &v);
+    }
+
+    let resp = req.send().await.map_err(|e| format!("HEAD request failed: {e}"))?;
+    Ok(resp.status().is_success())
+}
+
+/// Upload a file to R2.
+async fn upload_object(
+    client: &reqwest::Client,
+    account_id: &str,
+    bucket: &str,
+    access_key: &str,
+    secret_key: &str,
+    object_key: &str,
+    body: Vec<u8>,
+    content_type: &str,
+) -> Result<(), String> {
+    let (url, headers) = build_signed_put(
+        account_id, bucket, access_key, secret_key, object_key, &body, content_type,
+    )?;
+
+    let mut req = client.put(&url).body(body);
+    for (k, v) in headers {
+        req = req.header(&k, &v);
+    }
+
+    let resp = req.send().await.map_err(|e| format!("PUT request failed: {e}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("R2 upload failed ({status}): {text}"));
+    }
+    Ok(())
+}
+
+// ─── Tauri commands ─────────────────────────────────────────────────
+
+fn images_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    Ok(dir.join("assets").join("images"))
+}
+
+#[tauri::command]
+pub async fn sync_assets(app: AppHandle) -> Result<SyncProgress, String> {
+    let s = settings::get_settings(app.clone()).await?;
+    if s.r2_account_id.is_empty() || s.r2_access_key_id.is_empty() || s.r2_secret_access_key.is_empty() || s.r2_bucket.is_empty() {
+        return Err("R2 credentials not configured. Set them in Settings.".to_string());
+    }
+
+    let assets = assets::list_assets(app.clone()).await?;
+    let unsynced: Vec<&AssetEntry> = assets.iter().filter(|a| a.sync_status != "synced").collect();
+    let img_dir = images_dir(&app)?;
+    let client = reqwest::Client::new();
+
+    let mut progress = SyncProgress {
+        total: unsynced.len(),
+        uploaded: 0,
+        skipped: 0,
+        failed: 0,
+        errors: Vec::new(),
+    };
+
+    for asset in &unsynced {
+        let object_key = &asset.file_name;
+
+        // Check if already exists in R2 (dedup by content hash)
+        match object_exists(&client, &s.r2_account_id, &s.r2_bucket, &s.r2_access_key_id, &s.r2_secret_access_key, object_key).await {
+            Ok(true) => {
+                // Already in R2, just mark as synced
+                assets::update_sync_status(app.clone(), &asset.id, "synced").await?;
+                progress.skipped += 1;
+                continue;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                progress.failed += 1;
+                progress.errors.push(format!("{}: {e}", asset.file_name));
+                continue;
+            }
+        }
+
+        // Read local file
+        let file_path = img_dir.join(&asset.file_name);
+        let body = match tokio::fs::read(&file_path).await {
+            Ok(b) => b,
+            Err(e) => {
+                progress.failed += 1;
+                progress.errors.push(format!("{}: Failed to read file: {e}", asset.file_name));
+                continue;
+            }
+        };
+
+        let content_type = detect_content_type(&asset.file_name);
+
+        // Upload
+        match upload_object(
+            &client,
+            &s.r2_account_id,
+            &s.r2_bucket,
+            &s.r2_access_key_id,
+            &s.r2_secret_access_key,
+            object_key,
+            body,
+            content_type,
+        ).await {
+            Ok(()) => {
+                assets::update_sync_status(app.clone(), &asset.id, "synced").await?;
+                progress.uploaded += 1;
+            }
+            Err(e) => {
+                progress.failed += 1;
+                progress.errors.push(format!("{}: {e}", asset.file_name));
+            }
+        }
+    }
+
+    Ok(progress)
+}
+
+#[tauri::command]
+pub async fn get_sync_status(app: AppHandle) -> Result<SyncProgress, String> {
+    let assets = assets::list_assets(app).await?;
+    let synced = assets.iter().filter(|a| a.sync_status == "synced").count();
+    let unsynced = assets.len() - synced;
+    Ok(SyncProgress {
+        total: assets.len(),
+        uploaded: synced,
+        skipped: 0,
+        failed: unsynced,
+        errors: Vec::new(),
+    })
+}
+
+/// Resolve an asset file_name to its public R2 URL via custom domain.
+#[tauri::command]
+pub async fn resolve_asset_url(app: AppHandle, file_name: String) -> Result<String, String> {
+    let s = settings::get_settings(app).await?;
+    if s.r2_custom_domain.is_empty() {
+        return Err("R2 custom domain not configured".to_string());
+    }
+    let domain = s.r2_custom_domain.trim_end_matches('/');
+    Ok(format!("{domain}/{file_name}"))
+}

--- a/creator/src-tauri/src/settings.rs
+++ b/creator/src-tauri/src/settings.rs
@@ -12,6 +12,16 @@ pub struct Settings {
     pub image_model: String,
     #[serde(default = "default_enhance_model")]
     pub enhance_model: String,
+    #[serde(default)]
+    pub r2_account_id: String,
+    #[serde(default)]
+    pub r2_access_key_id: String,
+    #[serde(default)]
+    pub r2_secret_access_key: String,
+    #[serde(default)]
+    pub r2_bucket: String,
+    #[serde(default)]
+    pub r2_custom_domain: String,
 }
 
 fn default_image_model() -> String {
@@ -28,6 +38,11 @@ impl Default for Settings {
             deepinfra_api_key: String::new(),
             image_model: default_image_model(),
             enhance_model: default_enhance_model(),
+            r2_account_id: String::new(),
+            r2_access_key_id: String::new(),
+            r2_secret_access_key: String::new(),
+            r2_bucket: String::new(),
+            r2_custom_domain: String::new(),
         }
     }
 }

--- a/creator/src/components/AssetGallery.tsx
+++ b/creator/src/components/AssetGallery.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useAssetStore } from "@/stores/assetStore";
-import type { AssetEntry } from "@/types/assets";
+import type { AssetEntry, SyncProgress } from "@/types/assets";
 
 /** Triggers image loading when the element scrolls into view. */
 function LazyImage({
@@ -44,12 +44,19 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
   const assetsDir = useAssetStore((s) => s.assetsDir);
   const loadAssets = useAssetStore((s) => s.loadAssets);
   const deleteAsset = useAssetStore((s) => s.deleteAsset);
+  const syncing = useAssetStore((s) => s.syncing);
+  const syncToR2 = useAssetStore((s) => s.syncToR2);
+  const settings = useAssetStore((s) => s.settings);
 
   const [selected, setSelected] = useState<AssetEntry | null>(null);
   const [filter, setFilter] = useState<string>("all");
   const [sort, setSort] = useState<SortKey>("newest");
   const [deleting, setDeleting] = useState(false);
   const [imageCache, setImageCache] = useState<Record<string, string>>({});
+  const [syncResult, setSyncResult] = useState<SyncProgress | null>(null);
+
+  const hasR2 = !!(settings?.r2_account_id && settings?.r2_bucket && settings?.r2_access_key_id);
+  const unsyncedCount = assets.filter((a) => a.sync_status !== "synced").length;
 
   useEffect(() => {
     loadAssets();
@@ -113,6 +120,29 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
             <span className="text-xs text-text-muted">
               {sorted.length} asset{sorted.length !== 1 ? "s" : ""}
             </span>
+            {hasR2 && (
+              <>
+                <div className="mx-1 h-4 w-px bg-border-default" />
+                <button
+                  onClick={async () => {
+                    const result = await syncToR2();
+                    setSyncResult(result);
+                  }}
+                  disabled={syncing || unsyncedCount === 0}
+                  className="rounded px-2 py-0.5 text-[10px] font-medium transition-colors enabled:bg-accent/15 enabled:text-accent enabled:hover:bg-accent/25 disabled:cursor-not-allowed disabled:text-text-muted disabled:opacity-50"
+                >
+                  {syncing ? "Syncing..." : unsyncedCount > 0 ? `Sync ${unsyncedCount} to R2` : "All synced"}
+                </button>
+                {syncResult && !syncing && (
+                  <span className="text-[10px] text-text-muted">
+                    {syncResult.uploaded} uploaded, {syncResult.skipped} deduped
+                    {syncResult.failed > 0 && (
+                      <span className="text-status-error"> ({syncResult.failed} failed)</span>
+                    )}
+                  </span>
+                )}
+              </>
+            )}
           </div>
           <button
             onClick={onClose}
@@ -274,6 +304,15 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                     </p>
                     <p className="truncate font-mono text-[10px] text-text-muted">
                       {selected.hash.slice(0, 16)}...
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="text-[10px] uppercase tracking-wider text-text-muted">
+                      Sync
+                    </p>
+                    <p className={`text-xs ${selected.sync_status === "synced" ? "text-status-success" : "text-text-muted"}`}>
+                      {selected.sync_status === "synced" ? "Synced to R2" : "Local only"}
                     </p>
                   </div>
 

--- a/creator/src/components/config/panels/ApiSettingsPanel.tsx
+++ b/creator/src/components/config/panels/ApiSettingsPanel.tsx
@@ -109,6 +109,90 @@ export function ApiSettingsPanel() {
         />
       </div>
 
+      {/* R2 Section */}
+      <div className="border-t border-border-default pt-4">
+        <h3 className="mb-3 font-display text-xs uppercase tracking-widest text-text-muted">
+          Cloudflare R2 (Asset CDN)
+        </h3>
+        <div className="flex flex-col gap-3">
+          <div>
+            <label className="mb-1 block text-[10px] uppercase tracking-wider text-text-muted">
+              Account ID
+            </label>
+            <input
+              type="text"
+              value={draft.r2_account_id}
+              onChange={(e) =>
+                setDraft({ ...draft, r2_account_id: e.target.value })
+              }
+              placeholder="Cloudflare account ID"
+              className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="mb-1 block text-[10px] uppercase tracking-wider text-text-muted">
+                Access Key ID
+              </label>
+              <input
+                type="text"
+                value={draft.r2_access_key_id}
+                onChange={(e) =>
+                  setDraft({ ...draft, r2_access_key_id: e.target.value })
+                }
+                placeholder="R2 access key"
+                className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-[10px] uppercase tracking-wider text-text-muted">
+                Secret Access Key
+              </label>
+              <input
+                type="password"
+                value={draft.r2_secret_access_key}
+                onChange={(e) =>
+                  setDraft({ ...draft, r2_secret_access_key: e.target.value })
+                }
+                placeholder="R2 secret key"
+                className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="mb-1 block text-[10px] uppercase tracking-wider text-text-muted">
+              Bucket Name
+            </label>
+            <input
+              type="text"
+              value={draft.r2_bucket}
+              onChange={(e) =>
+                setDraft({ ...draft, r2_bucket: e.target.value })
+              }
+              placeholder="my-assets-bucket"
+              className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-[10px] uppercase tracking-wider text-text-muted">
+              Custom Domain
+            </label>
+            <input
+              type="text"
+              value={draft.r2_custom_domain}
+              onChange={(e) =>
+                setDraft({ ...draft, r2_custom_domain: e.target.value })
+              }
+              placeholder="https://assets.example.com"
+              className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50"
+            />
+            <p className="mt-1 text-[10px] text-text-muted">
+              Public URL for the game client to load images from
+            </p>
+          </div>
+        </div>
+      </div>
+
       {/* Save */}
       <div className="flex items-center gap-2">
         <button

--- a/creator/src/stores/assetStore.ts
+++ b/creator/src/stores/assetStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
-import type { AssetEntry, GeneratedImage, Settings } from "@/types/assets";
+import type { AssetEntry, GeneratedImage, Settings, SyncProgress } from "@/types/assets";
 import type { ArtStyle } from "@/lib/arcanumPrompts";
 
 interface AssetState {
@@ -10,6 +10,8 @@ interface AssetState {
   generatorOpen: boolean;
   galleryOpen: boolean;
   artStyle: ArtStyle;
+  syncing: boolean;
+  lastSyncResult: SyncProgress | null;
 
   loadSettings: () => Promise<void>;
   saveSettings: (settings: Settings) => Promise<void>;
@@ -17,6 +19,9 @@ interface AssetState {
   loadAssets: () => Promise<void>;
   acceptAsset: (image: GeneratedImage, assetType: string, enhancedPrompt?: string) => Promise<void>;
   deleteAsset: (id: string) => Promise<void>;
+
+  syncToR2: () => Promise<SyncProgress>;
+  getSyncStatus: () => Promise<SyncProgress>;
 
   setArtStyle: (style: ArtStyle) => void;
   openGenerator: () => void;
@@ -32,6 +37,8 @@ export const useAssetStore = create<AssetState>((set, get) => ({
   generatorOpen: false,
   galleryOpen: false,
   artStyle: "gentle_magic" as ArtStyle,
+  syncing: false,
+  lastSyncResult: null,
 
   loadSettings: async () => {
     const settings = await invoke<Settings>("get_settings");
@@ -71,6 +78,25 @@ export const useAssetStore = create<AssetState>((set, get) => ({
   deleteAsset: async (id: string) => {
     await invoke("delete_asset", { id });
     await get().loadAssets();
+  },
+
+  syncToR2: async () => {
+    set({ syncing: true });
+    try {
+      const result = await invoke<SyncProgress>("sync_assets");
+      set({ lastSyncResult: result, syncing: false });
+      await get().loadAssets(); // refresh sync_status
+      return result;
+    } catch (e) {
+      const err: SyncProgress = { total: 0, uploaded: 0, skipped: 0, failed: 0, errors: [String(e)] };
+      set({ lastSyncResult: err, syncing: false });
+      return err;
+    }
+  },
+
+  getSyncStatus: async () => {
+    const result = await invoke<SyncProgress>("get_sync_status");
+    return result;
   },
 
   setArtStyle: (artStyle) => set({ artStyle }),

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -45,6 +45,20 @@ export interface Settings {
   deepinfra_api_key: string;
   image_model: string;
   enhance_model: string;
+  r2_account_id: string;
+  r2_access_key_id: string;
+  r2_secret_access_key: string;
+  r2_bucket: string;
+  r2_custom_domain: string;
+}
+
+/** Mirrors the Rust SyncProgress struct */
+export interface SyncProgress {
+  total: number;
+  uploaded: number;
+  skipped: number;
+  failed: number;
+  errors: string[];
 }
 
 export const IMAGE_MODELS = [


### PR DESCRIPTION
## Summary

- **R2 sync backend** — New `r2.rs` module with AWS Signature V4 signing (HMAC-SHA256, no AWS SDK dependency). Three Tauri commands: `sync_assets`, `get_sync_status`, `resolve_asset_url`.
- **Content-addressed dedup** — HEAD-before-PUT check skips uploads when the hash-named object already exists in the bucket, keeping costs low and syncs fast.
- **Settings & UI** — R2 credentials (account ID, access key, secret key, bucket, custom domain) added to Settings struct on both Rust and TypeScript sides. Full configuration panel in API Settings. Sync button with unsynced count and result display in AssetGallery. Per-asset sync status shown in detail panel.

## Implementation details

- Signing uses `hmac`/`sha2`/`hex` crates already in the dependency tree (added `hmac` + `hex`)
- `sync_status` field on `AssetEntry` transitions from `"local"` → `"synced"` after successful upload
- `resolve_asset_url` maps `file_name` → `{custom_domain}/{file_name}` for game client consumption
- Gallery shows sync status per-asset and aggregate sync results (uploaded/deduped/failed)

## Test plan

- [ ] Configure R2 credentials in Settings → API panel
- [ ] Generate and accept an asset, verify it shows "Local only" status
- [ ] Click "Sync to R2" in gallery header, verify upload succeeds
- [ ] Re-sync — verify dedup skips already-uploaded assets
- [ ] Verify asset accessible at `{custom_domain}/{file_name}` URL
- [ ] Verify settings persist across app restarts