### PR TITLE
Add article duplication

### DIFF
--- a/creator/src/components/lore/ArticleEditor.tsx
+++ b/creator/src/components/lore/ArticleEditor.tsx
@@ -138,6 +138,7 @@ export function ArticleEditor({ articleId }: { articleId: string }) {
   const updateArticle = useLoreStore((s) => s.updateArticle);
   const renameArticle = useLoreStore((s) => s.renameArticle);
   const deleteArticle = useLoreStore((s) => s.deleteArticle);
+  const duplicateArticle = useLoreStore((s) => s.duplicateArticle);
   const [renaming, setRenaming] = useState(false);
   const [newId, setNewId] = useState("");
 
@@ -225,6 +226,15 @@ export function ArticleEditor({ articleId }: { articleId: string }) {
             />
             Draft
           </label>
+          <button
+            onClick={() => {
+              duplicateArticle(articleId);
+            }}
+            className="focus-ring rounded-full border border-white/10 px-3 py-1 text-2xs font-medium text-text-secondary transition hover:bg-white/8 hover:text-text-primary"
+            title="Duplicate this article"
+          >
+            Duplicate
+          </button>
           <button
             onClick={() => {
               if (window.confirm(`Delete "${article.title}"? This cannot be undone.`)) {

--- a/creator/src/stores/loreStore.ts
+++ b/creator/src/stores/loreStore.ts
@@ -32,6 +32,7 @@ interface LoreStore {
   updateArticle: (id: string, patch: Partial<Article>) => void;
   renameArticle: (oldId: string, newId: string) => void;
   deleteArticle: (id: string) => void;
+  duplicateArticle: (id: string) => void;
   moveArticle: (id: string, newParentId: string | undefined, sortOrder: number) => void;
   selectArticle: (id: string | null) => void;
 
@@ -167,6 +168,49 @@ export const useLoreStore = create<LoreStore>((set) => ({
         lore: { ...s.lore, articles: rest },
         dirty: true,
         selectedArticleId: s.selectedArticleId === id ? null : s.selectedArticleId,
+      };
+    }),
+
+  duplicateArticle: (id) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const source = s.lore.articles[id];
+      if (!source) return s;
+
+      // Generate a unique ID: id_copy, id_copy2, id_copy3, ...
+      let newId = `${id}_copy`;
+      let counter = 2;
+      while (s.lore.articles[newId]) {
+        newId = `${id}_copy${counter}`;
+        counter++;
+      }
+
+      const now = new Date().toISOString();
+      const clone: Article = {
+        id: newId,
+        template: source.template,
+        title: `${source.title} (Copy)`,
+        fields: JSON.parse(JSON.stringify(source.fields)),
+        content: source.content,
+        privateNotes: source.privateNotes,
+        tags: source.tags ? [...source.tags] : undefined,
+        relations: source.relations ? [...source.relations] : undefined,
+        image: source.image,
+        gallery: source.gallery ? [...source.gallery] : undefined,
+        parentId: source.parentId,
+        sortOrder: (source.sortOrder ?? 0) + 1,
+        draft: true,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      return {
+        lore: {
+          ...s.lore,
+          articles: { ...s.lore.articles, [newId]: clone },
+        },
+        selectedArticleId: newId,
+        dirty: true,
       };
     }),
 


### PR DESCRIPTION
## Summary
- Add `duplicateArticle(id)` method to lore store — clones all fields, content, tags, relations, image, gallery
- New article gets unique ID, "(Copy)" suffix, `draft: true`, fresh timestamps
- Duplicate button in ArticleEditor header, immediately selects the new article

Closes #83