### PR TITLE
Fix right panel scroll in zone editor

### DIFF
--- a/creator/src/components/StatusBar.tsx
+++ b/creator/src/components/StatusBar.tsx
@@ -23,7 +23,7 @@ export function StatusBar() {
   const warningCount = allIssues.filter((i) => i.severity === "warning").length;
 
   return (
-    <div className="relative z-10 px-4 pb-4">
+    <div className="relative z-10 shrink-0 px-4 pb-4">
       <div className="flex min-h-12 items-center gap-4 rounded-[28px] border border-white/10 bg-[linear-gradient(155deg,rgba(50,60,88,0.84),rgba(38,47,71,0.9))] px-5 py-3 text-xs shadow-bar">
       <span className="text-text-muted">
         {totalZones} zone{totalZones !== 1 ? "s" : ""} loaded

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -370,7 +370,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
         </div>
       ) : (
         <div className="flex min-h-0 flex-1">
-          <div className="relative flex-1">
+          <div className="relative min-h-0 flex-1">
             <Starfield />
             <ReactFlow
               nodes={nodes}


### PR DESCRIPTION
## Summary

Fixes the room/entity detail panels not scrolling in the zone editor, cutting off lower sections like image generation, media, and audio.

**Root cause:** The ReactFlow graph container (`div.relative.flex-1`) was missing `min-h-0`. In a flex row, `min-height` defaults to `auto`, which prevents the element from shrinking below its content height. This caused the row container to exceed the viewport, pushing the sibling panel's `overflow-y-auto` scroll container out of the visible area.

**Fix:** Add `min-h-0` to the graph container so it can shrink to fit the available space, allowing the sibling RoomPanel/EntityPanel to scroll properly.

Also adds `shrink-0` to the StatusBar wrapper — it was a direct child of the AppShell's `flex-col` layout without shrink protection.

## Test plan
- [ ] Open a zone, click a room — verify the right panel scrolls to the bottom (Description → Media → Audio sections all reachable)
- [ ] Click a mob/item entity — verify EntityPanel scrolls
- [ ] Resize the window smaller — verify scroll still works
- [ ] StatusBar stays visible at the bottom regardless of content height