### PR TITLE
Wire up automatic background removal for sprite asset types

### DIFF
--- a/creator/src/components/config/panels/ApiSettingsPanel.tsx
+++ b/creator/src/components/config/panels/ApiSettingsPanel.tsx
@@ -288,8 +288,11 @@ export function ApiSettingsPanel() {
               }
               className="accent-accent"
             />
-            Auto-remove background for mob/item sprites during batch generation
+            Auto-remove background for mob/item sprites
           </label>
+          <p className="ml-6 -mt-1 text-[10px] text-text-muted/60">
+            Runs client-side AI background removal on sprite-type assets (mobs, items, abilities, player sprites, race/class portraits) after generation. The transparent version is saved as a variant alongside the original.
+          </p>
         </div>
       </div>
 

--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -8,6 +8,7 @@ import { getEnhanceSystemPrompt, ART_STYLE_LABELS, UNIVERSAL_NEGATIVE, type ArtS
 import { IMAGE_MODELS, ENTITY_DIMENSIONS, DIMENSION_PRESETS } from "@/types/assets";
 import type { AssetContext, GeneratedImage } from "@/types/assets";
 import { VariantStrip } from "./VariantStrip";
+import { removeBgAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
 
 type Stage = "idle" | "generating" | "preview";
 
@@ -233,6 +234,13 @@ export function EntityArtGenerator({
     onAccept(result.file_path);
     if (assetType) {
       await acceptAsset(result, assetType, lastEnhancedPrompt ?? undefined, context, variantGroup, true).catch(() => {});
+
+      // Auto-remove background for sprite asset types
+      if (settings?.auto_remove_bg && shouldRemoveBg(assetType) && result.data_url) {
+        removeBgAndSave(result.data_url, assetType, context, variantGroup).then(async (entry) => {
+          if (entry) await useAssetStore.getState().loadAssets();
+        });
+      }
     }
     setStage("idle");
     setResult(null);

--- a/creator/src/components/wizard/steps/CreationStep.tsx
+++ b/creator/src/components/wizard/steps/CreationStep.tsx
@@ -93,6 +93,7 @@ export function CreationStep({
         },
         acceptAsset,
       },
+      settings?.auto_remove_bg,
     );
 
     // Persist image references to zone YAML and zoneStore

--- a/creator/src/components/zone/BatchArtGenerator.tsx
+++ b/creator/src/components/zone/BatchArtGenerator.tsx
@@ -63,6 +63,7 @@ export function BatchArtGenerator({
         onWorldUpdate: onWorldChange,
         acceptAsset,
       },
+      settings?.auto_remove_bg,
     );
 
     setRunning(false);

--- a/creator/src/lib/batchArt.ts
+++ b/creator/src/lib/batchArt.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/arcanumPrompts";
 import type { GeneratedImage } from "@/types/assets";
 import { ENTITY_DIMENSIONS } from "@/types/assets";
+import { removeBgAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
 
 export function assetTypeForKind(kind: string): string {
   if (kind === "room") return "background";
@@ -141,6 +142,7 @@ export async function runBatchArtGeneration(
   concurrency: number,
   abortRef: { current: boolean },
   callbacks: ArtGenerationCallbacks,
+  autoRemoveBg?: boolean,
 ): Promise<WorldFile> {
   let updatedWorld = { ...world };
 
@@ -209,20 +211,27 @@ export async function runBatchArtGeneration(
         callbacks.onTargetUpdate(idx, { status: "done", result: image });
 
         const variantGroup = `${target.kind}:${zoneId}:${target.id}`;
+        const batchAssetType = assetTypeForKind(target.kind);
+        const batchContext = {
+          zone: zoneId,
+          entity_type: target.kind,
+          entity_id: target.id,
+        };
         await callbacks
           .acceptAsset(
             image,
-            assetTypeForKind(target.kind),
+            batchAssetType,
             finalPrompt,
-            {
-              zone: zoneId,
-              entity_type: target.kind,
-              entity_id: target.id,
-            },
+            batchContext,
             variantGroup,
             true,
           )
           .catch(() => {});
+
+        // Auto-remove background for sprite asset types
+        if (autoRemoveBg && shouldRemoveBg(batchAssetType) && image.data_url) {
+          removeBgAndSave(image.data_url, batchAssetType, batchContext, variantGroup).catch(() => {});
+        }
 
         const { kind, id } = target;
         if (kind === "room") {

--- a/creator/src/lib/useBackgroundRemoval.ts
+++ b/creator/src/lib/useBackgroundRemoval.ts
@@ -1,4 +1,6 @@
 import { useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { AssetContext, AssetEntry } from "@/types/assets";
 
 let bgRemovalModule: typeof import("@imgly/background-removal") | null = null;
 
@@ -9,6 +11,57 @@ async function loadBgRemoval() {
   return bgRemovalModule;
 }
 
+/** Standalone bg removal — works outside React components. */
+export async function removeBackground(imageDataUrl: string): Promise<Blob> {
+  const mod = await loadBgRemoval();
+  return mod.removeBackground(imageDataUrl);
+}
+
+/** Asset types that benefit from background removal (sprites, not scene backgrounds). */
+const BG_REMOVAL_TYPES = new Set([
+  "mob", "item", "entity_portrait", "ability_sprite",
+  "player_sprite", "race_portrait", "class_portrait",
+]);
+
+/** Returns true if the given asset type should have bg removal applied. */
+export function shouldRemoveBg(assetType: string): boolean {
+  return BG_REMOVAL_TYPES.has(assetType);
+}
+
+/**
+ * Run background removal on a data URL and save the result as an asset variant.
+ * Returns the saved AssetEntry, or null if removal failed.
+ */
+export async function removeBgAndSave(
+  imageDataUrl: string,
+  assetType: string,
+  context?: AssetContext,
+  variantGroup?: string,
+): Promise<AssetEntry | null> {
+  try {
+    const blob = await removeBackground(imageDataUrl);
+    const buffer = await blob.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+    let binary = "";
+    for (let i = 0; i < bytes.length; i++) {
+      binary += String.fromCharCode(bytes[i]!);
+    }
+    const b64 = btoa(binary);
+
+    const entry = await invoke<AssetEntry>("save_bytes_as_asset", {
+      bytesB64: b64,
+      assetType,
+      context: context ?? null,
+      variantGroup: variantGroup ?? null,
+    });
+    return entry;
+  } catch {
+    // BG removal is best-effort — don't block the main flow
+    return null;
+  }
+}
+
+/** React hook for background removal with loading/error state. */
 export function useBackgroundRemoval() {
   const [processing, setProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -17,8 +70,7 @@ export function useBackgroundRemoval() {
     setProcessing(true);
     setError(null);
     try {
-      const mod = await loadBgRemoval();
-      const blob = await mod.removeBackground(imageDataUrl);
+      const blob = await removeBackground(imageDataUrl);
       return blob;
     } catch (e) {
       const msg = String(e);


### PR DESCRIPTION
Connect the existing useBackgroundRemoval hook and save_bytes_as_asset command into the image generation pipeline. When auto_remove_bg is enabled in settings, sprite-type assets (mobs, items, abilities, player sprites, race/class portraits) automatically get a transparent-background variant saved alongside the original after generation.

- Export standalone removeBackground() and removeBgAndSave() from the bg removal module for use outside React components
- Add shouldRemoveBg() helper to check asset types that need it
- Wire into EntityArtGenerator.handleAccept (single generation)
- Wire into batchArt.ts worker loop (batch generation)
- Pass autoRemoveBg flag from BatchArtGenerator and CreationStep
- Update ApiSettingsPanel checkbox label with description of what it does