### PR TITLE
Add deterministic relationship inference

### DIFF
--- a/creator/src/components/lore/RelationGraphPanel.tsx
+++ b/creator/src/components/lore/RelationGraphPanel.tsx
@@ -14,6 +14,7 @@ import type { ArticleTemplate } from "@/types/lore";
 import { buildRelationGraph, type RelationGraphFilters } from "@/lib/loreRelations";
 import { TEMPLATE_SCHEMAS } from "@/lib/loreTemplates";
 import { RelationGraphNode } from "./RelationGraphNode";
+import { RelationInferencePanel } from "./RelationInferencePanel";
 
 const nodeTypes: NodeTypes = {
   relationNode: RelationGraphNode,
@@ -37,6 +38,7 @@ function RelationGraphInner() {
   const articles = useLoreStore(selectArticles);
   const selectArticle = useLoreStore((s) => s.selectArticle);
 
+  const [inferenceOpen, setInferenceOpen] = useState(false);
   const [templateFilters, setTemplateFilters] = useState<Set<ArticleTemplate>>(new Set());
   const [relationFilters, setRelationFilters] = useState<Set<string>>(new Set());
 
@@ -77,6 +79,27 @@ function RelationGraphInner() {
 
   return (
     <div className="flex flex-col gap-4">
+      {/* Relation inference */}
+      <div className="rounded-xl border border-border-muted bg-bg-secondary/50 px-4 py-3">
+        <button
+          onClick={() => setInferenceOpen((o) => !o)}
+          className="flex w-full items-center gap-2 text-left text-xs font-medium text-text-secondary transition hover:text-text-primary"
+        >
+          <span
+            className="inline-block transition-transform"
+            style={{ transform: inferenceOpen ? "rotate(90deg)" : "rotate(0deg)" }}
+          >
+            &#9654;
+          </span>
+          Relation Suggestions
+        </button>
+        {inferenceOpen && (
+          <div className="mt-3">
+            <RelationInferencePanel />
+          </div>
+        )}
+      </div>
+
       {/* Filter toolbar */}
       <div className="flex flex-wrap items-center gap-4">
         <div className="flex items-center gap-1.5">

--- a/creator/src/components/lore/RelationInferencePanel.tsx
+++ b/creator/src/components/lore/RelationInferencePanel.tsx
@@ -1,0 +1,141 @@
+import { useState, useMemo, useCallback } from "react";
+import { useLoreStore, selectArticles } from "@/stores/loreStore";
+import { inferRelations, type RelationSuggestion } from "@/lib/loreRelationInference";
+
+function suggestionKey(s: RelationSuggestion) {
+  return `${s.sourceId}:${s.targetId}:${s.type}`;
+}
+
+export function RelationInferencePanel() {
+  const articles = useLoreStore(selectArticles);
+  const updateArticle = useLoreStore((s) => s.updateArticle);
+  const [suggestions, setSuggestions] = useState<RelationSuggestion[]>([]);
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const [accepted, setAccepted] = useState<Set<string>>(new Set());
+  const [scanned, setScanned] = useState(false);
+
+  const handleScan = useCallback(() => {
+    setSuggestions(inferRelations(articles));
+    setDismissed(new Set());
+    setAccepted(new Set());
+    setScanned(true);
+  }, [articles]);
+
+  const visible = useMemo(
+    () => suggestions.filter((s) => !dismissed.has(suggestionKey(s)) && !accepted.has(suggestionKey(s))),
+    [suggestions, dismissed, accepted],
+  );
+
+  const highCount = visible.filter((s) => s.confidence === "high").length;
+
+  const handleAccept = useCallback(
+    (s: RelationSuggestion) => {
+      const article = articles[s.sourceId];
+      if (!article) return;
+      const existing = article.relations ?? [];
+      const newRel = { targetId: s.targetId, type: s.type, label: s.label };
+      updateArticle(s.sourceId, { relations: [...existing, newRel] });
+      setAccepted((prev) => new Set(prev).add(suggestionKey(s)));
+    },
+    [articles, updateArticle],
+  );
+
+  const handleDismiss = useCallback((s: RelationSuggestion) => {
+    setDismissed((prev) => new Set(prev).add(suggestionKey(s)));
+  }, []);
+
+  const handleAcceptAllHigh = useCallback(() => {
+    for (const s of visible) {
+      if (s.confidence === "high") {
+        const article = articles[s.sourceId];
+        if (!article) continue;
+        const existing = article.relations ?? [];
+        const newRel = { targetId: s.targetId, type: s.type, label: s.label };
+        updateArticle(s.sourceId, { relations: [...existing, newRel] });
+        setAccepted((prev) => new Set(prev).add(suggestionKey(s)));
+      }
+    }
+  }, [visible, articles, updateArticle]);
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center gap-3">
+        <button
+          onClick={handleScan}
+          className="focus-ring rounded-full border border-accent/30 bg-accent/10 px-4 py-2 text-xs font-medium text-accent transition hover:bg-accent/20"
+        >
+          {scanned ? "Rescan" : "Suggest Relations"}
+        </button>
+        {scanned && visible.length > 0 && highCount > 0 && (
+          <button
+            onClick={handleAcceptAllHigh}
+            className="focus-ring rounded-full border border-white/10 px-3 py-1.5 text-[11px] text-text-secondary transition hover:bg-white/8"
+          >
+            Accept All High ({highCount})
+          </button>
+        )}
+        {scanned && (
+          <span className="text-2xs text-text-muted">
+            {visible.length} suggestion{visible.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {scanned && visible.length === 0 && (
+        <p className="rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-6 text-center text-sm text-text-muted">
+          {accepted.size > 0
+            ? `All done! ${accepted.size} relation${accepted.size !== 1 ? "s" : ""} accepted.`
+            : "No missing relations detected."}
+        </p>
+      )}
+
+      {visible.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {visible.map((s) => (
+            <div
+              key={suggestionKey(s)}
+              className="rounded-xl border border-white/8 bg-black/10 px-4 py-3"
+            >
+              <div className="mb-1 flex items-center gap-2">
+                <span className="text-xs text-text-primary">
+                  {articles[s.sourceId]?.title ?? s.sourceId}
+                </span>
+                <span className="rounded bg-white/10 px-1.5 py-0.5 text-[10px] text-text-muted">
+                  {s.label ?? s.type}
+                </span>
+                <span className="text-2xs text-text-muted">&rarr;</span>
+                <span className="text-xs text-accent">
+                  {articles[s.targetId]?.title ?? s.targetId}
+                </span>
+                <span
+                  className={`ml-auto rounded-full px-2 py-0.5 text-[10px] ${
+                    s.confidence === "high"
+                      ? "bg-accent/15 text-accent"
+                      : "bg-white/8 text-text-muted"
+                  }`}
+                >
+                  {s.confidence}
+                </span>
+              </div>
+              <p className="mb-2 text-2xs text-text-secondary">{s.evidence}</p>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handleAccept(s)}
+                  className="rounded-full border border-accent/30 bg-accent/10 px-2.5 py-1 text-[11px] text-accent transition hover:bg-accent/20"
+                >
+                  Accept
+                </button>
+                <button
+                  onClick={() => handleDismiss(s)}
+                  className="rounded-full border border-white/8 px-2.5 py-1 text-[11px] text-text-muted transition hover:bg-white/8"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/lib/loreRelationInference.ts
+++ b/creator/src/lib/loreRelationInference.ts
@@ -1,0 +1,169 @@
+import type { Article } from "@/types/lore";
+
+export interface RelationSuggestion {
+  sourceId: string;
+  targetId: string;
+  type: string;
+  label?: string;
+  /** Why this was inferred */
+  evidence: string;
+  confidence: "high" | "medium";
+}
+
+/**
+ * Scan articles for implicit relationships that should exist as formal relations.
+ * Phase 1: deterministic field-based inference only.
+ */
+export function inferRelations(
+  articles: Record<string, Article>,
+): RelationSuggestion[] {
+  const suggestions: RelationSuggestion[] = [];
+  const articleList = Object.values(articles);
+
+  // Build title→id map for text-field matching (leader, territory, etc.)
+  const titleToId = new Map<string, string>();
+  for (const a of articleList) {
+    titleToId.set(a.title.toLowerCase(), a.id);
+  }
+
+  for (const article of articleList) {
+    const existingRelations = new Set(
+      (article.relations ?? []).map((r) => `${r.targetId}:${r.type}`),
+    );
+
+    // 1. Affiliation field (article_ref → stores article ID) → member_of
+    if (article.template === "character") {
+      const affiliationId = article.fields.affiliation as string | undefined;
+      if (affiliationId && articles[affiliationId] && !existingRelations.has(`${affiliationId}:member_of`)) {
+        suggestions.push({
+          sourceId: article.id,
+          targetId: affiliationId,
+          type: "member_of",
+          evidence: `Character "${article.title}" has affiliation "${articles[affiliationId]!.title}"`,
+          confidence: "high",
+        });
+      }
+    }
+
+    // 2. Profession field (article_ref → stores article ID) → related
+    if (article.template === "ability") {
+      const professionId = article.fields.profession as string | undefined;
+      if (professionId && articles[professionId] && !existingRelations.has(`${professionId}:related`)) {
+        suggestions.push({
+          sourceId: article.id,
+          targetId: professionId,
+          type: "related",
+          label: "used by",
+          evidence: `Ability "${article.title}" is linked to profession "${articles[professionId]!.title}"`,
+          confidence: "high",
+        });
+      }
+    }
+
+    // 3. Participants / speakers / keyAbilities (article_refs → store article ID arrays) → related
+    for (const [fieldName, label] of [
+      ["participants", "participated in"],
+      ["speakers", "speaks"],
+      ["keyAbilities", "key ability of"],
+    ] as const) {
+      const ids = article.fields[fieldName] as string[] | undefined;
+      if (Array.isArray(ids)) {
+        for (const targetId of ids) {
+          if (articles[targetId] && !existingRelations.has(`${targetId}:related`)) {
+            suggestions.push({
+              sourceId: article.id,
+              targetId,
+              type: "related",
+              label,
+              evidence: `"${article.title}" references "${articles[targetId]!.title}" in ${fieldName} field`,
+              confidence: "high",
+            });
+          }
+        }
+      }
+    }
+
+    // 4. Text-based location fields (territory, habitat) → located_in via title matching
+    for (const fieldName of ["territory", "habitat"]) {
+      const value = article.fields[fieldName] as string | undefined;
+      if (value) {
+        const targetId = titleToId.get(value.toLowerCase());
+        if (targetId && targetId !== article.id && !existingRelations.has(`${targetId}:located_in`)) {
+          suggestions.push({
+            sourceId: article.id,
+            targetId,
+            type: "located_in",
+            evidence: `"${article.title}" has ${fieldName} field "${value}"`,
+            confidence: "high",
+          });
+        }
+      }
+    }
+
+    // 5. Leader field (text) → related via title matching
+    if (article.template === "organization") {
+      const leader = article.fields.leader as string | undefined;
+      if (leader) {
+        const targetId = titleToId.get(leader.toLowerCase());
+        if (targetId && targetId !== article.id && !existingRelations.has(`${targetId}:related`)) {
+          suggestions.push({
+            sourceId: article.id,
+            targetId,
+            type: "related",
+            label: "led by",
+            evidence: `Organization "${article.title}" has leader "${leader}"`,
+            confidence: "high",
+          });
+        }
+      }
+    }
+
+    // 6. Parent article → located_in for location/organization children of locations
+    if (
+      article.parentId &&
+      articles[article.parentId] &&
+      (article.template === "location" || article.template === "organization") &&
+      articles[article.parentId]!.template === "location" &&
+      !existingRelations.has(`${article.parentId}:located_in`)
+    ) {
+      suggestions.push({
+        sourceId: article.id,
+        targetId: article.parentId,
+        type: "located_in",
+        evidence: `"${article.title}" is a child of location "${articles[article.parentId]!.title}"`,
+        confidence: "high",
+      });
+    }
+
+    // 7. Bidirectional gaps: if A→B ally/rival exists but B→A doesn't
+    for (const rel of article.relations ?? []) {
+      if (rel.type === "ally" || rel.type === "rival") {
+        const target = articles[rel.targetId];
+        if (target) {
+          const targetRels = new Set(
+            (target.relations ?? []).map((r) => `${r.targetId}:${r.type}`),
+          );
+          if (!targetRels.has(`${article.id}:${rel.type}`)) {
+            suggestions.push({
+              sourceId: rel.targetId,
+              targetId: article.id,
+              type: rel.type,
+              label: rel.label,
+              evidence: `"${article.title}" is ${rel.type} of "${target.title}" but not reciprocated`,
+              confidence: "medium",
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Deduplicate
+  const seen = new Set<string>();
+  return suggestions.filter((s) => {
+    const key = `${s.sourceId}:${s.targetId}:${s.type}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary
- New `loreRelationInference.ts` with 7 inference rules: affiliation→member_of, location fields→located_in, parent hierarchy, bidirectional gaps (ally/rival), leader→related, allies/rivals arrays, article_ref fields
- `RelationInferencePanel` UI with accept/dismiss per suggestion, batch accept high-confidence
- Integrated into RelationGraphPanel as collapsible section

Closes #73 (Phase 1 — deterministic only)