### PR TITLE
Add smart @mention suggestions scanner

### DIFF
--- a/creator/src/components/lore/LoreCodexPanel.tsx
+++ b/creator/src/components/lore/LoreCodexPanel.tsx
@@ -4,6 +4,7 @@ import type { Article, ArticleRelation } from "@/types/lore";
 import { DefinitionWorkbench } from "@/components/config/DefinitionWorkbench";
 import { Section, FieldRow, TextInput, SelectInput } from "@/components/ui/FormWidgets";
 import { LoreEditor } from "./LoreEditor";
+import { MentionSuggestionsPanel } from "./MentionSuggestionsPanel";
 import { CODEX_GENERATE_PROMPT } from "@/lib/lorePrompts";
 import { tiptapToPlainText } from "@/lib/loreRelations";
 
@@ -402,6 +403,14 @@ export function LoreCodexPanel() {
         }}
         onItemsChange={handleItemsChange}
       />
+
+      <Section
+        title="Missing Mentions"
+        defaultExpanded={false}
+        description="Scan articles for plain-text references that should be @mentions."
+      >
+        <MentionSuggestionsPanel />
+      </Section>
     </div>
   );
 }

--- a/creator/src/components/lore/MentionSuggestionsPanel.tsx
+++ b/creator/src/components/lore/MentionSuggestionsPanel.tsx
@@ -1,0 +1,111 @@
+import { useState, useMemo, useCallback } from "react";
+import { useLoreStore, selectArticles } from "@/stores/loreStore";
+import {
+  scanForMissingSuggestions,
+  type MentionSuggestion,
+} from "@/lib/loreMentionScan";
+
+export function MentionSuggestionsPanel() {
+  const articles = useLoreStore(selectArticles);
+  const selectArticle = useLoreStore((s) => s.selectArticle);
+  const [suggestions, setSuggestions] = useState<MentionSuggestion[]>([]);
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const [scanned, setScanned] = useState(false);
+
+  const handleScan = useCallback(() => {
+    const results = scanForMissingSuggestions(articles);
+    setSuggestions(results);
+    setDismissed(new Set());
+    setScanned(true);
+  }, [articles]);
+
+  const handleDismiss = useCallback(
+    (sourceId: string, targetId: string) => {
+      setDismissed((s) => new Set(s).add(`${sourceId}:${targetId}`));
+    },
+    [],
+  );
+
+  const visible = useMemo(
+    () =>
+      suggestions.filter(
+        (s) => !dismissed.has(`${s.sourceId}:${s.targetId}`),
+      ),
+    [suggestions, dismissed],
+  );
+
+  const exactCount = visible.filter((s) => s.quality === "exact").length;
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center gap-3">
+        <button
+          onClick={handleScan}
+          className="focus-ring rounded-full border border-accent/30 bg-accent/10 px-4 py-2 text-xs font-medium text-accent transition hover:bg-accent/20"
+        >
+          {scanned ? "Rescan" : "Find Missing Mentions"}
+        </button>
+        {scanned && (
+          <span className="text-2xs text-text-muted">
+            {visible.length} suggestion{visible.length !== 1 ? "s" : ""}
+            {exactCount > 0 && ` (${exactCount} exact)`}
+          </span>
+        )}
+      </div>
+
+      {scanned && visible.length === 0 && (
+        <p className="rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-6 text-sm text-text-muted">
+          No missing mentions found. All plain-text references are already
+          linked.
+        </p>
+      )}
+
+      {visible.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {visible.map((s) => (
+            <div
+              key={`${s.sourceId}:${s.targetId}`}
+              className="rounded-xl border border-white/8 bg-black/10 px-4 py-3"
+            >
+              <div className="mb-1 flex items-center gap-2">
+                <button
+                  onClick={() => selectArticle(s.sourceId)}
+                  className="text-xs font-medium text-text-primary transition-colors hover:text-accent"
+                >
+                  {articles[s.sourceId]?.title ?? s.sourceId}
+                </button>
+                <span className="text-2xs text-text-muted">&rarr;</span>
+                <button
+                  onClick={() => selectArticle(s.targetId)}
+                  className="text-xs font-medium text-accent transition-colors hover:text-text-primary"
+                >
+                  {s.targetTitle}
+                </button>
+                <span
+                  className={`ml-auto rounded-full px-2 py-0.5 text-[10px] ${
+                    s.quality === "exact"
+                      ? "bg-accent/15 text-accent"
+                      : "bg-white/8 text-text-muted"
+                  }`}
+                >
+                  {s.quality}
+                </span>
+              </div>
+              <p className="mb-2 text-2xs leading-5 text-text-secondary">
+                {s.context}
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handleDismiss(s.sourceId, s.targetId)}
+                  className="rounded-full border border-white/8 px-2.5 py-1 text-[11px] text-text-muted transition hover:bg-white/8 hover:text-text-primary"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/lib/loreMentionScan.ts
+++ b/creator/src/lib/loreMentionScan.ts
@@ -1,0 +1,133 @@
+import type { Article } from "@/types/lore";
+
+export interface MentionSuggestion {
+  /** Article containing the plain-text reference */
+  sourceId: string;
+  /** Article being referenced */
+  targetId: string;
+  targetTitle: string;
+  /** The matched text in the source */
+  matchText: string;
+  /** Surrounding context (~40 chars each side) */
+  context: string;
+  /** Match quality: "exact" title match or "partial" */
+  quality: "exact" | "partial";
+}
+
+/**
+ * Scan all articles for plain-text references to other article titles
+ * that aren't already formal @mentions.
+ */
+export function scanForMissingSuggestions(
+  articles: Record<string, Article>,
+): MentionSuggestion[] {
+  const suggestions: MentionSuggestion[] = [];
+  const articleList = Object.values(articles);
+
+  // Build title lookup, filter out very short titles (< 4 chars) to reduce false positives
+  const targets = articleList.filter((a) => a.title.length >= 4);
+
+  for (const source of articleList) {
+    // Extract plain text from TipTap content
+    const plainText = tiptapToSearchText(source.content);
+    if (!plainText) continue;
+
+    // Get existing @mention target IDs to exclude
+    const existingMentions = extractExistingMentionIds(source.content);
+
+    for (const target of targets) {
+      // Don't suggest self-references
+      if (target.id === source.id) continue;
+      // Skip if already mentioned
+      if (existingMentions.has(target.id)) continue;
+
+      // Case-insensitive word-boundary search
+      const regex = new RegExp(`\\b${escapeRegex(target.title)}\\b`, "gi");
+      let match: RegExpExecArray | null;
+      while ((match = regex.exec(plainText)) !== null) {
+        const start = Math.max(0, match.index - 40);
+        const end = Math.min(
+          plainText.length,
+          match.index + match[0].length + 40,
+        );
+        const context =
+          (start > 0 ? "..." : "") +
+          plainText.slice(start, end) +
+          (end < plainText.length ? "..." : "");
+
+        suggestions.push({
+          sourceId: source.id,
+          targetId: target.id,
+          targetTitle: target.title,
+          matchText: match[0],
+          context,
+          quality:
+            match[0].toLowerCase() === target.title.toLowerCase()
+              ? "exact"
+              : "partial",
+        });
+        break; // One suggestion per source-target pair
+      }
+    }
+  }
+
+  // Sort: exact matches first, then by source article
+  suggestions.sort((a, b) => {
+    if (a.quality !== b.quality) return a.quality === "exact" ? -1 : 1;
+    return a.sourceId.localeCompare(b.sourceId);
+  });
+
+  return suggestions;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Extract plain text from TipTap JSON content for searching */
+function tiptapToSearchText(content: string): string {
+  if (!content) return "";
+  if (!content.startsWith("{")) return content;
+  try {
+    const doc = JSON.parse(content);
+    return extractText(doc);
+  } catch {
+    return content;
+  }
+}
+
+function extractText(node: Record<string, unknown>): string {
+  if (node.type === "text") return String(node.text ?? "");
+  // Skip mention nodes (they're already linked)
+  if (node.type === "mention") return "";
+  const children = node.content as Record<string, unknown>[] | undefined;
+  if (!children) return "";
+  return children.map(extractText).join(" ");
+}
+
+/** Extract IDs of existing @mention nodes in TipTap content */
+function extractExistingMentionIds(content: string): Set<string> {
+  const ids = new Set<string>();
+  if (!content || !content.startsWith("{")) return ids;
+  try {
+    const doc = JSON.parse(content);
+    collectMentionIds(doc, ids);
+  } catch {
+    /* ignore */
+  }
+  return ids;
+}
+
+function collectMentionIds(
+  node: Record<string, unknown>,
+  ids: Set<string>,
+): void {
+  if (node.type === "mention") {
+    const attrs = node.attrs as Record<string, unknown> | undefined;
+    if (attrs?.id) ids.add(String(attrs.id));
+  }
+  const children = node.content as Record<string, unknown>[] | undefined;
+  if (children) {
+    for (const child of children) collectMentionIds(child, ids);
+  }
+}


### PR DESCRIPTION
## Summary
- New `loreMentionScan.ts` library that scans all articles for plain-text references to other article titles not already linked as @mentions
- Word-boundary regex matching, filters short titles (<4 chars), extracts context snippets
- `MentionSuggestionsPanel` UI with scan button, results cards, dismiss per suggestion, quality badges (exact/partial)
- Added to LoreCodexPanel as a collapsible section

Closes #76