### PR TITLE
Add achievement sprite system

### DIFF
--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -559,7 +559,7 @@ pub async fn delete_from_r2(app: AppHandle, file_name: String) -> Result<(), Str
 /// Each sprite asset with variant_group "player_sprite:{key}" gets uploaded
 /// as "player_sprites/{key}.png" so the game server can find them.
 #[tauri::command]
-pub async fn deploy_sprites_to_r2(app: AppHandle) -> Result<SyncProgress, String> {
+pub async fn deploy_sprites_to_r2(app: AppHandle, sprites_yaml: Option<String>) -> Result<SyncProgress, String> {
     let s = settings::get_settings(app.clone()).await?;
     if s.r2_account_id.is_empty()
         || s.r2_access_key_id.is_empty()
@@ -633,6 +633,29 @@ pub async fn deploy_sprites_to_r2(app: AppHandle) -> Result<SyncProgress, String
             Err(e) => {
                 progress.failed += 1;
                 progress.errors.push(format!("{object_key}: {e}"));
+            }
+        }
+    }
+
+    // Upload sprites.yaml manifest if provided
+    if let Some(yaml) = sprites_yaml {
+        progress.total += 1;
+        match upload_object(
+            &client,
+            &s.r2_account_id,
+            &s.r2_bucket,
+            &s.r2_access_key_id,
+            &s.r2_secret_access_key,
+            "sprites.yaml",
+            yaml.into_bytes(),
+            "application/x-yaml",
+        )
+        .await
+        {
+            Ok(()) => progress.uploaded += 1,
+            Err(e) => {
+                progress.failed += 1;
+                progress.errors.push(format!("sprites.yaml: {e}"));
             }
         }
     }

--- a/creator/src/components/AchievementSpriteEditor.tsx
+++ b/creator/src/components/AchievementSpriteEditor.tsx
@@ -1,0 +1,421 @@
+import { useState, useCallback, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useSpriteDefinitionStore } from "@/stores/spriteDefinitionStore";
+import { useConfigStore } from "@/stores/configStore";
+import { useProjectStore } from "@/stores/projectStore";
+import { useAssetStore } from "@/stores/assetStore";
+import { useImageSrc } from "@/lib/useImageSrc";
+import { composePrompt, UNIVERSAL_NEGATIVE } from "@/lib/arcanumPrompts";
+import { removeBgAndSave } from "@/lib/useBackgroundRemoval";
+import { IMAGE_MODELS, ENTITY_DIMENSIONS } from "@/types/assets";
+import type { AchievementSpriteDef, SpriteVariant } from "@/types/sprites";
+import type { GeneratedImage, AssetContext } from "@/types/assets";
+
+function VariantThumb({ fileName }: { fileName: string | undefined }) {
+  const src = useImageSrc(fileName);
+  if (!src) {
+    return (
+      <div className="flex h-12 w-12 items-center justify-center rounded-lg border border-dashed border-white/12 bg-white/4 text-2xs text-text-muted">
+        --
+      </div>
+    );
+  }
+  return <img src={src} alt="" className="h-12 w-12 rounded-lg object-cover" />;
+}
+
+function emptyVariant(templateId: string, prefix?: string): SpriteVariant {
+  const imageId = prefix ? `${prefix}_${templateId}` : templateId;
+  return {
+    imageId,
+    imagePath: `player_sprites/${imageId}.png`,
+  };
+}
+
+export function AchievementSpriteEditor() {
+  const definitions = useSpriteDefinitionStore((s) => s.definitions);
+  const setDefinition = useSpriteDefinitionStore((s) => s.setDefinition);
+  const deleteDefinition = useSpriteDefinitionStore((s) => s.deleteDefinition);
+  const dirty = useSpriteDefinitionStore((s) => s.dirty);
+  const saveDefinitions = useSpriteDefinitionStore((s) => s.saveDefinitions);
+  const project = useProjectStore((s) => s.project);
+  const config = useConfigStore((s) => s.config);
+  const assets = useAssetStore((s) => s.assets);
+  const settings = useAssetStore((s) => s.settings);
+  const loadAssets = useAssetStore((s) => s.loadAssets);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [newId, setNewId] = useState("");
+  const [generating, setGenerating] = useState<string | null>(null);
+
+  const races = useMemo(() => config ? Object.keys(config.races) : [], [config]);
+  const classes = useMemo(() => config ? Object.keys(config.classes) : [], [config]);
+
+  const imageProvider = settings?.image_provider ?? "deepinfra";
+  const hasApiKey = settings && (
+    (imageProvider === "deepinfra" && settings.deepinfra_api_key.length > 0) ||
+    (imageProvider === "runware" && settings.runware_api_key.length > 0)
+  );
+
+  // Map imageId → asset file name for thumbnails
+  const spriteAssetMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const a of assets) {
+      if (a.asset_type === "player_sprite" && a.variant_group?.startsWith("player_sprite:")) {
+        const key = a.variant_group.replace("player_sprite:", "");
+        if (!map.has(key) || a.is_active) {
+          map.set(key, a.file_name);
+        }
+      }
+    }
+    return map;
+  }, [assets]);
+
+  const sortedDefs = useMemo(
+    () => Object.entries(definitions).sort(([, a], [, b]) => a.sortOrder - b.sortOrder),
+    [definitions],
+  );
+
+  const selectedDef = selectedId ? definitions[selectedId] : null;
+
+  const handleAdd = useCallback(() => {
+    const id = newId.trim().toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_]/g, "");
+    if (!id || definitions[id]) return;
+    setDefinition(id, {
+      displayName: newId.trim() || id,
+      sortOrder: Object.keys(definitions).length * 10,
+      achievementId: "",
+      brief: "",
+      variants: [emptyVariant(id)],
+    });
+    setNewId("");
+    setSelectedId(id);
+  }, [newId, definitions, setDefinition]);
+
+  const handleSave = useCallback(async () => {
+    if (!project) return;
+    await saveDefinitions(project);
+  }, [project, saveDefinitions]);
+
+  const patchSelected = useCallback(
+    (patch: Partial<AchievementSpriteDef>) => {
+      if (!selectedId || !selectedDef) return;
+      setDefinition(selectedId, { ...selectedDef, ...patch });
+    },
+    [selectedId, selectedDef, setDefinition],
+  );
+
+  const addVariant = useCallback(() => {
+    if (!selectedId || !selectedDef) return;
+    patchSelected({
+      variants: [...selectedDef.variants, emptyVariant(selectedId, `variant${selectedDef.variants.length}`)],
+    });
+  }, [selectedId, selectedDef, patchSelected]);
+
+  const patchVariant = useCallback(
+    (idx: number, patch: Partial<SpriteVariant>) => {
+      if (!selectedDef) return;
+      const variants = selectedDef.variants.map((v, i) => (i === idx ? { ...v, ...patch } : v));
+      patchSelected({ variants });
+    },
+    [selectedDef, patchSelected],
+  );
+
+  const removeVariant = useCallback(
+    (idx: number) => {
+      if (!selectedDef) return;
+      patchSelected({ variants: selectedDef.variants.filter((_, i) => i !== idx) });
+    },
+    [selectedDef, patchSelected],
+  );
+
+  const acceptAsset = useAssetStore((s) => s.acceptAsset);
+
+  const generateVariantImage = useCallback(
+    async (variant: SpriteVariant, brief: string) => {
+      if (!hasApiKey || !settings) return;
+      setGenerating(variant.imageId);
+
+      try {
+        const finalPrompt = composePrompt("player_sprite", "gentle_magic", brief);
+        const models = IMAGE_MODELS.filter((m) => m.provider === imageProvider);
+        const model = models[0];
+        if (!model) throw new Error("No image model available");
+
+        const dims = ENTITY_DIMENSIONS.player_sprite ?? { width: 512, height: 512 };
+        const cmd = imageProvider === "runware" ? "runware_generate_image" : "generate_image";
+
+        const image = await invoke<GeneratedImage>(cmd, {
+          prompt: finalPrompt,
+          negativePrompt: UNIVERSAL_NEGATIVE,
+          model: model.id,
+          width: dims.width,
+          height: dims.height,
+          steps: model.defaultSteps,
+        });
+
+        const assetContext: AssetContext = { zone: "sprites", entity_type: "player_sprite", entity_id: variant.imageId };
+        const variantGroup = `player_sprite:${variant.imageId}`;
+
+        await acceptAsset(image, "player_sprite", finalPrompt, assetContext, variantGroup, true);
+
+        if (image.data_url) {
+          removeBgAndSave(image.data_url, "player_sprite", assetContext, variantGroup).catch(() => {});
+        }
+
+        await loadAssets();
+      } catch (err) {
+        console.error("Failed to generate sprite variant:", err);
+      } finally {
+        setGenerating(null);
+      }
+    },
+    [hasApiKey, settings, imageProvider, acceptAsset, loadAssets],
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-border-default bg-bg-secondary px-4 py-2">
+        <h2 className="font-display text-xs uppercase tracking-widest text-text-muted">
+          Achievement Sprites
+        </h2>
+        <span className="text-2xs text-text-muted">
+          {sortedDefs.length} definition{sortedDefs.length !== 1 ? "s" : ""}
+        </span>
+        <div className="flex-1" />
+        {dirty && <span className="text-xs text-accent">modified</span>}
+        <button
+          onClick={handleSave}
+          disabled={!dirty}
+          className="rounded border border-accent/40 px-3 py-1 text-xs text-accent transition-colors hover:bg-accent/10 disabled:opacity-40"
+        >
+          Save
+        </button>
+      </div>
+
+      <div className="flex min-h-0 flex-1">
+        {/* Left: definition list */}
+        <div className="flex w-72 shrink-0 flex-col border-r border-border-default bg-bg-secondary">
+          <div className="flex items-center gap-1 border-b border-border-default px-3 py-2">
+            <input
+              className="flex-1 rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none placeholder:text-text-muted focus:border-accent/50"
+              placeholder="New sprite ID"
+              value={newId}
+              onChange={(e) => setNewId(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+            />
+            <button
+              onClick={handleAdd}
+              disabled={!newId.trim()}
+              className="rounded border border-border-default px-2 py-1 text-xs text-text-secondary hover:bg-bg-elevated disabled:opacity-40"
+            >
+              Add
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            {sortedDefs.map(([id, def]) => (
+              <button
+                key={id}
+                onClick={() => setSelectedId(id)}
+                className={`flex w-full items-center gap-2 border-b border-white/5 px-3 py-2.5 text-left text-xs transition ${
+                  selectedId === id
+                    ? "bg-gradient-active text-text-primary"
+                    : "text-text-secondary hover:bg-white/5"
+                }`}
+              >
+                <VariantThumb fileName={spriteAssetMap.get(def.variants[0]?.imageId ?? "")} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-medium">{def.displayName}</div>
+                  <div className="truncate text-2xs text-text-muted">{id}</div>
+                </div>
+                <span className="shrink-0 text-2xs text-text-muted">
+                  {def.variants.length}v
+                </span>
+              </button>
+            ))}
+            {sortedDefs.length === 0 && (
+              <div className="px-3 py-6 text-xs text-text-muted">
+                No achievement sprites defined yet.
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Right: detail editor */}
+        <div className="flex-1 overflow-y-auto p-5">
+          {selectedDef && selectedId ? (
+            <div className="mx-auto flex max-w-3xl flex-col gap-5">
+              {/* Basic fields */}
+              <div className="flex flex-col gap-3">
+                <div className="flex items-center justify-between">
+                  <h3 className="font-display text-lg text-text-primary">{selectedDef.displayName}</h3>
+                  <button
+                    onClick={() => { deleteDefinition(selectedId); setSelectedId(null); }}
+                    className="rounded border border-status-error/30 px-3 py-1 text-xs text-status-error hover:bg-status-error/10"
+                  >
+                    Delete
+                  </button>
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <label className="flex flex-col gap-1 text-xs text-text-secondary">
+                    Display Name
+                    <input
+                      className="rounded border border-border-default bg-bg-primary px-2 py-1.5 text-sm text-text-primary outline-none focus:border-accent/50"
+                      value={selectedDef.displayName}
+                      onChange={(e) => patchSelected({ displayName: e.target.value })}
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1 text-xs text-text-secondary">
+                    Sort Order
+                    <input
+                      type="number"
+                      className="rounded border border-border-default bg-bg-primary px-2 py-1.5 text-sm text-text-primary outline-none focus:border-accent/50"
+                      value={selectedDef.sortOrder}
+                      onChange={(e) => patchSelected({ sortOrder: parseInt(e.target.value) || 0 })}
+                    />
+                  </label>
+                </div>
+
+                <label className="flex flex-col gap-1 text-xs text-text-secondary">
+                  Achievement ID
+                  <input
+                    className="rounded border border-border-default bg-bg-primary px-2 py-1.5 text-sm text-text-primary outline-none focus:border-accent/50"
+                    placeholder="e.g. combat/beetle_exterminator"
+                    value={selectedDef.achievementId}
+                    onChange={(e) => patchSelected({ achievementId: e.target.value })}
+                  />
+                </label>
+
+                <label className="flex flex-col gap-1 text-xs text-text-secondary">
+                  Creative Brief
+                  <textarea
+                    className="h-20 resize-y rounded border border-border-default bg-bg-primary px-2 py-1.5 text-sm text-text-primary outline-none focus:border-accent/50"
+                    placeholder="Describe the visual theme for this sprite..."
+                    value={selectedDef.brief ?? ""}
+                    onChange={(e) => patchSelected({ brief: e.target.value })}
+                  />
+                </label>
+              </div>
+
+              {/* Variants */}
+              <div>
+                <div className="mb-3 flex items-center justify-between">
+                  <h4 className="font-display text-sm text-text-primary">
+                    Variants ({selectedDef.variants.length})
+                  </h4>
+                  <button
+                    onClick={addVariant}
+                    className="rounded border border-border-default px-2 py-1 text-xs text-text-secondary hover:bg-bg-elevated"
+                  >
+                    Add Variant
+                  </button>
+                </div>
+
+                <div className="flex flex-col gap-3">
+                  {selectedDef.variants.map((variant, idx) => (
+                    <div
+                      key={variant.imageId}
+                      className="flex items-start gap-3 rounded-xl border border-white/8 bg-black/12 p-3"
+                    >
+                      <VariantThumb fileName={spriteAssetMap.get(variant.imageId)} />
+
+                      <div className="flex min-w-0 flex-1 flex-col gap-2">
+                        <div className="grid grid-cols-2 gap-2">
+                          <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
+                            Image ID
+                            <input
+                              className="rounded border border-border-default bg-bg-primary px-1.5 py-1 text-xs text-text-primary outline-none"
+                              value={variant.imageId}
+                              onChange={(e) => {
+                                const imageId = e.target.value;
+                                patchVariant(idx, { imageId, imagePath: `player_sprites/${imageId}.png` });
+                              }}
+                            />
+                          </label>
+                          <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
+                            Display Name
+                            <input
+                              className="rounded border border-border-default bg-bg-primary px-1.5 py-1 text-xs text-text-primary outline-none"
+                              placeholder="(inherits parent)"
+                              value={variant.displayName ?? ""}
+                              onChange={(e) => patchVariant(idx, { displayName: e.target.value || undefined })}
+                            />
+                          </label>
+                        </div>
+
+                        <div className="grid grid-cols-3 gap-2">
+                          <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
+                            Race Filter
+                            <select
+                              className="rounded border border-border-default bg-bg-primary px-1.5 py-1 text-xs text-text-primary outline-none"
+                              value={variant.race ?? ""}
+                              onChange={(e) => patchVariant(idx, { race: e.target.value || undefined })}
+                            >
+                              <option value="">Any</option>
+                              {races.map((r) => (
+                                <option key={r} value={r.toUpperCase()}>{r}</option>
+                              ))}
+                            </select>
+                          </label>
+                          <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
+                            Class Filter
+                            <select
+                              className="rounded border border-border-default bg-bg-primary px-1.5 py-1 text-xs text-text-primary outline-none"
+                              value={variant.playerClass ?? ""}
+                              onChange={(e) => patchVariant(idx, { playerClass: e.target.value || undefined })}
+                            >
+                              <option value="">Any</option>
+                              {classes.map((c) => (
+                                <option key={c} value={c.toUpperCase()}>{c}</option>
+                              ))}
+                            </select>
+                          </label>
+                          <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
+                            Gender
+                            <select
+                              className="rounded border border-border-default bg-bg-primary px-1.5 py-1 text-xs text-text-primary outline-none"
+                              value={variant.gender ?? ""}
+                              onChange={(e) => patchVariant(idx, { gender: e.target.value || undefined })}
+                            >
+                              <option value="">Any</option>
+                              <option value="male">Male</option>
+                              <option value="female">Female</option>
+                              <option value="nonbinary">Nonbinary</option>
+                            </select>
+                          </label>
+                        </div>
+                      </div>
+
+                      <div className="flex shrink-0 flex-col gap-1">
+                        <button
+                          onClick={() => generateVariantImage(variant, selectedDef.brief ?? selectedDef.displayName)}
+                          disabled={!hasApiKey || generating === variant.imageId}
+                          className="rounded border border-accent/40 px-2 py-1 text-2xs text-accent hover:bg-accent/10 disabled:opacity-40"
+                        >
+                          {generating === variant.imageId ? "..." : "Gen"}
+                        </button>
+                        {selectedDef.variants.length > 1 && (
+                          <button
+                            onClick={() => removeVariant(idx)}
+                            className="rounded border border-status-error/30 px-2 py-1 text-2xs text-status-error hover:bg-status-error/10"
+                          >
+                            Del
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-text-muted">
+              Select a sprite definition or add a new one.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/PlayerSpriteManager.tsx
+++ b/creator/src/components/PlayerSpriteManager.tsx
@@ -30,6 +30,9 @@ import { IMAGE_MODELS, ENTITY_DIMENSIONS } from "@/types/assets";
 import type { AssetEntry, GeneratedImage, SyncProgress } from "@/types/assets";
 import type { AppConfig } from "@/types/config";
 import { removeBgAndSave } from "@/lib/useBackgroundRemoval";
+import { AchievementSpriteEditor } from "@/components/AchievementSpriteEditor";
+
+type SpriteTab = "tiers" | "achievements";
 
 interface SpriteImportResult {
   imported: number;
@@ -145,6 +148,7 @@ function SpriteLightbox({
 }
 
 export function PlayerSpriteManager() {
+  const [spriteTab, setSpriteTab] = useState<SpriteTab>("tiers");
   const config = useConfigStore((s) => s.config);
   const assets = useAssetStore((s) => s.assets);
   const loadAssets = useAssetStore((s) => s.loadAssets);
@@ -472,6 +476,27 @@ export function PlayerSpriteManager() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
+      {/* Tab bar */}
+      <div className="flex shrink-0 items-center gap-1 border-b border-border-default bg-bg-secondary px-4 py-1.5">
+        {(["tiers", "achievements"] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setSpriteTab(tab)}
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+              spriteTab === tab
+                ? "border-[var(--border-glow-strong)] bg-[linear-gradient(135deg,rgba(168,151,210,0.25),rgba(140,174,201,0.15))] text-text-primary shadow-glow-sm"
+                : "border-transparent text-text-secondary hover:text-text-primary"
+            }`}
+          >
+            {tab === "tiers" ? "Tier & Staff" : "Achievement Sprites"}
+          </button>
+        ))}
+      </div>
+
+      {spriteTab === "achievements" ? (
+        <AchievementSpriteEditor />
+      ) : (
+      <>
       {/* Header bar */}
       <div className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border-default bg-bg-secondary px-4 py-2">
         <h2 className="font-display text-xs uppercase tracking-widest text-text-muted">
@@ -821,6 +846,8 @@ export function PlayerSpriteManager() {
           }}
           onClose={() => setViewSprite(null)}
         />
+      )}
+      </>
       )}
     </div>
   );

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -6,7 +6,9 @@ import { useConfigStore } from "@/stores/configStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { useZoneStore, type ZoneState } from "@/stores/zoneStore";
 import { serializeZone } from "@/lib/saveZone";
+import { useSpriteDefinitionStore } from "@/stores/spriteDefinitionStore";
 import type { AppConfig } from "@/types/config";
+import type { SpriteDefinition } from "@/types/sprites";
 
 export type SlotPositionMap = Record<string, { x: number; y: number }>;
 
@@ -462,6 +464,12 @@ export async function exportMudFormat(outputDir: string): Promise<ExportResult> 
   const configYaml = buildMonolithicConfig(config, slotPositions);
   await writeTextFile(`${resourcesDir}/application.yaml`, configYaml);
 
+  // Write sprites manifest
+  const spritesYaml = generateSpritesYaml(config);
+  if (spritesYaml) {
+    await writeTextFile(`${resourcesDir}/sprites.yaml`, spritesYaml);
+  }
+
   // Write zone files
   let zonesExported = 0;
   const errors: string[] = [];
@@ -489,6 +497,71 @@ export interface ExportResult {
   zonesExported: number;
   outputDir: string;
   errors: string[];
+}
+
+// ─── Sprites YAML generation ────────────────────────────────────────
+
+export function generateSpritesYaml(config?: AppConfig | null): string {
+  const c = config ?? useConfigStore.getState().config;
+  if (!c) return "";
+
+  const races = Object.keys(c.races);
+  const classes = Object.keys(c.classes);
+  const tiers = Array.from(new Set([1, ...(c.images.spriteLevelTiers ?? [])])).sort((a, b) => a - b);
+  const achievementDefs = useSpriteDefinitionStore.getState().definitions;
+
+  const entries: Record<string, SpriteDefinition> = {};
+  let sortOrder = 0;
+
+  // Tier sprites: one per race × class × tier
+  for (const race of races) {
+    for (const cls of classes) {
+      for (const tier of tiers) {
+        const key = `${race}_${cls}_t${tier}`;
+        const raceName = c.races[race]?.displayName ?? race;
+        const className = c.classes[cls]?.displayName ?? cls;
+        entries[key] = {
+          displayName: `${raceName} ${className} (Level ${tier}+)`,
+          category: "level",
+          sortOrder: sortOrder++,
+          unlock: { type: "level", minLevel: tier },
+          variants: [{
+            imageId: key,
+            imagePath: `player_sprites/${key}.png`,
+          }],
+        };
+      }
+    }
+  }
+
+  // Staff sprites: one per race
+  for (const race of races) {
+    const key = `${race}_base_tstaff`;
+    const raceName = c.races[race]?.displayName ?? race;
+    entries[key] = {
+      displayName: `${raceName} Staff`,
+      category: "staff",
+      sortOrder: sortOrder++,
+      unlock: { type: "staff" },
+      variants: [{
+        imageId: key,
+        imagePath: `player_sprites/${key}.png`,
+      }],
+    };
+  }
+
+  // Achievement sprites from user definitions
+  for (const [id, def] of Object.entries(achievementDefs)) {
+    entries[id] = {
+      displayName: def.displayName,
+      category: "achievement",
+      sortOrder: def.sortOrder,
+      unlock: { type: "achievement", achievementId: def.achievementId },
+      variants: def.variants,
+    };
+  }
+
+  return stringify(entries, YAML_OPTS);
 }
 
 // ─── Slot position loading ──────────────────────────────────────────

--- a/creator/src/lib/runtimeHandoff.ts
+++ b/creator/src/lib/runtimeHandoff.ts
@@ -1,7 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
-import { exportMudFormat, buildMonolithicConfig, loadSlotPositions } from "@/lib/exportMud";
+import { exportMudFormat, buildMonolithicConfig, loadSlotPositions, generateSpritesYaml } from "@/lib/exportMud";
 import { saveProjectConfig } from "@/lib/saveConfig";
 import { saveAllZones } from "@/lib/saveZone";
+import { useSpriteDefinitionStore } from "@/stores/spriteDefinitionStore";
 import { validateConfig } from "@/lib/validateConfig";
 import { validateAllZones, type ValidationIssue } from "@/lib/validateZone";
 import { useAssetStore } from "@/stores/assetStore";
@@ -68,6 +69,11 @@ export async function saveWorkspace(project: Project): Promise<SaveWorkspaceResu
     await saveProjectConfig(project);
   }
 
+  const spriteStore = useSpriteDefinitionStore.getState();
+  if (spriteStore.dirty) {
+    await spriteStore.saveDefinitions(project);
+  }
+
   return {
     savedZones,
     configSaved: configDirty,
@@ -129,7 +135,8 @@ export async function publishGlobalAssets(): Promise<SyncProgress> {
 }
 
 export async function publishPlayerSprites(): Promise<SyncProgress> {
-  return invoke<SyncProgress>("deploy_sprites_to_r2");
+  const spritesYaml = generateSpritesYaml();
+  return invoke<SyncProgress>("deploy_sprites_to_r2", { spritesYaml });
 }
 
 export async function deployRuntimeConfig(project: Project): Promise<string> {

--- a/creator/src/lib/useOpenProject.ts
+++ b/creator/src/lib/useOpenProject.ts
@@ -5,6 +5,7 @@ import { useProjectStore } from "@/stores/projectStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useConfigStore } from "@/stores/configStore";
 import { loadProjectZones, loadProjectConfig } from "@/lib/loader";
+import { useSpriteDefinitionStore } from "@/stores/spriteDefinitionStore";
 import { loadUIState, addRecentProject } from "@/lib/uiPersistence";
 import type { Project, ProjectFormat, Tab } from "@/types/project";
 
@@ -68,6 +69,10 @@ export function useOpenProject() {
 
     setProject(project);
     addRecentProject(mudDir, project.name);
+
+    // Load achievement sprite definitions
+    useSpriteDefinitionStore.getState().loadDefinitions(project).catch(() => {});
+
 
     // Restore previously saved tabs (filter out stale zone refs)
     const saved = loadUIState();

--- a/creator/src/stores/spriteDefinitionStore.ts
+++ b/creator/src/stores/spriteDefinitionStore.ts
@@ -1,0 +1,116 @@
+import { create } from "zustand";
+import { exists, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import { parse, stringify } from "yaml";
+import type { Project } from "@/types/project";
+import type { AchievementSpriteDef } from "@/types/sprites";
+
+function spritesPath(project: Project): string {
+  return project.format === "standalone"
+    ? `${project.mudDir}/config/sprites.yaml`
+    : `${project.mudDir}/src/main/resources/sprites.yaml`;
+}
+
+interface SpriteDefinitionStore {
+  definitions: Record<string, AchievementSpriteDef>;
+  dirty: boolean;
+
+  loadDefinitions: (project: Project) => Promise<void>;
+  saveDefinitions: (project: Project) => Promise<void>;
+  setDefinition: (id: string, def: AchievementSpriteDef) => void;
+  deleteDefinition: (id: string) => void;
+  markClean: () => void;
+}
+
+export const useSpriteDefinitionStore = create<SpriteDefinitionStore>((set, get) => ({
+  definitions: {},
+  dirty: false,
+
+  loadDefinitions: async (project) => {
+    const path = spritesPath(project);
+    if (!(await exists(path))) {
+      set({ definitions: {}, dirty: false });
+      return;
+    }
+    try {
+      const raw = await readTextFile(path);
+      const parsed = parse(raw) as Record<string, any> | null;
+      if (!parsed || typeof parsed !== "object") {
+        set({ definitions: {}, dirty: false });
+        return;
+      }
+      // Extract only achievement entries
+      const defs: Record<string, AchievementSpriteDef> = {};
+      for (const [id, entry] of Object.entries(parsed)) {
+        if (entry?.category === "achievement" && entry?.unlock?.type === "achievement") {
+          defs[id] = {
+            displayName: entry.displayName ?? id,
+            sortOrder: entry.sortOrder ?? 0,
+            achievementId: entry.unlock.achievementId ?? "",
+            brief: entry.brief,
+            variants: Array.isArray(entry.variants) ? entry.variants : [],
+          };
+        }
+      }
+      set({ definitions: defs, dirty: false });
+    } catch {
+      set({ definitions: {}, dirty: false });
+    }
+  },
+
+  saveDefinitions: async (project) => {
+    const { definitions } = get();
+    const path = spritesPath(project);
+
+    // Read existing file to preserve non-achievement entries
+    let existing: Record<string, any> = {};
+    try {
+      if (await exists(path)) {
+        const raw = await readTextFile(path);
+        existing = (parse(raw) as Record<string, any>) ?? {};
+      }
+    } catch {
+      // start fresh
+    }
+
+    // Remove old achievement entries
+    for (const [id, entry] of Object.entries(existing)) {
+      if (entry?.category === "achievement") {
+        delete existing[id];
+      }
+    }
+
+    // Add current achievement definitions in sprites.yaml format
+    for (const [id, def] of Object.entries(definitions)) {
+      existing[id] = {
+        displayName: def.displayName,
+        category: "achievement",
+        sortOrder: def.sortOrder,
+        ...(def.brief ? { brief: def.brief } : {}),
+        unlock: {
+          type: "achievement",
+          achievementId: def.achievementId,
+        },
+        variants: def.variants,
+      };
+    }
+
+    const yaml = stringify(existing, { lineWidth: 120 });
+    await writeTextFile(path, yaml);
+    set({ dirty: false });
+  },
+
+  setDefinition: (id, def) =>
+    set((s) => ({
+      definitions: { ...s.definitions, [id]: def },
+      dirty: true,
+    })),
+
+  deleteDefinition: (id) =>
+    set((s) => {
+      const next = { ...s.definitions };
+      delete next[id];
+      return { definitions: next, dirty: true };
+    }),
+
+  markClean: () => set({ dirty: false }),
+}));

--- a/creator/src/types/sprites.ts
+++ b/creator/src/types/sprites.ts
@@ -1,0 +1,35 @@
+// ─── Sprite definition types ────────────────────────────────────────
+// These types model the sprites.yaml format used by the MUD server.
+
+export interface SpriteVariant {
+  imageId: string;
+  displayName?: string;
+  race?: string;
+  playerClass?: string;
+  gender?: string;
+  imagePath: string;
+}
+
+export interface SpriteUnlock {
+  type: "level" | "achievement" | "staff";
+  minLevel?: number;
+  achievementId?: string;
+}
+
+export interface SpriteDefinition {
+  displayName: string;
+  category: "level" | "achievement" | "staff";
+  sortOrder: number;
+  unlock: SpriteUnlock;
+  variants: SpriteVariant[];
+}
+
+/** User-authored achievement sprite definition (stored in project). */
+export interface AchievementSpriteDef {
+  displayName: string;
+  sortOrder: number;
+  achievementId: string;
+  /** Creative brief for image generation. */
+  brief?: string;
+  variants: SpriteVariant[];
+}


### PR DESCRIPTION
## Summary

- **Achievement sprite definitions** stored in `sprites.yaml` alongside zone/config files, with a dedicated Zustand store for CRUD + dirty tracking
- **`sprites.yaml` export** auto-generates tier entries (races × classes × `spriteLevelTiers`) and staff entries from config, merges in user-defined achievement sprites
- **R2 deployment** extended to upload `sprites.yaml` manifest alongside sprite images
- **Achievement Sprite Editor** UI: definition list with detail panel, variant management (race/class/gender filters, image ID, display name), per-variant image generation
- **PlayerSpriteManager** gains internal tab switcher between "Tier & Staff" and "Achievement Sprites"

## Test plan
- [ ] Open a project — achievement sprites load from `sprites.yaml` (or empty if none)
- [ ] Add an achievement sprite definition with variants
- [ ] Generate variant images (uses existing art pipeline + background removal)
- [ ] Save — writes to `sprites.yaml`, preserving non-achievement entries
- [ ] Export to MUD format — `sprites.yaml` written with tier + staff + achievement entries
- [ ] Deploy sprites to R2 — uploads images AND `sprites.yaml` manifest
- [ ] Tab switcher in Player Sprites works between Tier & Staff / Achievement views