### PR TITLE
Add backstory, concept art, and field hints to Classes panel

### DIFF
--- a/creator/src/components/config/panels/ClassesPanel.tsx
+++ b/creator/src/components/config/panels/ClassesPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useState } from "react";
 import type { ConfigPanelProps } from "./types";
 import type { ClassDefinitionConfig } from "@/types/config";
 import {
@@ -10,6 +10,9 @@ import {
 } from "@/components/ui/FormWidgets";
 import { RegistryPanel } from "./RegistryPanel";
 import { renameClassInConfig } from "@/lib/refactorId";
+import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import { composePrompt, type ArtStyle } from "@/lib/arcanumPrompts";
+import { useAssetStore } from "@/stores/assetStore";
 
 export function ClassesPanel({ config, onChange }: ConfigPanelProps) {
   const statOptions = useMemo(
@@ -46,78 +49,189 @@ export function ClassesPanel({ config, onChange }: ConfigPanelProps) {
         manaPerLevel: 8,
         selectable: true,
       })}
-      renderSummary={(_id, cls) =>
-        `HP+${cls.hpPerLevel} / MP+${cls.manaPerLevel}`
-      }
-      renderDetail={(_id, cls, patch) => (
-        <>
-          <FieldRow label="Display Name">
-            <TextInput
-              value={cls.displayName}
-              onCommit={(v) => patch({ displayName: v })}
-            />
-          </FieldRow>
-          <FieldRow label="Description">
-            <TextInput
-              value={cls.description ?? ""}
-              onCommit={(v) => patch({ description: v || undefined })}
-              placeholder="optional"
-            />
-          </FieldRow>
-          <FieldRow label="HP / Level">
-            <NumberInput
-              value={cls.hpPerLevel}
-              onCommit={(v) => patch({ hpPerLevel: v ?? 6 })}
-              min={0}
-            />
-          </FieldRow>
-          <FieldRow label="Mana / Level">
-            <NumberInput
-              value={cls.manaPerLevel}
-              onCommit={(v) => patch({ manaPerLevel: v ?? 8 })}
-              min={0}
-            />
-          </FieldRow>
-          <FieldRow label="Primary Stat">
-            <SelectInput
-              value={cls.primaryStat ?? ""}
-              onCommit={(v) => patch({ primaryStat: v || undefined })}
-              options={statOptions}
-              allowEmpty
-              placeholder="-- none --"
-            />
-          </FieldRow>
-          <FieldRow label="Start Room">
-            <TextInput
-              value={cls.startRoom ?? ""}
-              onCommit={(v) => patch({ startRoom: v || undefined })}
-              placeholder="zone:room_id"
-            />
-          </FieldRow>
-          <FieldRow label="Threat Mult.">
-            <NumberInput
-              value={cls.threatMultiplier ?? 1.0}
-              onCommit={(v) => patch({ threatMultiplier: v ?? 1.0 })}
-              min={0}
-              step={0.1}
-            />
-          </FieldRow>
-          <CheckboxInput
-            checked={cls.selectable ?? true}
-            onCommit={(v) => patch({ selectable: v })}
-            label="Selectable at character creation"
-          />
-
-          <HpManaCurve
-            hpPerLevel={cls.hpPerLevel}
-            manaPerLevel={cls.manaPerLevel}
-            maxLevel={maxLevel}
-            baseHp={config.progression.rewards.baseHp}
-            baseMana={config.progression.rewards.baseMana}
-          />
-        </>
+      renderSummary={(_id, cls) => {
+        const parts = [`HP+${cls.hpPerLevel} / MP+${cls.manaPerLevel}`];
+        if (cls.image) parts.push("art");
+        return parts.join(" | ");
+      }}
+      renderDetail={(id, cls, patch) => (
+        <ClassDetail
+          id={id}
+          cls={cls}
+          patch={patch}
+          statOptions={statOptions}
+          maxLevel={maxLevel}
+          baseHp={config.progression.rewards.baseHp}
+          baseMana={config.progression.rewards.baseMana}
+        />
       )}
     />
+  );
+}
+
+function ClassDetail({
+  id,
+  cls,
+  patch,
+  statOptions,
+  maxLevel,
+  baseHp,
+  baseMana,
+}: {
+  id: string;
+  cls: ClassDefinitionConfig;
+  patch: (p: Partial<ClassDefinitionConfig>) => void;
+  statOptions: { value: string; label: string }[];
+  maxLevel: number;
+  baseHp: number;
+  baseMana: number;
+}) {
+  const assetsDir = useAssetStore((s) => s.assetsDir);
+
+  const imagePath = cls.image && assetsDir
+    ? `${assetsDir}\\images\\${cls.image}`
+    : undefined;
+
+  const buildContext = () => {
+    const parts = [`Class: ${cls.displayName}`];
+    if (cls.description) parts.push(`Tagline: ${cls.description}`);
+    if (cls.backstory) parts.push(`Backstory: ${cls.backstory}`);
+    if (cls.primaryStat) parts.push(`Primary stat: ${cls.primaryStat}`);
+    parts.push(`HP/level: ${cls.hpPerLevel}, Mana/level: ${cls.manaPerLevel}`);
+    if (cls.threatMultiplier != null && cls.threatMultiplier !== 1.0) {
+      parts.push(`Threat multiplier: ${cls.threatMultiplier}`);
+    }
+    return parts.join("\n");
+  };
+
+  return (
+    <>
+      <FieldRow label="Display Name">
+        <TextInput
+          value={cls.displayName}
+          onCommit={(v) => patch({ displayName: v })}
+        />
+      </FieldRow>
+      <FieldRow label="Description" hint="Short tagline shown during character creation (e.g. 'Master of arcane forces').">
+        <TextInput
+          value={cls.description ?? ""}
+          onCommit={(v) => patch({ description: v || undefined })}
+          placeholder="Short tagline"
+        />
+      </FieldRow>
+
+      {/* Backstory */}
+      <ClassBackstory
+        value={cls.backstory ?? ""}
+        onChange={(v) => patch({ backstory: v || undefined })}
+      />
+
+      <FieldRow label="HP / Level" hint="Class-specific HP gained per level, stacked with the global HP/level in Progression.">
+        <NumberInput
+          value={cls.hpPerLevel}
+          onCommit={(v) => patch({ hpPerLevel: v ?? 6 })}
+          min={0}
+        />
+      </FieldRow>
+      <FieldRow label="Mana / Level" hint="Class-specific mana gained per level. Set high for casters, low for melee.">
+        <NumberInput
+          value={cls.manaPerLevel}
+          onCommit={(v) => patch({ manaPerLevel: v ?? 8 })}
+          min={0}
+        />
+      </FieldRow>
+      <FieldRow label="Primary Stat" hint="The stat this class benefits from most. Used for UI hints and may influence ability scaling.">
+        <SelectInput
+          value={cls.primaryStat ?? ""}
+          onCommit={(v) => patch({ primaryStat: v || undefined })}
+          options={statOptions}
+          allowEmpty
+          placeholder="-- none --"
+        />
+      </FieldRow>
+      <FieldRow label="Start Room" hint="Override the default start room for this class. Leave blank to use the world default.">
+        <TextInput
+          value={cls.startRoom ?? ""}
+          onCommit={(v) => patch({ startRoom: v || undefined })}
+          placeholder="zone:room_id"
+        />
+      </FieldRow>
+      <FieldRow label="Threat Mult." hint="Scales aggro generation. >1.0 for tanks (draw more aggro), <1.0 for healers/DPS (draw less).">
+        <NumberInput
+          value={cls.threatMultiplier ?? 1.0}
+          onCommit={(v) => patch({ threatMultiplier: v ?? 1.0 })}
+          min={0}
+          step={0.1}
+        />
+      </FieldRow>
+      <CheckboxInput
+        checked={cls.selectable ?? true}
+        onCommit={(v) => patch({ selectable: v })}
+        label="Selectable at character creation"
+      />
+
+      <HpManaCurve
+        hpPerLevel={cls.hpPerLevel}
+        manaPerLevel={cls.manaPerLevel}
+        maxLevel={maxLevel}
+        baseHp={baseHp}
+        baseMana={baseMana}
+      />
+
+      {/* Concept Art */}
+      <div className="mt-1 border-t border-border-muted pt-1.5">
+        <h5 className="mb-1 text-[10px] font-display uppercase tracking-widest text-text-muted">
+          Concept Art
+        </h5>
+        <EntityArtGenerator
+          getPrompt={(style: ArtStyle) =>
+            composePrompt("class_portrait", style, `Class: ${cls.displayName}`)
+          }
+          entityContext={buildContext()}
+          currentImage={imagePath}
+          onAccept={(filePath) => {
+            const fileName = filePath.split(/[\\/]/).pop() ?? "";
+            patch({ image: fileName });
+          }}
+          assetType="class_portrait"
+          context={{ zone: "", entity_type: "class", entity_id: id }}
+        />
+      </div>
+    </>
+  );
+}
+
+/** Multi-line backstory editor */
+function ClassBackstory({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+  const [focused, setFocused] = useState(false);
+
+  if (!focused && draft !== value) {
+    setDraft(value);
+  }
+
+  return (
+    <div className="mt-1">
+      <label className="text-xs text-text-muted">Backstory</label>
+      <textarea
+        rows={3}
+        className="mt-0.5 w-full resize-y rounded border border-border-default bg-bg-primary px-1.5 py-1 text-xs leading-relaxed text-text-primary outline-none focus:border-accent/50"
+        placeholder="Lore, training traditions, role in the world..."
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => {
+          setFocused(false);
+          if (draft !== value) onChange(draft);
+        }}
+      />
+    </div>
   );
 }
 

--- a/creator/src/lib/arcanumPrompts.ts
+++ b/creator/src/lib/arcanumPrompts.ts
@@ -125,6 +125,13 @@ export const ASSET_TEMPLATES: Record<AssetType, { label: string; templates: Reco
       gentle_magic: `A fantasy character portrait in a gentle enchanted setting — the character stands in a natural adventuring pose, rendered with faithful anatomy and detailed equipment appropriate to their class and level, soft ambient light in lavender and pale blue creates a dreamlike atmosphere, the character's race and gender are clearly depicted with warm approachable features, equipment has a handcrafted quality with subtle magical glow, floating motes of light and gentle atmospheric haze surround the figure, small organic details like moss or tiny flowers at their feet, centered square portrait composition, painterly, luminous, dreamlike, characterful`,
     },
   },
+  class_portrait: {
+    label: "Class Portrait",
+    templates: {
+      arcanum: `A full-body concept art portrait of a fantasy class archetype standing in a dramatic heroic pose against deep cosmic indigo void, the figure rendered with faithful anatomy wearing iconic class-defining armor and equipment — a warrior in plate with greatsword, a mage in flowing robes with arcane focus, a rogue in leather with daggers — baroque aurum-gold energy scrollwork frames the figure as an ornate vertical portrait border, warm golden light illuminates the subject from a central point creating soft bloom on key features, cool blue-violet atmospheric fill provides depth, the character's posture and gear instantly communicate their combat role, vertical portrait composition with the full figure visible head to toe, painterly, luminous, extremely detailed, archetypal and iconic`,
+      gentle_magic: `A full-body concept art portrait of a fantasy class archetype in a natural confident pose within a gentle enchanted setting, the figure rendered with faithful anatomy wearing iconic class-defining armor and equipment — a warrior in plate with greatsword, a mage in flowing robes with arcane focus, a rogue in leather with daggers — soft ambient light in lavender and pale blue creates a dreamlike atmosphere around the figure, small organic details like floating motes of light and gentle atmospheric haze frame the composition, the character's posture and gear instantly communicate their combat role, the figure feels approachable and heroic, vertical portrait composition with the full figure visible head to toe, painterly, luminous, dreamlike, characterful and iconic`,
+    },
+  },
   race_portrait: {
     label: "Race Portrait",
     templates: {

--- a/creator/src/lib/saveConfig.ts
+++ b/creator/src/lib/saveConfig.ts
@@ -162,10 +162,12 @@ export async function saveConfig(mudDir: string): Promise<void> {
           manaPerLevel: cls.manaPerLevel,
         };
         if (cls.description) obj.description = cls.description;
+        if (cls.backstory) obj.backstory = cls.backstory;
         if (cls.primaryStat) obj.primaryStat = cls.primaryStat;
         if (cls.selectable != null) obj.selectable = cls.selectable;
         if (cls.startRoom) obj.startRoom = cls.startRoom;
         if (cls.threatMultiplier != null) obj.threatMultiplier = cls.threatMultiplier;
+        if (cls.image) obj.image = cls.image;
         return obj;
       },
     );

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -49,7 +49,8 @@ export type AssetType =
   | "mob"
   | "item"
   | "player_sprite"
-  | "race_portrait";
+  | "race_portrait"
+  | "class_portrait";
 
 /** Mirrors the Rust Settings struct */
 export interface Settings {

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -286,12 +286,14 @@ export interface GuildRankDefinition {
 export interface ClassDefinitionConfig {
   displayName: string;
   description?: string;
+  backstory?: string;
   hpPerLevel: number;
   manaPerLevel: number;
   primaryStat?: string;
   selectable?: boolean;
   startRoom?: string;
   threatMultiplier?: number;
+  image?: string;
 }
 
 // ─── Character Creation ────────────────────────────────────────────


### PR DESCRIPTION
Enhance ClassesPanel to match RacesPanel with a multi-line backstory textarea and EntityArtGenerator for class concept art. Add class_portrait asset type with arcanum and gentle_magic prompt templates. Persist new backstory and image fields in saveConfig. Add hint text to all class fields explaining gameplay impact.