### PR TITLE
Add ability sprite support

### DIFF
--- a/creator/src/components/config/panels/AbilitiesPanel.tsx
+++ b/creator/src/components/config/panels/AbilitiesPanel.tsx
@@ -8,6 +8,9 @@ import {
   SelectInput,
 } from "@/components/ui/FormWidgets";
 import { RegistryPanel } from "./RegistryPanel";
+import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import { getPreamble } from "@/lib/arcanumPrompts";
+import type { ArtStyle } from "@/lib/arcanumPrompts";
 
 const TARGET_TYPES = [
   { value: "ENEMY", label: "Enemy" },
@@ -22,6 +25,12 @@ const EFFECT_TYPES = [
   { value: "AREA_DAMAGE", label: "Area Damage" },
   { value: "TAUNT", label: "Taunt" },
 ];
+
+function abilityPrompt(ability: AbilityDefinitionConfig, style: ArtStyle): string {
+  const preamble = getPreamble(style);
+  const effectDesc = ability.effect.type.toLowerCase().replace(/_/g, " ");
+  return `${preamble}, a game ability icon for "${ability.displayName}" — ${effectDesc} spell, ${ability.description || "magical ability"}, centered square composition like an RPG ability sprite, iconic symbol rendered as flowing energy, no text, no figures`;
+}
 
 export function AbilitiesPanel({ config, onChange }: ConfigPanelProps) {
   const statusEffectOptions = Object.keys(config.statusEffects).map((id) => ({
@@ -75,7 +84,7 @@ export function AbilitiesPanel({ config, onChange }: ConfigPanelProps) {
         effect: { type: "DIRECT_DAMAGE", value: 3 },
       })}
       renderSummary={(_id, a) => a.effect.type}
-      renderDetail={(_id, a, patch) => (
+      renderDetail={(id, a, patch) => (
         <>
           <FieldRow label="Display Name">
             <TextInput
@@ -191,6 +200,29 @@ export function AbilitiesPanel({ config, onChange }: ConfigPanelProps) {
                   </FieldRow>
                 </>
               )}
+            </div>
+          </div>
+
+          {/* Sprite section */}
+          <div className="mt-1 border-t border-border-muted pt-1.5">
+            <h5 className="mb-1 text-[10px] font-display uppercase tracking-widest text-text-muted">
+              Sprite
+            </h5>
+            <div className="flex flex-col gap-1.5">
+              <FieldRow label="Image">
+                <TextInput
+                  value={a.image ?? ""}
+                  onCommit={(v) => patch({ image: v || undefined })}
+                  placeholder="none"
+                />
+              </FieldRow>
+              <EntityArtGenerator
+                getPrompt={(style) => abilityPrompt(a, style)}
+                currentImage={a.image}
+                onAccept={(filePath) => patch({ image: filePath })}
+                assetType="ability_sprite"
+                context={{ zone: "", entity_type: "ability", entity_id: id }}
+              />
             </div>
           </div>
         </>

--- a/creator/src/lib/arcanumPrompts.ts
+++ b/creator/src/lib/arcanumPrompts.ts
@@ -54,6 +54,10 @@ export const ASSET_TEMPLATES: Record<AssetType, { label: string; template: strin
     label: "Entity Portrait",
     template: `Baroque cosmic portrait frame rendered in glowing aurum-gold scrollwork, deep indigo background with blue-violet nebula wisps, the subject depicted as an archetypal symbol rendered in flowing light rather than literal form, ornate frame edges curl and dissolve into darkness, warm golden light emanates from the center, painterly, luminous`,
   },
+  ability_sprite: {
+    label: "Ability Sprite",
+    template: `A single iconic ability symbol rendered as flowing energy against deep cosmic indigo void, baroque scrollwork frame dissolving at edges, the central icon glows with concentrated aurum-gold light and soft bloom, blue-violet atmospheric fill behind, centered square composition like a game ability icon, painterly, luminous, extremely detailed, no text, no figures`,
+  },
   zone_map: {
     label: "Zone Map",
     template: `Celestial cartography from above, a glowing world map rendered in baroque light threads on a deep cosmic indigo void, landmasses formed from swirling aurum-gold energy lines that curl and flourish at coastlines and mountain ranges in rococo scrollwork style, rivers traced as flowing silver-blue light, zone boundaries marked by gentle violet-glowing arcs, concentric circles of faint stardust suggesting scale and depth, fractal detail increasing toward the edges, bird's-eye perspective, painterly, luminous`,

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -38,6 +38,7 @@ export type AssetType =
   | "status_art"
   | "empty_state"
   | "entity_portrait"
+  | "ability_sprite"
   | "zone_map"
   | "splash_hero"
   | "loading_vignette"


### PR DESCRIPTION
## Summary
- Adds image sprite UI to the Abilities config panel — each ability gets a Sprite section with image field, art generator, style toggle, and prompt editor
- New `ability_sprite` asset type with a dedicated prompt template for icon-style ability art
- Sprites flow through the existing R2 pipeline: generate/pick -> import -> sync -> migrate (application.yaml `image:` fields already handled by `migrate_images_to_r2`)

## Test plan
- [ ] Open Config > Abilities, expand an ability — Sprite section visible
- [ ] Pick Image imports to asset gallery and sets the `image` field
- [ ] Generate Art creates an ability icon with the ability's name/effect in the prompt
- [ ] Save Config persists the `image` field in application.yaml
- [ ] Batch import + migrate rewrites ability image paths to R2 hashes