### PR TITLE
Strip <think> tags from prompt enhancement responses

### DIFF
--- a/creator/src-tauri/src/deepinfra.rs
+++ b/creator/src-tauri/src/deepinfra.rs
@@ -287,6 +287,23 @@ pub async fn enhance_prompt(
 
     resp.choices
         .first()
-        .map(|c| c.message.content.trim().to_string())
+        .map(|c| strip_think_tags(c.message.content.trim()))
         .ok_or_else(|| "No response from model".to_string())
+}
+
+/// Strip `<think>...</think>` reasoning blocks that some models emit.
+fn strip_think_tags(text: &str) -> String {
+    let result = text;
+    while let Some(start) = result.find("<think>") {
+        if let Some(end) = result.find("</think>") {
+            let before = &result[..start];
+            let after = &result[end + "</think>".len()..];
+            let combined = format!("{before}{after}");
+            return strip_think_tags(combined.trim());
+        } else {
+            // Unclosed <think> — strip from <think> to end
+            return result[..start].trim().to_string();
+        }
+    }
+    result.to_string()
 }


### PR DESCRIPTION
Fixes #50

## Summary
- The Qwen2.5-7B-Instruct model used for prompt enhancement emits `<think>...</think>` reasoning blocks before the actual enhanced prompt
- The `enhance_prompt` response was returning the full content including the reasoning, so the image generation model was getting the thinking text instead of the actual prompt
- Added `strip_think_tags()` to recursively remove all `<think>...</think>` blocks, handling nested content and unclosed tags

## Test plan
- [x] `cargo check` — compiles clean with no warnings
- [ ] Manual: enhance a prompt, verify only the final prompt text is returned (no `<think>` blocks)