### PR TITLE
Add sketch import for hand-drawn map conversion

### DIFF
--- a/creator/src-tauri/src/anthropic.rs
+++ b/creator/src-tauri/src/anthropic.rs
@@ -17,6 +17,39 @@ struct AnthropicMessage {
     content: String,
 }
 
+// ─── Vision support ─────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ContentBlock {
+    Text { text: String },
+    Image { source: ImageSource },
+}
+
+#[derive(Debug, Serialize)]
+struct ImageSource {
+    #[serde(rename = "type")]
+    source_type: String,
+    media_type: String,
+    data: String,
+}
+
+#[derive(Debug, Serialize)]
+struct VisionMessage {
+    role: String,
+    content: Vec<ContentBlock>,
+}
+
+#[derive(Debug, Serialize)]
+struct VisionRequest {
+    model: String,
+    max_tokens: u32,
+    system: String,
+    messages: Vec<VisionMessage>,
+}
+
+// ─── Shared response types ──────────────────────────────────────────
+
 #[derive(Debug, Deserialize)]
 struct AnthropicResponse {
     content: Vec<AnthropicContent>,
@@ -41,6 +74,64 @@ pub async fn complete(
         messages: vec![AnthropicMessage {
             role: "user".to_string(),
             content: user_prompt.to_string(),
+        }],
+    };
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(API_URL)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", API_VERSION)
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Anthropic API request failed: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("Anthropic API error ({status}): {text}"));
+    }
+
+    let resp: AnthropicResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Anthropic response: {e}"))?;
+
+    resp.content
+        .first()
+        .map(|c| c.text.clone())
+        .ok_or_else(|| "No content in Anthropic response".to_string())
+}
+
+pub async fn complete_with_vision(
+    api_key: &str,
+    model: &str,
+    system_prompt: &str,
+    user_prompt: &str,
+    image_base64: &str,
+    media_type: &str,
+    max_tokens: u32,
+) -> Result<String, String> {
+    let body = VisionRequest {
+        model: model.to_string(),
+        max_tokens,
+        system: system_prompt.to_string(),
+        messages: vec![VisionMessage {
+            role: "user".to_string(),
+            content: vec![
+                ContentBlock::Image {
+                    source: ImageSource {
+                        source_type: "base64".to_string(),
+                        media_type: media_type.to_string(),
+                        data: image_base64.to_string(),
+                    },
+                },
+                ContentBlock::Text {
+                    text: user_prompt.to_string(),
+                },
+            ],
         }],
     };
 

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod r2;
 mod runware;
 mod server;
 mod settings;
+mod sketch;
 mod vibes;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -69,6 +70,7 @@ pub fn run() {
             vibes::load_zone_vibe,
             arcanum_meta::load_arcanum_meta,
             arcanum_meta::save_arcanum_meta,
+            sketch::analyze_sketch,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/creator/src-tauri/src/sketch.rs
+++ b/creator/src-tauri/src/sketch.rs
@@ -1,0 +1,51 @@
+use tauri::AppHandle;
+
+use crate::{anthropic, settings};
+
+const SKETCH_MODEL: &str = "claude-sonnet-4-20250514";
+
+const SYSTEM_PROMPT: &str = r#"You are analyzing a hand-drawn map for a text-based MUD game.
+Identify rooms (rectangles, squares, circles, or any enclosed shapes) and
+connections (lines between shapes). Read any text labels as room names.
+
+Assign each room a grid coordinate (gridX, gridY) based on spatial position:
+- Leftmost rooms get the lowest gridX, topmost rooms get the lowest gridY
+- Adjacent rooms should differ by 1 in gridX or gridY
+- Diagonal adjacency is allowed
+
+Return ONLY valid JSON with no markdown fences, no explanation, no extra text:
+{
+  "rooms": [
+    { "id": "room_1", "label": "Entrance Hall", "gridX": 0, "gridY": 0 },
+    { "id": "room_2", "label": null, "gridX": 1, "gridY": 0 }
+  ],
+  "connections": [
+    { "from": "room_1", "to": "room_2" }
+  ]
+}"#;
+
+const USER_PROMPT: &str = "Analyze this hand-drawn map. Identify all rooms and connections between them. Read any text labels written inside or near each shape.";
+
+#[tauri::command]
+pub async fn analyze_sketch(
+    app: AppHandle,
+    image_base64: String,
+    media_type: String,
+) -> Result<String, String> {
+    let s = settings::get_settings(app).await?;
+
+    if s.anthropic_api_key.is_empty() {
+        return Err("Anthropic API key not configured. Set it in Settings.".to_string());
+    }
+
+    anthropic::complete_with_vision(
+        &s.anthropic_api_key,
+        SKETCH_MODEL,
+        SYSTEM_PROMPT,
+        USER_PROMPT,
+        &image_base64,
+        &media_type,
+        4096,
+    )
+    .await
+}

--- a/creator/src/components/SketchCanvas.tsx
+++ b/creator/src/components/SketchCanvas.tsx
@@ -1,0 +1,145 @@
+import { useRef, useEffect, useCallback, useState } from "react";
+
+interface SketchCanvasProps {
+  width?: number;
+  height?: number;
+  onExport: (base64: string) => void;
+}
+
+export function SketchCanvas({
+  width = 600,
+  height = 400,
+  onExport,
+}: SketchCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [isErasing, setIsErasing] = useState(false);
+
+  // Initialize white background
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, width, height);
+  }, [width, height]);
+
+  const getPos = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return { x: 0, y: 0 };
+      const rect = canvas.getBoundingClientRect();
+      return {
+        x: ((e.clientX - rect.left) * width) / rect.width,
+        y: ((e.clientY - rect.top) * height) / rect.height,
+      };
+    },
+    [width, height],
+  );
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+
+      const erasing = e.button === 2;
+      setIsDrawing(true);
+      setIsErasing(erasing);
+
+      const { x, y } = getPos(e);
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineCap = "round";
+      ctx.lineJoin = "round";
+      ctx.strokeStyle = erasing ? "#ffffff" : "#000000";
+      ctx.lineWidth = erasing ? 20 : 3;
+    },
+    [getPos],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!isDrawing) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+
+      const { x, y } = getPos(e);
+      ctx.lineTo(x, y);
+      ctx.stroke();
+    },
+    [isDrawing, getPos],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDrawing(false);
+    setIsErasing(false);
+  }, []);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+    },
+    [],
+  );
+
+  const handleClear = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, width, height);
+  }, [width, height]);
+
+  const handleExport = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const dataUrl = canvas.toDataURL("image/png");
+    const base64 = dataUrl.split(",")[1];
+    if (base64) onExport(base64);
+  }, [onExport]);
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="overflow-hidden rounded-lg border border-border-default">
+        <canvas
+          ref={canvasRef}
+          width={width}
+          height={height}
+          className={`block ${isErasing ? "cursor-cell" : "cursor-crosshair"}`}
+          style={{ width: `${width}px`, height: `${height}px` }}
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+          onMouseLeave={handleMouseUp}
+          onContextMenu={handleContextMenu}
+        />
+      </div>
+      <p className="text-2xs text-text-muted">
+        Left-click to draw &middot; Right-click to erase
+      </p>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleClear}
+          className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          onClick={handleExport}
+          className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:brightness-110"
+        >
+          Analyze Sketch
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/SketchImportWizard.tsx
+++ b/creator/src/components/SketchImportWizard.tsx
@@ -1,0 +1,678 @@
+import { useState, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import { stringify } from "yaml";
+import { useProjectStore } from "@/stores/projectStore";
+import { useZoneStore } from "@/stores/zoneStore";
+import { zoneFilePath } from "@/lib/projectPaths";
+import { useFocusTrap } from "@/lib/useFocusTrap";
+import { sketchToWorldData, mergeSketchRooms } from "@/lib/sketchToZone";
+import { SketchCanvas } from "./SketchCanvas";
+import type { SketchParseResult, SketchRoom } from "@/types/sketch";
+
+const YAML_OPTS = {
+  lineWidth: 120,
+  defaultKeyType: "PLAIN" as const,
+  defaultStringType: "PLAIN" as const,
+};
+
+const ZONE_ID_RE = /^[a-z][a-z0-9_]*$/;
+
+type WizardStep = "input" | "draw" | "analyzing" | "preview" | "done" | "error";
+
+interface SketchImportWizardProps {
+  onClose: () => void;
+}
+
+export function SketchImportWizard({ onClose }: SketchImportWizardProps) {
+  const project = useProjectStore((s) => s.project);
+  const loadZone = useZoneStore((s) => s.loadZone);
+  const updateZone = useZoneStore((s) => s.updateZone);
+  const zones = useZoneStore((s) => s.zones);
+  const openTab = useProjectStore((s) => s.openTab);
+  const trapRef = useFocusTrap<HTMLDivElement>(onClose);
+
+  // Wizard state
+  const [step, setStep] = useState<WizardStep>("input");
+  const [error, setError] = useState<string | null>(null);
+  const [hoveredRoomId, setHoveredRoomId] = useState<string | null>(null);
+
+  // Image state
+  const [imageBase64, setImageBase64] = useState<string | null>(null);
+  const [mediaType, setMediaType] = useState("image/png");
+
+  // Parse result state
+  const [parseResult, setParseResult] = useState<SketchParseResult | null>(null);
+  const [editedLabels, setEditedLabels] = useState<Record<string, string>>({});
+
+  // Target state
+  const [target, setTarget] = useState<"new" | "existing">("new");
+  const [zoneId, setZoneId] = useState("");
+  const [existingZoneId, setExistingZoneId] = useState("");
+  const [startRoomId, setStartRoomId] = useState("");
+
+  const trimmedZoneId = zoneId.trim().toLowerCase().replace(/\s+/g, "_");
+  const zoneIdValid = ZONE_ID_RE.test(trimmedZoneId);
+  const zoneIdTaken = zones.has(trimmedZoneId);
+
+  const zoneList = useMemo(() => Array.from(zones.keys()), [zones]);
+
+  // ─── Photo import ───────────────────────────────────────────────
+
+  const handlePickImage = async () => {
+    const selected = await open({
+      filters: [
+        { name: "Images", extensions: ["png", "jpg", "jpeg", "webp", "bmp"] },
+      ],
+    });
+    if (!selected) return;
+
+    try {
+      const dataUrl = await invoke<string>("read_image_data_url", {
+        path: selected,
+      });
+      // Extract base64 and mime from data URL
+      const match = dataUrl.match(/^data:(image\/[^;]+);base64,(.+)$/);
+      if (!match) {
+        setError("Failed to read image file.");
+        setStep("error");
+        return;
+      }
+      setMediaType(match[1]!);
+      setImageBase64(match[2]!);
+      analyzeImage(match[2]!, match[1]!);
+    } catch (err) {
+      setError(String(err));
+      setStep("error");
+    }
+  };
+
+  // ─── Canvas export ──────────────────────────────────────────────
+
+  const handleCanvasExport = (base64: string) => {
+    setImageBase64(base64);
+    setMediaType("image/png");
+    analyzeImage(base64, "image/png");
+  };
+
+  // ─── Analyze via Claude Vision ──────────────────────────────────
+
+  const analyzeImage = async (b64: string, mime: string) => {
+    setStep("analyzing");
+    setError(null);
+
+    try {
+      const raw = await invoke<string>("analyze_sketch", {
+        imageBase64: b64,
+        mediaType: mime,
+      });
+
+      // Strip markdown fences if present
+      let json = raw.trim();
+      if (json.startsWith("```")) {
+        json = json.replace(/^```(?:json)?\s*/, "").replace(/\s*```$/, "");
+      }
+
+      const parsed: SketchParseResult = JSON.parse(json);
+      if (!parsed.rooms || !Array.isArray(parsed.rooms)) {
+        throw new Error("Invalid response: missing rooms array");
+      }
+      if (!parsed.connections) {
+        parsed.connections = [];
+      }
+
+      setParseResult(parsed);
+      // Initialize labels for editing
+      const labels: Record<string, string> = {};
+      for (const room of parsed.rooms) {
+        labels[room.id] = room.label ?? "";
+      }
+      setEditedLabels(labels);
+      if (parsed.rooms.length > 0) {
+        setStartRoomId(parsed.rooms[0]!.id);
+      }
+      setStep("preview");
+    } catch (err) {
+      setError(String(err));
+      setStep("error");
+    }
+  };
+
+  // ─── Apply edited labels back to parse result ───────────────────
+
+  const getFinalResult = (): SketchParseResult => {
+    if (!parseResult) return { rooms: [], connections: [] };
+    return {
+      ...parseResult,
+      rooms: parseResult.rooms.map((r) => ({
+        ...r,
+        label: editedLabels[r.id]?.trim() || null,
+      })),
+    };
+  };
+
+  // ─── Import ─────────────────────────────────────────────────────
+
+  const handleImport = async () => {
+    if (!project || !parseResult) return;
+
+    try {
+      const finalResult = getFinalResult();
+
+      if (target === "new") {
+        if (!zoneIdValid || zoneIdTaken) return;
+
+        // Reorder rooms so startRoomId is first
+        const reordered = [...finalResult.rooms];
+        const startIdx = reordered.findIndex((r) => r.id === startRoomId);
+        if (startIdx > 0) {
+          const [startRoom] = reordered.splice(startIdx, 1);
+          reordered.unshift(startRoom!);
+        }
+
+        const world = sketchToWorldData(
+          { rooms: reordered, connections: finalResult.connections },
+          trimmedZoneId,
+        );
+
+        // Create zone directory for standalone projects
+        if (project.format === "standalone") {
+          await invoke("create_zone_directory", {
+            projectDir: project.mudDir,
+            zoneId: trimmedZoneId,
+          });
+        }
+
+        const filePath = zoneFilePath(project, trimmedZoneId);
+        const yaml = stringify(world, YAML_OPTS);
+        await writeTextFile(filePath, yaml);
+
+        loadZone(trimmedZoneId, filePath, world);
+        openTab({
+          id: `zone:${trimmedZoneId}`,
+          kind: "zone",
+          label: trimmedZoneId,
+        });
+      } else {
+        // Merge into existing zone
+        if (!existingZoneId || !zones.has(existingZoneId)) return;
+        const zoneState = zones.get(existingZoneId)!;
+        const merged = mergeSketchRooms(zoneState.data, finalResult);
+        updateZone(existingZoneId, merged);
+        openTab({
+          id: `zone:${existingZoneId}`,
+          kind: "zone",
+          label: existingZoneId,
+        });
+      }
+
+      setStep("done");
+    } catch (err) {
+      setError(String(err));
+      setStep("error");
+    }
+  };
+
+  // ─── Retry from error ───────────────────────────────────────────
+
+  const handleRetry = () => {
+    setError(null);
+    if (imageBase64) {
+      analyzeImage(imageBase64, mediaType);
+    } else {
+      setStep("input");
+    }
+  };
+
+  // ─── Direction label helper ─────────────────────────────────────
+
+  const dirLabel = (
+    from: SketchRoom,
+    to: SketchRoom,
+  ): string => {
+    const dx = Math.sign(to.gridX - from.gridX);
+    const dy = Math.sign(to.gridY - from.gridY);
+    const map: Record<string, string> = {
+      "0,-1": "N",
+      "0,1": "S",
+      "1,0": "E",
+      "-1,0": "W",
+      "1,-1": "NE",
+      "-1,-1": "NW",
+      "1,1": "SE",
+      "-1,1": "SW",
+    };
+    return map[`${dx},${dy}`] ?? "?";
+  };
+
+  // ─── Render ─────────────────────────────────────────────────────
+
+  const roomLookup = useMemo(() => {
+    const m = new Map<string, SketchRoom>();
+    for (const r of parseResult?.rooms ?? []) m.set(r.id, r);
+    return m;
+  }, [parseResult]);
+
+  // Grid bounds for the mini-map
+  const gridBounds = useMemo(() => {
+    const rooms = parseResult?.rooms ?? [];
+    if (rooms.length === 0) return { minX: 0, minY: 0, cols: 0, rows: 0 };
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (const r of rooms) {
+      if (r.gridX < minX) minX = r.gridX;
+      if (r.gridX > maxX) maxX = r.gridX;
+      if (r.gridY < minY) minY = r.gridY;
+      if (r.gridY > maxY) maxY = r.gridY;
+    }
+    return { minX, minY, cols: maxX - minX + 1, rows: maxY - minY + 1 };
+  }, [parseResult]);
+
+  // Build a grid cell lookup: "col,row" → room
+  const gridCells = useMemo(() => {
+    const m = new Map<string, SketchRoom>();
+    for (const r of parseResult?.rooms ?? []) {
+      m.set(`${r.gridX - gridBounds.minX},${r.gridY - gridBounds.minY}`, r);
+    }
+    return m;
+  }, [parseResult, gridBounds]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="sketch-wizard-title"
+        className="mx-4 flex w-full max-w-2xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl"
+      >
+        {/* Header */}
+        <div className="border-b border-border-default px-5 py-3">
+          <h2
+            id="sketch-wizard-title"
+            className="font-display text-sm tracking-wide text-accent-emphasis"
+          >
+            Sketch Import
+          </h2>
+          <p className="mt-0.5 text-2xs text-text-muted">
+            {step === "input" && "Choose how to provide your map sketch"}
+            {step === "draw" && "Draw your map layout"}
+            {step === "analyzing" && "Analyzing sketch..."}
+            {step === "preview" && "Review parsed rooms and configure import"}
+            {step === "done" && "Import complete"}
+            {step === "error" && "Something went wrong"}
+          </p>
+        </div>
+
+        {/* ── Step: Input mode ── */}
+        {step === "input" && (
+          <div className="px-5 py-6">
+            <div className="flex gap-4">
+              <button
+                onClick={handlePickImage}
+                className="flex flex-1 flex-col items-center gap-2 rounded-lg border border-border-default bg-bg-primary p-6 transition-colors hover:border-accent/50 hover:bg-bg-elevated"
+              >
+                <span className="text-2xl">&#128247;</span>
+                <span className="text-xs font-medium text-text-primary">
+                  Import Photo
+                </span>
+                <span className="text-2xs text-text-muted">
+                  Upload a photo or scan of a hand-drawn map
+                </span>
+              </button>
+              <button
+                onClick={() => setStep("draw")}
+                className="flex flex-1 flex-col items-center gap-2 rounded-lg border border-border-default bg-bg-primary p-6 transition-colors hover:border-accent/50 hover:bg-bg-elevated"
+              >
+                <span className="text-2xl">&#9998;</span>
+                <span className="text-xs font-medium text-text-primary">
+                  Draw Sketch
+                </span>
+                <span className="text-2xs text-text-muted">
+                  Draw a map directly in the app
+                </span>
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* ── Step: Draw canvas ── */}
+        {step === "draw" && (
+          <div className="px-5 py-4">
+            <SketchCanvas onExport={handleCanvasExport} />
+          </div>
+        )}
+
+        {/* ── Step: Analyzing ── */}
+        {step === "analyzing" && (
+          <div className="flex flex-col items-center gap-3 px-5 py-10">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+            <p className="text-sm text-text-secondary">Analyzing sketch...</p>
+            <p className="text-2xs text-text-muted">
+              Sending image to Claude for room detection
+            </p>
+          </div>
+        )}
+
+        {/* ── Step: Preview ── */}
+        {step === "preview" && parseResult && (
+          <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+            <div className="flex flex-col gap-4">
+              {/* Summary */}
+              <div className="flex gap-4 text-xs text-text-secondary">
+                <span>
+                  {parseResult.rooms.length} room
+                  {parseResult.rooms.length !== 1 ? "s" : ""} found
+                </span>
+                <span>
+                  {parseResult.connections.length} connection
+                  {parseResult.connections.length !== 1 ? "s" : ""}
+                </span>
+              </div>
+
+              {/* Mini-map grid + room name list side by side */}
+              <div className="flex gap-4">
+                {/* Mini-map */}
+                <div className="shrink-0">
+                  <h3 className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
+                    Layout
+                  </h3>
+                  <div
+                    className="inline-grid gap-1 rounded border border-border-default bg-bg-primary p-2"
+                    style={{
+                      gridTemplateColumns: `repeat(${gridBounds.cols}, 28px)`,
+                      gridTemplateRows: `repeat(${gridBounds.rows}, 28px)`,
+                    }}
+                  >
+                    {Array.from({ length: gridBounds.rows }, (_, row) =>
+                      Array.from({ length: gridBounds.cols }, (_, col) => {
+                        const room = gridCells.get(`${col},${row}`);
+                        const isHovered = room != null && hoveredRoomId === room.id;
+                        const label = room ? (editedLabels[room.id]?.trim() || room.label || "") : "";
+                        const initial = label ? label[0]!.toUpperCase() : "";
+                        return (
+                          <div
+                            key={`${col},${row}`}
+                            className={`flex items-center justify-center rounded text-2xs font-medium transition-colors ${
+                              room
+                                ? isHovered
+                                  ? "border border-accent bg-accent/30 text-accent-emphasis"
+                                  : "border border-border-active bg-bg-elevated text-text-primary"
+                                : ""
+                            }`}
+                            title={room ? label || room.id : undefined}
+                            onMouseEnter={() => room && setHoveredRoomId(room.id)}
+                            onMouseLeave={() => room && setHoveredRoomId(null)}
+                          >
+                            {room ? initial || "\u00B7" : ""}
+                          </div>
+                        );
+                      }),
+                    )}
+                  </div>
+                </div>
+
+                {/* Room name list */}
+                <div className="min-w-0 flex-1">
+                  <h3 className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
+                    Rooms
+                  </h3>
+                  <div className="flex flex-col gap-1.5">
+                    {parseResult.rooms.map((room, i) => {
+                      const isHovered = hoveredRoomId === room.id;
+                      return (
+                        <div
+                          key={room.id}
+                          className={`flex items-center gap-2 rounded px-1.5 py-0.5 transition-colors ${
+                            isHovered ? "bg-accent/10" : ""
+                          }`}
+                          onMouseEnter={() => setHoveredRoomId(room.id)}
+                          onMouseLeave={() => setHoveredRoomId(null)}
+                        >
+                          <span className="w-5 shrink-0 text-center text-2xs text-text-muted">
+                            {i + 1}
+                          </span>
+                          <input
+                            type="text"
+                            value={editedLabels[room.id] ?? ""}
+                            onChange={(e) =>
+                              setEditedLabels((prev) => ({
+                                ...prev,
+                                [room.id]: e.target.value,
+                              }))
+                            }
+                            placeholder="Unnamed room"
+                            className="min-w-0 flex-1 rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none placeholder:text-text-muted focus:border-accent/50"
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+
+              {/* Connections */}
+              {parseResult.connections.length > 0 && (
+                <div>
+                  <h3 className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
+                    Connections
+                  </h3>
+                  <div className="flex flex-col gap-1 text-xs text-text-secondary">
+                    {parseResult.connections.map((conn, i) => {
+                      const from = roomLookup.get(conn.from);
+                      const to = roomLookup.get(conn.to);
+                      const fromName =
+                        editedLabels[conn.from] ||
+                        from?.label ||
+                        conn.from;
+                      const toName =
+                        editedLabels[conn.to] || to?.label || conn.to;
+                      const dir =
+                        from && to ? dirLabel(from, to) : "?";
+                      return (
+                        <div key={i} className="flex items-center gap-1.5">
+                          <span className="text-text-primary">{fromName}</span>
+                          <span className="text-accent">{dir}</span>
+                          <span className="text-text-muted">&rarr;</span>
+                          <span className="text-text-primary">{toName}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Target selection */}
+              <div className="border-t border-border-default pt-4">
+                <h3 className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
+                  Import Target
+                </h3>
+                <div className="flex flex-col gap-2">
+                  <label className="flex items-center gap-2 text-xs text-text-primary">
+                    <input
+                      type="radio"
+                      name="target"
+                      checked={target === "new"}
+                      onChange={() => setTarget("new")}
+                      className="accent-accent"
+                    />
+                    Create new zone
+                  </label>
+                  {target === "new" && (
+                    <div className="ml-6">
+                      <input
+                        type="text"
+                        value={zoneId}
+                        onChange={(e) => setZoneId(e.target.value)}
+                        placeholder="e.g. dark_forest"
+                        className="w-full rounded border border-border-default bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none placeholder:text-text-muted focus:border-accent/50"
+                      />
+                      {zoneId && !zoneIdValid && (
+                        <p className="mt-1 text-2xs text-status-error">
+                          Must start with a letter, only lowercase letters,
+                          numbers, and underscores.
+                        </p>
+                      )}
+                      {zoneIdTaken && (
+                        <p className="mt-1 text-2xs text-status-error">
+                          Zone "{trimmedZoneId}" already exists.
+                        </p>
+                      )}
+                    </div>
+                  )}
+
+                  <label className="flex items-center gap-2 text-xs text-text-primary">
+                    <input
+                      type="radio"
+                      name="target"
+                      checked={target === "existing"}
+                      onChange={() => {
+                        setTarget("existing");
+                        if (!existingZoneId && zoneList.length > 0) {
+                          setExistingZoneId(zoneList[0]!);
+                        }
+                      }}
+                      className="accent-accent"
+                    />
+                    Add to existing zone
+                  </label>
+                  {target === "existing" && (
+                    <div className="ml-6">
+                      {zoneList.length === 0 ? (
+                        <p className="text-2xs text-text-muted">
+                          No zones loaded.
+                        </p>
+                      ) : (
+                        <select
+                          value={existingZoneId}
+                          onChange={(e) => setExistingZoneId(e.target.value)}
+                          className="w-full rounded border border-border-default bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50"
+                        >
+                          {zoneList.map((id) => (
+                            <option key={id} value={id}>
+                              {id}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Start room (new zone only) */}
+              {target === "new" && parseResult.rooms.length > 1 && (
+                <div>
+                  <h3 className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
+                    Start Room
+                  </h3>
+                  <select
+                    value={startRoomId}
+                    onChange={(e) => setStartRoomId(e.target.value)}
+                    className="w-full rounded border border-border-default bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50"
+                  >
+                    {parseResult.rooms.map((r) => (
+                      <option key={r.id} value={r.id}>
+                        {editedLabels[r.id] || r.label || r.id}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* ── Step: Done ── */}
+        {step === "done" && (
+          <div className="flex flex-col items-center gap-3 px-5 py-10">
+            <div className="text-lg text-status-success">&#10003;</div>
+            <p className="text-sm text-text-secondary">
+              {target === "new"
+                ? `Zone "${trimmedZoneId}" created with ${parseResult?.rooms.length ?? 0} rooms`
+                : `${parseResult?.rooms.length ?? 0} rooms added to "${existingZoneId}"`}
+            </p>
+          </div>
+        )}
+
+        {/* ── Step: Error ── */}
+        {step === "error" && (
+          <div className="flex flex-col items-center gap-3 px-5 py-10">
+            <div className="text-lg text-status-error">&#10007;</div>
+            <p className="max-w-sm text-center text-xs text-status-error">
+              {error}
+            </p>
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 border-t border-border-default px-5 py-3">
+          {step === "input" && (
+            <button
+              onClick={onClose}
+              className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+            >
+              Cancel
+            </button>
+          )}
+
+          {step === "draw" && (
+            <button
+              onClick={() => setStep("input")}
+              className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+            >
+              Back
+            </button>
+          )}
+
+          {step === "preview" && (
+            <>
+              <button
+                onClick={() => setStep("input")}
+                className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+              >
+                Back
+              </button>
+              <button
+                onClick={handleImport}
+                disabled={
+                  (target === "new" && (!zoneIdValid || zoneIdTaken)) ||
+                  (target === "existing" && !existingZoneId)
+                }
+                className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Import
+              </button>
+            </>
+          )}
+
+          {step === "done" && (
+            <button
+              onClick={onClose}
+              className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:brightness-110"
+            >
+              Close
+            </button>
+          )}
+
+          {step === "error" && (
+            <>
+              <button
+                onClick={onClose}
+                className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleRetry}
+                className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+              >
+                Retry
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/Toolbar.tsx
+++ b/creator/src/components/Toolbar.tsx
@@ -14,6 +14,7 @@ import { ValidationPanel } from "./ValidationPanel";
 import { DiffModal } from "./ui/DiffModal";
 import { useAssetStore } from "@/stores/assetStore";
 import { BatchLegacyImport } from "./BatchLegacyImport";
+import { SketchImportWizard } from "./SketchImportWizard";
 import toolbarBg from "@/assets/toolbar-bg.jpg";
 
 const STATUS_COLORS: Record<string, string> = {
@@ -49,6 +50,7 @@ export function Toolbar() {
   const [saved, setSaved] = useState(false);
   const [showDiff, setShowDiff] = useState(false);
   const [showLegacyImport, setShowLegacyImport] = useState(false);
+  const [showSketchImport, setShowSketchImport] = useState(false);
   const openGenerator = useAssetStore((s) => s.openGenerator);
   const openGallery = useAssetStore((s) => s.openGallery);
   const isStandalone = project?.format === "standalone";
@@ -143,6 +145,9 @@ export function Toolbar() {
           <button onClick={() => setShowLegacyImport(true)} title="Import legacy images" className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs font-medium text-text-primary transition hover:bg-white/10">
             Import
           </button>
+          <button onClick={() => setShowSketchImport(true)} title="Import zone from sketch" className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs font-medium text-text-primary transition hover:bg-white/10">
+            Sketch
+          </button>
           <button onClick={openGallery} title="Browse asset library" className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs font-medium text-text-primary transition hover:bg-white/10">
             Gallery
           </button>
@@ -226,6 +231,10 @@ export function Toolbar() {
 
       {showLegacyImport && (
         <BatchLegacyImport onClose={() => setShowLegacyImport(false)} />
+      )}
+
+      {showSketchImport && (
+        <SketchImportWizard onClose={() => setShowSketchImport(false)} />
       )}
     </>
   );

--- a/creator/src/lib/__tests__/sketchToZone.test.ts
+++ b/creator/src/lib/__tests__/sketchToZone.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  inferDirection,
+  sanitizeLabel,
+  sketchToWorldData,
+  mergeSketchRooms,
+} from "@/lib/sketchToZone";
+import type { SketchParseResult } from "@/types/sketch";
+import type { WorldFile } from "@/types/world";
+
+// ─── inferDirection ─────────────────────────────────────────────────
+
+describe("inferDirection", () => {
+  it("maps cardinal directions correctly", () => {
+    expect(inferDirection(0, 0, 1, 0)).toBe("e");
+    expect(inferDirection(0, 0, -1, 0)).toBe("w");
+    expect(inferDirection(0, 0, 0, -1)).toBe("n");
+    expect(inferDirection(0, 0, 0, 1)).toBe("s");
+  });
+
+  it("maps diagonal directions correctly", () => {
+    expect(inferDirection(0, 0, 1, -1)).toBe("ne");
+    expect(inferDirection(0, 0, -1, -1)).toBe("nw");
+    expect(inferDirection(0, 0, 1, 1)).toBe("se");
+    expect(inferDirection(0, 0, -1, 1)).toBe("sw");
+  });
+
+  it("returns null for same position", () => {
+    expect(inferDirection(0, 0, 0, 0)).toBeNull();
+    expect(inferDirection(3, 5, 3, 5)).toBeNull();
+  });
+
+  it("normalizes non-unit vectors", () => {
+    // room 3 cells to the east still = east
+    expect(inferDirection(0, 0, 3, 0)).toBe("e");
+    expect(inferDirection(0, 0, 2, -5)).toBe("ne");
+  });
+});
+
+// ─── sanitizeLabel ──────────────────────────────────────────────────
+
+describe("sanitizeLabel", () => {
+  it("lowercases and replaces spaces with underscores", () => {
+    expect(sanitizeLabel("Entrance Hall")).toBe("entrance_hall");
+  });
+
+  it("removes special characters", () => {
+    expect(sanitizeLabel("Room #1!")).toBe("room_1");
+  });
+
+  it("ensures ID starts with a letter", () => {
+    expect(sanitizeLabel("123 start")).toBe("room_123_start");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeLabel("")).toBe("room_");
+  });
+});
+
+// ─── sketchToWorldData ──────────────────────────────────────────────
+
+describe("sketchToWorldData", () => {
+  it("returns a fallback zone for empty sketch", () => {
+    const result: SketchParseResult = { rooms: [], connections: [] };
+    const world = sketchToWorldData(result, "test_zone");
+    expect(world.zone).toBe("test_zone");
+    expect(world.startRoom).toBe("entrance");
+    expect(Object.keys(world.rooms)).toHaveLength(1);
+  });
+
+  it("creates rooms with titles from labels", () => {
+    const result: SketchParseResult = {
+      rooms: [
+        { id: "room_1", label: "Tavern", gridX: 0, gridY: 0 },
+        { id: "room_2", label: "Market", gridX: 1, gridY: 0 },
+      ],
+      connections: [{ from: "room_1", to: "room_2" }],
+    };
+    const world = sketchToWorldData(result, "town");
+    expect(world.rooms["tavern"]).toBeDefined();
+    expect(world.rooms["tavern"].title).toBe("Tavern");
+    expect(world.rooms["market"]).toBeDefined();
+    expect(world.rooms["market"].title).toBe("Market");
+  });
+
+  it("assigns placeholder names for unlabeled rooms", () => {
+    const result: SketchParseResult = {
+      rooms: [
+        { id: "room_1", label: null, gridX: 0, gridY: 0 },
+        { id: "room_2", label: null, gridX: 1, gridY: 0 },
+      ],
+      connections: [],
+    };
+    const world = sketchToWorldData(result, "cave");
+    expect(world.rooms["cave_room1"]).toBeDefined();
+    expect(world.rooms["cave_room2"]).toBeDefined();
+  });
+
+  it("creates bidirectional exits", () => {
+    const result: SketchParseResult = {
+      rooms: [
+        { id: "room_1", label: "West Room", gridX: 0, gridY: 0 },
+        { id: "room_2", label: "East Room", gridX: 1, gridY: 0 },
+      ],
+      connections: [{ from: "room_1", to: "room_2" }],
+    };
+    const world = sketchToWorldData(result, "z");
+    expect(world.rooms["west_room"].exits?.["e"]).toBe("east_room");
+    expect(world.rooms["east_room"].exits?.["w"]).toBe("west_room");
+  });
+
+  it("sets the first room as startRoom", () => {
+    const result: SketchParseResult = {
+      rooms: [
+        { id: "room_1", label: "Start", gridX: 0, gridY: 0 },
+        { id: "room_2", label: "End", gridX: 1, gridY: 0 },
+      ],
+      connections: [],
+    };
+    const world = sketchToWorldData(result, "z");
+    expect(world.startRoom).toBe("start");
+  });
+
+  it("deduplicates room IDs from identical labels", () => {
+    const result: SketchParseResult = {
+      rooms: [
+        { id: "room_1", label: "Hall", gridX: 0, gridY: 0 },
+        { id: "room_2", label: "Hall", gridX: 1, gridY: 0 },
+      ],
+      connections: [],
+    };
+    const world = sketchToWorldData(result, "z");
+    const ids = Object.keys(world.rooms);
+    expect(ids).toHaveLength(2);
+    expect(ids).toContain("hall");
+    expect(ids).toContain("hall_2");
+  });
+
+  it("handles diagonal connections", () => {
+    const result: SketchParseResult = {
+      rooms: [
+        { id: "room_1", label: "A", gridX: 0, gridY: 0 },
+        { id: "room_2", label: "B", gridX: 1, gridY: 1 },
+      ],
+      connections: [{ from: "room_1", to: "room_2" }],
+    };
+    const world = sketchToWorldData(result, "z");
+    expect(world.rooms["a"].exits?.["se"]).toBe("b");
+    expect(world.rooms["b"].exits?.["nw"]).toBe("a");
+  });
+});
+
+// ─── mergeSketchRooms ───────────────────────────────────────────────
+
+describe("mergeSketchRooms", () => {
+  const baseWorld: WorldFile = {
+    zone: "town",
+    startRoom: "entrance",
+    rooms: {
+      entrance: { title: "Entrance", description: "The entrance." },
+    },
+  };
+
+  it("adds new rooms without overwriting existing", () => {
+    const result: SketchParseResult = {
+      rooms: [{ id: "room_1", label: "Market", gridX: 0, gridY: 0 }],
+      connections: [],
+    };
+    const merged = mergeSketchRooms(baseWorld, result);
+    expect(merged.rooms["entrance"]).toBeDefined();
+    expect(merged.rooms["market"]).toBeDefined();
+    expect(merged.startRoom).toBe("entrance");
+  });
+
+  it("avoids ID collisions with existing rooms", () => {
+    const result: SketchParseResult = {
+      rooms: [{ id: "room_1", label: "Entrance", gridX: 0, gridY: 0 }],
+      connections: [],
+    };
+    const merged = mergeSketchRooms(baseWorld, result);
+    const ids = Object.keys(merged.rooms);
+    expect(ids).toContain("entrance");
+    expect(ids).toContain("entrance_2");
+    expect(ids).toHaveLength(2);
+  });
+
+  it("returns world unchanged for empty sketch", () => {
+    const result: SketchParseResult = { rooms: [], connections: [] };
+    const merged = mergeSketchRooms(baseWorld, result);
+    expect(Object.keys(merged.rooms)).toHaveLength(1);
+  });
+});

--- a/creator/src/lib/sketchToZone.ts
+++ b/creator/src/lib/sketchToZone.ts
@@ -1,0 +1,208 @@
+import type { WorldFile, RoomFile } from "@/types/world";
+import type { SketchParseResult, SketchRoom } from "@/types/sketch";
+import { OPPOSITE } from "@/lib/zoneEdits";
+
+// ─── Direction inference ────────────────────────────────────────────
+
+const DIR_MAP: Record<string, string> = {
+  "0,-1": "n",
+  "0,1": "s",
+  "1,0": "e",
+  "-1,0": "w",
+  "1,-1": "ne",
+  "-1,-1": "nw",
+  "1,1": "se",
+  "-1,1": "sw",
+};
+
+export function inferDirection(
+  fromX: number,
+  fromY: number,
+  toX: number,
+  toY: number,
+): string | null {
+  const dx = Math.sign(toX - fromX);
+  const dy = Math.sign(toY - fromY);
+  if (dx === 0 && dy === 0) return null;
+  return DIR_MAP[`${dx},${dy}`] ?? null;
+}
+
+// ─── Room ID sanitization ───────────────────────────────────────────
+
+export function sanitizeLabel(label: string): string {
+  let id = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (!id || !/^[a-z]/.test(id)) {
+    id = "room_" + id;
+  }
+  return id;
+}
+
+function deduplicateId(id: string, existing: Set<string>): string {
+  if (!existing.has(id)) return id;
+  let n = 2;
+  while (existing.has(`${id}_${n}`)) n++;
+  return `${id}_${n}`;
+}
+
+// ─── Build room ID map from sketch rooms ────────────────────────────
+
+function buildRoomIdMap(
+  rooms: SketchRoom[],
+  zoneId: string,
+  existingIds?: Set<string>,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  const used = new Set<string>(existingIds ?? []);
+  let unlabeledCount = 0;
+
+  for (const room of rooms) {
+    let roomId: string;
+    if (room.label) {
+      roomId = sanitizeLabel(room.label);
+    } else {
+      unlabeledCount++;
+      roomId = `${zoneId}_room${unlabeledCount}`;
+    }
+    roomId = deduplicateId(roomId, used);
+    used.add(roomId);
+    map.set(room.id, roomId);
+  }
+
+  return map;
+}
+
+// ─── Create new zone from sketch ────────────────────────────────────
+
+export function sketchToWorldData(
+  result: SketchParseResult,
+  zoneId: string,
+): WorldFile {
+  if (result.rooms.length === 0) {
+    return {
+      zone: zoneId,
+      startRoom: "entrance",
+      rooms: {
+        entrance: { title: "Entrance", description: "A new room." },
+      },
+    };
+  }
+
+  const idMap = buildRoomIdMap(result.rooms, zoneId);
+  const rooms: Record<string, RoomFile> = {};
+
+  // Create room entries
+  for (const sketchRoom of result.rooms) {
+    const roomId = idMap.get(sketchRoom.id)!;
+    rooms[roomId] = {
+      title: sketchRoom.label ?? roomId.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+      description: "A new room.",
+    };
+  }
+
+  // Build grid lookup for direction inference
+  const gridLookup = new Map<string, SketchRoom>();
+  for (const room of result.rooms) {
+    gridLookup.set(room.id, room);
+  }
+
+  // Add exits from connections
+  for (const conn of result.connections) {
+    const fromRoom = gridLookup.get(conn.from);
+    const toRoom = gridLookup.get(conn.to);
+    if (!fromRoom || !toRoom) continue;
+
+    const fromId = idMap.get(conn.from);
+    const toId = idMap.get(conn.to);
+    if (!fromId || !toId) continue;
+    if (!rooms[fromId] || !rooms[toId]) continue;
+
+    const dir = inferDirection(
+      fromRoom.gridX,
+      fromRoom.gridY,
+      toRoom.gridX,
+      toRoom.gridY,
+    );
+    if (!dir) continue;
+
+    // Forward exit
+    if (!rooms[fromId].exits) rooms[fromId].exits = {};
+    rooms[fromId].exits![dir] = toId;
+
+    // Reverse exit
+    const rev = OPPOSITE[dir];
+    if (rev) {
+      if (!rooms[toId].exits) rooms[toId].exits = {};
+      rooms[toId].exits![rev] = fromId;
+    }
+  }
+
+  const startRoom = idMap.get(result.rooms[0]!.id) ?? Object.keys(rooms)[0]!;
+
+  return {
+    zone: zoneId,
+    startRoom,
+    rooms,
+  };
+}
+
+// ─── Merge sketch rooms into existing zone ──────────────────────────
+
+export function mergeSketchRooms(
+  world: WorldFile,
+  result: SketchParseResult,
+): WorldFile {
+  if (result.rooms.length === 0) return world;
+
+  const next = structuredClone(world);
+  const existingIds = new Set(Object.keys(next.rooms));
+  const idMap = buildRoomIdMap(result.rooms, next.zone, existingIds);
+
+  // Add rooms
+  for (const sketchRoom of result.rooms) {
+    const roomId = idMap.get(sketchRoom.id)!;
+    next.rooms[roomId] = {
+      title: sketchRoom.label ?? roomId.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+      description: "A new room.",
+    };
+  }
+
+  // Build grid lookup
+  const gridLookup = new Map<string, SketchRoom>();
+  for (const room of result.rooms) {
+    gridLookup.set(room.id, room);
+  }
+
+  // Add exits
+  for (const conn of result.connections) {
+    const fromRoom = gridLookup.get(conn.from);
+    const toRoom = gridLookup.get(conn.to);
+    if (!fromRoom || !toRoom) continue;
+
+    const fromId = idMap.get(conn.from);
+    const toId = idMap.get(conn.to);
+    if (!fromId || !toId) continue;
+    if (!next.rooms[fromId] || !next.rooms[toId]) continue;
+
+    const dir = inferDirection(
+      fromRoom.gridX,
+      fromRoom.gridY,
+      toRoom.gridX,
+      toRoom.gridY,
+    );
+    if (!dir) continue;
+
+    if (!next.rooms[fromId].exits) next.rooms[fromId].exits = {};
+    next.rooms[fromId].exits![dir] = toId;
+
+    const rev = OPPOSITE[dir];
+    if (rev) {
+      if (!next.rooms[toId].exits) next.rooms[toId].exits = {};
+      next.rooms[toId].exits![rev] = fromId;
+    }
+  }
+
+  return next;
+}

--- a/creator/src/types/sketch.ts
+++ b/creator/src/types/sketch.ts
@@ -1,0 +1,16 @@
+export interface SketchRoom {
+  id: string;
+  label: string | null;
+  gridX: number;
+  gridY: number;
+}
+
+export interface SketchConnection {
+  from: string;
+  to: string;
+}
+
+export interface SketchParseResult {
+  rooms: SketchRoom[];
+  connections: SketchConnection[];
+}


### PR DESCRIPTION
## Summary
- Users can photograph a paper sketch or draw directly in-app (left-click draw, right-click erase), then Claude Vision analyzes the image to extract rooms, connections, and labels
- Supports creating a new zone or merging rooms into an existing one, with auto-inferred cardinal directions from spatial layout
- Preview step shows an interactive mini-map grid with hover-linked room name editing

## Changes
- **Backend**: Extend Anthropic client with vision content blocks; add `analyze_sketch` Rust command (`sketch.rs`)
- **Frontend**: `SketchCanvas`, `SketchImportWizard` components; `sketchToZone.ts` transformation logic; `sketch.ts` types; "Sketch" button in toolbar
- **Tests**: 18 unit tests covering direction inference, label sanitization, zone creation, merge mode, and edge cases

## Test plan
- [ ] Draw a simple map in the canvas, verify rooms and connections parse correctly
- [ ] Import a photo of a hand-drawn map, verify room detection
- [ ] Edit room names in preview, verify they carry through to the zone
- [ ] Create a new zone from sketch, verify it opens in the zone editor with correct layout
- [ ] Merge rooms into an existing zone, verify no ID collisions
- [ ] Verify error states: missing API key, malformed response, cancel at each step
- [ ] `bun run test` passes (183 tests)
- [ ] `cargo check` and `tsc --noEmit` clean