### PR TITLE
Add video and audio media support

### DIFF
--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -131,12 +132,16 @@ pub async fn delete_asset(app: AppHandle, id: String) -> Result<(), String> {
     let entry = manifest.assets.iter().find(|a| a.id == id).cloned();
 
     if let Some(entry) = &entry {
-        // Delete the file
-        let file_path = assets_dir(&app)?.join("images").join(&entry.file_name);
-        if file_path.exists() {
-            tokio::fs::remove_file(&file_path)
-                .await
-                .map_err(|e| format!("Failed to delete file: {e}"))?;
+        // Delete the file — check all subdirectories
+        let base = assets_dir(&app)?;
+        for subdir in &["images", "video", "audio"] {
+            let file_path = base.join(subdir).join(&entry.file_name);
+            if file_path.exists() {
+                tokio::fs::remove_file(&file_path)
+                    .await
+                    .map_err(|e| format!("Failed to delete file: {e}"))?;
+                break;
+            }
         }
     }
 
@@ -151,6 +156,20 @@ pub async fn get_assets_dir(app: AppHandle) -> Result<String, String> {
     Ok(dir.to_string_lossy().to_string())
 }
 
+/// Resolve a media asset filename to its absolute local path.
+/// Searches images/, video/, and audio/ subdirectories.
+#[tauri::command]
+pub async fn resolve_media_path(app: AppHandle, file_name: String) -> Result<String, String> {
+    let base = assets_dir(&app)?;
+    for subdir in &["images", "video", "audio"] {
+        let path = base.join(subdir).join(&file_name);
+        if path.exists() {
+            return Ok(path.to_string_lossy().to_string());
+        }
+    }
+    Err(format!("Asset file not found: {file_name}"))
+}
+
 /// Update the sync_status of an asset by ID. Called from r2 module.
 pub async fn update_sync_status(app: AppHandle, id: &str, status: &str) -> Result<(), String> {
     let mut manifest = load_manifest(&app).await?;
@@ -161,18 +180,83 @@ pub async fn update_sync_status(app: AppHandle, id: &str, status: &str) -> Resul
 }
 
 fn detect_extension(bytes: &[u8]) -> &'static str {
+    // Images
     if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
         "png"
     } else if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
         "jpg"
     } else if bytes.starts_with(b"RIFF") && bytes.len() > 12 && &bytes[8..12] == b"WEBP" {
         "webp"
+    // Video
+    } else if bytes.len() > 12 && &bytes[4..8] == b"ftyp" {
+        "mp4"
+    } else if bytes.starts_with(b"\x1a\x45\xdf\xa3") {
+        "webm"
+    // Audio
+    } else if bytes.starts_with(b"OggS") {
+        "ogg"
+    } else if bytes.starts_with(b"ID3") || (bytes.len() >= 2 && bytes[0] == 0xFF && (bytes[1] & 0xE0) == 0xE0) {
+        "mp3"
+    } else if bytes.starts_with(b"fLaC") {
+        "flac"
+    } else if bytes.starts_with(b"RIFF") && bytes.len() > 12 && &bytes[8..12] == b"WAVE" {
+        "wav"
     } else {
-        "png"
+        "bin"
     }
 }
 
-/// Import an existing image file from disk into the asset library.
+fn extension_from_path(path: &str) -> Option<&str> {
+    std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+}
+
+fn mime_from_ext(ext: &str) -> &'static str {
+    match ext {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        "mp4" => "video/mp4",
+        "webm" => "video/webm",
+        "mp3" => "audio/mpeg",
+        "ogg" => "audio/ogg",
+        "flac" => "audio/flac",
+        "wav" => "audio/wav",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Read any media file from disk and return it as a data URL.
+/// Works for images, audio, and video.
+#[tauri::command]
+pub async fn read_media_data_url(path: String) -> Result<String, String> {
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|e| format!("Failed to read file: {e}"))?;
+
+    let detected = detect_extension(&bytes);
+    let ext = if detected == "bin" {
+        extension_from_path(&path).unwrap_or("bin")
+    } else {
+        detected
+    };
+    let mime = mime_from_ext(ext);
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Ok(format!("data:{mime};base64,{b64}"))
+}
+
+/// Determine the storage subdirectory for an asset based on its extension.
+fn media_subdir(ext: &str) -> &'static str {
+    match ext {
+        "mp4" | "webm" => "video",
+        "mp3" | "ogg" | "flac" | "wav" => "audio",
+        _ => "images",
+    }
+}
+
+/// Import an existing file from disk into the asset library.
+/// Works for images, audio, and video files.
 #[tauri::command]
 pub async fn import_asset(
     app: AppHandle,
@@ -189,27 +273,33 @@ pub async fn import_asset(
     hasher.update(&bytes);
     let hash = format!("{:x}", hasher.finalize());
 
-    // Determine extension and filename
-    let ext = detect_extension(&bytes);
+    // Determine extension — prefer magic bytes, fall back to source extension
+    let detected = detect_extension(&bytes);
+    let ext = if detected == "bin" {
+        extension_from_path(&source_path).unwrap_or("bin")
+    } else {
+        detected
+    };
     let file_name = format!("{hash}.{ext}");
 
-    // Read dimensions from image header
+    // Read dimensions from image header (0x0 for non-image files)
     let (width, height) = match imagesize::blob_size(&bytes) {
         Ok(size) => (size.width as u32, size.height as u32),
         Err(_) => (0, 0),
     };
 
-    // Copy to assets/images
-    let img_dir = assets_dir(&app)?.join("images");
-    tokio::fs::create_dir_all(&img_dir)
+    // Copy to assets/<subdir>
+    let subdir = media_subdir(ext);
+    let dest_dir = assets_dir(&app)?.join(subdir);
+    tokio::fs::create_dir_all(&dest_dir)
         .await
-        .map_err(|e| format!("Failed to create images dir: {e}"))?;
+        .map_err(|e| format!("Failed to create {subdir} dir: {e}"))?;
 
-    let dest = img_dir.join(&file_name);
+    let dest = dest_dir.join(&file_name);
     if !dest.exists() {
         tokio::fs::copy(&source_path, &dest)
             .await
-            .map_err(|e| format!("Failed to copy image: {e}"))?;
+            .map_err(|e| format!("Failed to copy file: {e}"))?;
     }
 
     // Extract original filename for the prompt field

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             project::validate_mud_dir,
             project::list_legacy_images,
+            project::list_legacy_media,
             project::migrate_images_to_r2,
             settings::get_settings,
             settings::save_settings,
@@ -26,6 +27,8 @@ pub fn run() {
             assets::list_assets,
             assets::delete_asset,
             assets::get_assets_dir,
+            assets::resolve_media_path,
+            assets::read_media_data_url,
             assets::import_asset,
             r2::sync_assets,
             r2::get_sync_status,

--- a/creator/src-tauri/src/project.rs
+++ b/creator/src-tauri/src/project.rs
@@ -48,9 +48,13 @@ pub fn validate_mud_dir(path: String) -> ValidationResult {
     }
 }
 
-const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp"];
+const MEDIA_EXTENSIONS: &[&str] = &[
+    "png", "jpg", "jpeg", "webp",
+    "mp4", "webm",
+    "mp3", "ogg", "flac", "wav",
+];
 
-fn collect_images(dir: &Path, base: &Path, out: &mut Vec<LegacyImage>) {
+fn collect_media(dir: &Path, base: &Path, out: &mut Vec<LegacyMedia>) {
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(_) => return,
@@ -58,11 +62,11 @@ fn collect_images(dir: &Path, base: &Path, out: &mut Vec<LegacyImage>) {
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            collect_images(&path, base, out);
+            collect_media(&path, base, out);
         } else if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-            if IMAGE_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()) {
+            if MEDIA_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()) {
                 let relative = path.strip_prefix(base).unwrap_or(&path);
-                out.push(LegacyImage {
+                out.push(LegacyMedia {
                     absolute_path: path.to_string_lossy().to_string(),
                     relative_path: relative.to_string_lossy().replace('\\', "/"),
                 });
@@ -72,7 +76,7 @@ fn collect_images(dir: &Path, base: &Path, out: &mut Vec<LegacyImage>) {
 }
 
 #[derive(Serialize)]
-pub struct LegacyImage {
+pub struct LegacyMedia {
     pub absolute_path: String,
     pub relative_path: String,
 }
@@ -80,7 +84,7 @@ pub struct LegacyImage {
 /// List all image files under the MUD project's resource directories.
 /// Checks both src/main/resources/world/images/ and src/main/resources/images/.
 #[tauri::command]
-pub fn list_legacy_images(mud_dir: String) -> Vec<LegacyImage> {
+pub fn list_legacy_images(mud_dir: String) -> Vec<LegacyMedia> {
     let base = PathBuf::from(&mud_dir).join("src/main/resources");
     let candidates = [
         base.join("world/images"),
@@ -89,7 +93,26 @@ pub fn list_legacy_images(mud_dir: String) -> Vec<LegacyImage> {
     let mut results = Vec::new();
     for dir in &candidates {
         if dir.is_dir() {
-            collect_images(dir, dir, &mut results);
+            collect_media(dir, dir, &mut results);
+        }
+    }
+    results
+}
+
+/// List all media files (images, audio, video) under the MUD project's resource directories.
+#[tauri::command]
+pub fn list_legacy_media(mud_dir: String) -> Vec<LegacyMedia> {
+    let base = PathBuf::from(&mud_dir).join("src/main/resources");
+    let candidates = [
+        "world/images", "images",
+        "world/audio", "audio",
+        "world/video", "video",
+    ];
+    let mut results = Vec::new();
+    for subdir in &candidates {
+        let dir = base.join(subdir);
+        if dir.is_dir() {
+            collect_media(&dir, &dir, &mut results);
         }
     }
     results
@@ -149,20 +172,24 @@ fn resolve_to_r2(path: &Path, hash_map: &HashMap<String, String>) -> Option<Stri
     hash_map.get(&hash).cloned()
 }
 
-/// Find the local file for a legacy image path.
-/// Tries both world/images/ and images/ directories.
-fn find_image_file(relative_path: &str, resources: &Path) -> Option<PathBuf> {
-    let candidates = [
-        resources.join("world/images").join(relative_path),
-        resources.join("images").join(relative_path),
-    ];
-    candidates.into_iter().find(|p| p.is_file())
+/// Find the local file for a legacy media path.
+/// Tries world/images/, images/, world/audio/, audio/, world/video/, and video/ directories.
+fn find_media_file(relative_path: &str, resources: &Path) -> Option<PathBuf> {
+    let prefixes = ["world/images", "images", "world/audio", "audio", "world/video", "video"];
+    for prefix in &prefixes {
+        let path = resources.join(prefix).join(relative_path);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    None
 }
 
-/// Rewrite image references in a YAML string.
-/// Scans for `image:` keys and replaces legacy relative paths with R2 hash filenames.
+/// Rewrite media references in a YAML string.
+/// Scans for `image:`, `video:`, `music:`, `ambient:`, and `audio:` keys
+/// and replaces legacy relative paths with R2 hash filenames.
 /// Returns the updated content and the count of replacements made.
-fn rewrite_yaml_images(
+fn rewrite_yaml_media(
     content: &str,
     resources: &Path,
     hash_map: &HashMap<String, String>,
@@ -170,7 +197,7 @@ fn rewrite_yaml_images(
     file_label: &str,
 ) -> (String, usize) {
     use regex::Regex;
-    let re = Regex::new(r#"(?m)^(\s*image:\s*)(?:"([^"]+)"|'([^']+)'|(\S+))\s*$"#).unwrap();
+    let re = Regex::new(r#"(?m)^(\s*(?:image|video|music|ambient|audio):\s*)(?:"([^"]+)"|'([^']+)'|(\S+))\s*$"#).unwrap();
 
     let mut count = 0;
     let result = re
@@ -193,7 +220,7 @@ fn rewrite_yaml_images(
                 .strip_prefix("/images/")
                 .unwrap_or(path);
 
-            if let Some(file_path) = find_image_file(relative, resources) {
+            if let Some(file_path) = find_media_file(relative, resources) {
                 if let Some(r2_name) = resolve_to_r2(&file_path, hash_map) {
                     count += 1;
                     return format!("{prefix}{r2_name}");
@@ -274,7 +301,7 @@ pub fn migrate_images_to_r2(
             };
 
             let (updated, count) =
-                rewrite_yaml_images(&content, &resources, &hash_map, &mut report.errors, name);
+                rewrite_yaml_media(&content, &resources, &hash_map, &mut report.errors, name);
             if count > 0 {
                 if let Err(e) = std::fs::write(&path, &updated) {
                     report
@@ -293,7 +320,7 @@ pub fn migrate_images_to_r2(
         let content = std::fs::read_to_string(&config_path)
             .map_err(|e| format!("Failed to read application.yaml: {e}"))?;
 
-        let (updated, count) = rewrite_yaml_images(
+        let (updated, count) = rewrite_yaml_media(
             &content,
             &resources,
             &hash_map,
@@ -307,9 +334,10 @@ pub fn migrate_images_to_r2(
         }
     }
 
-    // ─── Delete local image directories ────────────────────────
-    report.images_deleted += remove_dir_all_best_effort(&resources.join("world/images"));
-    report.images_deleted += remove_dir_all_best_effort(&resources.join("images"));
+    // ─── Delete local media directories ─────────────────────────
+    for subdir in &["world/images", "images", "world/audio", "audio", "world/video", "video"] {
+        report.images_deleted += remove_dir_all_best_effort(&resources.join(subdir));
+    }
 
     Ok(report)
 }

--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Manager};
 
 use crate::assets::{self, AssetEntry};
@@ -199,6 +199,18 @@ fn detect_content_type(file_name: &str) -> &'static str {
         "image/jpeg"
     } else if file_name.ends_with(".webp") {
         "image/webp"
+    } else if file_name.ends_with(".mp4") {
+        "video/mp4"
+    } else if file_name.ends_with(".webm") {
+        "video/webm"
+    } else if file_name.ends_with(".mp3") {
+        "audio/mpeg"
+    } else if file_name.ends_with(".ogg") {
+        "audio/ogg"
+    } else if file_name.ends_with(".flac") {
+        "audio/flac"
+    } else if file_name.ends_with(".wav") {
+        "audio/wav"
     } else {
         "image/png"
     }
@@ -255,12 +267,23 @@ async fn upload_object(
 
 // ─── Tauri commands ─────────────────────────────────────────────────
 
-fn images_dir(app: &AppHandle) -> Result<PathBuf, String> {
+fn assets_base_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = app
         .path()
         .app_data_dir()
         .map_err(|e| format!("Failed to get app data dir: {e}"))?;
-    Ok(dir.join("assets").join("images"))
+    Ok(dir.join("assets"))
+}
+
+/// Find a media file across all asset subdirectories.
+fn find_asset_file(base: &Path, file_name: &str) -> Option<PathBuf> {
+    for subdir in &["images", "video", "audio"] {
+        let path = base.join(subdir).join(file_name);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
 }
 
 #[tauri::command]
@@ -272,7 +295,7 @@ pub async fn sync_assets(app: AppHandle) -> Result<SyncProgress, String> {
 
     let assets = assets::list_assets(app.clone()).await?;
     let unsynced: Vec<&AssetEntry> = assets.iter().filter(|a| a.sync_status != "synced").collect();
-    let img_dir = images_dir(&app)?;
+    let base_dir = assets_base_dir(&app)?;
     let client = reqwest::Client::new();
 
     let mut progress = SyncProgress {
@@ -303,7 +326,14 @@ pub async fn sync_assets(app: AppHandle) -> Result<SyncProgress, String> {
         }
 
         // Read local file
-        let file_path = img_dir.join(&asset.file_name);
+        let file_path = match find_asset_file(&base_dir, &asset.file_name) {
+            Some(p) => p,
+            None => {
+                progress.failed += 1;
+                progress.errors.push(format!("{}: File not found in asset dirs", asset.file_name));
+                continue;
+            }
+        };
         let body = match tokio::fs::read(&file_path).await {
             Ok(b) => b,
             Err(e) => {

--- a/creator/src/components/BatchLegacyImport.tsx
+++ b/creator/src/components/BatchLegacyImport.tsx
@@ -4,13 +4,13 @@ import { useProjectStore } from "@/stores/projectStore";
 import { useAssetStore } from "@/stores/assetStore";
 import type { AssetEntry } from "@/types/assets";
 
-interface LegacyImage {
+interface LegacyMedia {
   absolute_path: string;
   relative_path: string;
 }
 
 interface ImportTarget {
-  image: LegacyImage;
+  image: LegacyMedia;
   status: "pending" | "importing" | "done" | "skipped" | "error";
   error?: string;
 }
@@ -50,12 +50,12 @@ export function BatchLegacyImport({ onClose }: { onClose: () => void }) {
     if (!mudDir) return;
     setScanning(true);
     try {
-      const images = await invoke<LegacyImage[]>("list_legacy_images", { mudDir });
+      const media = await invoke<LegacyMedia[]>("list_legacy_media", { mudDir });
       setTargets(
-        images.map((image) => ({ image, status: "pending" as const })),
+        media.map((image) => ({ image, status: "pending" as const })),
       );
-      if (images.length === 0) {
-        // No local images — skip straight to migrate
+      if (media.length === 0) {
+        // No local media — skip straight to migrate
         setPhase("migrate");
       }
     } catch {
@@ -81,9 +81,14 @@ export function BatchLegacyImport({ onClose }: { onClose: () => void }) {
       );
 
       try {
+        const ext = target.image.relative_path.split(".").pop()?.toLowerCase() ?? "";
+        const assetType = ["mp4", "webm"].includes(ext) ? "video"
+          : ["mp3", "ogg", "flac", "wav"].includes(ext) ? "audio"
+          : "background";
+
         const entry = await invoke<AssetEntry>("import_asset", {
           sourcePath: target.image.absolute_path,
-          assetType: "background",
+          assetType,
           context: null,
         });
 
@@ -178,7 +183,7 @@ export function BatchLegacyImport({ onClose }: { onClose: () => void }) {
           {phase === "scan" && !targets && !scanning && (
             <div className="flex flex-col items-center gap-3 py-6">
               <p className="text-sm text-text-secondary">
-                Scan for local images, import them, sync to R2, then rewrite all YAML references to use R2 filenames.
+                Scan for local media (images, audio, video), import them, sync to R2, then rewrite all YAML references to use R2 filenames.
               </p>
               <p className="rounded bg-bg-primary px-3 py-1.5 font-mono text-[10px] text-text-muted">
                 {mudDir}/src/main/resources/
@@ -187,7 +192,7 @@ export function BatchLegacyImport({ onClose }: { onClose: () => void }) {
                 onClick={handleScan}
                 className="rounded bg-accent/15 px-4 py-1.5 text-xs font-medium text-accent transition-colors hover:bg-accent/25"
               >
-                Scan for Images
+                Scan for Media
               </button>
             </div>
           )}

--- a/creator/src/components/editors/EditorShared.tsx
+++ b/creator/src/components/editors/EditorShared.tsx
@@ -1,5 +1,6 @@
 import { Section, FieldRow, TextInput } from "@/components/ui/FormWidgets";
 import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import { MediaPicker } from "@/components/ui/MediaPicker";
 import type { ArtStyle } from "@/lib/arcanumPrompts";
 import type { AssetContext } from "@/types/assets";
 
@@ -25,12 +26,16 @@ export function DeleteEntityButton({
 export function MediaSection({
   image,
   onImageChange,
+  video,
+  onVideoChange,
   getPrompt,
   assetType,
   context,
 }: {
   image: string | undefined;
   onImageChange: (v: string | undefined) => void;
+  video?: string;
+  onVideoChange?: (v: string | undefined) => void;
   getPrompt?: (style: ArtStyle) => string;
   assetType?: string;
   context?: AssetContext;
@@ -53,6 +58,100 @@ export function MediaSection({
             assetType={assetType}
             context={context}
           />
+        )}
+        {onVideoChange && (
+          <>
+            <FieldRow label="Video">
+              <TextInput
+                value={video ?? ""}
+                onCommit={(v) => onVideoChange(v || undefined)}
+                placeholder="none"
+              />
+            </FieldRow>
+            <MediaPicker
+              value={video}
+              onChange={onVideoChange}
+              mediaType="video"
+              assetType="video"
+            />
+          </>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+export function AudioSection({
+  music,
+  onMusicChange,
+  ambient,
+  onAmbientChange,
+  audio,
+  onAudioChange,
+}: {
+  music?: string;
+  onMusicChange?: (v: string | undefined) => void;
+  ambient?: string;
+  onAmbientChange?: (v: string | undefined) => void;
+  audio?: string;
+  onAudioChange?: (v: string | undefined) => void;
+}) {
+  const hasAny = onMusicChange || onAmbientChange || onAudioChange;
+  if (!hasAny) return null;
+
+  return (
+    <Section title="Audio">
+      <div className="flex flex-col gap-1.5">
+        {onMusicChange && (
+          <>
+            <FieldRow label="Music">
+              <TextInput
+                value={music ?? ""}
+                onCommit={(v) => onMusicChange(v || undefined)}
+                placeholder="none"
+              />
+            </FieldRow>
+            <MediaPicker
+              value={music}
+              onChange={onMusicChange}
+              mediaType="audio"
+              assetType="music"
+            />
+          </>
+        )}
+        {onAmbientChange && (
+          <>
+            <FieldRow label="Ambient">
+              <TextInput
+                value={ambient ?? ""}
+                onCommit={(v) => onAmbientChange(v || undefined)}
+                placeholder="none"
+              />
+            </FieldRow>
+            <MediaPicker
+              value={ambient}
+              onChange={onAmbientChange}
+              mediaType="audio"
+              assetType="ambient"
+            />
+          </>
+        )}
+        {onAudioChange && (
+          <>
+            <FieldRow label="Audio">
+              <TextInput
+                value={audio ?? ""}
+                onCommit={(v) => onAudioChange(v || undefined)}
+                placeholder="none"
+              />
+            </FieldRow>
+            <MediaPicker
+              value={audio}
+              onChange={onAudioChange}
+              mediaType="audio"
+              assetType="audio"
+            />
+          </>
         )}
       </div>
     </Section>

--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -216,7 +216,7 @@ export function ItemEditor({
         </div>
       </Section>
 
-      <MediaSection image={item.image} onImageChange={(v) => patch({ image: v })} getPrompt={(style) => itemPrompt(itemId, item, style)} assetType="entity_portrait" context={zoneId ? { zone: zoneId, entity_type: "item", entity_id: itemId } : undefined} />
+      <MediaSection image={item.image} onImageChange={(v) => patch({ image: v })} video={item.video} onVideoChange={(v) => patch({ video: v })} getPrompt={(style) => itemPrompt(itemId, item, style)} assetType="entity_portrait" context={zoneId ? { zone: zoneId, entity_type: "item", entity_id: itemId } : undefined} />
       <DeleteEntityButton onClick={handleDelete} label="Delete Item" />
     </>
   );

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -381,7 +381,7 @@ export function MobEditor({
         onWorldChange={onWorldChange}
       />
 
-      <MediaSection image={mob.image} onImageChange={(v) => patch({ image: v })} getPrompt={(style) => mobPrompt(mobId, mob, style)} assetType="entity_portrait" context={zoneId ? { zone: zoneId, entity_type: "mob", entity_id: mobId } : undefined} />
+      <MediaSection image={mob.image} onImageChange={(v) => patch({ image: v })} video={mob.video} onVideoChange={(v) => patch({ video: v })} getPrompt={(style) => mobPrompt(mobId, mob, style)} assetType="entity_portrait" context={zoneId ? { zone: zoneId, entity_type: "mob", entity_id: mobId } : undefined} />
       <DeleteEntityButton onClick={handleDelete} label="Delete Mob" />
     </>
   );

--- a/creator/src/components/ui/MediaPicker.tsx
+++ b/creator/src/components/ui/MediaPicker.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useAssetStore } from "@/stores/assetStore";
+import { useMediaSrc } from "@/lib/useMediaSrc";
+
+interface MediaPickerProps {
+  /** Current media path (R2 hash, legacy relative, or absolute) */
+  value?: string;
+  /** Called when user picks a file — receives the local asset path */
+  onChange: (path: string | undefined) => void;
+  /** "audio" or "video" */
+  mediaType: "audio" | "video";
+  /** Asset type for manifest */
+  assetType?: string;
+}
+
+const AUDIO_EXTENSIONS = ["mp3", "ogg", "flac", "wav"];
+const VIDEO_EXTENSIONS = ["mp4", "webm"];
+
+export function MediaPicker({ value, onChange, mediaType, assetType }: MediaPickerProps) {
+  const importAsset = useAssetStore((s) => s.importAsset);
+  const assetsDir = useAssetStore((s) => s.assetsDir);
+  const [importing, setImporting] = useState(false);
+
+  const dataSrc = useMediaSrc(value);
+
+  const extensions = mediaType === "audio" ? AUDIO_EXTENSIONS : VIDEO_EXTENSIONS;
+
+  const handlePick = async () => {
+    const path = await open({
+      filters: [{
+        name: mediaType === "audio" ? "Audio" : "Video",
+        extensions,
+      }],
+      multiple: false,
+    });
+    if (!path) return;
+
+    setImporting(true);
+    try {
+      const entry = await importAsset(path, assetType ?? mediaType, undefined);
+      const subdir = mediaType === "audio" ? "audio" : "video";
+      onChange(`${assetsDir}\\${subdir}\\${entry.file_name}`);
+    } catch (e) {
+      console.error("Failed to import media:", e);
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      {/* Preview */}
+      {dataSrc && mediaType === "audio" && (
+        <audio
+          src={dataSrc}
+          controls
+          className="h-8 w-full"
+          preload="metadata"
+        />
+      )}
+      {dataSrc && mediaType === "video" && (
+        <video
+          src={dataSrc}
+          controls
+          className="w-full rounded border border-border-default"
+          preload="metadata"
+        />
+      )}
+
+      {/* Pick button */}
+      <div className="flex gap-1">
+        <button
+          onClick={handlePick}
+          disabled={importing}
+          className="flex-1 rounded bg-bg-elevated px-2 py-1 text-[10px] font-medium text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary disabled:opacity-50"
+        >
+          {importing ? "Importing..." : `Pick ${mediaType === "audio" ? "Audio" : "Video"}`}
+        </button>
+        {value && (
+          <button
+            onClick={() => onChange(undefined)}
+            className="rounded px-1.5 py-1 text-[10px] text-text-muted transition-colors hover:text-text-secondary"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -10,9 +10,10 @@ import {
   addGatheringNode,
   generateEntityId,
 } from "@/lib/zoneEdits";
-import { EditableField, EditableTextArea, Section, IconButton } from "@/components/ui/FormWidgets";
+import { EditableField, EditableTextArea, Section, IconButton, FieldRow, TextInput } from "@/components/ui/FormWidgets";
 import { YamlPreview } from "@/components/ui/YamlPreview";
 import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import { MediaPicker } from "@/components/ui/MediaPicker";
 import { roomPrompt } from "@/lib/entityPrompts";
 
 export type EntityKind = "mob" | "item" | "shop" | "quest" | "gatheringNode" | "recipe";
@@ -387,15 +388,64 @@ export function RoomPanel({
             assetType="background"
             context={{ zone: zoneId, entity_type: "room", entity_id: roomId }}
           />
-          {room.music && (
-            <p className="text-xs text-text-muted">Music: {room.music}</p>
-          )}
-          {room.ambient && (
-            <p className="text-xs text-text-muted">Ambient: {room.ambient}</p>
-          )}
-          {room.audio && (
-            <p className="text-xs text-text-muted">Audio: {room.audio}</p>
-          )}
+          <FieldRow label="Video">
+            <TextInput
+              value={room.video ?? ""}
+              onCommit={(v) => onWorldChange(updateRoom(world, roomId, { video: v || undefined }))}
+              placeholder="none"
+            />
+          </FieldRow>
+          <MediaPicker
+            value={room.video}
+            onChange={(v) => onWorldChange(updateRoom(world, roomId, { video: v }))}
+            mediaType="video"
+            assetType="video"
+          />
+        </div>
+      </Section>
+
+      {/* Audio */}
+      <Section title="Audio">
+        <div className="flex flex-col gap-1.5">
+          <FieldRow label="Music">
+            <TextInput
+              value={room.music ?? ""}
+              onCommit={(v) => onWorldChange(updateRoom(world, roomId, { music: v || undefined }))}
+              placeholder="none"
+            />
+          </FieldRow>
+          <MediaPicker
+            value={room.music}
+            onChange={(v) => onWorldChange(updateRoom(world, roomId, { music: v }))}
+            mediaType="audio"
+            assetType="music"
+          />
+          <FieldRow label="Ambient">
+            <TextInput
+              value={room.ambient ?? ""}
+              onCommit={(v) => onWorldChange(updateRoom(world, roomId, { ambient: v || undefined }))}
+              placeholder="none"
+            />
+          </FieldRow>
+          <MediaPicker
+            value={room.ambient}
+            onChange={(v) => onWorldChange(updateRoom(world, roomId, { ambient: v }))}
+            mediaType="audio"
+            assetType="ambient"
+          />
+          <FieldRow label="Audio">
+            <TextInput
+              value={room.audio ?? ""}
+              onCommit={(v) => onWorldChange(updateRoom(world, roomId, { audio: v || undefined }))}
+              placeholder="none"
+            />
+          </FieldRow>
+          <MediaPicker
+            value={room.audio}
+            onChange={(v) => onWorldChange(updateRoom(world, roomId, { audio: v }))}
+            mediaType="audio"
+            assetType="audio"
+          />
         </div>
       </Section>
 

--- a/creator/src/lib/useMediaSrc.ts
+++ b/creator/src/lib/useMediaSrc.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useProjectStore } from "@/stores/projectStore";
+import { useAssetStore } from "@/stores/assetStore";
+import { isR2HashPath, isLegacyImagePath } from "./useImageSrc";
+
+/**
+ * Load a media file (audio/video) from a local file path via IPC, returning a data URL.
+ * Handles R2 hash filenames, legacy relative paths, and absolute paths.
+ */
+export function useMediaSrc(filePath: string | undefined): string | null {
+  const mudDir = useProjectStore((s) => s.project?.mudDir);
+  const assetsDir = useAssetStore((s) => s.assetsDir);
+  const [src, setSrc] = useState<string | null>(null);
+
+  const candidates = useMemo(() => {
+    if (!filePath) return [];
+
+    // R2 hash filename — resolve from local asset cache
+    if (isR2HashPath(filePath)) {
+      if (!assetsDir) return [];
+      return [
+        `${assetsDir}\\video\\${filePath}`,
+        `${assetsDir}\\audio\\${filePath}`,
+        `${assetsDir}\\images\\${filePath}`,
+      ];
+    }
+
+    // Absolute path
+    if (!isLegacyImagePath(filePath)) return [filePath];
+
+    // Legacy relative path — try MUD media directories
+    if (!mudDir) return [];
+    return [
+      `${mudDir}/src/main/resources/world/audio/${filePath}`,
+      `${mudDir}/src/main/resources/audio/${filePath}`,
+      `${mudDir}/src/main/resources/world/video/${filePath}`,
+      `${mudDir}/src/main/resources/video/${filePath}`,
+      `${mudDir}/src/main/resources/world/images/${filePath}`,
+      `${mudDir}/src/main/resources/images/${filePath}`,
+    ];
+  }, [filePath, mudDir, assetsDir]);
+
+  useEffect(() => {
+    if (candidates.length === 0) {
+      setSrc(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      for (const path of candidates) {
+        if (cancelled) return;
+        try {
+          const dataUrl = await invoke<string>("read_media_data_url", { path });
+          if (!cancelled) setSrc(dataUrl);
+          return;
+        } catch {
+          // Try next candidate
+        }
+      }
+      if (!cancelled) setSrc(null);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [candidates]);
+
+  return src;
+}


### PR DESCRIPTION
## Summary
- Full audio/video support across the asset pipeline: import, R2 sync, migration, and YAML rewriting
- New **MediaPicker** component with HTML5 `<audio>` and `<video>` preview + file picker
- **Rooms** get editable Video, Music, Ambient, and Audio fields with pickers
- **Mobs** and **Items** get editable Video field
- **Batch import** now scans images/, audio/, and video/ directories and auto-detects asset type
- **R2 migration** rewrites `video:`, `music:`, `ambient:`, and `audio:` YAML keys to R2 hash filenames (alongside existing `image:` support)
- Assets stored in content-addressed subdirs: `assets/images/`, `assets/video/`, `assets/audio/`

## Test plan
- [ ] Open a room — Video, Music, Ambient, Audio sections visible with text inputs and pickers
- [ ] Pick an audio file — imports, previews inline with `<audio>` player
- [ ] Pick a video file — imports, previews inline with `<video>` player
- [ ] Open mob/item editor — Video field visible in Media section
- [ ] Save zone — video/audio fields persist in YAML
- [ ] Batch import scans audio/video directories alongside images
- [ ] R2 sync uploads audio/video files with correct MIME types
- [ ] Migration rewrites video:/music:/ambient:/audio: refs in zone YAMLs
- [ ] `bunx tsc --noEmit` passes, `bun run test` passes (159 tests)