### PR TITLE
Complete admin API coverage: world, content, broadcast

### DIFF
--- a/creator/src-tauri/src/admin.rs
+++ b/creator/src-tauri/src/admin.rs
@@ -132,6 +132,35 @@ async fn admin_get<T: serde::de::DeserializeOwned>(
         .map_err(|e| format!("Failed to parse response: {e}"))
 }
 
+async fn admin_get_with_query<T: serde::de::DeserializeOwned>(
+    url: &str,
+    token: &str,
+    path: &str,
+    query: &[(&str, &str)],
+) -> Result<T, String> {
+    let client = get_client();
+    let auth = build_auth_header(token)?;
+    let full_url = format!("{}{}", url.trim_end_matches('/'), path);
+
+    let resp = client
+        .get(&full_url)
+        .header(AUTHORIZATION, auth)
+        .query(query)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("HTTP {status}: {body}"));
+    }
+
+    resp.json::<T>()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))
+}
+
 async fn admin_post<T: serde::de::DeserializeOwned>(
     url: &str,
     token: &str,
@@ -144,6 +173,35 @@ async fn admin_post<T: serde::de::DeserializeOwned>(
     let resp = client
         .post(&full_url)
         .header(AUTHORIZATION, auth)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("HTTP {status}: {body}"));
+    }
+
+    resp.json::<T>()
+        .await
+        .map_err(|e| format!("Failed to parse response: {e}"))
+}
+
+async fn admin_post_with_body<B: serde::Serialize, T: serde::de::DeserializeOwned>(
+    url: &str,
+    token: &str,
+    path: &str,
+    body: &B,
+) -> Result<T, String> {
+    let client = get_client();
+    let auth = build_auth_header(token)?;
+    let full_url = format!("{}{}", url.trim_end_matches('/'), path);
+
+    let resp = client
+        .post(&full_url)
+        .header(AUTHORIZATION, auth)
+        .json(body)
         .send()
         .await
         .map_err(|e| format!("Request failed: {e}"))?;
@@ -242,6 +300,209 @@ pub struct ReloadResult {
     pub summary: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthResponse {
+    pub status: String,
+    pub uptime_ms: u64,
+    pub players_online: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StaffToggleResult {
+    pub name: String,
+    pub is_staff: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoomDetailResponse {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub exits: Vec<ExitDetail>,
+    pub players: Vec<String>,
+    pub mobs: Vec<RoomMobInfo>,
+    pub features: Vec<String>,
+    pub station: Option<String>,
+    pub image: Option<String>,
+    pub video: Option<String>,
+    pub music: Option<String>,
+    pub ambient: Option<String>,
+    pub map_x: Option<i32>,
+    pub map_y: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExitDetail {
+    pub direction: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RoomMobInfo {
+    pub id: String,
+    pub name: String,
+    pub hp: i32,
+    pub max_hp: i32,
+    pub template_key: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MobSummary {
+    pub id: String,
+    pub name: String,
+    pub room_id: String,
+    pub hp: i32,
+    pub max_hp: i32,
+    pub template_key: String,
+    pub aggressive: bool,
+    pub xp_reward: i64,
+    pub armor: i32,
+    pub image: Option<String>,
+    pub quest_ids: Vec<String>,
+    pub spawn_room_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AbilityEntry {
+    pub id: String,
+    pub display_name: String,
+    pub description: String,
+    pub mana_cost: i32,
+    pub cooldown_ms: i64,
+    pub level_required: u32,
+    pub target_type: String,
+    pub required_class: Option<String>,
+    pub image: Option<String>,
+    pub effect_type: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EffectEntry {
+    pub id: String,
+    pub display_name: String,
+    pub effect_type: String,
+    pub duration_ms: i64,
+    pub tick_interval_ms: i64,
+    pub tick_min_value: i32,
+    pub tick_max_value: i32,
+    pub shield_amount: i32,
+    pub stat_mods: std::collections::HashMap<String, i32>,
+    pub stack_behavior: String,
+    pub max_stacks: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuestObjective {
+    pub r#type: String,
+    pub target_id: String,
+    pub count: i32,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuestRewards {
+    pub xp: Option<i64>,
+    pub gold: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuestEntry {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub giver_mob_id: String,
+    pub completion_type: String,
+    pub objectives: Vec<QuestObjective>,
+    pub rewards: QuestRewards,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AchievementCriterion {
+    pub r#type: String,
+    pub target_id: String,
+    pub count: i32,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AchievementRewards {
+    pub xp: Option<i64>,
+    pub gold: Option<i64>,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AchievementEntry {
+    pub id: String,
+    pub display_name: String,
+    pub description: String,
+    pub category: String,
+    pub hidden: bool,
+    pub criteria: Vec<AchievementCriterion>,
+    pub rewards: AchievementRewards,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShopItemEntry {
+    pub id: String,
+    pub display_name: String,
+    pub base_price: i64,
+    pub slot: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShopEntry {
+    pub id: String,
+    pub name: String,
+    pub room_id: String,
+    pub items: Vec<ShopItemEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ItemEntry {
+    pub id: String,
+    pub display_name: String,
+    pub description: String,
+    pub slot: Option<String>,
+    pub damage: i32,
+    pub armor: i32,
+    pub stats: std::collections::HashMap<String, i32>,
+    pub consumable: bool,
+    pub base_price: i64,
+    pub image: Option<String>,
+    pub spawn_room: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BroadcastResult {
+    pub status: String,
+    pub recipients: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BroadcastRequest {
+    message: String,
+}
+
 // ─── Tauri commands ────────────────────────────────────────────────
 
 #[tauri::command]
@@ -294,4 +555,149 @@ pub async fn admin_reload(
         format!("/api/reload?target={target}")
     };
     admin_post(&url, &token, &path).await
+}
+
+// ─── New commands (phase 2) ────────────────────────────────────────
+
+#[tauri::command]
+pub async fn admin_health(url: String, token: String) -> Result<HealthResponse, String> {
+    admin_get(&url, &token, "/api/health").await
+}
+
+#[tauri::command]
+pub async fn admin_player_search(
+    url: String,
+    token: String,
+    query: String,
+) -> Result<PlayerDetail, String> {
+    admin_get_with_query(&url, &token, "/api/players/search", &[("q", &query)]).await
+}
+
+#[tauri::command]
+pub async fn admin_player_toggle_staff(
+    url: String,
+    token: String,
+    name: String,
+) -> Result<StaffToggleResult, String> {
+    let safe_name = encode_path_segment(&name)?;
+    admin_post(&url, &token, &format!("/api/players/{safe_name}/staff")).await
+}
+
+#[tauri::command]
+pub async fn admin_room_detail(
+    url: String,
+    token: String,
+    zone: String,
+    room: String,
+) -> Result<RoomDetailResponse, String> {
+    let safe_zone = encode_path_segment(&zone)?;
+    let safe_room = encode_path_segment(&room)?;
+    admin_get(&url, &token, &format!("/api/world/zones/{safe_zone}/rooms/{safe_room}")).await
+}
+
+#[tauri::command]
+pub async fn admin_mobs(
+    url: String,
+    token: String,
+    zone: Option<String>,
+) -> Result<Vec<MobSummary>, String> {
+    match zone {
+        Some(z) => admin_get_with_query(&url, &token, "/api/mobs", &[("zone", &z)]).await,
+        None => admin_get(&url, &token, "/api/mobs").await,
+    }
+}
+
+#[tauri::command]
+pub async fn admin_mob_detail(
+    url: String,
+    token: String,
+    id: String,
+) -> Result<MobSummary, String> {
+    let safe_id = encode_path_segment(&id)?;
+    admin_get(&url, &token, &format!("/api/mobs/{safe_id}")).await
+}
+
+#[tauri::command]
+pub async fn admin_abilities(url: String, token: String) -> Result<Vec<AbilityEntry>, String> {
+    admin_get(&url, &token, "/api/abilities").await
+}
+
+#[tauri::command]
+pub async fn admin_ability_detail(
+    url: String,
+    token: String,
+    id: String,
+) -> Result<AbilityEntry, String> {
+    let safe_id = encode_path_segment(&id)?;
+    admin_get(&url, &token, &format!("/api/abilities/{safe_id}")).await
+}
+
+#[tauri::command]
+pub async fn admin_effects(url: String, token: String) -> Result<Vec<EffectEntry>, String> {
+    admin_get(&url, &token, "/api/effects").await
+}
+
+#[tauri::command]
+pub async fn admin_effect_detail(
+    url: String,
+    token: String,
+    id: String,
+) -> Result<EffectEntry, String> {
+    let safe_id = encode_path_segment(&id)?;
+    admin_get(&url, &token, &format!("/api/effects/{safe_id}")).await
+}
+
+#[tauri::command]
+pub async fn admin_quests(url: String, token: String) -> Result<Vec<QuestEntry>, String> {
+    admin_get(&url, &token, "/api/quests").await
+}
+
+#[tauri::command]
+pub async fn admin_quest_detail(
+    url: String,
+    token: String,
+    id: String,
+) -> Result<QuestEntry, String> {
+    let safe_id = encode_path_segment(&id)?;
+    admin_get(&url, &token, &format!("/api/quests/{safe_id}")).await
+}
+
+#[tauri::command]
+pub async fn admin_achievements(
+    url: String,
+    token: String,
+) -> Result<Vec<AchievementEntry>, String> {
+    admin_get(&url, &token, "/api/achievements").await
+}
+
+#[tauri::command]
+pub async fn admin_achievement_detail(
+    url: String,
+    token: String,
+    id: String,
+) -> Result<AchievementEntry, String> {
+    let safe_id = encode_path_segment(&id)?;
+    admin_get(&url, &token, &format!("/api/achievements/{safe_id}")).await
+}
+
+#[tauri::command]
+pub async fn admin_shops(url: String, token: String) -> Result<Vec<ShopEntry>, String> {
+    admin_get(&url, &token, "/api/shops").await
+}
+
+#[tauri::command]
+pub async fn admin_items(url: String, token: String) -> Result<Vec<ItemEntry>, String> {
+    admin_get(&url, &token, "/api/items").await
+}
+
+#[tauri::command]
+pub async fn admin_broadcast(
+    url: String,
+    token: String,
+    message: String,
+) -> Result<BroadcastResult, String> {
+    if message.trim().is_empty() {
+        return Err("Broadcast message cannot be empty".to_string());
+    }
+    admin_post_with_body(&url, &token, "/api/broadcast", &BroadcastRequest { message }).await
 }

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -75,6 +75,23 @@ pub fn run() {
             admin::admin_zones,
             admin::admin_zone_detail,
             admin::admin_reload,
+            admin::admin_health,
+            admin::admin_player_search,
+            admin::admin_player_toggle_staff,
+            admin::admin_room_detail,
+            admin::admin_mobs,
+            admin::admin_mob_detail,
+            admin::admin_abilities,
+            admin::admin_ability_detail,
+            admin::admin_effects,
+            admin::admin_effect_detail,
+            admin::admin_quests,
+            admin::admin_quest_detail,
+            admin::admin_achievements,
+            admin::admin_achievement_detail,
+            admin::admin_shops,
+            admin::admin_items,
+            admin::admin_broadcast,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/creator/src/components/admin/AdminAbilityList.tsx
+++ b/creator/src/components/admin/AdminAbilityList.tsx
@@ -1,0 +1,147 @@
+import { useEffect } from "react";
+import { useAdminStore } from "@/stores/adminStore";
+import type { AbilityEntry } from "@/types/admin";
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+      <span className="text-xs text-text-muted">{label}</span>
+      <span className="text-xs text-text-primary">{value}</span>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-[22px] border border-white/10 bg-gradient-panel-light p-4 shadow-section-sm">
+      <h4 className="mb-2 text-[11px] uppercase tracking-wide-ui text-text-muted">{title}</h4>
+      {children}
+    </div>
+  );
+}
+
+function AbilityRow({
+  ability,
+  onSelect,
+}: {
+  ability: AbilityEntry;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <button
+      onClick={() => onSelect(ability.id)}
+      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-all duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-display text-sm text-text-primary">
+            {ability.displayName}
+          </span>
+          <span className="rounded-full bg-stellar-blue/12 px-2 py-0.5 text-2xs text-stellar-blue">
+            {ability.effectType}
+          </span>
+        </div>
+        <div className="mt-1 flex flex-wrap gap-2 text-[11px]">
+          <span className="text-text-muted">
+            Mana {ability.manaCost}
+          </span>
+          <span className="text-text-muted">
+            CD {(ability.cooldownMs / 1000).toFixed(1)}s
+          </span>
+          <span className="text-text-muted">Lv {ability.levelRequired}</span>
+          {ability.requiredClass && (
+            <span className="text-stellar-blue">{ability.requiredClass}</span>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function AbilityDetail({
+  ability,
+  onBack,
+}: {
+  ability: AbilityEntry;
+  onBack: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onBack}
+          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+        >
+          &#x2190; Back
+        </button>
+        <h3 className="font-display text-xl text-text-primary">{ability.displayName}</h3>
+        <span className="rounded-full bg-stellar-blue/12 px-2 py-0.5 text-2xs text-stellar-blue">
+          {ability.effectType}
+        </span>
+      </div>
+
+      {ability.description && (
+        <p className="text-sm leading-6 text-text-secondary">{ability.description}</p>
+      )}
+
+      <Section title="Properties">
+        <StatRow label="Display Name" value={ability.displayName} />
+        <StatRow label="Effect Type" value={ability.effectType} />
+        <StatRow label="Target Type" value={ability.targetType} />
+        <StatRow label="Mana Cost" value={ability.manaCost} />
+        <StatRow label="Cooldown" value={`${(ability.cooldownMs / 1000).toFixed(1)}s`} />
+        <StatRow label="Level Required" value={ability.levelRequired} />
+        {ability.requiredClass && (
+          <StatRow label="Required Class" value={ability.requiredClass} />
+        )}
+      </Section>
+    </div>
+  );
+}
+
+export function AdminAbilityList() {
+  const abilities = useAdminStore((s) => s.abilities);
+  const selectedAbility = useAdminStore((s) => s.selectedAbility);
+  const fetchAbilities = useAdminStore((s) => s.fetchAbilities);
+  const fetchAbilityDetail = useAdminStore((s) => s.fetchAbilityDetail);
+  const clearSelectedAbility = useAdminStore((s) => s.clearSelectedAbility);
+
+  useEffect(() => {
+    fetchAbilities();
+  }, [fetchAbilities]);
+
+  if (selectedAbility) {
+    return <AbilityDetail ability={selectedAbility} onBack={clearSelectedAbility} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-display text-lg text-text-primary">Abilities</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            All registered abilities. Click to inspect.
+          </p>
+        </div>
+        <span className="text-[11px] uppercase tracking-wide-ui text-text-muted">
+          {abilities.length} registered
+        </span>
+      </div>
+
+      {abilities.length === 0 ? (
+        <div className="rounded-[22px] border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+          <p className="font-display text-base text-text-secondary">No abilities found</p>
+          <p className="mt-1 text-sm text-text-muted">
+            The server has no abilities registered.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {abilities.map((a) => (
+            <AbilityRow key={a.id} ability={a} onSelect={fetchAbilityDetail} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminAchievementList.tsx
+++ b/creator/src/components/admin/AdminAchievementList.tsx
@@ -1,0 +1,198 @@
+import { useEffect } from "react";
+import { useAdminStore } from "@/stores/adminStore";
+import type { AchievementEntry } from "@/types/admin";
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+      <span className="text-xs text-text-muted">{label}</span>
+      <span className="text-xs text-text-primary">{value}</span>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-[22px] border border-white/10 bg-gradient-panel-light p-4 shadow-section-sm">
+      <h4 className="mb-2 text-[11px] uppercase tracking-wide-ui text-text-muted">{title}</h4>
+      {children}
+    </div>
+  );
+}
+
+function AchievementRow({
+  achievement,
+  onSelect,
+}: {
+  achievement: AchievementEntry;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <button
+      onClick={() => onSelect(achievement.id)}
+      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-all duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-display text-sm text-text-primary">
+            {achievement.displayName}
+          </span>
+          <span className="rounded-full bg-violet/12 px-2 py-0.5 text-2xs text-violet">
+            {achievement.category}
+          </span>
+          {achievement.hidden && (
+            <span className="rounded-full bg-black/20 px-2 py-0.5 text-2xs text-text-muted">
+              Hidden
+            </span>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function AchievementDetail({
+  achievement,
+  onBack,
+}: {
+  achievement: AchievementEntry;
+  onBack: () => void;
+}) {
+  const hasRewards =
+    (achievement.rewards.xp != null && achievement.rewards.xp > 0) ||
+    (achievement.rewards.gold != null && achievement.rewards.gold > 0) ||
+    achievement.rewards.title;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onBack}
+          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+        >
+          &#x2190; Back
+        </button>
+        <h3 className="font-display text-xl text-text-primary">
+          {achievement.displayName}
+        </h3>
+        <span className="rounded-full bg-violet/12 px-2 py-0.5 text-2xs text-violet">
+          {achievement.category}
+        </span>
+        {achievement.hidden && (
+          <span className="rounded-full bg-black/20 px-2 py-0.5 text-2xs text-text-muted">
+            Hidden
+          </span>
+        )}
+      </div>
+
+      {achievement.description && (
+        <p className="text-sm leading-6 text-text-secondary">{achievement.description}</p>
+      )}
+
+      <Section title="Properties">
+        <StatRow label="Category" value={achievement.category} />
+        <StatRow label="Hidden" value={achievement.hidden ? "Yes" : "No"} />
+      </Section>
+
+      {achievement.criteria.length > 0 && (
+        <Section title="Criteria">
+          <div className="flex flex-col gap-2">
+            {achievement.criteria.map((c, i) => (
+              <div
+                key={i}
+                className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="rounded-full bg-stellar-blue/12 px-2 py-0.5 text-2xs text-stellar-blue">
+                    {c.type}
+                  </span>
+                  <span className="text-xs text-text-muted">{c.targetId}</span>
+                  <span className="ml-auto text-xs text-text-primary">
+                    x{c.count}
+                  </span>
+                </div>
+                {c.description && (
+                  <p className="mt-1.5 text-xs leading-5 text-text-secondary">
+                    {c.description}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {hasRewards && (
+        <Section title="Rewards">
+          {achievement.rewards.xp != null && achievement.rewards.xp > 0 && (
+            <StatRow label="XP" value={achievement.rewards.xp.toLocaleString()} />
+          )}
+          {achievement.rewards.gold != null && achievement.rewards.gold > 0 && (
+            <StatRow label="Gold" value={achievement.rewards.gold.toLocaleString()} />
+          )}
+          {achievement.rewards.title && (
+            <StatRow label="Title" value={achievement.rewards.title} />
+          )}
+        </Section>
+      )}
+    </div>
+  );
+}
+
+export function AdminAchievementList() {
+  const achievements = useAdminStore((s) => s.achievements);
+  const selectedAchievement = useAdminStore((s) => s.selectedAchievement);
+  const fetchAchievements = useAdminStore((s) => s.fetchAchievements);
+  const fetchAchievementDetail = useAdminStore((s) => s.fetchAchievementDetail);
+  const clearSelectedAchievement = useAdminStore((s) => s.clearSelectedAchievement);
+
+  useEffect(() => {
+    fetchAchievements();
+  }, [fetchAchievements]);
+
+  if (selectedAchievement) {
+    return (
+      <AchievementDetail
+        achievement={selectedAchievement}
+        onBack={clearSelectedAchievement}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-display text-lg text-text-primary">Achievements</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            All registered achievements. Click to inspect.
+          </p>
+        </div>
+        <span className="text-[11px] uppercase tracking-wide-ui text-text-muted">
+          {achievements.length} registered
+        </span>
+      </div>
+
+      {achievements.length === 0 ? (
+        <div className="rounded-[22px] border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+          <p className="font-display text-base text-text-secondary">
+            No achievements found
+          </p>
+          <p className="mt-1 text-sm text-text-muted">
+            The server has no achievements registered.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {achievements.map((a) => (
+            <AchievementRow
+              key={a.id}
+              achievement={a}
+              onSelect={fetchAchievementDetail}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminActionsPanel.tsx
+++ b/creator/src/components/admin/AdminActionsPanel.tsx
@@ -1,0 +1,12 @@
+import { AdminReloadPanel } from "./AdminReloadPanel";
+import { AdminBroadcastPanel } from "./AdminBroadcastPanel";
+
+export function AdminActionsPanel() {
+  return (
+    <div className="flex flex-col gap-8">
+      <AdminReloadPanel />
+      <div className="h-px bg-white/8" />
+      <AdminBroadcastPanel />
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminBroadcastPanel.tsx
+++ b/creator/src/components/admin/AdminBroadcastPanel.tsx
@@ -1,0 +1,120 @@
+import { useState, useRef, useEffect } from "react";
+import { useAdminStore } from "@/stores/adminStore";
+import { Spinner } from "@/components/ui/FormWidgets";
+
+const MAX_LENGTH = 500;
+
+export function AdminBroadcastPanel() {
+  const broadcast = useAdminStore((s) => s.broadcast);
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [resultMessage, setResultMessage] = useState<string | null>(null);
+  const [resultError, setResultError] = useState<string | null>(null);
+  const confirmTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (confirmTimer.current) clearTimeout(confirmTimer.current);
+    };
+  }, []);
+
+  const handleSendClick = () => {
+    if (!confirming) {
+      setConfirming(true);
+      setResultMessage(null);
+      setResultError(null);
+      confirmTimer.current = setTimeout(() => setConfirming(false), 4000);
+      return;
+    }
+    setConfirming(false);
+    if (confirmTimer.current) clearTimeout(confirmTimer.current);
+    doSend();
+  };
+
+  const handleCancel = () => {
+    setConfirming(false);
+    if (confirmTimer.current) clearTimeout(confirmTimer.current);
+  };
+
+  const doSend = async () => {
+    setLoading(true);
+    setResultMessage(null);
+    setResultError(null);
+    const result = await broadcast(message);
+    setLoading(false);
+    if (result) {
+      setResultMessage(`Delivered to ${result.recipients} player${result.recipients !== 1 ? "s" : ""}`);
+      setMessage("");
+    } else {
+      setResultError(useAdminStore.getState().lastError ?? "Broadcast failed");
+    }
+  };
+
+  const trimmed = message.trim();
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div>
+        <h3 className="font-display text-lg text-text-primary">Address the world</h3>
+        <p className="mt-1 text-sm text-text-secondary">
+          Send a message to all connected players.
+        </p>
+      </div>
+
+      <div>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value.slice(0, MAX_LENGTH))}
+          placeholder="Enter your message to the world..."
+          rows={3}
+          className="w-full resize-none rounded-xl border border-white/10 bg-black/15 px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-border-active focus:outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+        />
+        <div className="mt-1 text-right text-[11px] text-text-muted">
+          {message.length}/{MAX_LENGTH}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button
+          onClick={handleSendClick}
+          disabled={loading || !trimmed}
+          className={`rounded-xl border px-5 py-2 text-sm font-medium transition-all duration-200 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40 ${
+            confirming
+              ? "border-status-warning/50 bg-status-warning/15 text-status-warning"
+              : "border-border-active bg-gradient-active-strong text-text-primary hover:-translate-y-0.5 hover:shadow-glow"
+          }`}
+        >
+          {loading ? (
+            <span className="flex items-center gap-2">
+              <Spinner /> Sending...
+            </span>
+          ) : confirming ? (
+            "Confirm broadcast"
+          ) : (
+            "Send broadcast"
+          )}
+        </button>
+        {confirming && (
+          <button
+            onClick={handleCancel}
+            className="rounded text-xs text-text-muted hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+          >
+            Cancel
+          </button>
+        )}
+
+        {resultMessage && (
+          <span className="motion-safe:animate-unfurl-in rounded-full bg-status-success/12 px-3 py-1 text-xs text-status-success">
+            {resultMessage}
+          </span>
+        )}
+        {resultError && (
+          <span className="motion-safe:animate-unfurl-in rounded-full bg-status-error/15 px-3 py-1 text-xs text-status-error">
+            {resultError}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminContentPanel.tsx
+++ b/creator/src/components/admin/AdminContentPanel.tsx
@@ -1,0 +1,71 @@
+import { Suspense, lazy } from "react";
+import { useProjectStore } from "@/stores/projectStore";
+import type { AdminContentSubView } from "@/types/project";
+
+const AdminAbilityList = lazy(() =>
+  import("./AdminAbilityList").then((m) => ({ default: m.AdminAbilityList }))
+);
+const AdminEffectList = lazy(() =>
+  import("./AdminEffectList").then((m) => ({ default: m.AdminEffectList }))
+);
+const AdminQuestList = lazy(() =>
+  import("./AdminQuestList").then((m) => ({ default: m.AdminQuestList }))
+);
+const AdminAchievementList = lazy(() =>
+  import("./AdminAchievementList").then((m) => ({ default: m.AdminAchievementList }))
+);
+const AdminShopList = lazy(() =>
+  import("./AdminShopList").then((m) => ({ default: m.AdminShopList }))
+);
+const AdminItemList = lazy(() =>
+  import("./AdminItemList").then((m) => ({ default: m.AdminItemList }))
+);
+
+const CONTENT_VIEWS: Array<{ id: AdminContentSubView; label: string }> = [
+  { id: "abilities", label: "Abilities" },
+  { id: "effects", label: "Effects" },
+  { id: "quests", label: "Quests" },
+  { id: "achievements", label: "Achievements" },
+  { id: "shops", label: "Shops" },
+  { id: "items", label: "Items" },
+];
+
+export function AdminContentPanel() {
+  const activeView = useProjectStore((s) => s.adminContentSubView);
+  const setActiveView = useProjectStore((s) => s.setAdminContentSubView);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Sub-navigation pills */}
+      <div className="flex gap-0.5 rounded-full border border-white/8 bg-black/15 p-0.5">
+        {CONTENT_VIEWS.map((view) => (
+          <button
+            key={view.id}
+            onClick={() => setActiveView(view.id)}
+            className={`rounded-full px-3 py-1.5 text-2xs font-medium transition-all duration-200 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none ${
+              activeView === view.id
+                ? "bg-gradient-active-strong text-text-primary shadow-sm shadow-accent/10"
+                : "border border-transparent text-text-muted hover:border-white/8 hover:text-text-secondary"
+            }`}
+          >
+            {view.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Active panel */}
+      <Suspense
+        fallback={
+          <div className="py-12 text-center text-sm text-text-muted">Loading...</div>
+        }
+      >
+        {activeView === "abilities" && <AdminAbilityList />}
+        {activeView === "effects" && <AdminEffectList />}
+        {activeView === "quests" && <AdminQuestList />}
+        {activeView === "achievements" && <AdminAchievementList />}
+        {activeView === "shops" && <AdminShopList />}
+        {activeView === "items" && <AdminItemList />}
+      </Suspense>
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminDashboard.tsx
+++ b/creator/src/components/admin/AdminDashboard.tsx
@@ -1,18 +1,21 @@
-import { useEffect } from "react";
+import { useEffect, lazy, Suspense } from "react";
 import { useProjectStore } from "@/stores/projectStore";
 import { useAdminStore, startAdminPolling, stopAdminPolling } from "@/stores/adminStore";
 import type { AdminSubView } from "@/types/project";
 import { AdminConnectionBar } from "./AdminConnectionBar";
 import { AdminOverviewPanel } from "./AdminOverviewPanel";
 import { AdminPlayerList } from "./AdminPlayerList";
-import { AdminZoneList } from "./AdminZoneList";
-import { AdminReloadPanel } from "./AdminReloadPanel";
 import configBg from "@/assets/config-bg.png";
+
+const AdminWorldPanel = lazy(() => import("./AdminWorldPanel").then(m => ({ default: m.AdminWorldPanel })));
+const AdminContentPanel = lazy(() => import("./AdminContentPanel").then(m => ({ default: m.AdminContentPanel })));
+const AdminActionsPanel = lazy(() => import("./AdminActionsPanel").then(m => ({ default: m.AdminActionsPanel })));
 
 const ADMIN_VIEWS: Array<{ id: AdminSubView; label: string }> = [
   { id: "overview", label: "Overview" },
   { id: "players", label: "Players" },
-  { id: "zones", label: "Zones" },
+  { id: "world", label: "World" },
+  { id: "content", label: "Content" },
   { id: "actions", label: "Actions" },
 ];
 
@@ -25,6 +28,13 @@ export function AdminDashboard() {
   const loadConfig = useAdminStore((s) => s.loadConfig);
   const clearSelectedPlayer = useAdminStore((s) => s.clearSelectedPlayer);
   const clearSelectedZone = useAdminStore((s) => s.clearSelectedZone);
+  const clearSelectedRoom = useAdminStore((s) => s.clearSelectedRoom);
+  const clearSelectedMob = useAdminStore((s) => s.clearSelectedMob);
+  const clearSelectedAbility = useAdminStore((s) => s.clearSelectedAbility);
+  const clearSelectedEffect = useAdminStore((s) => s.clearSelectedEffect);
+  const clearSelectedQuest = useAdminStore((s) => s.clearSelectedQuest);
+  const clearSelectedAchievement = useAdminStore((s) => s.clearSelectedAchievement);
+  const clearPlayerSearch = useAdminStore((s) => s.clearPlayerSearch);
 
   // Load saved admin config when the dashboard mounts
   useEffect(() => {
@@ -37,7 +47,14 @@ export function AdminDashboard() {
   useEffect(() => {
     clearSelectedPlayer();
     clearSelectedZone();
-  }, [adminSubView, clearSelectedPlayer, clearSelectedZone]);
+    clearSelectedRoom();
+    clearSelectedMob();
+    clearSelectedAbility();
+    clearSelectedEffect();
+    clearSelectedQuest();
+    clearSelectedAchievement();
+    clearPlayerSearch();
+  }, [adminSubView, clearSelectedPlayer, clearSelectedZone, clearSelectedRoom, clearSelectedMob, clearSelectedAbility, clearSelectedEffect, clearSelectedQuest, clearSelectedAchievement, clearPlayerSearch]);
 
   // Manage polling — only poll when admin tab is active and connected
   const isAdminTabActive = activeTabId === "admin";
@@ -141,10 +158,13 @@ export function AdminDashboard() {
             </div>
           ) : (
             <div className="motion-safe:animate-unfurl-in">
-              {adminSubView === "overview" && <AdminOverviewPanel />}
-              {adminSubView === "players" && <AdminPlayerList />}
-              {adminSubView === "zones" && <AdminZoneList />}
-              {adminSubView === "actions" && <AdminReloadPanel />}
+              <Suspense fallback={<div className="py-12 text-center text-sm text-text-muted">Loading...</div>}>
+                {adminSubView === "overview" && <AdminOverviewPanel />}
+                {adminSubView === "players" && <AdminPlayerList />}
+                {adminSubView === "world" && <AdminWorldPanel />}
+                {adminSubView === "content" && <AdminContentPanel />}
+                {adminSubView === "actions" && <AdminActionsPanel />}
+              </Suspense>
             </div>
           )}
         </div>

--- a/creator/src/components/admin/AdminEffectList.tsx
+++ b/creator/src/components/admin/AdminEffectList.tsx
@@ -1,0 +1,151 @@
+import { useEffect } from "react";
+import { useAdminStore } from "@/stores/adminStore";
+import type { EffectEntry } from "@/types/admin";
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+      <span className="text-xs text-text-muted">{label}</span>
+      <span className="text-xs text-text-primary">{value}</span>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-[22px] border border-white/10 bg-gradient-panel-light p-4 shadow-section-sm">
+      <h4 className="mb-2 text-[11px] uppercase tracking-wide-ui text-text-muted">{title}</h4>
+      {children}
+    </div>
+  );
+}
+
+function EffectRow({
+  effect,
+  onSelect,
+}: {
+  effect: EffectEntry;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <button
+      onClick={() => onSelect(effect.id)}
+      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-all duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-display text-sm text-text-primary">
+            {effect.displayName}
+          </span>
+          <span className="rounded-full bg-stellar-blue/12 px-2 py-0.5 text-2xs text-stellar-blue">
+            {effect.effectType}
+          </span>
+        </div>
+        <div className="mt-1 flex flex-wrap gap-2 text-[11px]">
+          <span className="text-text-muted">
+            {(effect.durationMs / 1000).toFixed(1)}s
+          </span>
+          <span className="text-text-muted">{effect.stackBehavior}</span>
+          <span className="text-text-muted">Max {effect.maxStacks}</span>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function EffectDetail({
+  effect,
+  onBack,
+}: {
+  effect: EffectEntry;
+  onBack: () => void;
+}) {
+  const statModEntries = Object.entries(effect.statMods);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onBack}
+          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+        >
+          &#x2190; Back
+        </button>
+        <h3 className="font-display text-xl text-text-primary">{effect.displayName}</h3>
+        <span className="rounded-full bg-stellar-blue/12 px-2 py-0.5 text-2xs text-stellar-blue">
+          {effect.effectType}
+        </span>
+      </div>
+
+      <Section title="Properties">
+        <StatRow label="Display Name" value={effect.displayName} />
+        <StatRow label="Effect Type" value={effect.effectType} />
+        <StatRow label="Duration" value={`${(effect.durationMs / 1000).toFixed(1)}s`} />
+        <StatRow label="Tick Interval" value={`${(effect.tickIntervalMs / 1000).toFixed(1)}s`} />
+        <StatRow label="Tick Value" value={`${effect.tickMinValue} - ${effect.tickMaxValue}`} />
+        <StatRow label="Shield Amount" value={effect.shieldAmount} />
+        <StatRow label="Stack Behavior" value={effect.stackBehavior} />
+        <StatRow label="Max Stacks" value={effect.maxStacks} />
+      </Section>
+
+      {statModEntries.length > 0 && (
+        <Section title="Stat Modifiers">
+          {statModEntries.map(([stat, mod]) => (
+            <StatRow
+              key={stat}
+              label={stat}
+              value={mod > 0 ? `+${mod}` : String(mod)}
+            />
+          ))}
+        </Section>
+      )}
+    </div>
+  );
+}
+
+export function AdminEffectList() {
+  const effects = useAdminStore((s) => s.effects);
+  const selectedEffect = useAdminStore((s) => s.selectedEffect);
+  const fetchEffects = useAdminStore((s) => s.fetchEffects);
+  const fetchEffectDetail = useAdminStore((s) => s.fetchEffectDetail);
+  const clearSelectedEffect = useAdminStore((s) => s.clearSelectedEffect);
+
+  useEffect(() => {
+    fetchEffects();
+  }, [fetchEffects]);
+
+  if (selectedEffect) {
+    return <EffectDetail effect={selectedEffect} onBack={clearSelectedEffect} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-display text-lg text-text-primary">Effects</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            All registered status effects. Click to inspect.
+          </p>
+        </div>
+        <span className="text-[11px] uppercase tracking-wide-ui text-text-muted">
+          {effects.length} registered
+        </span>
+      </div>
+
+      {effects.length === 0 ? (
+        <div className="rounded-[22px] border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+          <p className="font-display text-base text-text-secondary">No effects found</p>
+          <p className="mt-1 text-sm text-text-muted">
+            The server has no status effects registered.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {effects.map((e) => (
+            <EffectRow key={e.id} effect={e} onSelect={fetchEffectDetail} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminItemList.tsx
+++ b/creator/src/components/admin/AdminItemList.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from "react";
+import { useAdminStore } from "@/stores/adminStore";
+import type { ItemEntry } from "@/types/admin";
+
+function ItemRow({ item }: { item: ItemEntry }) {
+  return (
+    <div className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 transition-all duration-200">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-display text-sm text-text-primary">
+            {item.displayName}
+          </span>
+          {item.slot && (
+            <span className="rounded-full bg-stellar-blue/12 px-2 py-0.5 text-2xs text-stellar-blue">
+              {item.slot}
+            </span>
+          )}
+          {item.consumable && (
+            <span className="rounded-full bg-status-success/12 px-2 py-0.5 text-2xs text-status-success">
+              Consumable
+            </span>
+          )}
+        </div>
+        <div className="mt-1 flex flex-wrap gap-2 text-[11px]">
+          <span className="text-status-warning">
+            {item.basePrice.toLocaleString()}g
+          </span>
+          {item.damage > 0 && (
+            <span className="text-text-secondary">
+              DMG {item.damage}
+            </span>
+          )}
+          {item.armor > 0 && (
+            <span className="text-text-secondary">
+              ARM {item.armor}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AdminItemList() {
+  const items = useAdminStore((s) => s.items);
+  const fetchItems = useAdminStore((s) => s.fetchItems);
+
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-display text-lg text-text-primary">Items</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            All registered items in the world.
+          </p>
+        </div>
+        <span className="text-[11px] uppercase tracking-wide-ui text-text-muted">
+          {items.length} registered
+        </span>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="rounded-[22px] border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+          <p className="font-display text-base text-text-secondary">No items found</p>
+          <p className="mt-1 text-sm text-text-muted">
+            The server has no items registered.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {items.map((item) => (
+            <ItemRow key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminMobDetail.tsx
+++ b/creator/src/components/admin/AdminMobDetail.tsx
@@ -1,0 +1,126 @@
+import { useAdminStore } from "@/stores/adminStore";
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-[22px] border border-white/10 bg-gradient-panel-light p-4 shadow-section-sm">
+      <h4 className="mb-2 text-[11px] uppercase tracking-wide-ui text-text-muted">{title}</h4>
+      {children}
+    </div>
+  );
+}
+
+function StatRow({ label, value, valueClass }: { label: string; value: string | number; valueClass?: string }) {
+  return (
+    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+      <span className="text-xs capitalize text-text-muted">{label}</span>
+      <span className={`text-xs ${valueClass ?? "text-text-primary"}`}>{value}</span>
+    </div>
+  );
+}
+
+function VitalBar({
+  label,
+  current,
+  max,
+  color,
+  ariaLabel,
+}: {
+  label: string;
+  current: number;
+  max: number;
+  color: string;
+  ariaLabel: string;
+}) {
+  const pct = max > 0 ? Math.round((current / max) * 100) : 0;
+  return (
+    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+      <span className="text-xs text-text-muted">{label}</span>
+      <div className="flex items-center gap-2">
+        <div
+          className="h-1.5 w-14 overflow-hidden rounded-full bg-white/10"
+          role="progressbar"
+          aria-valuenow={current}
+          aria-valuemin={0}
+          aria-valuemax={max}
+          aria-label={ariaLabel}
+        >
+          <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+        </div>
+        <span className="text-xs text-text-primary">
+          {current} / {max}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function AdminMobDetail() {
+  const mob = useAdminStore((s) => s.selectedMob);
+  const clearSelectedMob = useAdminStore((s) => s.clearSelectedMob);
+
+  if (!mob) return null;
+
+  const hpPct = mob.maxHp > 0 ? (mob.hp / mob.maxHp) * 100 : 0;
+  const hpColor = hpPct > 60 ? "bg-status-success" : hpPct > 25 ? "bg-status-warning" : "bg-status-error";
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={clearSelectedMob}
+          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+        >
+          &#x2190; Back
+        </button>
+        <h3 className="font-display text-xl text-text-primary">{mob.name}</h3>
+        {mob.aggressive && (
+          <span className="rounded-full bg-status-error/12 px-2 py-0.5 text-2xs text-status-error">
+            Aggressive
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+        {/* Identity */}
+        <Section title="Identity">
+          <StatRow label="Name" value={mob.name} />
+          <StatRow label="ID" value={mob.id} valueClass="font-mono text-text-secondary" />
+          <StatRow label="Template" value={mob.templateKey} valueClass="text-stellar-blue" />
+          <StatRow label="Room" value={mob.roomId} valueClass="font-mono text-text-secondary" />
+          <StatRow label="Spawn room" value={mob.spawnRoomId} valueClass="font-mono text-text-secondary" />
+        </Section>
+
+        {/* Combat */}
+        <Section title="Combat">
+          <VitalBar label="HP" current={mob.hp} max={mob.maxHp} color={hpColor} ariaLabel="Health" />
+          <StatRow label="Armor" value={mob.armor} />
+          <StatRow label="XP reward" value={mob.xpReward.toLocaleString()} valueClass="text-status-warning" />
+          <StatRow
+            label="Aggressive"
+            value={mob.aggressive ? "Yes" : "No"}
+            valueClass={mob.aggressive ? "text-status-error" : "text-text-primary"}
+          />
+        </Section>
+
+        {/* Quests */}
+        <Section title="Quests">
+          {mob.questIds.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {mob.questIds.map((id) => (
+                <span
+                  key={id}
+                  className="rounded-full bg-status-warning/12 px-2.5 py-1 text-2xs text-status-warning"
+                >
+                  {id}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-text-muted">None</p>
+          )}
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminMobList.tsx
+++ b/creator/src/components/admin/AdminMobList.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import { useAdminStore } from "@/stores/adminStore";
+import type { MobSummary } from "@/types/admin";
+
+function HpBar({ hp, maxHp }: { hp: number; maxHp: number }) {
+  if (maxHp <= 0) return null;
+  const pct = Math.round((hp / maxHp) * 100);
+  const color =
+    pct > 60 ? "bg-status-success" : pct > 25 ? "bg-status-warning" : "bg-status-error";
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        className="h-1.5 w-16 overflow-hidden rounded-full bg-white/10"
+        role="progressbar"
+        aria-valuenow={hp}
+        aria-valuemin={0}
+        aria-valuemax={maxHp}
+        aria-label="Health"
+      >
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="text-2xs text-text-muted">
+        {hp}/{maxHp}
+      </span>
+    </div>
+  );
+}
+
+function MobRow({
+  mob,
+  onSelect,
+}: {
+  mob: MobSummary;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <button
+      onClick={() => onSelect(mob.id)}
+      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-all duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-display text-sm text-text-primary">{mob.name}</span>
+          {mob.aggressive && (
+            <span className="rounded-full bg-status-error/12 px-2 py-0.5 text-2xs text-status-error">
+              Aggressive
+            </span>
+          )}
+        </div>
+        <div className="mt-1 flex flex-wrap gap-2 text-[11px]">
+          <span className="font-mono text-text-muted" title={mob.roomId}>
+            {mob.roomId.length > 30 ? mob.roomId.slice(0, 27) + "..." : mob.roomId}
+          </span>
+          <span className="text-text-secondary">{mob.templateKey}</span>
+        </div>
+      </div>
+      <div className="shrink-0">
+        <HpBar hp={mob.hp} maxHp={mob.maxHp} />
+      </div>
+    </button>
+  );
+}
+
+export function AdminMobList() {
+  const mobs = useAdminStore((s) => s.mobs);
+  const zones = useAdminStore((s) => s.zones);
+  const fetchMobs = useAdminStore((s) => s.fetchMobs);
+  const fetchMobDetail = useAdminStore((s) => s.fetchMobDetail);
+  const [zoneFilter, setZoneFilter] = useState("");
+
+  useEffect(() => {
+    fetchMobs(zoneFilter || undefined);
+  }, [fetchMobs, zoneFilter]);
+
+  const filteredMobs = mobs;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-display text-lg text-text-primary">Live creatures</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            All active mob instances across the world.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {zones.length > 0 && (
+            <select
+              value={zoneFilter}
+              onChange={(e) => setZoneFilter(e.target.value)}
+              className="rounded-full border border-white/10 bg-black/20 px-3 py-1.5 text-xs text-text-secondary backdrop-blur-sm transition focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+              aria-label="Filter by zone"
+            >
+              <option value="">All zones</option>
+              {zones.map((z) => (
+                <option key={z.name} value={z.name}>
+                  {z.name}
+                </option>
+              ))}
+            </select>
+          )}
+          <span className="text-[11px] uppercase tracking-ui text-text-muted">
+            {filteredMobs.length} active
+          </span>
+        </div>
+      </div>
+
+      {filteredMobs.length === 0 ? (
+        <div className="rounded-[22px] border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+          <p className="font-display text-base text-text-secondary">No creatures stir</p>
+          <p className="mt-1 text-sm text-text-muted">
+            {zoneFilter
+              ? "No mobs are alive in this zone."
+              : "No mobs are alive on the server."}
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {filteredMobs.map((mob) => (
+            <MobRow key={mob.id} mob={mob} onSelect={fetchMobDetail} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminPlayerDetail.tsx
+++ b/creator/src/components/admin/AdminPlayerDetail.tsx
@@ -1,3 +1,5 @@
+import { useState, useRef, useEffect } from "react";
+import { useAdminStore } from "@/stores/adminStore";
 import type { PlayerDetail } from "@/types/admin";
 
 function StatRow({ label, value, valueClass }: { label: string; value: string | number; valueClass?: string }) {
@@ -169,6 +171,83 @@ export function AdminPlayerDetail({
           </div>
         </Section>
       )}
+
+      <StaffToggleSection playerName={player.name} isStaff={player.isStaff} />
     </div>
+  );
+}
+
+// ─── Staff toggle ──────────────────────────────────────────────────
+
+function StaffToggleSection({ playerName, isStaff }: { playerName: string; isStaff: boolean }) {
+  const toggleStaff = useAdminStore((s) => s.toggleStaff);
+  const [confirming, setConfirming] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [resultMsg, setResultMsg] = useState<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => { if (timer.current) clearTimeout(timer.current); };
+  }, []);
+
+  const handleClick = () => {
+    if (!confirming) {
+      setConfirming(true);
+      setResultMsg(null);
+      timer.current = setTimeout(() => setConfirming(false), 4000);
+      return;
+    }
+    setConfirming(false);
+    if (timer.current) clearTimeout(timer.current);
+    doToggle();
+  };
+
+  const doToggle = async () => {
+    setLoading(true);
+    const result = await toggleStaff(playerName);
+    setLoading(false);
+    if (result) {
+      setResultMsg(result.isStaff ? "Staff granted" : "Staff revoked");
+      setTimeout(() => setResultMsg(null), 3000);
+    }
+  };
+
+  return (
+    <Section title="Admin actions">
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-xs text-text-primary">Staff privileges</p>
+          <p className="mt-0.5 text-[11px] text-text-muted">
+            {isStaff ? "This player has staff access." : "This player has no staff access."}
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {resultMsg && (
+            <span className="motion-safe:animate-unfurl-in text-2xs text-status-success">{resultMsg}</span>
+          )}
+          {confirming && (
+            <button
+              onClick={() => { setConfirming(false); if (timer.current) clearTimeout(timer.current); }}
+              className="rounded text-2xs text-text-muted hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+            >
+              Cancel
+            </button>
+          )}
+          <button
+            onClick={handleClick}
+            disabled={loading}
+            className={`shrink-0 rounded-xl border px-4 py-1.5 text-xs font-medium transition-all duration-200 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none disabled:opacity-40 ${
+              confirming
+                ? "border-status-warning/50 bg-status-warning/15 text-status-warning"
+                : isStaff
+                  ? "border-status-error/30 bg-status-error/10 text-status-error hover:bg-status-error/20"
+                  : "border-white/10 bg-black/10 text-text-primary hover:bg-white/10"
+            }`}
+          >
+            {loading ? "..." : confirming ? "Confirm" : isStaff ? "Revoke staff" : "Grant staff"}
+          </button>
+        </div>
+      </div>
+    </Section>
   );
 }

--- a/creator/src/components/admin/AdminPlayerList.tsx
+++ b/creator/src/components/admin/AdminPlayerList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useAdminStore } from "@/stores/adminStore";
 import type { PlayerSummary } from "@/types/admin";
 import { AdminPlayerDetail } from "./AdminPlayerDetail";
@@ -66,27 +67,70 @@ export function AdminPlayerList() {
   const selectedPlayer = useAdminStore((s) => s.selectedPlayer);
   const fetchPlayerDetail = useAdminStore((s) => s.fetchPlayerDetail);
   const clearSelectedPlayer = useAdminStore((s) => s.clearSelectedPlayer);
+  const searchPlayer = useAdminStore((s) => s.searchPlayer);
+  const playerSearchResults = useAdminStore((s) => s.playerSearchResults);
+  const clearPlayerSearch = useAdminStore((s) => s.clearPlayerSearch);
+  const lastError = useAdminStore((s) => s.lastError);
+  const [searchQuery, setSearchQuery] = useState("");
 
   if (selectedPlayer) {
     return <AdminPlayerDetail player={selectedPlayer} onBack={clearSelectedPlayer} />;
   }
 
+  // If viewing a search result, show that player's detail
+  if (playerSearchResults) {
+    return (
+      <AdminPlayerDetail
+        player={playerSearchResults}
+        onBack={clearPlayerSearch}
+      />
+    );
+  }
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (searchQuery.trim()) {
+      searchPlayer(searchQuery.trim());
+    }
+  };
+
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-between">
+      <div className="flex items-start justify-between gap-4">
         <div>
           <h3 className="font-display text-lg text-text-primary">Inhabitants</h3>
           <p className="mt-0.5 text-xs text-text-muted">Players currently in the world. Click a name to inspect.</p>
         </div>
-        <span className="text-[11px] uppercase tracking-ui text-text-muted">
+        <span className="shrink-0 text-[11px] uppercase tracking-ui text-text-muted">
           {players.length} present
         </span>
       </div>
 
+      {/* Player search */}
+      <form onSubmit={handleSearch} className="flex gap-2">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search by name (online or offline)..."
+          className="h-9 min-w-0 flex-1 rounded-xl border border-white/10 bg-black/15 px-3 text-sm text-text-primary placeholder:text-text-muted focus:border-border-active focus:outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+        />
+        <button
+          type="submit"
+          disabled={!searchQuery.trim()}
+          className="h-9 rounded-xl border border-white/10 bg-black/10 px-4 text-xs font-medium text-text-primary transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+        >
+          Search
+        </button>
+      </form>
+      {lastError && searchQuery && (
+        <p className="text-xs text-status-error">{lastError}</p>
+      )}
+
       {players.length === 0 ? (
         <div className="rounded-[22px] border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
           <p className="font-display text-base text-text-secondary">The world is still</p>
-          <p className="mt-1 text-sm text-text-muted">No souls walk the land at this moment.</p>
+          <p className="mt-1 text-sm text-text-muted">No souls walk the land at this moment. Use search to find offline players.</p>
         </div>
       ) : (
         <div className="flex flex-col gap-1.5">

--- a/creator/src/components/admin/AdminQuestList.tsx
+++ b/creator/src/components/admin/AdminQuestList.tsx
@@ -1,0 +1,176 @@
+import { useEffect } from "react";
+import { useAdminStore } from "@/stores/adminStore";
+import type { QuestEntry } from "@/types/admin";
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+      <span className="text-xs text-text-muted">{label}</span>
+      <span className="text-xs text-text-primary">{value}</span>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-[22px] border border-white/10 bg-gradient-panel-light p-4 shadow-section-sm">
+      <h4 className="mb-2 text-[11px] uppercase tracking-wide-ui text-text-muted">{title}</h4>
+      {children}
+    </div>
+  );
+}
+
+function QuestRow({
+  quest,
+  onSelect,
+}: {
+  quest: QuestEntry;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <button
+      onClick={() => onSelect(quest.id)}
+      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-all duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-display text-sm text-text-primary">
+            {quest.name}
+          </span>
+          <span className="rounded-full bg-status-warning/12 px-2 py-0.5 text-2xs text-status-warning">
+            {quest.completionType}
+          </span>
+        </div>
+        <div className="mt-1 flex flex-wrap gap-2 text-[11px]">
+          <span className="truncate text-text-muted" title={quest.giverMobId}>
+            {quest.giverMobId.length > 24
+              ? quest.giverMobId.slice(0, 24) + "..."
+              : quest.giverMobId}
+          </span>
+          <span className="text-text-secondary">
+            {quest.objectives.length} objective{quest.objectives.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function QuestDetail({
+  quest,
+  onBack,
+}: {
+  quest: QuestEntry;
+  onBack: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onBack}
+          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+        >
+          &#x2190; Back
+        </button>
+        <h3 className="font-display text-xl text-text-primary">{quest.name}</h3>
+      </div>
+
+      {quest.description && (
+        <p className="text-sm leading-6 text-text-secondary">{quest.description}</p>
+      )}
+
+      <Section title="Properties">
+        <StatRow label="Giver Mob" value={quest.giverMobId} />
+        <StatRow label="Completion Type" value={quest.completionType} />
+      </Section>
+
+      {quest.objectives.length > 0 && (
+        <Section title="Objectives">
+          <div className="flex flex-col gap-2">
+            {quest.objectives.map((obj, i) => (
+              <div
+                key={i}
+                className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="rounded-full bg-stellar-blue/12 px-2 py-0.5 text-2xs text-stellar-blue">
+                    {obj.type}
+                  </span>
+                  <span className="text-xs text-text-muted">
+                    {obj.targetId}
+                  </span>
+                  <span className="ml-auto text-xs text-text-primary">
+                    x{obj.count}
+                  </span>
+                </div>
+                {obj.description && (
+                  <p className="mt-1.5 text-xs leading-5 text-text-secondary">
+                    {obj.description}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {(quest.rewards.xp || quest.rewards.gold) && (
+        <Section title="Rewards">
+          {quest.rewards.xp != null && quest.rewards.xp > 0 && (
+            <StatRow label="XP" value={quest.rewards.xp.toLocaleString()} />
+          )}
+          {quest.rewards.gold != null && quest.rewards.gold > 0 && (
+            <StatRow label="Gold" value={quest.rewards.gold.toLocaleString()} />
+          )}
+        </Section>
+      )}
+    </div>
+  );
+}
+
+export function AdminQuestList() {
+  const quests = useAdminStore((s) => s.quests);
+  const selectedQuest = useAdminStore((s) => s.selectedQuest);
+  const fetchQuests = useAdminStore((s) => s.fetchQuests);
+  const fetchQuestDetail = useAdminStore((s) => s.fetchQuestDetail);
+  const clearSelectedQuest = useAdminStore((s) => s.clearSelectedQuest);
+
+  useEffect(() => {
+    fetchQuests();
+  }, [fetchQuests]);
+
+  if (selectedQuest) {
+    return <QuestDetail quest={selectedQuest} onBack={clearSelectedQuest} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-display text-lg text-text-primary">Quests</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            All registered quests. Click to inspect.
+          </p>
+        </div>
+        <span className="text-[11px] uppercase tracking-wide-ui text-text-muted">
+          {quests.length} registered
+        </span>
+      </div>
+
+      {quests.length === 0 ? (
+        <div className="rounded-[22px] border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+          <p className="font-display text-base text-text-secondary">No quests found</p>
+          <p className="mt-1 text-sm text-text-muted">
+            The server has no quests registered.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {quests.map((q) => (
+            <QuestRow key={q.id} quest={q} onSelect={fetchQuestDetail} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminRoomDetail.tsx
+++ b/creator/src/components/admin/AdminRoomDetail.tsx
@@ -1,0 +1,176 @@
+import { useAdminStore } from "@/stores/adminStore";
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-[22px] border border-white/10 bg-gradient-panel-light p-4 shadow-section-sm">
+      <h4 className="mb-2 text-[11px] uppercase tracking-wide-ui text-text-muted">{title}</h4>
+      {children}
+    </div>
+  );
+}
+
+function StatRow({ label, value, valueClass }: { label: string; value: string | number; valueClass?: string }) {
+  return (
+    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+      <span className="text-xs capitalize text-text-muted">{label}</span>
+      <span className={`text-xs ${valueClass ?? "text-text-primary"}`}>{value}</span>
+    </div>
+  );
+}
+
+function HpBar({ label, current, max }: { label: string; current: number; max: number }) {
+  if (max <= 0) return null;
+  const pct = Math.round((current / max) * 100);
+  const color = pct > 60 ? "bg-status-success" : pct > 25 ? "bg-status-warning" : "bg-status-error";
+  return (
+    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+      <span className="text-xs text-text-muted">{label}</span>
+      <div className="flex items-center gap-2">
+        <div
+          className="h-1.5 w-16 overflow-hidden rounded-full bg-white/10"
+          role="progressbar"
+          aria-valuenow={current}
+          aria-valuemin={0}
+          aria-valuemax={max}
+          aria-label={`${label} health`}
+        >
+          <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+        </div>
+        <span className="text-2xs text-text-muted">
+          {current}/{max}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function AdminRoomDetail() {
+  const room = useAdminStore((s) => s.selectedRoom);
+  const clearSelectedRoom = useAdminStore((s) => s.clearSelectedRoom);
+
+  if (!room) return null;
+
+  const hasMedia = room.image || room.music || room.ambient || room.video;
+  const hasCoords = room.mapX != null && room.mapY != null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={clearSelectedRoom}
+          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+        >
+          &#x2190; Back
+        </button>
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate font-display text-xl text-text-primary">{room.title}</h3>
+          <p className="mt-0.5 font-mono text-[11px] text-text-muted">{room.id}</p>
+        </div>
+        {hasCoords && (
+          <span className="shrink-0 rounded-full bg-black/15 px-2.5 py-0.5 font-mono text-2xs text-text-muted">
+            ({room.mapX}, {room.mapY})
+          </span>
+        )}
+      </div>
+
+      {/* Description */}
+      {room.description && (
+        <div className="rounded-[22px] border border-white/10 bg-gradient-panel-light p-4 shadow-section-sm">
+          <p className="text-sm leading-6 text-text-secondary">{room.description}</p>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+        {/* Exits */}
+        <Section title="Exits">
+          {room.exits.length > 0 ? (
+            <div className="flex flex-col gap-1">
+              {room.exits.map((exit) => (
+                <div
+                  key={exit.direction}
+                  className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0"
+                >
+                  <span className="text-xs font-medium text-stellar-blue">{exit.direction}</span>
+                  <span className="font-mono text-xs text-text-secondary">{exit.target}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-text-muted">No exits</p>
+          )}
+        </Section>
+
+        {/* Players */}
+        <Section title="Players present">
+          {room.players.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {room.players.map((name) => (
+                <span
+                  key={name}
+                  className="rounded-full bg-status-success/12 px-2.5 py-1 text-2xs text-status-success"
+                >
+                  {name}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-text-muted">None</p>
+          )}
+        </Section>
+
+        {/* Mobs */}
+        <Section title="Creatures">
+          {room.mobs.length > 0 ? (
+            <div className="flex flex-col gap-1">
+              {room.mobs.map((mob) => (
+                <div key={mob.id}>
+                  <div className="flex items-center justify-between py-1">
+                    <span className="text-xs text-text-primary">{mob.name}</span>
+                    <span className="font-mono text-[11px] text-text-muted">{mob.templateKey}</span>
+                  </div>
+                  <HpBar label="HP" current={mob.hp} max={mob.maxHp} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-text-muted">None</p>
+          )}
+        </Section>
+      </div>
+
+      {/* Features */}
+      {room.features.length > 0 && (
+        <Section title="Features">
+          <div className="flex flex-wrap gap-1.5">
+            {room.features.map((feature) => (
+              <span
+                key={feature}
+                className="rounded-full bg-black/15 px-2.5 py-1 text-2xs text-text-muted"
+              >
+                {feature}
+              </span>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {/* Station */}
+      {room.station && (
+        <Section title="Station">
+          <StatRow label="Type" value={room.station} valueClass="text-stellar-blue" />
+        </Section>
+      )}
+
+      {/* Media */}
+      {hasMedia && (
+        <Section title="Media">
+          {room.image && <StatRow label="Image" value={room.image} valueClass="font-mono text-text-secondary" />}
+          {room.music && <StatRow label="Music" value={room.music} valueClass="font-mono text-text-secondary" />}
+          {room.ambient && <StatRow label="Ambient" value={room.ambient} valueClass="font-mono text-text-secondary" />}
+          {room.video && <StatRow label="Video" value={room.video} valueClass="font-mono text-text-secondary" />}
+        </Section>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminShopList.tsx
+++ b/creator/src/components/admin/AdminShopList.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { useAdminStore } from "@/stores/adminStore";
+import type { ShopEntry } from "@/types/admin";
+
+function ShopRow({ shop }: { shop: ShopEntry }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-2xl border border-white/8 bg-white/4 transition-all duration-200">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left transition-all duration-200 hover:bg-accent/[0.04] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none rounded-2xl"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate font-display text-sm text-text-primary">
+              {shop.name}
+            </span>
+            <span className="text-[11px] text-text-muted">
+              {shop.items.length} item{shop.items.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+          <div className="mt-1 text-[11px] text-text-muted">
+            Room: <span className="font-mono text-text-secondary">{shop.roomId}</span>
+          </div>
+        </div>
+        <span className="shrink-0 text-xs text-text-muted transition-transform duration-200"
+          style={{ transform: expanded ? "rotate(180deg)" : "rotate(0deg)" }}
+        >
+          &#x25BC;
+        </span>
+      </button>
+
+      {expanded && shop.items.length > 0 && (
+        <div className="border-t border-white/6 px-4 pb-3 pt-2">
+          <div className="flex flex-col gap-1">
+            {shop.items.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-center justify-between rounded-xl bg-white/[0.02] px-3 py-2"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-text-primary">{item.displayName}</span>
+                  {item.slot && (
+                    <span className="rounded-full bg-stellar-blue/12 px-2 py-0.5 text-2xs text-stellar-blue">
+                      {item.slot}
+                    </span>
+                  )}
+                </div>
+                <span className="text-xs text-status-warning">
+                  {item.basePrice.toLocaleString()}g
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AdminShopList() {
+  const shops = useAdminStore((s) => s.shops);
+  const fetchShops = useAdminStore((s) => s.fetchShops);
+
+  useEffect(() => {
+    fetchShops();
+  }, [fetchShops]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="font-display text-lg text-text-primary">Shops</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            All registered shops and their inventories.
+          </p>
+        </div>
+        <span className="text-[11px] uppercase tracking-wide-ui text-text-muted">
+          {shops.length} registered
+        </span>
+      </div>
+
+      {shops.length === 0 ? (
+        <div className="rounded-[22px] border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+          <p className="font-display text-base text-text-secondary">No shops found</p>
+          <p className="mt-1 text-sm text-text-muted">
+            The server has no shops registered.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {shops.map((s) => (
+            <ShopRow key={s.id} shop={s} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminWorldPanel.tsx
+++ b/creator/src/components/admin/AdminWorldPanel.tsx
@@ -1,0 +1,20 @@
+import { useAdminStore } from "@/stores/adminStore";
+import { AdminZoneList } from "./AdminZoneList";
+import { AdminMobList } from "./AdminMobList";
+import { AdminRoomDetail } from "./AdminRoomDetail";
+import { AdminMobDetail } from "./AdminMobDetail";
+
+export function AdminWorldPanel() {
+  const selectedRoom = useAdminStore((s) => s.selectedRoom);
+  const selectedMob = useAdminStore((s) => s.selectedMob);
+
+  if (selectedRoom) return <AdminRoomDetail />;
+  if (selectedMob) return <AdminMobDetail />;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <AdminZoneList />
+      <AdminMobList />
+    </div>
+  );
+}

--- a/creator/src/components/admin/AdminZoneDetail.tsx
+++ b/creator/src/components/admin/AdminZoneDetail.tsx
@@ -1,3 +1,4 @@
+import { useAdminStore } from "@/stores/adminStore";
 import type { ZoneDetail } from "@/types/admin";
 
 export function AdminZoneDetail({
@@ -7,6 +8,15 @@ export function AdminZoneDetail({
   zone: ZoneDetail;
   onBack: () => void;
 }) {
+  const fetchRoomDetail = useAdminStore((s) => s.fetchRoomDetail);
+
+  const handleRoomClick = (roomId: string) => {
+    // Room ID format is "zone:room" — extract the room part
+    const parts = roomId.split(":");
+    const roomPart = parts.length > 1 ? parts.slice(1).join(":") : roomId;
+    fetchRoomDetail(zone.name, roomPart);
+  };
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-3">
@@ -22,13 +32,16 @@ export function AdminZoneDetail({
         </span>
       </div>
 
+      <p className="text-xs text-text-muted">Click a room to inspect its full detail.</p>
+
       <div className="flex flex-col gap-1.5">
         {zone.rooms.map((room) => (
-          <div
+          <button
             key={room.id}
-            className={`rounded-2xl border px-4 py-3 transition-colors duration-200 ${
+            onClick={() => handleRoomClick(room.id)}
+            className={`w-full rounded-2xl border px-4 py-3 text-left transition-all duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none ${
               room.players.length > 0
-                ? "border-accent/15 bg-accent/[0.03] shadow-[inset_3px_0_0_var(--color-accent)]"
+                ? "border-accent/15 bg-accent/[0.03]"
                 : "border-white/8 bg-white/4"
             }`}
           >
@@ -68,7 +81,7 @@ export function AdminZoneDetail({
                 ))}
               </div>
             )}
-          </div>
+          </button>
         ))}
       </div>
     </div>

--- a/creator/src/stores/adminStore.ts
+++ b/creator/src/stores/adminStore.ts
@@ -4,12 +4,23 @@ import type {
   AdminConfig,
   AdminConnectionStatus,
   AdminOverview,
+  HealthResponse,
   PlayerSummary,
   PlayerDetail,
+  StaffToggleResult,
   ZoneSummary,
   ZoneDetail,
+  RoomDetailResponse,
+  MobSummary,
+  AbilityEntry,
+  EffectEntry,
+  QuestEntry,
+  AchievementEntry,
+  ShopEntry,
+  ItemEntry,
   ReloadResult,
   ReloadTarget,
+  BroadcastResult,
 } from "@/types/admin";
 
 const POLL_INTERVAL = 10_000; // 10 seconds
@@ -20,14 +31,38 @@ interface AdminStore {
   token: string;
   connectionStatus: AdminConnectionStatus;
   lastError: string | null;
+  health: HealthResponse | null;
 
-  // Cached data
+  // Cached data — overview
   overview: AdminOverview | null;
+
+  // Cached data — players
   players: PlayerSummary[];
-  zones: ZoneSummary[];
   selectedPlayer: PlayerDetail | null;
+  playerSearchResults: PlayerDetail | null;
+
+  // Cached data — world
+  zones: ZoneSummary[];
   selectedZone: ZoneDetail | null;
+  selectedRoom: RoomDetailResponse | null;
+  mobs: MobSummary[];
+  selectedMob: MobSummary | null;
+
+  // Cached data — content
+  abilities: AbilityEntry[];
+  selectedAbility: AbilityEntry | null;
+  effects: EffectEntry[];
+  selectedEffect: EffectEntry | null;
+  quests: QuestEntry[];
+  selectedQuest: QuestEntry | null;
+  achievements: AchievementEntry[];
+  selectedAchievement: AchievementEntry | null;
+  shops: ShopEntry[];
+  items: ItemEntry[];
+
+  // Cached data — actions
   lastReload: ReloadResult | null;
+  lastBroadcast: BroadcastResult | null;
 
   // Polling
   lastRefreshed: Date | null;
@@ -40,15 +75,51 @@ interface AdminStore {
   loadConfig: (projectPath: string) => Promise<void>;
   saveConfig: (projectPath: string) => Promise<void>;
 
-  // Actions — data fetching
+  // Actions — overview
   fetchOverview: () => Promise<void>;
+
+  // Actions — players
   fetchPlayers: () => Promise<void>;
   fetchPlayerDetail: (name: string) => Promise<void>;
   clearSelectedPlayer: () => void;
+  searchPlayer: (query: string) => Promise<void>;
+  clearPlayerSearch: () => void;
+  toggleStaff: (name: string) => Promise<StaffToggleResult | null>;
+
+  // Actions — world
   fetchZones: () => Promise<void>;
   fetchZoneDetail: (zone: string) => Promise<void>;
   clearSelectedZone: () => void;
+  fetchRoomDetail: (zone: string, room: string) => Promise<void>;
+  clearSelectedRoom: () => void;
+  fetchMobs: (zone?: string) => Promise<void>;
+  fetchMobDetail: (id: string) => Promise<void>;
+  clearSelectedMob: () => void;
+
+  // Actions — content
+  fetchAbilities: () => Promise<void>;
+  fetchAbilityDetail: (id: string) => Promise<void>;
+  clearSelectedAbility: () => void;
+  fetchEffects: () => Promise<void>;
+  fetchEffectDetail: (id: string) => Promise<void>;
+  clearSelectedEffect: () => void;
+  fetchQuests: () => Promise<void>;
+  fetchQuestDetail: (id: string) => Promise<void>;
+  clearSelectedQuest: () => void;
+  fetchAchievements: () => Promise<void>;
+  fetchAchievementDetail: (id: string) => Promise<void>;
+  clearSelectedAchievement: () => void;
+  fetchShops: () => Promise<void>;
+  fetchItems: () => Promise<void>;
+
+  // Actions — reload + broadcast
   reload: (target: ReloadTarget) => Promise<ReloadResult | null>;
+  broadcast: (message: string) => Promise<BroadcastResult | null>;
+}
+
+// Helper to extract error message
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 export const useAdminStore = create<AdminStore>((set, get) => ({
@@ -56,13 +127,33 @@ export const useAdminStore = create<AdminStore>((set, get) => ({
   token: "",
   connectionStatus: "disconnected",
   lastError: null,
+  health: null,
 
   overview: null,
+
   players: [],
-  zones: [],
   selectedPlayer: null,
+  playerSearchResults: null,
+
+  zones: [],
   selectedZone: null,
+  selectedRoom: null,
+  mobs: [],
+  selectedMob: null,
+
+  abilities: [],
+  selectedAbility: null,
+  effects: [],
+  selectedEffect: null,
+  quests: [],
+  selectedQuest: null,
+  achievements: [],
+  selectedAchievement: null,
+  shops: [],
+  items: [],
+
   lastReload: null,
+  lastBroadcast: null,
 
   lastRefreshed: null,
 
@@ -77,13 +168,10 @@ export const useAdminStore = create<AdminStore>((set, get) => ({
     }
     set({ connectionStatus: "connecting", lastError: null });
     try {
-      const overview = await invoke<AdminOverview>("admin_overview", { url, token });
-      set({ connectionStatus: "connected", overview, lastRefreshed: new Date() });
+      const health = await invoke<HealthResponse>("admin_health", { url, token });
+      set({ connectionStatus: "connected", health, lastRefreshed: new Date() });
     } catch (err) {
-      set({
-        connectionStatus: "error",
-        lastError: err instanceof Error ? err.message : String(err),
-      });
+      set({ connectionStatus: "error", lastError: errMsg(err) });
     }
   },
 
@@ -91,12 +179,28 @@ export const useAdminStore = create<AdminStore>((set, get) => ({
     set({
       connectionStatus: "disconnected",
       lastError: null,
+      health: null,
       overview: null,
       players: [],
-      zones: [],
       selectedPlayer: null,
+      playerSearchResults: null,
+      zones: [],
       selectedZone: null,
+      selectedRoom: null,
+      mobs: [],
+      selectedMob: null,
+      abilities: [],
+      selectedAbility: null,
+      effects: [],
+      selectedEffect: null,
+      quests: [],
+      selectedQuest: null,
+      achievements: [],
+      selectedAchievement: null,
+      shops: [],
+      items: [],
       lastReload: null,
+      lastBroadcast: null,
       lastRefreshed: null,
     }),
 
@@ -111,11 +215,10 @@ export const useAdminStore = create<AdminStore>((set, get) => ({
 
   saveConfig: async (projectPath) => {
     const { url, token } = get();
-    await invoke("save_admin_config", {
-      projectPath,
-      config: { url, token },
-    });
+    await invoke("save_admin_config", { projectPath, config: { url, token } });
   },
+
+  // ─── Overview ──────────────────────────────────────────────────
 
   fetchOverview: async () => {
     const { url, token, connectionStatus } = get();
@@ -124,12 +227,11 @@ export const useAdminStore = create<AdminStore>((set, get) => ({
       const overview = await invoke<AdminOverview>("admin_overview", { url, token });
       set({ overview, lastRefreshed: new Date() });
     } catch (err) {
-      set({
-        connectionStatus: "error",
-        lastError: err instanceof Error ? err.message : String(err),
-      });
+      set({ connectionStatus: "error", lastError: errMsg(err) });
     }
   },
+
+  // ─── Players ───────────────────────────────────────────────────
 
   fetchPlayers: async () => {
     const { url, token, connectionStatus } = get();
@@ -138,10 +240,7 @@ export const useAdminStore = create<AdminStore>((set, get) => ({
       const players = await invoke<PlayerSummary[]>("admin_players", { url, token });
       set({ players, lastRefreshed: new Date() });
     } catch (err) {
-      set({
-        connectionStatus: "error",
-        lastError: err instanceof Error ? err.message : String(err),
-      });
+      set({ connectionStatus: "error", lastError: errMsg(err) });
     }
   },
 
@@ -152,11 +251,43 @@ export const useAdminStore = create<AdminStore>((set, get) => ({
       const detail = await invoke<PlayerDetail>("admin_player_detail", { url, token, name });
       set({ selectedPlayer: detail });
     } catch (err) {
-      set({ lastError: err instanceof Error ? err.message : String(err) });
+      set({ lastError: errMsg(err) });
     }
   },
 
   clearSelectedPlayer: () => set({ selectedPlayer: null }),
+
+  searchPlayer: async (query) => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const result = await invoke<PlayerDetail>("admin_player_search", { url, token, query });
+      set({ playerSearchResults: result });
+    } catch (err) {
+      set({ lastError: errMsg(err), playerSearchResults: null });
+    }
+  },
+
+  clearPlayerSearch: () => set({ playerSearchResults: null }),
+
+  toggleStaff: async (name) => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return null;
+    try {
+      const result = await invoke<StaffToggleResult>("admin_player_toggle_staff", { url, token, name });
+      // Update selectedPlayer if it matches
+      const { selectedPlayer } = get();
+      if (selectedPlayer && selectedPlayer.name === name) {
+        set({ selectedPlayer: { ...selectedPlayer, isStaff: result.isStaff } });
+      }
+      return result;
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+      return null;
+    }
+  },
+
+  // ─── World ─────────────────────────────────────────────────────
 
   fetchZones: async () => {
     const { url, token, connectionStatus } = get();
@@ -165,10 +296,7 @@ export const useAdminStore = create<AdminStore>((set, get) => ({
       const zones = await invoke<ZoneSummary[]>("admin_zones", { url, token });
       set({ zones, lastRefreshed: new Date() });
     } catch (err) {
-      set({
-        connectionStatus: "error",
-        lastError: err instanceof Error ? err.message : String(err),
-      });
+      set({ connectionStatus: "error", lastError: errMsg(err) });
     }
   },
 
@@ -179,11 +307,170 @@ export const useAdminStore = create<AdminStore>((set, get) => ({
       const detail = await invoke<ZoneDetail>("admin_zone_detail", { url, token, zone });
       set({ selectedZone: detail });
     } catch (err) {
-      set({ lastError: err instanceof Error ? err.message : String(err) });
+      set({ lastError: errMsg(err) });
     }
   },
 
-  clearSelectedZone: () => set({ selectedZone: null }),
+  clearSelectedZone: () => set({ selectedZone: null, selectedRoom: null }),
+
+  fetchRoomDetail: async (zone, room) => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const detail = await invoke<RoomDetailResponse>("admin_room_detail", { url, token, zone, room });
+      set({ selectedRoom: detail });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  clearSelectedRoom: () => set({ selectedRoom: null }),
+
+  fetchMobs: async (zone) => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const mobs = await invoke<MobSummary[]>("admin_mobs", { url, token, zone: zone ?? null });
+      set({ mobs, lastRefreshed: new Date() });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  fetchMobDetail: async (id) => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const mob = await invoke<MobSummary>("admin_mob_detail", { url, token, id });
+      set({ selectedMob: mob });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  clearSelectedMob: () => set({ selectedMob: null }),
+
+  // ─── Content ───────────────────────────────────────────────────
+
+  fetchAbilities: async () => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const abilities = await invoke<AbilityEntry[]>("admin_abilities", { url, token });
+      set({ abilities });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  fetchAbilityDetail: async (id) => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const detail = await invoke<AbilityEntry>("admin_ability_detail", { url, token, id });
+      set({ selectedAbility: detail });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  clearSelectedAbility: () => set({ selectedAbility: null }),
+
+  fetchEffects: async () => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const effects = await invoke<EffectEntry[]>("admin_effects", { url, token });
+      set({ effects });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  fetchEffectDetail: async (id) => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const detail = await invoke<EffectEntry>("admin_effect_detail", { url, token, id });
+      set({ selectedEffect: detail });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  clearSelectedEffect: () => set({ selectedEffect: null }),
+
+  fetchQuests: async () => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const quests = await invoke<QuestEntry[]>("admin_quests", { url, token });
+      set({ quests });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  fetchQuestDetail: async (id) => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const detail = await invoke<QuestEntry>("admin_quest_detail", { url, token, id });
+      set({ selectedQuest: detail });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  clearSelectedQuest: () => set({ selectedQuest: null }),
+
+  fetchAchievements: async () => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const achievements = await invoke<AchievementEntry[]>("admin_achievements", { url, token });
+      set({ achievements });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  fetchAchievementDetail: async (id) => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const detail = await invoke<AchievementEntry>("admin_achievement_detail", { url, token, id });
+      set({ selectedAchievement: detail });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  clearSelectedAchievement: () => set({ selectedAchievement: null }),
+
+  fetchShops: async () => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const shops = await invoke<ShopEntry[]>("admin_shops", { url, token });
+      set({ shops });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  fetchItems: async () => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return;
+    try {
+      const items = await invoke<ItemEntry[]>("admin_items", { url, token });
+      set({ items });
+    } catch (err) {
+      set({ lastError: errMsg(err) });
+    }
+  },
+
+  // ─── Actions ───────────────────────────────────────────────────
 
   reload: async (target) => {
     const { url, token, connectionStatus } = get();
@@ -193,8 +480,20 @@ export const useAdminStore = create<AdminStore>((set, get) => ({
       set({ lastReload: result });
       return result;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      set({ lastError: message });
+      set({ lastError: errMsg(err) });
+      return null;
+    }
+  },
+
+  broadcast: async (message) => {
+    const { url, token, connectionStatus } = get();
+    if (connectionStatus !== "connected") return null;
+    try {
+      const result = await invoke<BroadcastResult>("admin_broadcast", { url, token, message });
+      set({ lastBroadcast: result });
+      return result;
+    } catch (err) {
+      set({ lastError: errMsg(err) });
       return null;
     }
   },
@@ -219,10 +518,10 @@ export function startAdminPolling(view: string) {
       case "players":
         store.fetchPlayers();
         break;
-      case "zones":
+      case "world":
         store.fetchZones();
         break;
-      // "actions" doesn't need polling
+      // "content" and "actions" don't need polling — fetched on mount
     }
   };
 

--- a/creator/src/stores/projectStore.ts
+++ b/creator/src/stores/projectStore.ts
@@ -11,6 +11,7 @@ import type {
   ContentStudioSubView,
   OperationsSubView,
   AdminSubView,
+  AdminContentSubView,
 } from "@/types/project";
 
 /** Navigation target for sidebar -> zone editor entity selection. */
@@ -33,6 +34,7 @@ interface ProjectStore {
   contentStudioSubView: ContentStudioSubView;
   operationsSubView: OperationsSubView;
   adminSubView: AdminSubView;
+  adminContentSubView: AdminContentSubView;
   pendingNavigation: PendingNavigation | null;
 
   setProject: (project: Project) => void;
@@ -52,6 +54,7 @@ interface ProjectStore {
   setContentStudioSubView: (subView: ContentStudioSubView) => void;
   setOperationsSubView: (subView: OperationsSubView) => void;
   setAdminSubView: (subView: AdminSubView) => void;
+  setAdminContentSubView: (subView: AdminContentSubView) => void;
   navigateTo: (nav: PendingNavigation) => void;
   consumeNavigation: () => PendingNavigation | null;
 }
@@ -68,6 +71,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   contentStudioSubView: "achievements",
   operationsSubView: "services",
   adminSubView: "overview",
+  adminContentSubView: "abilities",
   pendingNavigation: null,
 
   setProject: (project) =>
@@ -83,6 +87,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
       contentStudioSubView: "achievements",
       operationsSubView: "services",
       adminSubView: "overview",
+      adminContentSubView: "abilities",
     }),
 
   closeProject: () =>
@@ -119,6 +124,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   setContentStudioSubView: (contentStudioSubView) => set({ contentStudioSubView }),
   setOperationsSubView: (operationsSubView) => set({ operationsSubView }),
   setAdminSubView: (adminSubView) => set({ adminSubView }),
+  setAdminContentSubView: (adminContentSubView) => set({ adminContentSubView }),
 
   navigateTo: (nav) => {
     const tab: Tab = { id: `zone:${nav.zoneId}`, kind: "zone", label: nav.zoneId };

--- a/creator/src/types/admin.ts
+++ b/creator/src/types/admin.ts
@@ -71,3 +71,174 @@ export interface ReloadResult {
 }
 
 export type ReloadTarget = "world" | "abilities" | "effects" | "all";
+
+// ─── Phase 2: New API response types ──────────────────────────────
+
+export interface HealthResponse {
+  status: string;
+  uptimeMs: number;
+  playersOnline: number;
+}
+
+export interface StaffToggleResult {
+  name: string;
+  isStaff: boolean;
+}
+
+export interface ExitDetail {
+  direction: string;
+  target: string;
+}
+
+export interface RoomMobInfo {
+  id: string;
+  name: string;
+  hp: number;
+  maxHp: number;
+  templateKey: string;
+}
+
+export interface RoomDetailResponse {
+  id: string;
+  title: string;
+  description: string;
+  exits: ExitDetail[];
+  players: string[];
+  mobs: RoomMobInfo[];
+  features: string[];
+  station?: string;
+  image?: string;
+  video?: string;
+  music?: string;
+  ambient?: string;
+  mapX?: number;
+  mapY?: number;
+}
+
+export interface MobSummary {
+  id: string;
+  name: string;
+  roomId: string;
+  hp: number;
+  maxHp: number;
+  templateKey: string;
+  aggressive: boolean;
+  xpReward: number;
+  armor: number;
+  image?: string;
+  questIds: string[];
+  spawnRoomId: string;
+}
+
+export interface AbilityEntry {
+  id: string;
+  displayName: string;
+  description: string;
+  manaCost: number;
+  cooldownMs: number;
+  levelRequired: number;
+  targetType: string;
+  requiredClass?: string;
+  image?: string;
+  effectType: string;
+}
+
+export interface EffectEntry {
+  id: string;
+  displayName: string;
+  effectType: string;
+  durationMs: number;
+  tickIntervalMs: number;
+  tickMinValue: number;
+  tickMaxValue: number;
+  shieldAmount: number;
+  statMods: Record<string, number>;
+  stackBehavior: string;
+  maxStacks: number;
+}
+
+export interface QuestObjective {
+  type: string;
+  targetId: string;
+  count: number;
+  description: string;
+}
+
+export interface QuestRewards {
+  xp?: number;
+  gold?: number;
+}
+
+export interface QuestEntry {
+  id: string;
+  name: string;
+  description: string;
+  giverMobId: string;
+  completionType: string;
+  objectives: QuestObjective[];
+  rewards: QuestRewards;
+}
+
+export interface AchievementCriterion {
+  type: string;
+  targetId: string;
+  count: number;
+  description: string;
+}
+
+export interface AchievementRewards {
+  xp?: number;
+  gold?: number;
+  title?: string;
+}
+
+export interface AchievementEntry {
+  id: string;
+  displayName: string;
+  description: string;
+  category: string;
+  hidden: boolean;
+  criteria: AchievementCriterion[];
+  rewards: AchievementRewards;
+}
+
+export interface ShopItemEntry {
+  id: string;
+  displayName: string;
+  basePrice: number;
+  slot?: string;
+}
+
+export interface ShopEntry {
+  id: string;
+  name: string;
+  roomId: string;
+  items: ShopItemEntry[];
+}
+
+export interface ItemEntry {
+  id: string;
+  displayName: string;
+  description: string;
+  slot?: string;
+  damage: number;
+  armor: number;
+  stats: Record<string, number>;
+  consumable: boolean;
+  basePrice: number;
+  image?: string;
+  spawnRoom?: string;
+}
+
+export interface BroadcastResult {
+  status: string;
+  recipients: number;
+}
+
+export type AdminContentCategory =
+  | "abilities"
+  | "effects"
+  | "quests"
+  | "achievements"
+  | "shops"
+  | "items";

--- a/creator/src/types/project.ts
+++ b/creator/src/types/project.ts
@@ -71,8 +71,17 @@ export type OperationsSubView =
 export type AdminSubView =
   | "overview"
   | "players"
-  | "zones"
+  | "world"
+  | "content"
   | "actions";
+
+export type AdminContentSubView =
+  | "abilities"
+  | "effects"
+  | "quests"
+  | "achievements"
+  | "shops"
+  | "items";
 
 export interface Tab {
   id: string;


### PR DESCRIPTION
## Summary

Expands the admin dashboard from 6 endpoints to full 23-endpoint coverage of the AmbonMUD admin API.

- **Navigation:** 5 pills (Overview | Players | World | Content | Actions) — "Zones" renamed to "World"
- **Health check:** `GET /api/health` replaces overview probe for connectivity testing
- **Player search:** Search bar finds online + offline players by name
- **Staff toggle:** Confirm-then-act button in player detail to grant/revoke staff
- **World drilldown:** Zone → clickable rooms → full room detail (description, structured exits, live mobs with HP bars, media paths, map coordinates)
- **Mob inspection:** Live mob list with zone filter, individual mob detail
- **Content inspection:** 6-category internal pill nav for abilities, effects, quests, achievements, shops, items — each with list + detail panels
- **Broadcast:** Send messages to all online players with confirm-then-send pattern and recipient count

### Technical details
- 17 new Rust Tauri commands with `admin_get_with_query` and `admin_post_with_body` helpers
- ~15 new response structs (camelCase serde) matching the API JSON shapes exactly
- Zustand store expanded with ~15 new state fields and ~20 new fetch actions
- Polling: "world" polls zone list, "content" fetches on mount only (static definitions)
- All path parameters sanitized via `encode_path_segment`

## Test plan
- [ ] `cargo check` — zero warnings
- [ ] `bunx tsc --noEmit` — zero errors
- [ ] `bun run test` — 183 tests pass
- [ ] Connect via health endpoint, verify overview still works
- [ ] Search for an offline player by name, inspect detail
- [ ] Toggle staff on a player with confirmation, verify badge updates
- [ ] World: drill zone → room → full room detail with exits/mobs/media
- [ ] World: view mob list, filter by zone, click mob detail
- [ ] Content: browse each of 6 categories (abilities, effects, quests, achievements, shops, items)
- [ ] Content: click an ability/quest/achievement to see detail view
- [ ] Content: expand a shop to see its item inventory
- [ ] Actions: send a broadcast with confirm-then-send, verify recipient count
- [ ] Verify polling stops on Content/Actions views (no unnecessary requests)