### PR TITLE
Add player housing config editor and mob broker flag

### DIFF
--- a/creator/src/components/config/ConfigPanelHost.tsx
+++ b/creator/src/components/config/ConfigPanelHost.tsx
@@ -37,6 +37,7 @@ import { EconomyPanel } from "./panels/EconomyPanel";
 import { CraftingStudio } from "./CraftingStudio";
 import { GuildDesigner } from "./GuildDesigner";
 import { EmotePresetsPanel } from "./panels/EmotePresetsPanel";
+import { HousingPanel } from "./panels/HousingPanel";
 
 // ─── Content panels ─────────────────────────────────────────────────
 import { AchievementDesigner } from "./AchievementDesigner";
@@ -160,6 +161,8 @@ function renderPanel(panelId: string, props: ConfigPanelProps): ReactNode {
       return <GuildDesigner config={config} onChange={onChange} section="guilds" />;
     case "emotes":
       return <EmotePresetsPanel config={config} onChange={onChange} />;
+    case "housing":
+      return <HousingPanel config={config} onChange={onChange} />;
 
     // Content
     case "achievements":

--- a/creator/src/components/config/panels/HousingPanel.tsx
+++ b/creator/src/components/config/panels/HousingPanel.tsx
@@ -1,0 +1,152 @@
+import type { ConfigPanelProps, AppConfig } from "./types";
+import type { HousingTemplateDefinition } from "@/types/config";
+import {
+  Section,
+  FieldRow,
+  TextInput,
+  NumberInput,
+  SelectInput,
+  CheckboxInput,
+  CommitTextarea,
+} from "@/components/ui/FormWidgets";
+import { RegistryPanel } from "./RegistryPanel";
+import { useConfigStore } from "@/stores/configStore";
+
+const DIRECTION_OPTIONS = [
+  { value: "NORTH", label: "North" },
+  { value: "SOUTH", label: "South" },
+  { value: "EAST", label: "East" },
+  { value: "WEST", label: "West" },
+  { value: "UP", label: "Up" },
+  { value: "DOWN", label: "Down" },
+];
+
+const defaultTemplate = (raw: string): HousingTemplateDefinition => ({
+  title: raw,
+  description: "",
+  cost: 0,
+});
+
+function summarize(_id: string, t: HousingTemplateDefinition): string {
+  const parts: string[] = [];
+  if (t.isEntry) parts.push("entry");
+  if (t.safe) parts.push("safe");
+  if (t.station) parts.push(t.station);
+  if (t.maxDroppedItems) parts.push(`vault(${t.maxDroppedItems})`);
+  parts.push(`${t.cost}g`);
+  return parts.join(" | ");
+}
+
+export function HousingPanel({ config, onChange }: ConfigPanelProps) {
+  const housing = config.housing;
+
+  const patchHousing = (p: Partial<AppConfig["housing"]>) =>
+    onChange({ housing: { ...housing, ...p } });
+
+  const stationOptions = [
+    { value: "", label: "-- none --" },
+    ...Object.entries(
+      useConfigStore.getState().config?.craftingStationTypes ?? {},
+    ).map(([id, s]) => ({ value: id, label: s.displayName || id })),
+  ];
+
+  return (
+    <>
+      <Section
+        title="Housing System"
+        description="Enable player housing and configure how houses connect to the world. Each player can own one house with expandable rooms purchased from a housing broker NPC."
+      >
+        <div className="flex flex-col gap-1.5">
+          <FieldRow label="Enabled" hint="Toggle the entire housing system on or off.">
+            <CheckboxInput
+              checked={housing.enabled}
+              onCommit={(v) => patchHousing({ enabled: v })}
+              label="Housing enabled"
+            />
+          </FieldRow>
+          <FieldRow label="Exit Direction" hint="The direction that leads out of the house entry room back to the world. Players use this exit to leave.">
+            <SelectInput
+              value={housing.entryExitDirection}
+              options={DIRECTION_OPTIONS}
+              onCommit={(v) => patchHousing({ entryExitDirection: v })}
+            />
+          </FieldRow>
+        </div>
+      </Section>
+
+      <RegistryPanel<HousingTemplateDefinition>
+        title="Room Templates"
+        items={housing.templates}
+        onItemsChange={(templates) => patchHousing({ templates })}
+        defaultItem={defaultTemplate}
+        renderSummary={summarize}
+        getDisplayName={(t) => t.title}
+        placeholder="template_id"
+        renderDetail={(_id, t, patch) => (
+          <>
+            <FieldRow label="Title" hint="Default room title shown to players. They can override this.">
+              <TextInput
+                value={t.title}
+                onCommit={(v) => patch({ title: v })}
+              />
+            </FieldRow>
+            <FieldRow label="Description">
+              <CommitTextarea
+                label="Description"
+                value={t.description}
+                onCommit={(v) => patch({ description: v })}
+                placeholder="Default room description..."
+                rows={3}
+              />
+            </FieldRow>
+            <FieldRow label="Cost" hint="Gold cost to purchase this room.">
+              <NumberInput
+                value={t.cost}
+                onCommit={(v) => patch({ cost: v ?? 0 })}
+                min={0}
+              />
+            </FieldRow>
+            <FieldRow label="Entry Room" hint="Exactly one template must be the entry. This is the first room when a player buys a house.">
+              <CheckboxInput
+                checked={t.isEntry ?? false}
+                onCommit={(v) => patch({ isEntry: v || undefined })}
+                label="This is the entry room"
+              />
+            </FieldRow>
+            <FieldRow label="Safe" hint="When enabled, combat is blocked in this room.">
+              <CheckboxInput
+                checked={t.safe ?? false}
+                onCommit={(v) => patch({ safe: v || undefined })}
+                label="Combat blocked"
+              />
+            </FieldRow>
+            <FieldRow label="Vault Capacity" hint="When > 0, items dropped here persist across sessions. 0 means items are transient.">
+              <NumberInput
+                value={t.maxDroppedItems ?? 0}
+                onCommit={(v) =>
+                  patch({ maxDroppedItems: v && v > 0 ? v : undefined })
+                }
+                min={0}
+                placeholder="0"
+              />
+            </FieldRow>
+            <FieldRow label="Station" hint="Optional crafting station type (e.g. forge, alchemy_bench).">
+              <SelectInput
+                value={t.station ?? ""}
+                options={stationOptions}
+                onCommit={(v) => patch({ station: v || undefined })}
+              />
+            </FieldRow>
+            <FieldRow label="Image" hint="Optional room image path.">
+              <TextInput
+                value={t.image ?? ""}
+                onCommit={(v) => patch({ image: v || undefined })}
+                placeholder="Optional"
+              />
+            </FieldRow>
+          </>
+        )}
+      />
+    </>
+  );
+}

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
   NumberInput,
   SelectInput,
+  CheckboxInput,
   IconButton,
 } from "@/components/ui/FormWidgets";
 import { DialogueEditor } from "./DialogueEditor";
@@ -152,6 +153,13 @@ export function MobEditor({
               onCommit={(v) => patch({ respawnSeconds: v })}
               placeholder="Default"
               min={0}
+            />
+          </FieldRow>
+          <FieldRow label="Housing Broker">
+            <CheckboxInput
+              checked={mob.housingBroker ?? false}
+              onCommit={(v) => patch({ housingBroker: v || undefined })}
+              label="Can broker housing"
             />
           </FieldRow>
         </div>

--- a/creator/src/lib/__tests__/exportMud.test.ts
+++ b/creator/src/lib/__tests__/exportMud.test.ts
@@ -96,6 +96,7 @@ const BASE_CONFIG: AppConfig = {
   abilityTargetTypes: {},
   craftingSkills: {},
   craftingStationTypes: {},
+  housing: { enabled: false, entryExitDirection: "SOUTH", templates: {} },
   guild: { founderRank: "leader", defaultRank: "member" },
   guildRanks: {},
   friends: { maxFriends: 50 },

--- a/creator/src/lib/__tests__/validateConfig.test.ts
+++ b/creator/src/lib/__tests__/validateConfig.test.ts
@@ -79,6 +79,7 @@ const BASE_CONFIG: AppConfig = {
   abilityTargetTypes: {},
   craftingSkills: {},
   craftingStationTypes: {},
+  housing: { enabled: false, entryExitDirection: "SOUTH", templates: {} },
   guildRanks: {},
   mobActionDelay: { minActionDelayMillis: 8000, maxActionDelayMillis: 20000 },
   characterCreation: { startingGold: 0 },

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -284,6 +284,11 @@ export function buildMonolithicConfigObject(
   if (c.emotePresets?.presets?.length > 0) {
     engine.emotePresets = c.emotePresets;
   }
+
+  // Housing
+  if (c.housing.enabled || Object.keys(c.housing.templates).length > 0) {
+    engine.housing = housingToPlain(c.housing);
+  }
   engine.classStartRooms = classStartRooms;
   engine.achievementCategories = { categories: withFallbackMap(c.achievementCategories, DEFAULT_ACHIEVEMENT_CATEGORIES) };
   engine.achievementCriterionTypes = { types: withFallbackMap(c.achievementCriterionTypes, DEFAULT_ACHIEVEMENT_CRITERION_TYPES) };
@@ -665,6 +670,28 @@ export function classToPlain(cls: AppConfig["classes"][string]): Record<string, 
   if (cls.outfitDescription) obj.outfitDescription = cls.outfitDescription;
   if (cls.showcaseRace) obj.showcaseRace = cls.showcaseRace;
   return obj;
+}
+
+export function housingToPlain(h: AppConfig["housing"]): Record<string, unknown> {
+  const templates: Record<string, unknown> = {};
+  for (const [id, t] of Object.entries(h.templates)) {
+    const obj: Record<string, unknown> = {
+      title: t.title,
+      description: t.description,
+      cost: t.cost,
+    };
+    if (t.isEntry) obj.isEntry = true;
+    if (t.image) obj.image = normalizeAssetRef(t.image);
+    if (t.maxDroppedItems != null && t.maxDroppedItems > 0) obj.maxDroppedItems = t.maxDroppedItems;
+    if (t.safe) obj.safe = true;
+    if (t.station) obj.station = t.station;
+    templates[id] = obj;
+  }
+  return {
+    enabled: h.enabled,
+    entryExitDirection: h.entryExitDirection,
+    templates,
+  };
 }
 
 export function raceToPlain(race: AppConfig["races"][string]): Record<string, unknown> {

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -89,6 +89,7 @@ export function parseAppConfigYaml(content: string): AppConfig {
     abilityTargetTypes: parseMapSection(engine.targetTypes, "types"),
     craftingSkills: parseMapSection(engine.craftingSkills, "skills"),
     craftingStationTypes: parseMapSection(engine.craftingStationTypes, "stationTypes"),
+    housing: parseHousingConfig(engine.housing),
     guild: parseGuildConfig(engine.guildRanks),
     guildRanks: parseMapSection(engine.guildRanks, "ranks"),
     friends: parseFriendsConfig(engine.friends),
@@ -459,7 +460,7 @@ function collectRawSections(
     "questObjectiveTypes", "questCompletionTypes",
     "effectTypes", "targetTypes", "stackBehaviors",
     "craftingSkills", "craftingStationTypes",
-    "scheduler", "friends", "debug", "classStartRooms", "emotePresets",
+    "scheduler", "friends", "debug", "classStartRooms", "emotePresets", "housing",
   ]);
 
   const raw: Record<string, unknown> = {};
@@ -503,6 +504,29 @@ function parseGuildConfig(raw: unknown): AppConfig["guild"] {
   return {
     founderRank: asString(s.founderRank, "leader"),
     defaultRank: asString(s.defaultRank, "member"),
+  };
+}
+
+function parseHousingConfig(raw: unknown): AppConfig["housing"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  const templates: AppConfig["housing"]["templates"] = {};
+  const rawTemplates = (s.templates ?? {}) as Record<string, Record<string, unknown>>;
+  for (const [id, t] of Object.entries(rawTemplates)) {
+    templates[id] = {
+      title: asString(t.title, id),
+      description: asString(t.description, ""),
+      cost: asNumber(t.cost, 0),
+      isEntry: t.isEntry === true ? true : undefined,
+      image: typeof t.image === "string" ? t.image : undefined,
+      maxDroppedItems: typeof t.maxDroppedItems === "number" ? t.maxDroppedItems : undefined,
+      safe: t.safe === true ? true : undefined,
+      station: typeof t.station === "string" ? t.station : undefined,
+    };
+  }
+  return {
+    enabled: asBool(s.enabled, false),
+    entryExitDirection: asString(s.entryExitDirection, "SOUTH"),
+    templates,
   };
 }
 
@@ -664,6 +688,7 @@ async function loadSplitConfig(projectDir: string): Promise<AppConfig | null> {
       navigation: parseNavigationConfig(worldRaw.navigation),
       commands: asRecord(worldRaw.commands),
       group: parseSimpleSection(worldRaw.group, { maxSize: 5, inviteTimeoutMs: 60000, xpBonusPerMember: 0.1 }),
+      housing: parseHousingConfig(worldRaw.housing),
       guild: parseGuildConfig(worldRaw.guildRanks),
       guildRanks: parseMapSection(worldRaw.guildRanks, "ranks"),
       friends: parseFriendsConfig(worldRaw.friends),

--- a/creator/src/lib/panelRegistry.ts
+++ b/creator/src/lib/panelRegistry.ts
@@ -65,6 +65,7 @@ const WORLD_PANELS: PanelDef[] = [
   { id: "groups", label: "Groups", group: "world", host: "config", kicker: "Groups", title: "Party system", description: "Party size, XP sharing, and invite rules.", maxWidth: "max-w-5xl" },
   { id: "guilds", label: "Guilds", group: "world", host: "config", kicker: "Guilds", title: "Guild system", description: "Guild ranks, permissions, friends, and defaults.", maxWidth: "max-w-5xl" },
   { id: "emotes", label: "Emotes", group: "world", host: "config", kicker: "Social", title: "Emote presets", description: "Quick-action emotes available to players in the chat panel.", maxWidth: "max-w-5xl" },
+  { id: "housing", label: "Housing", group: "world", host: "config", kicker: "Housing", title: "Player housing", description: "Room templates, costs, and housing system settings.", maxWidth: "max-w-5xl" },
 ];
 
 // ─── Lore panels ───────────────────────────────────────────────────

--- a/creator/src/lib/saveConfig.ts
+++ b/creator/src/lib/saveConfig.ts
@@ -9,6 +9,7 @@ import {
   statusEffectToPlain,
   classToPlain,
   raceToPlain,
+  housingToPlain,
   buildMonolithicConfigObject,
   loadSlotPositions,
 } from "@/lib/exportMud";
@@ -177,6 +178,8 @@ async function saveSplitConfig(projectDir: string): Promise<void> {
       achievementCriterionTypes: { types: config.achievementCriterionTypes },
       questObjectiveTypes: { types: config.questObjectiveTypes },
       questCompletionTypes: { types: config.questCompletionTypes },
+      housing: (config.housing.enabled || Object.keys(config.housing.templates).length > 0)
+        ? housingToPlain(config.housing) : undefined,
     })),
 
     write("assets", cleanObj({

--- a/creator/src/lib/validateConfig.ts
+++ b/creator/src/lib/validateConfig.ts
@@ -231,6 +231,49 @@ export function validateConfig(config: AppConfig): ValidationIssue[] {
     }
   }
 
+  // ─── Housing ──────────────────────────────────────────────────
+  const housingTemplates = config.housing.templates;
+  if (Object.keys(housingTemplates).length > 0) {
+    const entryTemplates = Object.entries(housingTemplates).filter(([, t]) => t.isEntry);
+    if (entryTemplates.length === 0) {
+      issues.push({
+        severity: "error",
+        entity: "housing",
+        message: "No entry template defined — exactly one template must have isEntry: true",
+      });
+    } else if (entryTemplates.length > 1) {
+      issues.push({
+        severity: "error",
+        entity: "housing",
+        message: `Multiple entry templates: ${entryTemplates.map(([id]) => id).join(", ")} — only one is allowed`,
+      });
+    }
+    const stationTypeIds = new Set(Object.keys(config.craftingStationTypes));
+    for (const [id, t] of Object.entries(housingTemplates)) {
+      if (!t.title?.trim()) {
+        issues.push({
+          severity: "error",
+          entity: `housingTemplate:${id}`,
+          message: "Title is required",
+        });
+      }
+      if (t.cost < 0) {
+        issues.push({
+          severity: "error",
+          entity: `housingTemplate:${id}`,
+          message: "Cost must be >= 0",
+        });
+      }
+      if (t.station && stationTypeIds.size > 0 && !stationTypeIds.has(t.station)) {
+        issues.push({
+          severity: "warning",
+          entity: `housingTemplate:${id}`,
+          message: `Station "${t.station}" is not a defined crafting station type`,
+        });
+      }
+    }
+  }
+
   // ─── Combat ───────────────────────────────────────────────────
   if (config.combat.minDamage > config.combat.maxDamage) {
     issues.push({

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -307,6 +307,25 @@ export interface CraftingStationTypeDefinition {
   image?: string;
 }
 
+// ─── Housing ───────────────────────────────────────────────────────
+
+export interface HousingTemplateDefinition {
+  title: string;
+  description: string;
+  cost: number;
+  isEntry?: boolean;
+  image?: string;
+  maxDroppedItems?: number;
+  safe?: boolean;
+  station?: string;
+}
+
+export interface HousingConfig {
+  enabled: boolean;
+  entryExitDirection: string;
+  templates: Record<string, HousingTemplateDefinition>;
+}
+
 // ─── Friends ────────────────────────────────────────────────────────
 
 export interface FriendsConfig {
@@ -470,6 +489,7 @@ export interface AppConfig {
   abilityTargetTypes: Record<string, AbilityTargetTypeDefinition>;
   craftingSkills: Record<string, CraftingSkillDefinition>;
   craftingStationTypes: Record<string, CraftingStationTypeDefinition>;
+  housing: HousingConfig;
   guild: GuildConfig;
   guildRanks: Record<string, GuildRankDefinition>;
   friends: FriendsConfig;

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -70,6 +70,7 @@ export interface MobFile {
   behavior?: BehaviorFile;
   dialogue?: Record<string, DialogueNodeFile>;
   quests?: string[];
+  housingBroker?: boolean;
   image?: string;
   video?: string;
 }


### PR DESCRIPTION
Integrate the new AmbonMUD player housing system into the Arcanum creator tool. Adds a Housing panel under World for managing room templates (cost, entry flag, vault capacity, crafting stations, safe rooms) and system settings (enabled toggle, exit direction). Adds housingBroker checkbox to the mob editor for marking NPCs as housing brokers. Includes full YAML round-trip (load/save/export), validation (exactly one entry template, station cross-refs, cost bounds), and test fixture updates.