### PR TITLE
Add descriptions and gameplay hints to all config panel settings

### DIFF
--- a/creator/src/components/config/panels/CharacterCreationPanel.tsx
+++ b/creator/src/components/config/panels/CharacterCreationPanel.tsx
@@ -10,9 +10,12 @@ export function CharacterCreationPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="Character Creation">
+      <Section
+        title="Character Creation"
+        description="Initial resources given to newly created characters. Starting gold lets players buy basic equipment right away. Set to 0 for a 'start from nothing' experience where players must earn their first gear."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Starting Gold">
+          <FieldRow label="Starting Gold" hint="Gold given to new characters. 0 = earn everything. 50-100 = enough for a basic weapon. 500+ = well-equipped start.">
             <NumberInput
               value={cc.startingGold}
               onCommit={(v) => patch({ startingGold: v ?? 0 })}
@@ -39,7 +42,7 @@ export function CharacterCreationPanel({ config, onChange }: ConfigPanelProps) {
                 onCommit={(v) => patchGender({ displayName: v })}
               />
             </FieldRow>
-            <FieldRow label="Sprite Code">
+            <FieldRow label="Sprite Code" hint="Code used in sprite filenames (e.g. 'm' or 'f'). Defaults to the gender's ID if left blank.">
               <TextInput
                 value={g.spriteCode ?? ""}
                 onCommit={(v) => patchGender({ spriteCode: v || undefined })}

--- a/creator/src/components/config/panels/CombatPanel.tsx
+++ b/creator/src/components/config/panels/CombatPanel.tsx
@@ -13,16 +13,19 @@ export function CombatPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="Timing">
+      <Section
+        title="Timing"
+        description="Controls the pace of combat. Each tick, the server processes one round of attacks for all active fights. Shorter ticks feel faster and more action-oriented; longer ticks give players more time to react and use abilities."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Tick (ms)">
+          <FieldRow label="Tick (ms)" hint="Milliseconds between combat rounds. 2000ms (2s) is a classic MUD pace. Try 1500 for faster action or 3000 for a more strategic feel.">
             <NumberInput
               value={c.tickMillis}
               onCommit={(v) => patch({ tickMillis: v ?? 2000 })}
               min={100}
             />
           </FieldRow>
-          <FieldRow label="Max / Tick">
+          <FieldRow label="Max / Tick" hint="Maximum simultaneous combats processed per tick. Higher values support more concurrent fights but increase server load. 20 is comfortable for most MUDs.">
             <NumberInput
               value={c.maxCombatsPerTick}
               onCommit={(v) => patch({ maxCombatsPerTick: v ?? 20 })}
@@ -32,16 +35,19 @@ export function CombatPanel({ config, onChange }: ConfigPanelProps) {
         </div>
       </Section>
 
-      <Section title="Base Damage">
+      <Section
+        title="Base Damage"
+        description="Unarmed/base damage range before stat bonuses, equipment, and abilities are applied. This is the floor for all combat damage calculations."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Min Damage">
+          <FieldRow label="Min Damage" hint="Minimum base damage per hit. Even with bad rolls, players deal at least this much. Set to 0 for potential misses, 1+ to guarantee some damage.">
             <NumberInput
               value={c.minDamage}
               onCommit={(v) => patch({ minDamage: v ?? 1 })}
               min={0}
             />
           </FieldRow>
-          <FieldRow label="Max Damage">
+          <FieldRow label="Max Damage" hint="Maximum base damage per hit. The gap between min and max creates variance — a wider range feels more unpredictable. Suggested: 3-6 for low-level content.">
             <NumberInput
               value={c.maxDamage}
               onCommit={(v) => patch({ maxDamage: v ?? 4 })}
@@ -51,7 +57,10 @@ export function CombatPanel({ config, onChange }: ConfigPanelProps) {
         </div>
       </Section>
 
-      <Section title="Feedback">
+      <Section
+        title="Feedback"
+        description="Combat feedback shows damage numbers and hit/miss messages to players. Room broadcast lets bystanders see fights happening around them, adding immersion."
+      >
         <div className="flex flex-col gap-1.5">
           <CheckboxInput
             checked={c.feedback.enabled}

--- a/creator/src/components/config/panels/CraftingPanel.tsx
+++ b/creator/src/components/config/panels/CraftingPanel.tsx
@@ -10,23 +10,26 @@ export function CraftingPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="Skill Progression">
+      <Section
+        title="Skill Progression"
+        description="Crafting skills level independently from character level. The XP formula is: XP(level) = baseXp * level^exponent. Higher exponents make mastery take significantly longer, rewarding dedicated crafters."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Max Skill Level">
+          <FieldRow label="Max Skill Level" hint="Cap for all crafting skills. 100 is the classic 'mastery' target. Lower values (e.g. 50) make crafting easier to max out.">
             <NumberInput
               value={c.maxSkillLevel}
               onCommit={(v) => patch({ maxSkillLevel: v ?? 100 })}
               min={1}
             />
           </FieldRow>
-          <FieldRow label="Base XP / Level">
+          <FieldRow label="Base XP / Level" hint="XP constant in the skill-up formula. Higher values make each level take longer. 50 is a moderate pace.">
             <NumberInput
               value={c.baseXpPerLevel}
               onCommit={(v) => patch({ baseXpPerLevel: v ?? 50 })}
               min={1}
             />
           </FieldRow>
-          <FieldRow label="XP Exponent">
+          <FieldRow label="XP Exponent" hint="Growth rate of XP requirements. 1.0 = linear (every level takes the same effort). 1.5 = moderate curve. 2.0+ = steep late-game grind.">
             <NumberInput
               value={c.xpExponent}
               onCommit={(v) => patch({ xpExponent: v ?? 1.5 })}
@@ -37,16 +40,19 @@ export function CraftingPanel({ config, onChange }: ConfigPanelProps) {
         </div>
       </Section>
 
-      <Section title="Gathering">
+      <Section
+        title="Gathering"
+        description="Controls the resource-gathering loop. Gathering cooldown determines how often players can harvest nodes, while the station bonus rewards players who craft at dedicated stations rather than in the field."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Cooldown (ms)">
+          <FieldRow label="Cooldown (ms)" hint="Delay between gathering attempts on the same node. 3000ms (3s) feels responsive. Higher values (10000+) make gathering a slower, more deliberate activity.">
             <NumberInput
               value={c.gatherCooldownMs}
               onCommit={(v) => patch({ gatherCooldownMs: v ?? 3000 })}
               min={0}
             />
           </FieldRow>
-          <FieldRow label="Station Bonus">
+          <FieldRow label="Station Bonus" hint="Extra items yielded when gathering at a crafting station vs. in the field. 1 = one bonus item. Set to 0 to remove the station advantage.">
             <NumberInput
               value={c.stationBonusQuantity}
               onCommit={(v) => patch({ stationBonusQuantity: v ?? 1 })}
@@ -73,7 +79,7 @@ export function CraftingPanel({ config, onChange }: ConfigPanelProps) {
                 onCommit={(v) => patch({ displayName: v })}
               />
             </FieldRow>
-            <FieldRow label="Type">
+            <FieldRow label="Type" hint="Gathering skills harvest raw materials; Crafting skills transform materials into items.">
               <SelectInput
                 value={s.type}
                 onCommit={(v) => patch({ type: v })}
@@ -97,7 +103,7 @@ export function CraftingPanel({ config, onChange }: ConfigPanelProps) {
         defaultItem={(raw) => ({ displayName: raw })}
         renderSummary={() => ""}
         renderDetail={(_id, s, patch) => (
-          <FieldRow label="Display Name">
+          <FieldRow label="Display Name" hint="Name shown to players (e.g. Forge, Alchemy Table, Loom).">
             <TextInput
               value={s.displayName}
               onCommit={(v) => patch({ displayName: v })}

--- a/creator/src/components/config/panels/EconomyPanel.tsx
+++ b/creator/src/components/config/panels/EconomyPanel.tsx
@@ -8,9 +8,12 @@ export function EconomyPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="Multipliers">
+      <Section
+        title="Multipliers"
+        description="Shop price multipliers control the gold economy. The buy multiplier scales the cost of purchasing items, while the sell multiplier determines how much players get back. A sell multiplier below the buy multiplier creates a gold sink that prevents inflation."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Buy Multiplier">
+          <FieldRow label="Buy Multiplier" hint="Multiplied against an item's base price when purchasing from shops. 1.0 = full price. Values above 1.0 make items more expensive, creating a tighter economy.">
             <NumberInput
               value={e.buyMultiplier}
               onCommit={(v) => patch({ buyMultiplier: v ?? 1.0 })}
@@ -18,7 +21,7 @@ export function EconomyPanel({ config, onChange }: ConfigPanelProps) {
               step={0.1}
             />
           </FieldRow>
-          <FieldRow label="Sell Multiplier">
+          <FieldRow label="Sell Multiplier" hint="Multiplied against an item's base price when selling to shops. 0.5 = half price (classic MUD default). Lower values are a stronger gold sink. Set to 0 to disable selling entirely.">
             <NumberInput
               value={e.sellMultiplier}
               onCommit={(v) => patch({ sellMultiplier: v ?? 0.5 })}

--- a/creator/src/components/config/panels/GroupPanel.tsx
+++ b/creator/src/components/config/panels/GroupPanel.tsx
@@ -27,23 +27,26 @@ export function GroupPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="Group Settings">
+      <Section
+        title="Group Settings"
+        description="Groups let players team up for combat and exploration. Members in a group share XP from kills. Larger groups are more powerful but split XP more ways — the XP bonus per member offsets this to encourage grouping."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Max Size">
+          <FieldRow label="Max Size" hint="Maximum players in a group. 5 is the classic party size. Larger groups (8-10) suit raid-style content.">
             <NumberInput
               value={g.maxSize}
               onCommit={(v) => patch({ maxSize: v ?? 5 })}
               min={2}
             />
           </FieldRow>
-          <FieldRow label="Invite Timeout">
+          <FieldRow label="Invite Timeout" hint="Milliseconds before a group invite expires. 60000ms (1 minute) is standard. Shorter timeouts prevent stale invites.">
             <NumberInput
               value={g.inviteTimeoutMs}
               onCommit={(v) => patch({ inviteTimeoutMs: v ?? 60000 })}
               min={1000}
             />
           </FieldRow>
-          <FieldRow label="XP Bonus / Member">
+          <FieldRow label="XP Bonus / Member" hint="Fractional XP bonus per additional group member. 0.1 = +10% per member, so a 5-person group gets +40% total XP. Encourages grouping without making it mandatory.">
             <NumberInput
               value={g.xpBonusPerMember}
               onCommit={(v) => patch({ xpBonusPerMember: v ?? 0.1 })}
@@ -54,9 +57,12 @@ export function GroupPanel({ config, onChange }: ConfigPanelProps) {
         </div>
       </Section>
 
-      <Section title="Guild Settings">
+      <Section
+        title="Guild Settings"
+        description="Guilds are persistent player organizations. The founder rank is assigned to the guild creator, and new members receive the default rank. Configure rank names and permissions below."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Founder Rank">
+          <FieldRow label="Founder Rank" hint="Rank automatically assigned to the player who creates a new guild. Should have all permissions.">
             <SelectInput
               value={config.guild.founderRank}
               onCommit={(v) => onChange({ guild: { ...config.guild, founderRank: v } })}
@@ -66,7 +72,7 @@ export function GroupPanel({ config, onChange }: ConfigPanelProps) {
               }))}
             />
           </FieldRow>
-          <FieldRow label="Default Rank">
+          <FieldRow label="Default Rank" hint="Rank given to new guild members when they join. Should have minimal permissions.">
             <SelectInput
               value={config.guild.defaultRank}
               onCommit={(v) => onChange({ guild: { ...config.guild, defaultRank: v } })}
@@ -96,7 +102,7 @@ export function GroupPanel({ config, onChange }: ConfigPanelProps) {
                 onCommit={(v) => patchRank({ displayName: v })}
               />
             </FieldRow>
-            <FieldRow label="Level">
+            <FieldRow label="Level" hint="Numeric rank level used for ordering. Higher = more authority. The founder rank should have the highest level.">
               <NumberInput
                 value={r.level}
                 onCommit={(v) => patchRank({ level: v ?? 0 })}

--- a/creator/src/components/config/panels/ImagesPanel.tsx
+++ b/creator/src/components/config/panels/ImagesPanel.tsx
@@ -23,9 +23,12 @@ export function ImagesPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="Image Serving">
+      <Section
+        title="Image Serving"
+        description="Base URL for serving images to the game client. In production this typically points to your CDN or Cloudflare R2 custom domain."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Base URL">
+          <FieldRow label="Base URL" hint="URL prefix for all image assets. Use '/images/' for local serving, or a full CDN URL like 'https://assets.yourgame.com/' for production.">
             <TextInput
               value={img.baseUrl}
               onCommit={(v) => patch({ baseUrl: v || "/images/" })}
@@ -35,7 +38,10 @@ export function ImagesPanel({ config, onChange }: ConfigPanelProps) {
         </div>
       </Section>
 
-      <Section title="Player Sprite Tiers">
+      <Section
+        title="Player Sprite Tiers"
+        description="Player characters use different sprite art at different level ranges, giving visual progression as they advance. The server picks the highest tier threshold at or below the player's level."
+      >
         <p className="mb-2 text-[10px] text-text-muted">
           Level breakpoints for player sprite art. Sprites use the filename
           format:{" "}
@@ -44,27 +50,20 @@ export function ImagesPanel({ config, onChange }: ConfigPanelProps) {
           </code>
         </p>
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Level Tiers">
+          <FieldRow label="Level Tiers" hint="Comma-separated descending thresholds. Level 25 matches l20 (highest threshold at or below level). More tiers = more visual variety.">
             <TextInput
               value={tierDraft}
               onCommit={commitTiers}
               placeholder="50, 40, 30, 20, 10, 1"
             />
           </FieldRow>
-          <p className="ml-[6.5rem] text-[10px] text-text-muted">
-            Comma-separated descending thresholds. Level 25 matches l20 (highest
-            threshold &le; level).
-          </p>
-          <FieldRow label="Staff Tier">
+          <FieldRow label="Staff Tier" hint="Special tier used for staff/admin sprites. Default 60 is above the normal max (50) so staff always look distinct.">
             <NumberInput
               value={img.staffSpriteTier}
               onCommit={(v) => patch({ staffSpriteTier: v ?? 60 })}
               min={1}
             />
           </FieldRow>
-          <p className="ml-[6.5rem] text-[10px] text-text-muted">
-            Tier used for staff members (default 60).
-          </p>
         </div>
       </Section>
     </>

--- a/creator/src/components/config/panels/MobTiersPanel.tsx
+++ b/creator/src/components/config/panels/MobTiersPanel.tsx
@@ -4,18 +4,25 @@ import { Section, FieldRow, NumberInput } from "@/components/ui/FormWidgets";
 
 const TIER_NAMES = ["weak", "standard", "elite", "boss"] as const;
 
-const TIER_FIELDS: { key: keyof MobTierConfig; label: string }[] = [
-  { key: "baseHp", label: "Base HP" },
-  { key: "hpPerLevel", label: "HP / Level" },
-  { key: "baseMinDamage", label: "Min Damage" },
-  { key: "baseMaxDamage", label: "Max Damage" },
-  { key: "damagePerLevel", label: "Dmg / Level" },
-  { key: "baseArmor", label: "Armor" },
-  { key: "baseXpReward", label: "Base XP" },
-  { key: "xpRewardPerLevel", label: "XP / Level" },
-  { key: "baseGoldMin", label: "Gold Min" },
-  { key: "baseGoldMax", label: "Gold Max" },
-  { key: "goldPerLevel", label: "Gold / Level" },
+const TIER_DESCRIPTIONS: Record<(typeof TIER_NAMES)[number], string> = {
+  weak: "Fodder mobs meant to be dispatched quickly. Good for new players learning combat and for populating areas with ambient danger. Typically killed in 2-3 hits.",
+  standard: "Bread-and-butter enemies that provide a fair fight for on-level players. Most mobs in the world should be this tier. Expect fights lasting 4-8 rounds.",
+  elite: "Dangerous foes that require preparation or a group. Use sparingly as mini-bosses, rare spawns, or guardians. Deal significant damage and reward proportionally more XP and gold.",
+  boss: "Zone bosses and storyline antagonists. Designed for group content or high-level solo players. High HP pools create extended encounters. Generous gold and XP rewards make them worth seeking out.",
+};
+
+const TIER_FIELDS: { key: keyof MobTierConfig; label: string; hint?: string }[] = [
+  { key: "baseHp", label: "Base HP", hint: "Starting HP at level 1. Higher values mean longer fights." },
+  { key: "hpPerLevel", label: "HP / Level", hint: "HP gained per mob level. Controls how much tougher higher-level mobs feel." },
+  { key: "baseMinDamage", label: "Min Damage", hint: "Minimum damage per hit at level 1." },
+  { key: "baseMaxDamage", label: "Max Damage", hint: "Maximum damage per hit at level 1." },
+  { key: "damagePerLevel", label: "Dmg / Level", hint: "Extra damage added per mob level. Keep this modest to avoid one-shotting players." },
+  { key: "baseArmor", label: "Armor", hint: "Flat damage reduction. High armor makes mobs feel 'tanky' against weak attacks." },
+  { key: "baseXpReward", label: "Base XP", hint: "XP granted at level 1. Balance against the XP curve in Progression to control leveling speed." },
+  { key: "xpRewardPerLevel", label: "XP / Level", hint: "Additional XP per mob level. Higher values reward players for fighting tougher enemies." },
+  { key: "baseGoldMin", label: "Gold Min", hint: "Minimum gold dropped at level 1." },
+  { key: "baseGoldMax", label: "Gold Max", hint: "Maximum gold dropped at level 1. The min/max range adds loot variance." },
+  { key: "goldPerLevel", label: "Gold / Level", hint: "Extra gold per mob level. Controls how quickly gold accumulates at higher levels." },
 ];
 
 export function MobTiersPanel({ config, onChange }: ConfigPanelProps) {
@@ -29,9 +36,12 @@ export function MobTiersPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="Action Delay">
+      <Section
+        title="Action Delay"
+        description="How often mobs take autonomous actions (attacking, using abilities, wandering). Shorter delays make mobs feel more aggressive; longer delays give players breathing room between attacks."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Min Delay (ms)">
+          <FieldRow label="Min Delay (ms)" hint="Fastest a mob can act. 8000ms (8s) prevents mobs from overwhelming players. Lower values create frantic combat.">
             <NumberInput
               value={config.mobActionDelay.minActionDelayMillis}
               onCommit={(v) =>
@@ -45,7 +55,7 @@ export function MobTiersPanel({ config, onChange }: ConfigPanelProps) {
               min={0}
             />
           </FieldRow>
-          <FieldRow label="Max Delay (ms)">
+          <FieldRow label="Max Delay (ms)" hint="Slowest a mob can act. The actual delay is random between min and max. 20000ms (20s) keeps mobs from feeling idle.">
             <NumberInput
               value={config.mobActionDelay.maxActionDelayMillis}
               onCommit={(v) =>
@@ -62,10 +72,14 @@ export function MobTiersPanel({ config, onChange }: ConfigPanelProps) {
         </div>
       </Section>
       {TIER_NAMES.map((tier) => (
-        <Section key={tier} title={tier.charAt(0).toUpperCase() + tier.slice(1)}>
+        <Section
+          key={tier}
+          title={tier.charAt(0).toUpperCase() + tier.slice(1)}
+          description={TIER_DESCRIPTIONS[tier]}
+        >
           <div className="flex flex-col gap-1.5">
             {TIER_FIELDS.map((field) => (
-              <FieldRow key={field.key} label={field.label}>
+              <FieldRow key={field.key} label={field.label} hint={field.hint}>
                 <NumberInput
                   value={config.mobTiers[tier][field.key]}
                   onCommit={(v) =>

--- a/creator/src/components/config/panels/NavigationPanel.tsx
+++ b/creator/src/components/config/panels/NavigationPanel.tsx
@@ -12,9 +12,12 @@ export function NavigationPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="Recall">
+      <Section
+        title="Recall"
+        description="Recall teleports a player back to their start room. The cooldown prevents abuse as an instant escape from danger. Longer cooldowns make recall a strategic decision; shorter ones prioritize convenience."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Cooldown (ms)">
+          <FieldRow label="Cooldown (ms)" hint="300000ms = 5 minutes (classic MUD default). Set to 0 for unlimited recall. 600000ms (10 min) for a more punishing world.">
             <NumberInput
               value={recall.cooldownMs}
               onCommit={(v) => patchRecall({ cooldownMs: v ?? 300000 })}
@@ -24,46 +27,49 @@ export function NavigationPanel({ config, onChange }: ConfigPanelProps) {
         </div>
       </Section>
 
-      <Section title="Recall Messages">
+      <Section
+        title="Recall Messages"
+        description="Customize the messages players see during the recall process. These add flavor and communicate state to the player. Use {seconds} as a placeholder in the cooldown message."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Combat Blocked">
+          <FieldRow label="Combat Blocked" hint="Shown when a player tries to recall while in combat.">
             <TextInput
               value={recall.messages.combatBlocked}
               onCommit={(v) => patchMessages({ combatBlocked: v })}
             />
           </FieldRow>
-          <FieldRow label="Cooldown">
+          <FieldRow label="Cooldown" hint="Shown when recall is still on cooldown. Use {seconds} for the remaining time.">
             <TextInput
               value={recall.messages.cooldownRemaining}
               onCommit={(v) => patchMessages({ cooldownRemaining: v })}
               placeholder="Use {seconds} for remaining time"
             />
           </FieldRow>
-          <FieldRow label="Cast Begin">
+          <FieldRow label="Cast Begin" hint="Shown to the player when they start casting recall.">
             <TextInput
               value={recall.messages.castBegin}
               onCommit={(v) => patchMessages({ castBegin: v })}
             />
           </FieldRow>
-          <FieldRow label="Unreachable">
+          <FieldRow label="Unreachable" hint="Shown when the destination room cannot be reached (e.g. deleted or inaccessible).">
             <TextInput
               value={recall.messages.unreachable}
               onCommit={(v) => patchMessages({ unreachable: v })}
             />
           </FieldRow>
-          <FieldRow label="Depart Notice">
+          <FieldRow label="Depart Notice" hint="Broadcast to other players in the room when someone recalls away.">
             <TextInput
               value={recall.messages.departNotice}
               onCommit={(v) => patchMessages({ departNotice: v })}
             />
           </FieldRow>
-          <FieldRow label="Arrive Notice">
+          <FieldRow label="Arrive Notice" hint="Broadcast to other players in the destination room when someone arrives via recall.">
             <TextInput
               value={recall.messages.arriveNotice}
               onCommit={(v) => patchMessages({ arriveNotice: v })}
             />
           </FieldRow>
-          <FieldRow label="Arrival">
+          <FieldRow label="Arrival" hint="Shown to the player themselves upon arriving at their recall destination.">
             <TextInput
               value={recall.messages.arrival}
               onCommit={(v) => patchMessages({ arrival: v })}

--- a/creator/src/components/config/panels/ProgressionPanel.tsx
+++ b/creator/src/components/config/panels/ProgressionPanel.tsx
@@ -14,8 +14,11 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="Level Cap">
-        <FieldRow label="Max Level">
+      <Section
+        title="Level Cap"
+        description="The maximum level a player character can reach. Higher caps extend the endgame grind; lower caps let players reach max power sooner. Most classic MUDs use 30-100."
+      >
+        <FieldRow label="Max Level" hint="Suggested: 30 for a focused experience, 50 for a standard MUD, 100 for an extended grind.">
           <NumberInput
             value={p.maxLevel}
             onCommit={(v) => patchProg({ maxLevel: v ?? 50 })}
@@ -24,9 +27,12 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
         </FieldRow>
       </Section>
 
-      <Section title="XP Curve">
+      <Section
+        title="XP Curve"
+        description="Controls how much XP is needed to level up. The formula is: XP(level) = baseXp * level^exponent + linearXp * level, then multiplied by the global multiplier. Higher exponents create a steep late-game curve where each level takes dramatically more effort."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Base XP">
+          <FieldRow label="Base XP" hint="Starting XP constant in the curve formula. Higher values slow down all leveling uniformly. 100 is a good starting point.">
             <NumberInput
               value={p.xp.baseXp}
               onCommit={(v) =>
@@ -35,7 +41,7 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
               min={1}
             />
           </FieldRow>
-          <FieldRow label="Exponent">
+          <FieldRow label="Exponent" hint="How steeply XP requirements grow. 1.5 = gentle curve, 2.0 = classic quadratic, 3.0 = very steep late game. Most MUDs use 1.5-2.5.">
             <NumberInput
               value={p.xp.exponent}
               onCommit={(v) =>
@@ -45,7 +51,7 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
               step={0.1}
             />
           </FieldRow>
-          <FieldRow label="Linear XP">
+          <FieldRow label="Linear XP" hint="Flat XP added per level on top of the exponential curve. Useful for smoothing out the early-level experience. 0 disables it.">
             <NumberInput
               value={p.xp.linearXp}
               onCommit={(v) =>
@@ -54,7 +60,7 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
               min={0}
             />
           </FieldRow>
-          <FieldRow label="Multiplier">
+          <FieldRow label="Multiplier" hint="Global XP requirement multiplier. 1.0 = normal. Set below 1.0 for faster leveling (e.g. 0.5 = double speed). Useful for testing or events.">
             <NumberInput
               value={p.xp.multiplier}
               onCommit={(v) =>
@@ -64,7 +70,7 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
               step={0.1}
             />
           </FieldRow>
-          <FieldRow label="Default Kill XP">
+          <FieldRow label="Default Kill XP" hint="XP awarded per mob kill when no specific XP is set on the mob. Acts as a fallback. 50 is reasonable for standard-tier mobs near level 1.">
             <NumberInput
               value={p.xp.defaultKillXp}
               onCommit={(v) =>
@@ -76,9 +82,12 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
         </div>
       </Section>
 
-      <Section title="Level-Up Rewards">
+      <Section
+        title="Level-Up Rewards"
+        description="What players gain each time they level up. HP and Mana per level stack with class-specific bonuses defined in the Classes tab. Base values are the starting pool at level 1."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="HP / Level">
+          <FieldRow label="HP / Level" hint="Global HP gained per level, added on top of class-specific HP/level. Set to 0 if classes should fully control HP growth.">
             <NumberInput
               value={p.rewards.hpPerLevel}
               onCommit={(v) =>
@@ -89,7 +98,7 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
               min={0}
             />
           </FieldRow>
-          <FieldRow label="Mana / Level">
+          <FieldRow label="Mana / Level" hint="Global Mana gained per level. Combined with class-specific mana/level. Melee classes may not benefit from this.">
             <NumberInput
               value={p.rewards.manaPerLevel}
               onCommit={(v) =>
@@ -100,7 +109,7 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
               min={0}
             />
           </FieldRow>
-          <FieldRow label="Base HP">
+          <FieldRow label="Base HP" hint="Every character starts with this much HP at level 1, before class and stat bonuses. 10-20 is typical for a low-power start.">
             <NumberInput
               value={p.rewards.baseHp}
               onCommit={(v) =>
@@ -111,7 +120,7 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
               min={1}
             />
           </FieldRow>
-          <FieldRow label="Base Mana">
+          <FieldRow label="Base Mana" hint="Starting mana pool at level 1. Set higher if you want new players to cast several spells before running dry. 0 for mana-less systems.">
             <NumberInput
               value={p.rewards.baseMana}
               onCommit={(v) =>

--- a/creator/src/components/config/panels/RegenPanel.tsx
+++ b/creator/src/components/config/panels/RegenPanel.tsx
@@ -8,30 +8,33 @@ export function RegenPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="HP Regen">
+      <Section
+        title="HP Regen"
+        description="Controls how quickly players recover HP outside of combat. The regen interval is reduced by the HP Regen Stat binding (configured in the Stats tab), down to the minimum interval. Faster regen reduces downtime between fights."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Max / Tick">
+          <FieldRow label="Max / Tick" hint="Maximum players processed per regen tick. Higher values ensure all players regen simultaneously, but cost more CPU. 50 is fine for most servers.">
             <NumberInput
               value={r.maxPlayersPerTick}
               onCommit={(v) => patch({ maxPlayersPerTick: v ?? 50 })}
               min={1}
             />
           </FieldRow>
-          <FieldRow label="Base Interval">
+          <FieldRow label="Base Interval" hint="Milliseconds between regen ticks with no stat bonus. 5000ms (5s) means a player heals every 5 seconds at minimum. Lower = faster recovery.">
             <NumberInput
               value={r.baseIntervalMillis}
               onCommit={(v) => patch({ baseIntervalMillis: v ?? 5000 })}
               min={100}
             />
           </FieldRow>
-          <FieldRow label="Min Interval">
+          <FieldRow label="Min Interval" hint="Fastest possible regen rate even with maximum stat investment. Prevents regen from becoming instant. 1000ms (1s) is a reasonable floor.">
             <NumberInput
               value={r.minIntervalMillis}
               onCommit={(v) => patch({ minIntervalMillis: v ?? 1000 })}
               min={100}
             />
           </FieldRow>
-          <FieldRow label="Regen Amount">
+          <FieldRow label="Regen Amount" hint="HP restored per tick. 1 is slow and steady; higher values create burst healing between fights. Scale with your HP pools.">
             <NumberInput
               value={r.regenAmount}
               onCommit={(v) => patch({ regenAmount: v ?? 1 })}
@@ -41,9 +44,12 @@ export function RegenPanel({ config, onChange }: ConfigPanelProps) {
         </div>
       </Section>
 
-      <Section title="Mana Regen">
+      <Section
+        title="Mana Regen"
+        description="How quickly mana recovers. Mana regen is separate from HP regen and is reduced by the Mana Regen Stat binding. Faster mana regen lets casters use abilities more freely; slower regen makes mana a strategic resource."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Base Interval">
+          <FieldRow label="Base Interval" hint="Milliseconds between mana regen ticks at base. 3000ms (3s) is faster than HP regen by default, reflecting mana as a more fluid resource.">
             <NumberInput
               value={r.mana.baseIntervalMillis}
               onCommit={(v) =>
@@ -54,7 +60,7 @@ export function RegenPanel({ config, onChange }: ConfigPanelProps) {
               min={100}
             />
           </FieldRow>
-          <FieldRow label="Min Interval">
+          <FieldRow label="Min Interval" hint="Fastest possible mana regen rate. Same principle as HP min interval — prevents regen from trivializing mana costs.">
             <NumberInput
               value={r.mana.minIntervalMillis}
               onCommit={(v) =>
@@ -65,7 +71,7 @@ export function RegenPanel({ config, onChange }: ConfigPanelProps) {
               min={100}
             />
           </FieldRow>
-          <FieldRow label="Regen Amount">
+          <FieldRow label="Regen Amount" hint="Mana restored per tick. Higher values let casters recover faster between encounters. Balance against ability mana costs.">
             <NumberInput
               value={r.mana.regenAmount}
               onCommit={(v) =>

--- a/creator/src/components/config/panels/ServerPanel.tsx
+++ b/creator/src/components/config/panels/ServerPanel.tsx
@@ -8,9 +8,12 @@ export function ServerPanel({ config, onChange }: ConfigPanelProps) {
 
   return (
     <>
-      <Section title="Network">
+      <Section
+        title="Network"
+        description="Ports the AmbonMUD server listens on. Telnet is for traditional MUD clients; the web port serves the browser-based client and REST API. Avoid conflicts with other services on the host machine."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Telnet Port">
+          <FieldRow label="Telnet Port" hint="Classic MUD client connections. Standard MUD port is 4000. Use 23 for the well-known telnet port, though it may require elevated privileges.">
             <NumberInput
               value={s.telnetPort}
               onCommit={(v) => patch({ telnetPort: v ?? 4000 })}
@@ -18,7 +21,7 @@ export function ServerPanel({ config, onChange }: ConfigPanelProps) {
               max={65535}
             />
           </FieldRow>
-          <FieldRow label="Web Port">
+          <FieldRow label="Web Port" hint="HTTP port for the web client and API. Default 8080 avoids requiring admin privileges. Use 80 or 443 for production behind a reverse proxy.">
             <NumberInput
               value={s.webPort}
               onCommit={(v) => patch({ webPort: v ?? 8080 })}

--- a/creator/src/components/config/panels/StatsPanel.tsx
+++ b/creator/src/components/config/panels/StatsPanel.tsx
@@ -68,6 +68,7 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
     <>
       <Section
         title="Stat Definitions"
+        description="Define the core attributes for player characters. Common setups include the classic six (STR, DEX, CON, INT, WIS, CHA) or simplified systems with 3-4 stats. Each stat can be linked to game mechanics via Stat Bindings below."
         actions={
           <div className="flex items-center gap-1">
             <input
@@ -109,25 +110,25 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
                     </IconButton>
                   </div>
                   <div className="flex flex-col gap-1">
-                    <FieldRow label="Display Name">
+                    <FieldRow label="Display Name" hint="Shown in the character sheet and UI.">
                       <TextInput
                         value={def.displayName}
                         onCommit={(v) => patchDef(id, { displayName: v })}
                       />
                     </FieldRow>
-                    <FieldRow label="Abbreviation">
+                    <FieldRow label="Abbreviation" hint="Short form used in compact displays (e.g. STR, DEX).">
                       <TextInput
                         value={def.abbreviation}
                         onCommit={(v) => patchDef(id, { abbreviation: v })}
                       />
                     </FieldRow>
-                    <FieldRow label="Description">
+                    <FieldRow label="Description" hint="Flavor text explaining what this stat does for the player.">
                       <TextInput
                         value={def.description}
                         onCommit={(v) => patchDef(id, { description: v })}
                       />
                     </FieldRow>
-                    <FieldRow label="Base Value">
+                    <FieldRow label="Base Value" hint="Default value before racial modifiers and equipment. 10 is a standard neutral baseline.">
                       <NumberInput
                         value={def.baseStat}
                         onCommit={(v) => patchDef(id, { baseStat: v ?? 10 })}
@@ -142,16 +143,19 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
         )}
       </Section>
 
-      <Section title="Stat Bindings">
+      <Section
+        title="Stat Bindings"
+        description="Connect stats to game mechanics. Each binding links a stat to a formula that affects combat, regen, or progression. Divisors control how many stat points are needed per unit of effect — higher divisors make stats less impactful per point."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Melee Dmg Stat">
+          <FieldRow label="Melee Dmg Stat" hint="Which stat adds bonus melee damage. Typically Strength.">
             <SelectInput
               value={bindings.meleeDamageStat}
               onCommit={(v) => patchBindings({ meleeDamageStat: v })}
               options={statOptions}
             />
           </FieldRow>
-          <FieldRow label="Melee Divisor">
+          <FieldRow label="Melee Divisor" hint="Bonus damage = stat / divisor. At divisor 3, a stat of 15 adds +5 damage. Lower divisor = stronger scaling.">
             <NumberInput
               value={bindings.meleeDamageDivisor}
               onCommit={(v) =>
@@ -160,14 +164,14 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
               min={1}
             />
           </FieldRow>
-          <FieldRow label="Dodge Stat">
+          <FieldRow label="Dodge Stat" hint="Which stat grants dodge chance. Typically Dexterity or Agility.">
             <SelectInput
               value={bindings.dodgeStat}
               onCommit={(v) => patchBindings({ dodgeStat: v })}
               options={statOptions}
             />
           </FieldRow>
-          <FieldRow label="Dodge / Point">
+          <FieldRow label="Dodge / Point" hint="Dodge % gained per stat point. At 2.0, a stat of 15 gives 30% dodge (capped by Max Dodge %).">
             <NumberInput
               value={bindings.dodgePerPoint}
               onCommit={(v) => patchBindings({ dodgePerPoint: v ?? 2 })}
@@ -175,7 +179,7 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
               step={0.1}
             />
           </FieldRow>
-          <FieldRow label="Max Dodge %">
+          <FieldRow label="Max Dodge %" hint="Hard cap on dodge chance regardless of stat investment. 30% is a classic cap. 50%+ makes dodge builds dominant.">
             <NumberInput
               value={bindings.maxDodgePercent}
               onCommit={(v) =>
@@ -185,14 +189,14 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
               max={100}
             />
           </FieldRow>
-          <FieldRow label="Spell Dmg Stat">
+          <FieldRow label="Spell Dmg Stat" hint="Which stat adds bonus spell/ability damage. Typically Intelligence or Wisdom.">
             <SelectInput
               value={bindings.spellDamageStat}
               onCommit={(v) => patchBindings({ spellDamageStat: v })}
               options={statOptions}
             />
           </FieldRow>
-          <FieldRow label="Spell Divisor">
+          <FieldRow label="Spell Divisor" hint="Bonus spell damage = stat / divisor. Same scaling logic as melee. Typically matched to melee divisor for balance.">
             <NumberInput
               value={bindings.spellDamageDivisor}
               onCommit={(v) =>
@@ -201,14 +205,14 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
               min={1}
             />
           </FieldRow>
-          <FieldRow label="HP Scaling Stat">
+          <FieldRow label="HP Scaling Stat" hint="Which stat provides bonus max HP. Typically Constitution or Vitality.">
             <SelectInput
               value={bindings.hpScalingStat}
               onCommit={(v) => patchBindings({ hpScalingStat: v })}
               options={statOptions}
             />
           </FieldRow>
-          <FieldRow label="HP Divisor">
+          <FieldRow label="HP Divisor" hint="Bonus HP = stat / divisor. At divisor 5, a stat of 20 adds +4 max HP. Lower values make the stat more impactful.">
             <NumberInput
               value={bindings.hpScalingDivisor}
               onCommit={(v) =>
@@ -217,14 +221,14 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
               min={1}
             />
           </FieldRow>
-          <FieldRow label="Mana Stat">
+          <FieldRow label="Mana Stat" hint="Which stat provides bonus max mana. Typically Intelligence or Wisdom.">
             <SelectInput
               value={bindings.manaScalingStat}
               onCommit={(v) => patchBindings({ manaScalingStat: v })}
               options={statOptions}
             />
           </FieldRow>
-          <FieldRow label="Mana Divisor">
+          <FieldRow label="Mana Divisor" hint="Bonus mana = stat / divisor. Same logic as HP divisor but for the mana pool.">
             <NumberInput
               value={bindings.manaScalingDivisor}
               onCommit={(v) =>
@@ -233,14 +237,14 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
               min={1}
             />
           </FieldRow>
-          <FieldRow label="HP Regen Stat">
+          <FieldRow label="HP Regen Stat" hint="Which stat speeds up HP regeneration. Typically Constitution.">
             <SelectInput
               value={bindings.hpRegenStat}
               onCommit={(v) => patchBindings({ hpRegenStat: v })}
               options={statOptions}
             />
           </FieldRow>
-          <FieldRow label="HP Regen ms/pt">
+          <FieldRow label="HP Regen ms/pt" hint="Milliseconds reduced from regen interval per stat point. At 200, a stat of 10 shaves 2s off the regen timer.">
             <NumberInput
               value={bindings.hpRegenMsPerPoint}
               onCommit={(v) =>
@@ -249,14 +253,14 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
               min={1}
             />
           </FieldRow>
-          <FieldRow label="Mana Regen Stat">
+          <FieldRow label="Mana Regen Stat" hint="Which stat speeds up mana regeneration. Typically Wisdom or Intelligence.">
             <SelectInput
               value={bindings.manaRegenStat}
               onCommit={(v) => patchBindings({ manaRegenStat: v })}
               options={statOptions}
             />
           </FieldRow>
-          <FieldRow label="Mana Regen ms/pt">
+          <FieldRow label="Mana Regen ms/pt" hint="Milliseconds reduced from mana regen interval per stat point. Same mechanic as HP regen.">
             <NumberInput
               value={bindings.manaRegenMsPerPoint}
               onCommit={(v) =>
@@ -265,14 +269,14 @@ export function StatsPanel({ config, onChange }: ConfigPanelProps) {
               min={1}
             />
           </FieldRow>
-          <FieldRow label="XP Bonus Stat">
+          <FieldRow label="XP Bonus Stat" hint="Which stat grants bonus XP from kills. A niche stat that rewards players who invest in it with faster leveling.">
             <SelectInput
               value={bindings.xpBonusStat}
               onCommit={(v) => patchBindings({ xpBonusStat: v })}
               options={statOptions}
             />
           </FieldRow>
-          <FieldRow label="XP / Point">
+          <FieldRow label="XP / Point" hint="Fractional XP bonus per stat point. At 0.005, a stat of 20 gives +10% bonus XP. Keep this small to avoid snowballing.">
             <NumberInput
               value={bindings.xpBonusPerPoint}
               onCommit={(v) =>

--- a/creator/src/components/ui/FormWidgets.tsx
+++ b/creator/src/components/ui/FormWidgets.tsx
@@ -108,10 +108,12 @@ export function EditableTextArea({
 /** Collapsible section with a header label. */
 export function Section({
   title,
+  description,
   children,
   actions,
 }: {
   title: string;
+  description?: string;
   children: ReactNode;
   actions?: ReactNode;
 }) {
@@ -123,6 +125,9 @@ export function Section({
         </h4>
         {actions && <div className="ml-auto flex items-center gap-1">{actions}</div>}
       </div>
+      {description && (
+        <p className="mb-2 text-[11px] leading-relaxed text-text-muted/70">{description}</p>
+      )}
       {children}
     </div>
   );
@@ -131,16 +136,23 @@ export function Section({
 /** Labeled text input for forms. */
 export function FieldRow({
   label,
+  hint,
   children,
 }: {
   label: string;
+  hint?: string;
   children: ReactNode;
 }) {
   return (
-    <label className="flex items-center gap-2 py-0.5 text-xs">
-      <span className="w-24 shrink-0 text-text-muted">{label}</span>
-      <div className="min-w-0 flex-1">{children}</div>
-    </label>
+    <div className="py-0.5">
+      <label className="flex items-center gap-2 text-xs">
+        <span className="w-24 shrink-0 text-text-muted">{label}</span>
+        <div className="min-w-0 flex-1">{children}</div>
+      </label>
+      {hint && (
+        <p className="ml-[6.5rem] mt-0.5 text-[10px] leading-snug text-text-muted/60">{hint}</p>
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
Add optional description prop to Section and hint prop to FieldRow in FormWidgets, then populate all 12 config panels with section-level descriptions explaining what each group of settings controls, and field-level hints with suggested values, formulas, and gameplay trade-off explanations.