### PR TITLE
Add asset import from disk

### DIFF
--- a/creator/src-tauri/Cargo.toml
+++ b/creator/src-tauri/Cargo.toml
@@ -28,3 +28,4 @@ base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["fs"] }
 tauri-plugin-window-state = "2.4.1"
+imagesize = "0.13"

--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 
@@ -157,4 +158,86 @@ pub async fn update_sync_status(app: AppHandle, id: &str, status: &str) -> Resul
         entry.sync_status = status.to_string();
     }
     save_manifest(&app, &manifest).await
+}
+
+fn detect_extension(bytes: &[u8]) -> &'static str {
+    if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
+        "png"
+    } else if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        "jpg"
+    } else if bytes.starts_with(b"RIFF") && bytes.len() > 12 && &bytes[8..12] == b"WEBP" {
+        "webp"
+    } else {
+        "png"
+    }
+}
+
+/// Import an existing image file from disk into the asset library.
+#[tauri::command]
+pub async fn import_asset(
+    app: AppHandle,
+    source_path: String,
+    asset_type: String,
+    context: Option<AssetContext>,
+) -> Result<AssetEntry, String> {
+    let bytes = tokio::fs::read(&source_path)
+        .await
+        .map_err(|e| format!("Failed to read source file: {e}"))?;
+
+    // Content-addressed hash
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let hash = format!("{:x}", hasher.finalize());
+
+    // Determine extension and filename
+    let ext = detect_extension(&bytes);
+    let file_name = format!("{hash}.{ext}");
+
+    // Read dimensions from image header
+    let (width, height) = match imagesize::blob_size(&bytes) {
+        Ok(size) => (size.width as u32, size.height as u32),
+        Err(_) => (0, 0),
+    };
+
+    // Copy to assets/images
+    let img_dir = assets_dir(&app)?.join("images");
+    tokio::fs::create_dir_all(&img_dir)
+        .await
+        .map_err(|e| format!("Failed to create images dir: {e}"))?;
+
+    let dest = img_dir.join(&file_name);
+    if !dest.exists() {
+        tokio::fs::copy(&source_path, &dest)
+            .await
+            .map_err(|e| format!("Failed to copy image: {e}"))?;
+    }
+
+    // Extract original filename for the prompt field
+    let original_name = std::path::Path::new(&source_path)
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    let entry = AssetEntry {
+        id: uuid::Uuid::new_v4().to_string(),
+        hash,
+        prompt: format!("Imported: {original_name}"),
+        enhanced_prompt: String::new(),
+        model: "imported".to_string(),
+        asset_type,
+        context: context.unwrap_or_default(),
+        created_at: Utc::now(),
+        file_name,
+        width,
+        height,
+        sync_status: "local".to_string(),
+    };
+
+    let mut manifest = load_manifest(&app).await?;
+    // Dedup by hash — update existing entry if same content
+    manifest.assets.retain(|a| a.hash != entry.hash);
+    manifest.assets.push(entry.clone());
+    save_manifest(&app, &manifest).await?;
+
+    Ok(entry)
 }

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ pub fn run() {
             assets::list_assets,
             assets::delete_asset,
             assets::get_assets_dir,
+            assets::import_asset,
             r2::sync_assets,
             r2::get_sync_status,
             r2::resolve_asset_url,

--- a/creator/src/components/AssetGallery.tsx
+++ b/creator/src/components/AssetGallery.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
 import { useAssetStore } from "@/stores/assetStore";
-import type { AssetEntry, SyncProgress } from "@/types/assets";
+import type { AssetEntry, AssetType, SyncProgress } from "@/types/assets";
 
 /** Triggers image loading when the element scrolls into view. */
 function LazyImage({
@@ -44,6 +45,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
   const assetsDir = useAssetStore((s) => s.assetsDir);
   const loadAssets = useAssetStore((s) => s.loadAssets);
   const deleteAsset = useAssetStore((s) => s.deleteAsset);
+  const importAsset = useAssetStore((s) => s.importAsset);
   const syncing = useAssetStore((s) => s.syncing);
   const syncToR2 = useAssetStore((s) => s.syncToR2);
   const settings = useAssetStore((s) => s.settings);
@@ -53,6 +55,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
   const [zoneFilter, setZoneFilter] = useState<string>("all");
   const [sort, setSort] = useState<SortKey>("newest");
   const [deleting, setDeleting] = useState(false);
+  const [importing, setImporting] = useState(false);
   const [imageCache, setImageCache] = useState<Record<string, string>>({});
   const [syncResult, setSyncResult] = useState<SyncProgress | null>(null);
 
@@ -99,6 +102,25 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
     }
   };
 
+  const handleImport = async () => {
+    const files = await open({
+      multiple: true,
+      filters: [{ name: "Images", extensions: ["png", "jpg", "jpeg", "webp"] }],
+    });
+    if (!files) return;
+    const paths = Array.isArray(files) ? files : [files];
+    setImporting(true);
+    try {
+      for (const filePath of paths) {
+        // Infer asset type from current filter, default to "background"
+        const assetType: AssetType = filter !== "all" ? filter as AssetType : "background";
+        await importAsset(filePath, assetType);
+      }
+    } finally {
+      setImporting(false);
+    }
+  };
+
   const formatDate = (iso: string) => {
     try {
       return new Date(iso).toLocaleDateString(undefined, {
@@ -124,6 +146,14 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
             <span className="text-xs text-text-muted">
               {sorted.length} asset{sorted.length !== 1 ? "s" : ""}
             </span>
+            <div className="mx-1 h-4 w-px bg-border-default" />
+            <button
+              onClick={handleImport}
+              disabled={importing}
+              className="rounded px-2 py-0.5 text-[10px] font-medium text-accent transition-colors hover:bg-accent/15 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {importing ? "Importing..." : "Import"}
+            </button>
             {hasR2 && (
               <>
                 <div className="mx-1 h-4 w-px bg-border-default" />

--- a/creator/src/stores/assetStore.ts
+++ b/creator/src/stores/assetStore.ts
@@ -18,6 +18,7 @@ interface AssetState {
 
   loadAssets: () => Promise<void>;
   acceptAsset: (image: GeneratedImage, assetType: string, enhancedPrompt?: string, context?: AssetContext) => Promise<void>;
+  importAsset: (sourcePath: string, assetType: string, context?: AssetContext) => Promise<void>;
   deleteAsset: (id: string) => Promise<void>;
 
   syncToR2: () => Promise<SyncProgress>;
@@ -71,6 +72,15 @@ export const useAssetStore = create<AssetState>((set, get) => ({
       fileName,
       width: image.width,
       height: image.height,
+    });
+    await get().loadAssets();
+  },
+
+  importAsset: async (sourcePath, assetType, context) => {
+    await invoke("import_asset", {
+      sourcePath,
+      assetType,
+      context: context ?? null,
     });
     await get().loadAssets();
   },


### PR DESCRIPTION
## Summary
- New `import_asset` Rust command: reads image from disk, SHA-256 hashes it for content-addressed dedup, copies to asset library, reads dimensions via `imagesize` crate, creates manifest entry
- "Import" button in Asset Gallery header opens a native file dialog (multi-select, filtered to png/jpg/webp)
- Imported assets get the currently selected type filter as their asset_type (defaults to "background")
- Imported files integrate with the existing sync/delete/gallery pipeline — they can be synced to R2, assigned to entities, etc.

## Test plan
- [ ] Open Asset Gallery, click Import, select one or more images — verify they appear in the grid
- [ ] Import the same image twice — verify it deduplicates by hash (single entry)
- [ ] Verify imported assets show correct dimensions, can be deleted, and can be synced to R2
- [ ] Filter by type, then import — verify the imported asset gets that type