### PR TITLE
Add admin, observability, and logging config panels

### DIFF
--- a/creator/src/components/config/WorldSystemsStudio.tsx
+++ b/creator/src/components/config/WorldSystemsStudio.tsx
@@ -2,6 +2,9 @@ import type { ReactNode } from "react";
 import type { AppConfig } from "@/types/config";
 import type { WorldSystemsSubView } from "@/types/project";
 import { ServerPanel } from "./panels/ServerPanel";
+import { AdminConfigPanel } from "./panels/AdminConfigPanel";
+import { ObservabilityPanel } from "./panels/ObservabilityPanel";
+import { LoggingPanel } from "./panels/LoggingPanel";
 import { CombatPanel } from "./panels/CombatPanel";
 import { MobTiersPanel } from "./panels/MobTiersPanel";
 import { ProgressionPanel } from "./panels/ProgressionPanel";
@@ -63,6 +66,27 @@ export function WorldSystemsStudio({
             description="Ports and server process settings."
           >
             <ServerPanel config={config} onChange={onChange} />
+          </StudioSection>
+          <StudioSection
+            kicker="Admin server"
+            title="Remote administration API"
+            description="Enable the admin HTTP server for the Arcanum to connect to. Set a token for authentication."
+          >
+            <AdminConfigPanel config={config} onChange={onChange} />
+          </StudioSection>
+          <StudioSection
+            kicker="Observability"
+            title="Metrics and monitoring"
+            description="Prometheus metrics endpoint for server health and performance data."
+          >
+            <ObservabilityPanel config={config} onChange={onChange} />
+          </StudioSection>
+          <StudioSection
+            kicker="Logging"
+            title="Log levels"
+            description="Control the verbosity of server logs. Per-package overrides let you debug specific systems without flooding the console."
+          >
+            <LoggingPanel config={config} onChange={onChange} />
           </StudioSection>
         </>
       )}

--- a/creator/src/components/config/panels/AdminConfigPanel.tsx
+++ b/creator/src/components/config/panels/AdminConfigPanel.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import type { ConfigPanelProps, AppConfig } from "./types";
+import { Section, FieldRow, NumberInput, TextInput, CheckboxInput } from "@/components/ui/FormWidgets";
+
+export function AdminConfigPanel({ config, onChange }: ConfigPanelProps) {
+  const a = config.admin;
+  const patch = (p: Partial<AppConfig["admin"]>) =>
+    onChange({ admin: { ...a, ...p } });
+  const [showToken, setShowToken] = useState(false);
+
+  return (
+    <>
+      <Section
+        title="Admin API"
+        description="The admin server lets the Arcanum monitor players, inspect zones, trigger hot reloads, and broadcast messages — all without restarting the server."
+      >
+        <div className="flex flex-col gap-1.5">
+          <FieldRow label="Enabled" hint="Start the admin HTTP server alongside the game engine. Required for the Arcanum's Admin tab to connect.">
+            <CheckboxInput
+              checked={a.enabled}
+              onCommit={(v) => patch({ enabled: v })}
+              label="Enable admin server"
+            />
+          </FieldRow>
+          <FieldRow label="Port" hint="HTTP port for the admin API. Default 9091 avoids conflicts with the game's web port.">
+            <NumberInput
+              value={a.port}
+              onCommit={(v) => patch({ port: v ?? 9091 })}
+              min={1}
+              max={65535}
+            />
+          </FieldRow>
+          <FieldRow label="Auth Token" hint="Required. Every API request must include this token via HTTP Basic Auth. Leave blank to block all access.">
+            <div className="flex items-center gap-2">
+              <TextInput
+                value={a.token}
+                onCommit={(v) => patch({ token: v })}
+                placeholder="Set a secure token"
+                type={showToken ? "text" : "text"}
+              />
+              <button
+                type="button"
+                onClick={() => setShowToken((v) => !v)}
+                className="shrink-0 text-2xs text-text-muted hover:text-text-primary"
+              >
+                {showToken ? "Hide" : "Show"}
+              </button>
+            </div>
+          </FieldRow>
+          <FieldRow label="Grafana URL" hint="Optional. If set, the admin dashboard will show a link to your Grafana board.">
+            <TextInput
+              value={a.grafanaUrl}
+              onCommit={(v) => patch({ grafanaUrl: v })}
+              placeholder="https://grafana.example.com/d/ambonmud"
+            />
+          </FieldRow>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/creator/src/components/config/panels/LoggingPanel.tsx
+++ b/creator/src/components/config/panels/LoggingPanel.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import type { ConfigPanelProps, AppConfig } from "./types";
+import { Section, FieldRow, SelectInput, TextInput } from "@/components/ui/FormWidgets";
+
+const LOG_LEVELS = ["TRACE", "DEBUG", "INFO", "WARN", "ERROR"];
+
+export function LoggingPanel({ config, onChange }: ConfigPanelProps) {
+  const l = config.logging;
+  const patch = (p: Partial<AppConfig["logging"]>) =>
+    onChange({ logging: { ...l, ...p } });
+
+  const [newPkg, setNewPkg] = useState("");
+
+  const packageEntries = Object.entries(l.packageLevels).sort(([a], [b]) => a.localeCompare(b));
+
+  const updatePackageLevel = (pkg: string, level: string) => {
+    patch({ packageLevels: { ...l.packageLevels, [pkg]: level } });
+  };
+
+  const removePackageLevel = (pkg: string) => {
+    const next = { ...l.packageLevels };
+    delete next[pkg];
+    patch({ packageLevels: next });
+  };
+
+  const addPackageLevel = () => {
+    const trimmed = newPkg.trim();
+    if (!trimmed || trimmed in l.packageLevels) return;
+    patch({ packageLevels: { ...l.packageLevels, [trimmed]: "INFO" } });
+    setNewPkg("");
+  };
+
+  return (
+    <>
+      <Section
+        title="Root level"
+        description="The default log level for all packages unless overridden below."
+      >
+        <FieldRow label="Log Level" hint="TRACE and DEBUG are verbose. INFO is recommended for production. WARN and ERROR suppress informational messages.">
+          <SelectInput
+            value={l.level}
+            options={LOG_LEVELS.map((lv) => ({ value: lv, label: lv }))}
+            onCommit={(v) => patch({ level: v })}
+          />
+        </FieldRow>
+      </Section>
+
+      <Section
+        title="Package overrides"
+        description="Set different log levels for specific packages. Useful for debugging a single system without flooding the console."
+      >
+        <div className="flex flex-col gap-1.5">
+          {packageEntries.map(([pkg, level]) => (
+            <div key={pkg} className="flex items-center gap-2">
+              <span className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary" title={pkg}>
+                {pkg}
+              </span>
+              <div className="w-24">
+                <SelectInput
+                  value={level}
+                  options={LOG_LEVELS.map((lv) => ({ value: lv, label: lv }))}
+                  onCommit={(v) => updatePackageLevel(pkg, v)}
+                />
+              </div>
+              <button
+                onClick={() => removePackageLevel(pkg)}
+                className="shrink-0 rounded px-2 py-0.5 text-2xs text-text-muted hover:text-status-error focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+                title="Remove override"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+
+          {packageEntries.length === 0 && (
+            <p className="text-xs text-text-muted">No package-level overrides. All packages use the root level.</p>
+          )}
+
+          <div className="mt-2 flex items-center gap-2">
+            <TextInput
+              value={newPkg}
+              onCommit={() => addPackageLevel()}
+              placeholder="dev.ambon.transport"
+            />
+            <button
+              onClick={addPackageLevel}
+              disabled={!newPkg.trim()}
+              className="shrink-0 rounded-xl border border-white/10 bg-black/10 px-3 py-1 text-2xs text-text-primary transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/creator/src/components/config/panels/ObservabilityPanel.tsx
+++ b/creator/src/components/config/panels/ObservabilityPanel.tsx
@@ -1,0 +1,42 @@
+import type { ConfigPanelProps, AppConfig } from "./types";
+import { Section, FieldRow, NumberInput, TextInput, CheckboxInput } from "@/components/ui/FormWidgets";
+
+export function ObservabilityPanel({ config, onChange }: ConfigPanelProps) {
+  const o = config.observability;
+  const patch = (p: Partial<AppConfig["observability"]>) =>
+    onChange({ observability: { ...o, ...p } });
+
+  return (
+    <>
+      <Section
+        title="Prometheus metrics"
+        description="Expose server metrics for monitoring dashboards. The metrics endpoint runs on a separate HTTP port."
+      >
+        <div className="flex flex-col gap-1.5">
+          <FieldRow label="Enabled" hint="Start the Prometheus metrics HTTP server alongside the game engine.">
+            <CheckboxInput
+              checked={o.metricsEnabled}
+              onCommit={(v) => patch({ metricsEnabled: v })}
+              label="Enable metrics"
+            />
+          </FieldRow>
+          <FieldRow label="HTTP Port" hint="Port for the metrics endpoint. Default 9090. Prometheus scrapes this port.">
+            <NumberInput
+              value={o.metricsHttpPort}
+              onCommit={(v) => patch({ metricsHttpPort: v ?? 9090 })}
+              min={1}
+              max={65535}
+            />
+          </FieldRow>
+          <FieldRow label="Endpoint Path" hint="HTTP path where metrics are served. Standard is /metrics.">
+            <TextInput
+              value={o.metricsEndpoint}
+              onCommit={(v) => patch({ metricsEndpoint: v || "/metrics" })}
+              placeholder="/metrics"
+            />
+          </FieldRow>
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -372,22 +372,22 @@ export function buildMonolithicConfigObject(
       webClientUrl: null,
     },
     observability: {
-      metricsEnabled: true,
-      metricsEndpoint: "/metrics",
-      metricsHttpPort: 9090,
+      metricsEnabled: c.observability?.metricsEnabled ?? true,
+      metricsEndpoint: c.observability?.metricsEndpoint ?? "/metrics",
+      metricsHttpPort: c.observability?.metricsHttpPort ?? 9090,
       staticTags: {},
     },
     admin: {
-      enabled: false,
-      port: 9091,
-      token: "",
-      grafanaUrl: "",
+      enabled: c.admin?.enabled ?? false,
+      port: c.admin?.port ?? 9091,
+      token: c.admin?.token ?? "",
+      grafanaUrl: c.admin?.grafanaUrl || undefined,
     },
     logging: {
-      level: "INFO",
+      level: c.logging?.level ?? "INFO",
       packageLevels: {
-        "dev.ambon.transport": "INFO",
-        "dev.ambon.engine": "INFO",
+        ...{ "dev.ambon.transport": "INFO", "dev.ambon.engine": "INFO" },
+        ...(c.logging?.packageLevels ?? {}),
       },
     },
     redis: {

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -56,6 +56,9 @@ export function parseAppConfigYaml(content: string): AppConfig {
 
   return {
     server: parseServerConfig(root.server),
+    admin: parseAdminConfig(root.admin),
+    observability: parseObservabilityConfig(root.observability),
+    logging: parseLoggingConfig(root.logging),
     world: parseWorldConfig(root.world),
     classStartRooms: parseClassStartRooms(engine.classStartRooms),
     stats: parseStatsConfig(engine.stats),
@@ -127,6 +130,38 @@ function parseServerConfig(raw: unknown): AppConfig["server"] {
   return {
     telnetPort: asNumber(s.telnetPort, 4000),
     webPort: asNumber(s.webPort, 8080),
+  };
+}
+
+function parseAdminConfig(raw: unknown): AppConfig["admin"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: s.enabled === true,
+    port: asNumber(s.port, 9091),
+    token: asString(s.token, ""),
+    grafanaUrl: asString(s.grafanaUrl, ""),
+  };
+}
+
+function parseObservabilityConfig(raw: unknown): AppConfig["observability"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  return {
+    metricsEnabled: s.metricsEnabled === true,
+    metricsEndpoint: asString(s.metricsEndpoint, "/metrics"),
+    metricsHttpPort: asNumber(s.metricsHttpPort, 9090),
+  };
+}
+
+function parseLoggingConfig(raw: unknown): AppConfig["logging"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  const packageLevels = (s.packageLevels ?? {}) as Record<string, unknown>;
+  const parsed: Record<string, string> = {};
+  for (const [k, v] of Object.entries(packageLevels)) {
+    parsed[k] = String(v ?? "INFO");
+  }
+  return {
+    level: asString(s.level, "INFO"),
+    packageLevels: parsed,
   };
 }
 
@@ -561,6 +596,9 @@ async function loadSplitConfig(projectDir: string): Promise<AppConfig | null> {
     const config: AppConfig = {
       // world.yaml
       server: parseServerConfig(worldRaw.server),
+      admin: parseAdminConfig(worldRaw.admin),
+      observability: parseObservabilityConfig(worldRaw.observability),
+      logging: parseLoggingConfig(worldRaw.logging),
       world: parseWorldConfig(worldRaw.world),
       classStartRooms: parseClassStartRooms(worldRaw.classStartRooms),
       navigation: parseNavigationConfig(worldRaw.navigation),

--- a/creator/src/lib/saveConfig.ts
+++ b/creator/src/lib/saveConfig.ts
@@ -133,6 +133,14 @@ async function saveSplitConfig(projectDir: string): Promise<void> {
 
     write("world", cleanObj({
       server: config.server,
+      admin: config.admin,
+      observability: config.observability,
+      logging: cleanObj({
+        level: config.logging.level,
+        packageLevels: Object.keys(config.logging.packageLevels).length > 0
+          ? config.logging.packageLevels
+          : undefined,
+      }),
       world: config.world,
       classStartRooms: Object.keys(config.classStartRooms).length > 0 ? config.classStartRooms : undefined,
       navigation: config.navigation,

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -365,10 +365,37 @@ export interface ServerConfig {
   webPort: number;
 }
 
+// ─── Admin ──────────────────────────────────────────────────────────
+
+export interface AdminServerConfig {
+  enabled: boolean;
+  port: number;
+  token: string;
+  grafanaUrl: string;
+}
+
+// ─── Observability ──────────────────────────────────────────────────
+
+export interface ObservabilityConfig {
+  metricsEnabled: boolean;
+  metricsEndpoint: string;
+  metricsHttpPort: number;
+}
+
+// ─── Logging ────────────────────────────────────────────────────────
+
+export interface LoggingConfig {
+  level: string;
+  packageLevels: Record<string, string>;
+}
+
 // ─── Top-level config state ─────────────────────────────────────────
 
 export interface AppConfig {
   server: ServerConfig;
+  admin: AdminServerConfig;
+  observability: ObservabilityConfig;
+  logging: LoggingConfig;
   world: WorldConfig;
   classStartRooms: Record<string, string>;
   stats: {


### PR DESCRIPTION
## Summary

Adds three new server configuration sections to the World Systems studio so the admin server, metrics, and logging can be configured directly from the Arcanum.

- **Admin panel:** Enable toggle, port, auth token, Grafana URL. Unblocks the Admin tab workflow — previously required hand-editing YAML to set `ambonmud.admin.enabled: true`.
- **Observability panel:** Prometheus metrics toggle, HTTP port, endpoint path.
- **Logging panel:** Root log level selector (TRACE through ERROR), per-package overrides with add/remove UI.

All three sections are loaded from and saved to the world config file (standalone format) or monolithic `application.yaml` (legacy format), with safe defaults when fields are absent.

### Files changed
- `types/config.ts` — `AdminServerConfig`, `ObservabilityConfig`, `LoggingConfig` interfaces + `AppConfig` fields
- `lib/loader.ts` — `parseAdminConfig`, `parseObservabilityConfig`, `parseLoggingConfig` parsers (both load paths)
- `lib/saveConfig.ts` — Write admin/observability/logging into the world config file
- `lib/exportMud.ts` — Include real config values in monolithic export (replaces hardcoded stubs)
- `WorldSystemsStudio.tsx` — Three new `StudioSection` entries in the "world" sub-view
- 3 new panel components: `AdminConfigPanel`, `ObservabilityPanel`, `LoggingPanel`

## Test plan
- [ ] `bunx tsc --noEmit` — zero errors
- [ ] `bun run test` — 183 tests pass (including exportMud test with optional fields)
- [ ] Open World Systems → World view, verify Admin/Observability/Logging sections appear below Server
- [ ] Toggle admin enabled, set a token, save — verify YAML contains `admin.enabled: true`
- [ ] Toggle metrics, change port — verify YAML round-trips
- [ ] Change root log level, add a package override, remove it — verify YAML round-trips
- [ ] Export for MUD — verify monolithic YAML includes admin/observability/logging with real values