### PR TITLE
Add full-text search across lore articles

### DIFF
--- a/creator/src/components/lore/ArticleTree.tsx
+++ b/creator/src/components/lore/ArticleTree.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState, useCallback, useRef } from "react";
+import { useMemo, useState, useCallback, useRef, useEffect } from "react";
 import { Tree, type NodeRendererProps, type TreeApi } from "react-arborist";
 import { useLoreStore, selectArticles } from "@/stores/loreStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { panelTab } from "@/lib/panelRegistry";
 import type { Article, ArticleTemplate } from "@/types/lore";
 import { TEMPLATE_SCHEMAS } from "@/lib/loreTemplates";
+import { searchArticles } from "@/lib/loreSearch";
 
 const TEMPLATE_DOT_COLORS: Record<ArticleTemplate, string> = {
   world_setting: "var(--color-template-world)",
@@ -124,9 +125,27 @@ export function ArticleTree() {
   const selectArticle = useLoreStore((s) => s.selectArticle);
 
   const [search, setSearch] = useState("");
+  const [searchContent, setSearchContent] = useState(false);
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [newTitle, setNewTitle] = useState("");
   const [newTemplate, setNewTemplate] = useState<ArticleTemplate>("freeform");
   const treeRef = useRef<TreeApi<TreeNode>>(null);
+  const openTab = useProjectStore((s) => s.openTab);
+
+  // Debounce content search queries
+  useEffect(() => {
+    if (!searchContent) return;
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search, searchContent]);
+
+  const contentResults = useMemo(
+    () =>
+      searchContent && debouncedSearch.trim().length >= 3
+        ? searchArticles(articles, debouncedSearch)
+        : [],
+    [articles, debouncedSearch, searchContent],
+  );
 
   const treeData = useMemo(() => buildTree(articles), [articles]);
 
@@ -191,34 +210,96 @@ export function ArticleTree() {
   return (
     <div className="flex h-full flex-col">
       {/* Search */}
-      <input
-        aria-label="Search articles"
-        className="ornate-input mb-2 w-full rounded px-2 py-1.5 text-xs text-text-primary"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        placeholder="Search legends..."
-      />
-
-      {/* Tree */}
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <Tree<TreeNode>
-          ref={treeRef}
-          data={filteredData}
-          onMove={handleMove}
-          openByDefault={true}
-          width="100%"
-          indent={16}
-          rowHeight={32}
-          overscanCount={10}
-          disableDrag={!!search.trim()}
-          disableDrop={!!search.trim()}
+      <div className="mb-2 flex items-center gap-1.5">
+        <input
+          aria-label="Search articles"
+          className="ornate-input min-w-0 flex-1 rounded px-2 py-1.5 text-xs text-text-primary"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={searchContent ? "Search all content..." : "Search legends..."}
+        />
+        <button
+          onClick={() => setSearchContent((v) => !v)}
+          title={searchContent ? "Searching content" : "Searching titles only"}
+          className={`shrink-0 rounded px-1.5 py-1 text-[10px] transition ${
+            searchContent
+              ? "bg-accent/15 text-accent"
+              : "text-text-muted hover:text-text-secondary"
+          }`}
         >
-          {Node}
-        </Tree>
-        {filteredData.length === 0 && (
-          <div className="px-2 py-4 text-xs text-text-muted">
-            {search ? "No matching articles found." : "The first legend remains unwritten."}
+          {searchContent ? "Content" : "Titles"}
+        </button>
+      </div>
+
+      {/* Tree / Content search results */}
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {searchContent && search.trim().length >= 3 ? (
+          <div className="flex flex-col gap-1">
+            {contentResults.map((r) => (
+              <button
+                key={r.articleId}
+                onClick={() => {
+                  selectArticle(r.articleId);
+                  openTab(panelTab("lore"));
+                }}
+                className="rounded-lg border border-white/6 bg-black/10 px-3 py-2 text-left transition hover:bg-white/6"
+              >
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className="inline-block h-2 w-2 shrink-0 rounded-full"
+                    style={{
+                      background:
+                        TEMPLATE_DOT_COLORS[
+                          articles[r.articleId]?.template ?? "freeform"
+                        ],
+                    }}
+                  />
+                  <span className="truncate text-xs text-text-primary">
+                    {r.title}
+                  </span>
+                  <span className="ml-auto shrink-0 rounded bg-white/8 px-1.5 py-0.5 text-[9px] text-text-muted">
+                    {r.matchIn}
+                  </span>
+                </div>
+                <p className="mt-1 truncate text-[11px] leading-4 text-text-muted">
+                  {r.snippet}
+                </p>
+              </button>
+            ))}
+            {contentResults.length === 0 && (
+              <p className="px-2 py-3 text-xs text-text-muted">
+                No content matches found.
+              </p>
+            )}
           </div>
+        ) : searchContent && search.trim().length > 0 && search.trim().length < 3 ? (
+          <p className="px-2 py-3 text-xs text-text-muted">
+            Type at least 3 characters to search content.
+          </p>
+        ) : (
+          <>
+            <Tree<TreeNode>
+              ref={treeRef}
+              data={filteredData}
+              onMove={handleMove}
+              openByDefault={true}
+              width="100%"
+              indent={16}
+              rowHeight={32}
+              overscanCount={10}
+              disableDrag={!!search.trim()}
+              disableDrop={!!search.trim()}
+            >
+              {Node}
+            </Tree>
+            {filteredData.length === 0 && (
+              <div className="px-2 py-4 text-xs text-text-muted">
+                {search
+                  ? "No matching articles found."
+                  : "The first legend remains unwritten."}
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/creator/src/lib/loreSearch.ts
+++ b/creator/src/lib/loreSearch.ts
@@ -1,0 +1,174 @@
+import type { Article } from "@/types/lore";
+
+export interface SearchResult {
+  articleId: string;
+  title: string;
+  template: string;
+  /** The matching snippet with highlighted term context (±50 chars) */
+  snippet: string;
+  /** Where the match was found */
+  matchIn: "title" | "content" | "fields" | "tags" | "notes";
+}
+
+/** Extract searchable plain text from an article */
+export function buildSearchText(article: Article): string {
+  const parts: string[] = [article.title];
+
+  // Tags
+  if (article.tags) parts.push(...article.tags);
+
+  // Field values
+  for (const [, value] of Object.entries(article.fields)) {
+    if (typeof value === "string") parts.push(value);
+    else if (Array.isArray(value))
+      parts.push(value.filter((v) => typeof v === "string").join(" "));
+  }
+
+  // TipTap content -> plain text
+  if (article.content) {
+    parts.push(tiptapToPlainText(article.content));
+  }
+
+  // Private notes
+  if (article.privateNotes) {
+    parts.push(tiptapToPlainText(article.privateNotes));
+  }
+
+  return parts.join("\n").toLowerCase();
+}
+
+function tiptapToPlainText(content: string): string {
+  if (!content) return "";
+  if (!content.startsWith("{")) return content;
+  try {
+    const doc = JSON.parse(content);
+    return extractText(doc);
+  } catch {
+    return content;
+  }
+}
+
+function extractText(node: Record<string, unknown>): string {
+  if (node.type === "text") return String(node.text ?? "");
+  if (node.type === "mention") {
+    const attrs = node.attrs as Record<string, unknown> | undefined;
+    return String(attrs?.label ?? attrs?.id ?? "");
+  }
+  const children = node.content as Record<string, unknown>[] | undefined;
+  if (!children) return "";
+  return children.map(extractText).join(" ");
+}
+
+/** Search articles by query string, returning results with snippets */
+export function searchArticles(
+  articles: Record<string, Article>,
+  query: string,
+): SearchResult[] {
+  const q = query.toLowerCase().trim();
+  if (!q) return [];
+
+  const results: SearchResult[] = [];
+
+  for (const article of Object.values(articles)) {
+    // Check title
+    if (article.title.toLowerCase().includes(q)) {
+      results.push({
+        articleId: article.id,
+        title: article.title,
+        template: article.template,
+        snippet: article.title,
+        matchIn: "title",
+      });
+      continue; // Title match is sufficient
+    }
+
+    // Check tags
+    if (article.tags?.some((t) => t.toLowerCase().includes(q))) {
+      const tag = article.tags.find((t) => t.toLowerCase().includes(q))!;
+      results.push({
+        articleId: article.id,
+        title: article.title,
+        template: article.template,
+        snippet: `Tag: ${tag}`,
+        matchIn: "tags",
+      });
+      continue;
+    }
+
+    // Check field values
+    let fieldMatch: string | null = null;
+    for (const [key, value] of Object.entries(article.fields)) {
+      const text =
+        typeof value === "string"
+          ? value
+          : Array.isArray(value)
+            ? value.join(", ")
+            : "";
+      if (text.toLowerCase().includes(q)) {
+        fieldMatch = `${key}: ${text.slice(0, 100)}`;
+        break;
+      }
+    }
+    if (fieldMatch) {
+      results.push({
+        articleId: article.id,
+        title: article.title,
+        template: article.template,
+        snippet: fieldMatch,
+        matchIn: "fields",
+      });
+      continue;
+    }
+
+    // Check content body
+    const plainContent = tiptapToPlainText(article.content);
+    const contentLower = plainContent.toLowerCase();
+    const idx = contentLower.indexOf(q);
+    if (idx !== -1) {
+      const start = Math.max(0, idx - 50);
+      const end = Math.min(plainContent.length, idx + q.length + 50);
+      const snippet =
+        (start > 0 ? "..." : "") +
+        plainContent.slice(start, end) +
+        (end < plainContent.length ? "..." : "");
+      results.push({
+        articleId: article.id,
+        title: article.title,
+        template: article.template,
+        snippet,
+        matchIn: "content",
+      });
+      continue;
+    }
+
+    // Check private notes
+    if (article.privateNotes) {
+      const notesPlain = tiptapToPlainText(article.privateNotes);
+      const notesIdx = notesPlain.toLowerCase().indexOf(q);
+      if (notesIdx !== -1) {
+        const start = Math.max(0, notesIdx - 50);
+        const end = Math.min(notesPlain.length, notesIdx + q.length + 50);
+        const snippet =
+          (start > 0 ? "..." : "") +
+          notesPlain.slice(start, end) +
+          (end < notesPlain.length ? "..." : "");
+        results.push({
+          articleId: article.id,
+          title: article.title,
+          template: article.template,
+          snippet,
+          matchIn: "notes",
+        });
+      }
+    }
+  }
+
+  // Sort: title matches first, then by title alpha
+  results.sort((a, b) => {
+    if (a.matchIn === "title" && b.matchIn !== "title") return -1;
+    if (a.matchIn !== "title" && b.matchIn === "title") return 1;
+    return a.title.localeCompare(b.title);
+  });
+
+  return results;
+}


### PR DESCRIPTION
## Summary
- Adds `creator/src/lib/loreSearch.ts` with `searchArticles()` that searches across article titles, tags, field values, TipTap rich text content, and private notes, returning ranked results with contextual snippets
- Adds a "Titles / Content" toggle button next to the search input in `ArticleTree` that switches between the existing title-only tree filter and the new full-text content search
- Content search results render as a flat list with template color dot, article title, match location badge, and snippet text; clicking a result navigates to the article

Closes #81

## Test plan
- [ ] Toggle the search mode button between "Titles" and "Content" and verify the visual state changes
- [ ] In "Titles" mode, confirm existing title/template tree filtering still works as before
- [ ] In "Content" mode, type fewer than 3 characters and verify the "Type at least 3 characters" hint appears
- [ ] Search for a term that appears only in article body content and confirm the result appears with a snippet
- [ ] Search for a term that appears in tags, fields, and private notes to verify each match type shows correctly
- [ ] Click a content search result and confirm it selects the article and opens the lore panel
- [ ] Verify the debounce (300ms delay) works smoothly without lag on rapid typing
- [ ] Run `bunx tsc --noEmit` in `creator/` to confirm no type errors