### PR TITLE
Add sidebar entity tree with inline creation

### DIFF
--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -1,10 +1,208 @@
 import { useRef, useState, useEffect, useCallback } from "react";
-import { useZoneStore } from "@/stores/zoneStore";
+import { useZoneStore, type ZoneState } from "@/stores/zoneStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useProjectStore } from "@/stores/projectStore";
 import type { Tab, ConfigSubTab } from "@/types/project";
+import type { WorldFile } from "@/types/world";
 import { useGlobalSearch, ENTITY_TYPE_LABELS } from "@/lib/useGlobalSearch";
 import { NewZoneDialog } from "./NewZoneDialog";
+import {
+  addRoom,
+  addMob,
+  addItem,
+  addShop,
+  generateEntityId,
+  generateRoomId,
+} from "@/lib/zoneEdits";
+import type { MobFile, ItemFile, ShopFile } from "@/types/world";
+
+// ─── Entity category definitions ────────────────────────────────────
+
+interface CategoryDef {
+  key: string;
+  label: string;
+  collection: keyof WorldFile;
+  nameField: string;
+  addFn?: (world: WorldFile, zoneId: string) => WorldFile;
+}
+
+const CATEGORIES: CategoryDef[] = [
+  {
+    key: "room",
+    label: "Rooms",
+    collection: "rooms",
+    nameField: "title",
+    addFn: (world) => {
+      const id = generateRoomId(world);
+      return addRoom(world, id, { title: id, description: "", exits: {} });
+    },
+  },
+  {
+    key: "mob",
+    label: "Mobs",
+    collection: "mobs",
+    nameField: "name",
+    addFn: (world) => {
+      const id = generateEntityId(world, "mobs");
+      const firstRoom = Object.keys(world.rooms)[0] ?? "";
+      return addMob(world, id, { name: id, room: firstRoom, tier: "standard", level: 1 } as MobFile);
+    },
+  },
+  {
+    key: "item",
+    label: "Items",
+    collection: "items",
+    nameField: "displayName",
+    addFn: (world) => {
+      const id = generateEntityId(world, "items");
+      return addItem(world, id, { displayName: id, description: "", keyword: id } as ItemFile);
+    },
+  },
+  {
+    key: "shop",
+    label: "Shops",
+    collection: "shops",
+    nameField: "name",
+    addFn: (world) => {
+      const id = generateEntityId(world, "shops");
+      const firstRoom = Object.keys(world.rooms)[0] ?? "";
+      return addShop(world, id, { name: id, room: firstRoom, items: [] } as ShopFile);
+    },
+  },
+  { key: "quest", label: "Quests", collection: "quests", nameField: "name" },
+  { key: "gatheringNode", label: "Gathering", collection: "gatheringNodes", nameField: "skill" },
+  { key: "recipe", label: "Recipes", collection: "recipes", nameField: "displayName" },
+];
+
+// ─── Zone tree item ─────────────────────────────────────────────────
+
+function ZoneTree({
+  zoneId,
+  zoneState,
+  isActive,
+}: {
+  zoneId: string;
+  zoneState: ZoneState;
+  isActive: boolean;
+}) {
+  const openTab = useProjectStore((s) => s.openTab);
+  const navigateTo = useProjectStore((s) => s.navigateTo);
+  const updateZone = useZoneStore((s) => s.updateZone);
+  const [expanded, setExpanded] = useState(false);
+
+  const world = zoneState.data;
+
+  const handleZoneClick = () => {
+    openTab({ id: `zone:${zoneId}`, kind: "zone", label: zoneId });
+  };
+
+  const handleEntityClick = (cat: CategoryDef, entityId: string) => {
+    if (cat.key === "room") {
+      navigateTo({ zoneId, roomId: entityId });
+    } else {
+      navigateTo({ zoneId, entityKind: cat.key, entityId });
+    }
+  };
+
+  const handleAdd = (cat: CategoryDef) => {
+    if (!cat.addFn) return;
+    try {
+      const next = cat.addFn(world, zoneId);
+      updateZone(zoneId, next);
+      // Navigate to the newly created entity
+      const collection = next[cat.collection] as Record<string, unknown> | undefined;
+      const oldCollection = world[cat.collection] as Record<string, unknown> | undefined;
+      if (collection && oldCollection) {
+        const newId = Object.keys(collection).find((k) => !(k in oldCollection));
+        if (newId) {
+          if (cat.key === "room") {
+            navigateTo({ zoneId, roomId: newId });
+          } else {
+            navigateTo({ zoneId, entityKind: cat.key, entityId: newId });
+          }
+        }
+      }
+    } catch {
+      // ignore duplicate ID errors etc.
+    }
+  };
+
+  return (
+    <li>
+      <div className="flex items-center">
+        <button
+          onClick={() => setExpanded((v) => !v)}
+          className="w-4 shrink-0 text-center text-[10px] text-text-muted"
+        >
+          {expanded ? "\u25BE" : "\u25B8"}
+        </button>
+        <button
+          onClick={handleZoneClick}
+          className={`min-w-0 flex-1 rounded px-1.5 py-1 text-left text-xs transition-colors ${
+            isActive
+              ? "bg-bg-hover text-text-primary"
+              : "text-text-secondary hover:bg-bg-hover hover:text-text-primary"
+          }`}
+        >
+          <span className="truncate">{zoneId}</span>
+          {zoneState.dirty && <span className="ml-1 text-accent">*</span>}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="ml-4 mt-0.5 flex flex-col gap-0.5 border-l border-border-default pl-2">
+          {CATEGORIES.map((cat) => {
+            const collection = world[cat.collection] as Record<string, Record<string, unknown>> | undefined;
+            const entries = collection ? Object.entries(collection) : [];
+            if (entries.length === 0 && !cat.addFn) return null;
+
+            return (
+              <div key={cat.key}>
+                <div className="flex items-center gap-1">
+                  <span className="text-[10px] uppercase tracking-wider text-text-muted">
+                    {cat.label}
+                  </span>
+                  <span className="text-[10px] text-text-muted">
+                    {entries.length}
+                  </span>
+                  {cat.addFn && (
+                    <button
+                      onClick={() => handleAdd(cat)}
+                      className="ml-auto rounded px-1 text-[10px] text-text-muted transition-colors hover:bg-bg-elevated hover:text-text-primary"
+                      title={`Add ${cat.label.replace(/s$/, "").toLowerCase()}`}
+                    >
+                      +
+                    </button>
+                  )}
+                </div>
+                {entries.length > 0 && (
+                  <ul className="flex flex-col">
+                    {entries.map(([id, entity]) => {
+                      const name = (entity as Record<string, unknown>)[cat.nameField] as string | undefined;
+                      return (
+                        <li key={id}>
+                          <button
+                            onClick={() => handleEntityClick(cat, id)}
+                            className="w-full truncate rounded px-1.5 py-0.5 text-left text-[11px] text-text-muted transition-colors hover:bg-bg-hover hover:text-text-secondary"
+                            title={id}
+                          >
+                            {name || id}
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </li>
+  );
+}
+
+// ─── Main Sidebar ───────────────────────────────────────────────────
 
 export function Sidebar() {
   const zones = useZoneStore((s) => s.zones);
@@ -135,38 +333,14 @@ export function Sidebar() {
             <p className="text-xs text-text-muted">No zones loaded</p>
           ) : (
             <ul className="flex flex-col gap-0.5">
-              {sortedZones.map(([zoneId, zoneState]) => {
-                const tabId = `zone:${zoneId}`;
-                const isActive = activeTabId === tabId;
-                return (
-                  <li key={zoneId}>
-                    <button
-                      onClick={() => {
-                        const tab: Tab = {
-                          id: tabId,
-                          kind: "zone",
-                          label: zoneId,
-                        };
-                        openTab(tab);
-                      }}
-                      className={`w-full rounded px-2 py-1 text-left text-sm transition-colors ${
-                        isActive
-                          ? "bg-bg-hover text-text-primary"
-                          : "text-text-secondary hover:bg-bg-hover hover:text-text-primary"
-                      }`}
-                    >
-                      <span>{zoneId}</span>
-                      {zoneState.dirty && (
-                        <span className="ml-1 text-accent">*</span>
-                      )}
-                      <span className="ml-auto text-xs text-text-muted">
-                        {" "}
-                        {Object.keys(zoneState.data.rooms).length}r
-                      </span>
-                    </button>
-                  </li>
-                );
-              })}
+              {sortedZones.map(([zoneId, zoneState]) => (
+                <ZoneTree
+                  key={zoneId}
+                  zoneId={zoneId}
+                  zoneState={zoneState}
+                  isActive={activeTabId === `zone:${zoneId}`}
+                />
+              ))}
             </ul>
           )}
         </div>

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -15,6 +15,7 @@ import {
 import "@xyflow/react/dist/style.css";
 
 import { useZoneStore } from "@/stores/zoneStore";
+import { useProjectStore } from "@/stores/projectStore";
 import { zoneToGraph } from "@/lib/zoneToGraph";
 import { compassLayout } from "@/lib/dagreLayout";
 import { addRoom, addExit, generateRoomId } from "@/lib/zoneEdits";
@@ -74,6 +75,20 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
       setSelectedEntity(null);
     }
   }, [zoneState, selectedEntity]);
+
+  // Consume pending navigation from sidebar
+  const consumeNavigation = useProjectStore((s) => s.consumeNavigation);
+  useEffect(() => {
+    const nav = consumeNavigation();
+    if (!nav || nav.zoneId !== zoneId) return;
+    if (nav.entityKind && nav.entityId) {
+      setSelectedEntity({ kind: nav.entityKind as EntitySelection["kind"], id: nav.entityId });
+      setSelectedRoomId(null);
+    } else if (nav.roomId) {
+      setSelectedRoomId(nav.roomId);
+      setSelectedEntity(null);
+    }
+  }, [zoneId, consumeNavigation]);
 
   // Rebuild graph when WorldFile changes
   const { layoutNodes, layoutEdges } = useMemo(() => {

--- a/creator/src/stores/projectStore.ts
+++ b/creator/src/stores/projectStore.ts
@@ -2,11 +2,20 @@ import { create } from "zustand";
 import { saveUIState } from "@/lib/uiPersistence";
 import type { Project, Tab, ConfigSubTab } from "@/types/project";
 
+/** Navigation target for sidebar -> zone editor entity selection. */
+export interface PendingNavigation {
+  zoneId: string;
+  roomId?: string;
+  entityKind?: string;
+  entityId?: string;
+}
+
 interface ProjectStore {
   project: Project | null;
   tabs: Tab[];
   activeTabId: string | null;
   configSubTab: ConfigSubTab;
+  pendingNavigation: PendingNavigation | null;
 
   setProject: (project: Project) => void;
   closeProject: () => void;
@@ -18,6 +27,8 @@ interface ProjectStore {
   /** Restore previously open tabs after project load. */
   restoreTabs: (tabs: Tab[], activeTabId: string | null) => void;
   setConfigSubTab: (subTab: ConfigSubTab) => void;
+  navigateTo: (nav: PendingNavigation) => void;
+  consumeNavigation: () => PendingNavigation | null;
 }
 
 export const useProjectStore = create<ProjectStore>((set, get) => ({
@@ -25,6 +36,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   tabs: [],
   activeTabId: null,
   configSubTab: "server" as ConfigSubTab,
+  pendingNavigation: null,
 
   setProject: (project) =>
     set({
@@ -60,6 +72,17 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
   restoreTabs: (tabs, activeTabId) => set({ tabs, activeTabId }),
   setConfigSubTab: (subTab) => set({ configSubTab: subTab }),
+
+  navigateTo: (nav) => {
+    const tab: Tab = { id: `zone:${nav.zoneId}`, kind: "zone", label: nav.zoneId };
+    get().openTab(tab);
+    set({ pendingNavigation: nav });
+  },
+  consumeNavigation: () => {
+    const nav = get().pendingNavigation;
+    if (nav) set({ pendingNavigation: null });
+    return nav;
+  },
 }));
 
 // ─── Debounced persistence ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Sidebar zones are now expandable, showing categorized entity trees (Rooms, Mobs, Items, Shops, Quests, Gathering Nodes, Recipes) with counts
- "+" buttons on each category allow quick entity creation with sensible defaults
- Clicking any entity navigates to it via a new `pendingNavigation` mechanism in `projectStore`, which `ZoneEditor` consumes to select the correct room or entity panel

## Test plan
- [ ] Expand a zone in the sidebar — verify all entity categories appear with correct counts
- [ ] Click "+" on Rooms/Mobs/Items/Shops — verify entity is created and editor panel opens
- [ ] Click an existing entity — verify the zone tab opens and the correct panel is selected
- [ ] Verify search still works correctly when typing in the search box