### PR TITLE
Add command palette with Ctrl+K

### DIFF
--- a/creator/src/components/AppShell.tsx
+++ b/creator/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { Toolbar } from "./Toolbar";
 import { Sidebar } from "./Sidebar";
 import { TabBar } from "./TabBar";
@@ -8,6 +8,7 @@ import { useKeyboardShortcuts } from "@/lib/useKeyboardShortcuts";
 import { useAssetStore } from "@/stores/assetStore";
 import type { Workspace } from "@/lib/panelRegistry";
 import { loadWorkspace, saveWorkspace } from "@/lib/uiPersistence";
+import { CommandPalette } from "./ui/CommandPalette";
 
 const ShortcutsHelp = lazy(() => import("./ui/ShortcutsHelp").then((m) => ({ default: m.ShortcutsHelp })));
 const AssetGenerator = lazy(() => import("./AssetGenerator").then((m) => ({ default: m.AssetGenerator })));
@@ -22,6 +23,18 @@ export function AppShell() {
   const setWorkspace = useCallback((next: Workspace) => {
     setWorkspaceState(next);
     saveWorkspace(next);
+  }, []);
+  const [showPalette, setShowPalette] = useState(false);
+
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key === "k") {
+        e.preventDefault();
+        setShowPalette((v) => !v);
+      }
+    }
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
   }, []);
 
   return (
@@ -39,6 +52,7 @@ export function AppShell() {
         </main>
       </div>
       <footer><StatusBar /></footer>
+      {showPalette && <CommandPalette onClose={() => setShowPalette(false)} />}
       <Suspense>
         {showHelp && <ShortcutsHelp onClose={() => setShowHelp(false)} />}
         {generatorOpen && <AssetGenerator />}

--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useCallback, useMemo } from "react";
+import { useRef, useState, useCallback, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useZoneStore, type ZoneState } from "@/stores/zoneStore";
 import { useProjectStore } from "@/stores/projectStore";
@@ -318,18 +318,6 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const hasProject = !!useProjectStore((s) => s.project);
 
-  // Ctrl+K to focus search
-  useEffect(() => {
-    function handler(e: KeyboardEvent) {
-      if ((e.ctrlKey || e.metaKey) && e.key === "k") {
-        e.preventDefault();
-        searchRef.current?.focus();
-      }
-    }
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, []);
-
   const handleSearchKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "Escape") {
@@ -455,8 +443,8 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleSearchKeyDown}
-            aria-label="Search entities (Ctrl+K)"
-            placeholder="Seek rooms, mobs, quests... (Ctrl+K)"
+            aria-label="Search entities"
+            placeholder="Seek rooms, mobs, quests..."
             className="ornate-input h-10 w-full rounded-full px-4 pr-10 text-sm text-text-primary"
           />
           {query && (
@@ -557,7 +545,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
       </div>
 
       <div className="relative z-10 border-t border-white/10 px-4 py-3 text-[11px] text-text-muted">
-        `Ctrl+K` seek | `Ctrl+S` commit | `Ctrl+,` tune the instrument
+        `Ctrl+K` command palette | `Ctrl+S` commit | `Ctrl+,` tune the instrument
       </div>
 
       {showNewZone && <NewZoneDialog onClose={() => setShowNewZone(false)} />}

--- a/creator/src/components/ui/CommandPalette.tsx
+++ b/creator/src/components/ui/CommandPalette.tsx
@@ -1,0 +1,195 @@
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { useProjectStore } from "@/stores/projectStore";
+import { useLoreStore, selectArticles } from "@/stores/loreStore";
+import { useZoneStore } from "@/stores/zoneStore";
+import { ALL_PANELS, panelTab } from "@/lib/panelRegistry";
+
+interface PaletteItem {
+  id: string;
+  type: "panel" | "article" | "zone";
+  title: string;
+  subtitle: string;
+  action: () => void;
+}
+
+export function CommandPalette({ onClose }: { onClose: () => void }) {
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const openTab = useProjectStore((s) => s.openTab);
+  const selectArticle = useLoreStore((s) => s.selectArticle);
+  const articles = useLoreStore(selectArticles);
+  const zones = useZoneStore((s) => s.zones);
+
+  // Build searchable items
+  const items = useMemo<PaletteItem[]>(() => {
+    const result: PaletteItem[] = [];
+
+    // Panels
+    for (const panel of ALL_PANELS) {
+      result.push({
+        id: `panel:${panel.id}`,
+        type: "panel",
+        title: panel.label,
+        subtitle: panel.description,
+        action: () => openTab(panelTab(panel.id)),
+      });
+    }
+
+    // Articles
+    for (const article of Object.values(articles)) {
+      result.push({
+        id: `article:${article.id}`,
+        type: "article",
+        title: article.title,
+        subtitle: article.template,
+        action: () => {
+          selectArticle(article.id);
+          openTab(panelTab("lore"));
+        },
+      });
+    }
+
+    // Zones
+    for (const [zoneId, zoneState] of zones.entries()) {
+      result.push({
+        id: `zone:${zoneId}`,
+        type: "zone",
+        title: zoneState.data.zone || zoneId,
+        subtitle: `${Object.keys(zoneState.data.rooms).length} rooms`,
+        action: () =>
+          openTab({ id: `zone:${zoneId}`, kind: "zone", label: zoneId }),
+      });
+    }
+
+    return result;
+  }, [articles, zones, openTab, selectArticle]);
+
+  // Filter
+  const filtered = useMemo(() => {
+    if (!query.trim()) return items.slice(0, 12);
+    const q = query.toLowerCase();
+    return items
+      .filter(
+        (item) =>
+          item.title.toLowerCase().includes(q) ||
+          item.subtitle.toLowerCase().includes(q),
+      )
+      .slice(0, 12);
+  }, [items, query]);
+
+  // Reset selection when results change
+  useEffect(() => setSelectedIndex(0), [filtered]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const el = listRef.current?.children[selectedIndex] as
+      | HTMLElement
+      | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  // Focus input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const activate = useCallback(
+    (item: PaletteItem) => {
+      item.action();
+      onClose();
+    },
+    [onClose],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        if (filtered[selectedIndex]) activate(filtered[selectedIndex]);
+      }
+    },
+    [filtered, selectedIndex, activate, onClose],
+  );
+
+  const typeBadge = (type: string) => {
+    const colors: Record<string, string> = {
+      panel: "bg-stellar-blue/20 text-stellar-blue",
+      article: "bg-accent/15 text-accent",
+      zone: "bg-status-success/20 text-status-success",
+    };
+    return colors[type] ?? "bg-white/10 text-text-muted";
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+      <div
+        className="relative w-full max-w-lg rounded-2xl border border-white/10 bg-bg-primary shadow-[0_24px_80px_rgba(8,10,18,0.6)]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Jump to article, panel, or zone..."
+          className="w-full rounded-t-2xl border-b border-white/8 bg-transparent px-5 py-4 text-sm text-text-primary placeholder:text-text-muted outline-none"
+        />
+        <div ref={listRef} className="max-h-[360px] overflow-y-auto py-2">
+          {filtered.length === 0 ? (
+            <p className="px-5 py-6 text-center text-sm text-text-muted">
+              No matches found
+            </p>
+          ) : (
+            filtered.map((item, i) => (
+              <button
+                key={item.id}
+                onClick={() => activate(item)}
+                onMouseEnter={() => setSelectedIndex(i)}
+                className={`flex w-full items-center gap-3 px-5 py-2.5 text-left transition ${
+                  i === selectedIndex ? "bg-white/8" : "hover:bg-white/4"
+                }`}
+              >
+                <span
+                  className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase ${typeBadge(item.type)}`}
+                >
+                  {item.type}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <span className="block truncate text-sm text-text-primary">
+                    {item.title}
+                  </span>
+                  <span className="block truncate text-2xs text-text-muted">
+                    {item.subtitle}
+                  </span>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+        <div className="border-t border-white/6 px-5 py-2 text-[10px] text-text-muted">
+          <kbd className="rounded bg-white/8 px-1.5 py-0.5">&uarr;&darr;</kbd>{" "}
+          navigate
+          <span className="mx-2">&middot;</span>
+          <kbd className="rounded bg-white/8 px-1.5 py-0.5">&crarr;</kbd> open
+          <span className="mx-2">&middot;</span>
+          <kbd className="rounded bg-white/8 px-1.5 py-0.5">esc</kbd> close
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `CommandPalette` component: search across panels, articles, and zones
- Keyboard navigable (arrows, Enter, Escape), auto-focused, color-coded type badges
- Global Ctrl+K/Cmd+K shortcut registered in AppShell
- Removed old Ctrl+K sidebar search focus handler
- Updated footer hint text

Closes #82