### PR TITLE
Add related articles sidebar to showcase

### DIFF
--- a/showcase/src/pages/ArticlePage.tsx
+++ b/showcase/src/pages/ArticlePage.tsx
@@ -3,6 +3,154 @@ import { useEffect, useMemo, useState } from "react";
 import DOMPurify from "dompurify";
 import { useShowcase } from "@/lib/DataContext";
 import { TEMPLATE_LABELS, TEMPLATE_COLORS } from "@/lib/templates";
+import type { ShowcaseArticle } from "@/types/showcase";
+
+const RELATION_TYPE_LABELS: Record<string, string> = {
+  ally: "Allies",
+  rival: "Rivals",
+  member_of: "Member of",
+  located_in: "Located in",
+  related: "Related",
+  mentioned: "Mentioned",
+};
+
+/** Order in which relation groups appear in the sidebar */
+const RELATION_TYPE_ORDER = ["ally", "rival", "member_of", "located_in", "related", "mentioned"];
+
+const MENTIONED_LIMIT = 5;
+
+interface ResolvedRelation {
+  targetId: string;
+  type: string;
+  label?: string;
+  target?: ShowcaseArticle;
+  /** For reverse relations, the title of the article that references this one */
+  sourceTitle?: string;
+  reverse?: boolean;
+}
+
+function ConnectionsSection({
+  relations,
+  color,
+}: {
+  relations: ResolvedRelation[];
+  color: string;
+}) {
+  const [mentionedExpanded, setMentionedExpanded] = useState(false);
+
+  // Group relations by type
+  const grouped = useMemo(() => {
+    const map = new Map<string, ResolvedRelation[]>();
+    for (const r of relations) {
+      const key = r.type;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(r);
+    }
+    return map;
+  }, [relations]);
+
+  // Sort groups by defined order, unknown types go last
+  const sortedGroups = useMemo(() => {
+    const entries = [...grouped.entries()];
+    entries.sort((a, b) => {
+      const ai = RELATION_TYPE_ORDER.indexOf(a[0]);
+      const bi = RELATION_TYPE_ORDER.indexOf(b[0]);
+      return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
+    });
+    return entries;
+  }, [grouped]);
+
+  if (relations.length === 0) return null;
+
+  return (
+    <div className="rounded-xl overflow-hidden" style={{ borderTop: `2px solid ${color}40` }}>
+      <div className="px-5 py-3 bg-bg-tertiary/40">
+        <h3 className="font-display text-[11px] tracking-[0.2em] uppercase" style={{ color }}>
+          Connections
+        </h3>
+      </div>
+      <div className="px-5 py-4 space-y-4 bg-bg-secondary/30">
+        {sortedGroups.map(([type, items]) => {
+          const isMentioned = type === "mentioned";
+          const displayItems =
+            isMentioned && !mentionedExpanded ? items.slice(0, MENTIONED_LIMIT) : items;
+          const hiddenCount = items.length - MENTIONED_LIMIT;
+
+          return (
+            <div key={type}>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-text-muted text-[10px] tracking-[0.15em] uppercase font-display">
+                  {RELATION_TYPE_LABELS[type] ?? type}
+                </span>
+                <span className="text-text-muted/50 text-[10px]">({items.length})</span>
+              </div>
+              <div className="space-y-1.5">
+                {displayItems.map((r) => (
+                  <RelationLink key={`${r.targetId}:${r.type}:${r.reverse ? "rev" : "fwd"}`} relation={r} />
+                ))}
+              </div>
+              {isMentioned && hiddenCount > 0 && !mentionedExpanded && (
+                <button
+                  onClick={() => setMentionedExpanded(true)}
+                  className="mt-1.5 text-[11px] text-text-link hover:text-accent transition-colors duration-200"
+                >
+                  and {hiddenCount} more...
+                </button>
+              )}
+              {isMentioned && mentionedExpanded && items.length > MENTIONED_LIMIT && (
+                <button
+                  onClick={() => setMentionedExpanded(false)}
+                  className="mt-1.5 text-[11px] text-text-link hover:text-accent transition-colors duration-200"
+                >
+                  show less
+                </button>
+              )}
+            </div>
+          );
+        })}
+
+        <Link
+          to="/connections"
+          className="mt-3 block text-center text-[11px] text-text-link hover:text-accent transition-colors duration-200"
+        >
+          See all connections &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function RelationLink({ relation }: { relation: ResolvedRelation }) {
+  const title = relation.target?.title ?? relation.sourceTitle ?? relation.targetId;
+  const imageUrl = relation.target?.imageUrl;
+
+  return (
+    <div className="flex items-center gap-2">
+      {imageUrl && (
+        <img
+          src={imageUrl}
+          alt=""
+          className="w-8 h-8 rounded-md object-cover shrink-0"
+          loading="lazy"
+        />
+      )}
+      {relation.target ? (
+        <Link
+          to={`/articles/${encodeURIComponent(relation.targetId)}`}
+          className="text-sm px-2 py-0.5 rounded-md bg-accent/6 text-text-link hover:bg-accent/14
+                     hover:text-accent transition-all duration-200 truncate min-w-0"
+        >
+          {title}
+        </Link>
+      ) : (
+        <span className="text-text-muted text-sm italic truncate min-w-0">{title}</span>
+      )}
+      {relation.reverse && (
+        <span className="text-text-muted/40 text-[9px] italic shrink-0">&larr;</span>
+      )}
+    </div>
+  );
+}
 
 function ArticleGallery({ images, title }: { images: string[]; title: string }) {
   const [activeIndex, setActiveIndex] = useState(0);
@@ -91,10 +239,51 @@ export function ArticlePage() {
   const fieldEntries = Object.entries(article.fields).filter(
     ([, v]) => v !== undefined && v !== null && v !== "",
   );
-  const relations = article.relations.map((r) => ({
+  // Forward relations: this article → targets
+  const forwardRelations: ResolvedRelation[] = article.relations.map((r) => ({
     ...r,
     target: articleById.get(r.targetId),
+    reverse: false,
   }));
+
+  // Reverse relations: other articles → this article
+  const reverseRelations = useMemo(() => {
+    if (!data) return [];
+    return data.articles
+      .filter((a) => a.id !== article.id && a.relations.some((r) => r.targetId === article.id))
+      .flatMap((a) =>
+        a.relations
+          .filter((r) => r.targetId === article.id)
+          .map((r) => ({
+            ...r,
+            targetId: a.id,
+            sourceTitle: a.title,
+            target: articleById.get(a.id),
+            reverse: true,
+          }))
+      );
+  }, [data, article.id, articleById]);
+
+  // Merge forward and reverse, deduplicating by targetId+type
+  const allRelations = useMemo(() => {
+    const seen = new Set<string>();
+    const result: ResolvedRelation[] = [];
+    for (const r of forwardRelations) {
+      const key = `${r.targetId}:${r.type}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push(r);
+      }
+    }
+    for (const r of reverseRelations) {
+      const key = `${r.targetId}:${r.type}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push(r);
+      }
+    }
+    return result;
+  }, [forwardRelations, reverseRelations]);
 
   return (
     <div className="max-w-4xl mx-auto">
@@ -213,35 +402,7 @@ export function ArticlePage() {
             </div>
           )}
 
-          {relations.length > 0 && (
-            <div className="rounded-xl overflow-hidden" style={{ borderTop: `2px solid ${color}40` }}>
-              <div className="px-5 py-3 bg-bg-tertiary/40">
-                <h3 className="font-display text-[11px] tracking-[0.2em] uppercase" style={{ color }}>
-                  Connections
-                </h3>
-              </div>
-              <div className="px-5 py-4 space-y-2.5 bg-bg-secondary/30">
-                {relations.map((r) => (
-                  <div key={`${r.targetId}:${r.type}`} className="flex items-baseline gap-2">
-                    <span className="text-text-muted text-[10px] tracking-[0.1em] uppercase shrink-0">
-                      {r.label ?? r.type}
-                    </span>
-                    {r.target ? (
-                      <Link
-                        to={`/articles/${encodeURIComponent(r.targetId)}`}
-                        className="text-sm px-2 py-0.5 rounded-md bg-accent/6 text-text-link hover:bg-accent/14
-                                   hover:text-accent transition-all duration-200 truncate"
-                      >
-                        {r.target.title}
-                      </Link>
-                    ) : (
-                      <span className="text-text-muted text-sm italic truncate">{r.targetId}</span>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
+          <ConnectionsSection relations={allRelations} color={color} />
         </aside>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Enhanced Connections sidebar on article detail page with grouped relations (Allies, Rivals, Member of, Located in, Related, Mentioned)
- Bidirectional relations — shows articles that reference this one (reverse lookup)
- Image thumbnails for related articles that have art
- Mentioned relations capped at 5 with expand/collapse
- "See all connections" link to graph page

Closes #84