### PR TITLE
Add deterministic lore consistency auditor

### DIFF
--- a/creator/src/components/lore/AuditPanel.tsx
+++ b/creator/src/components/lore/AuditPanel.tsx
@@ -1,0 +1,93 @@
+import { useState, useCallback } from "react";
+import { useLoreStore } from "@/stores/loreStore";
+import { auditLore, type AuditIssue } from "@/lib/loreAudit";
+
+const SEVERITY_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+  error: { bg: "bg-status-danger/15", text: "text-status-danger", label: "Error" },
+  warning: { bg: "bg-status-warning/15", text: "text-status-warning", label: "Warning" },
+  info: { bg: "bg-accent/10", text: "text-accent", label: "Info" },
+};
+
+export function AuditPanel() {
+  const lore = useLoreStore((s) => s.lore);
+  const selectArticle = useLoreStore((s) => s.selectArticle);
+  const [issues, setIssues] = useState<AuditIssue[]>([]);
+  const [dismissed, setDismissed] = useState<Set<number>>(new Set());
+  const [audited, setAudited] = useState(false);
+
+  const handleAudit = useCallback(() => {
+    if (!lore) return;
+    setIssues(auditLore(lore));
+    setDismissed(new Set());
+    setAudited(true);
+  }, [lore]);
+
+  const visible = issues.filter((_, i) => !dismissed.has(i));
+  const errorCount = visible.filter((i) => i.severity === "error").length;
+  const warnCount = visible.filter((i) => i.severity === "warning").length;
+  const infoCount = visible.filter((i) => i.severity === "info").length;
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="font-display text-lg text-text-primary">Lore Audit</h2>
+        <button
+          onClick={handleAudit}
+          disabled={!lore}
+          className="focus-ring rounded-full border border-accent/30 bg-accent/10 px-4 py-2 text-xs font-medium text-accent transition hover:bg-accent/20 disabled:opacity-40"
+        >
+          {audited ? "Re-audit" : "Run Audit"}
+        </button>
+      </div>
+      <p className="mb-4 text-2xs text-text-secondary">
+        Check for orphaned references, duplicate titles, timeline mismatches, and structural issues.
+      </p>
+
+      {audited && (
+        <div className="mb-4 flex gap-3 text-2xs">
+          {errorCount > 0 && <span className="text-status-danger">{errorCount} error{errorCount !== 1 ? "s" : ""}</span>}
+          {warnCount > 0 && <span className="text-status-warning">{warnCount} warning{warnCount !== 1 ? "s" : ""}</span>}
+          {infoCount > 0 && <span className="text-accent">{infoCount} info</span>}
+          {visible.length === 0 && <span className="text-status-success">All clear!</span>}
+        </div>
+      )}
+
+      {visible.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {visible.map((issue) => {
+            const style = SEVERITY_STYLES[issue.severity]!;
+            const realIdx = issues.indexOf(issue);
+            return (
+              <div key={realIdx} className="rounded-xl border border-white/8 bg-black/10 px-4 py-3">
+                <div className="mb-1 flex items-center gap-2">
+                  <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${style.bg} ${style.text}`}>
+                    {style.label}
+                  </span>
+                  <span className="text-[10px] text-text-muted">{issue.category}</span>
+                </div>
+                <p className="mb-2 text-xs text-text-secondary">{issue.message}</p>
+                <div className="flex items-center gap-2">
+                  {issue.articleIds.map((id) => (
+                    <button
+                      key={id}
+                      onClick={() => selectArticle(id)}
+                      className="text-[11px] text-accent hover:text-text-primary transition-colors"
+                    >
+                      {lore?.articles[id]?.title ?? id}
+                    </button>
+                  ))}
+                  <button
+                    onClick={() => setDismissed((s) => new Set(s).add(realIdx))}
+                    className="ml-auto rounded-full border border-white/8 px-2 py-0.5 text-[10px] text-text-muted transition hover:bg-white/8"
+                  >
+                    Dismiss
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/lore/LoreCodexPanel.tsx
+++ b/creator/src/components/lore/LoreCodexPanel.tsx
@@ -5,6 +5,7 @@ import { DefinitionWorkbench } from "@/components/config/DefinitionWorkbench";
 import { Section, FieldRow, TextInput, SelectInput } from "@/components/ui/FormWidgets";
 import { LoreEditor } from "./LoreEditor";
 import { MentionSuggestionsPanel } from "./MentionSuggestionsPanel";
+import { AuditPanel } from "./AuditPanel";
 import { CODEX_GENERATE_PROMPT } from "@/lib/lorePrompts";
 import { tiptapToPlainText } from "@/lib/loreRelations";
 
@@ -410,6 +411,14 @@ export function LoreCodexPanel() {
         description="Scan articles for plain-text references that should be @mentions."
       >
         <MentionSuggestionsPanel />
+      </Section>
+
+      <Section
+        title="Lore Audit"
+        defaultExpanded={false}
+        description="Check for orphaned references, duplicate titles, timeline mismatches, and structural issues."
+      >
+        <AuditPanel />
       </Section>
     </div>
   );

--- a/creator/src/lib/loreAudit.ts
+++ b/creator/src/lib/loreAudit.ts
@@ -1,0 +1,178 @@
+import type { WorldLore } from "@/types/lore";
+
+export type AuditSeverity = "error" | "warning" | "info";
+
+export interface AuditIssue {
+  severity: AuditSeverity;
+  category: string;
+  message: string;
+  articleIds: string[];
+}
+
+export function auditLore(lore: WorldLore): AuditIssue[] {
+  const issues: AuditIssue[] = [];
+  const articles = lore.articles;
+  const articleIds = new Set(Object.keys(articles));
+
+  // 1. Orphaned relations — pointing to nonexistent articles
+  for (const article of Object.values(articles)) {
+    for (const rel of article.relations ?? []) {
+      if (!articleIds.has(rel.targetId)) {
+        issues.push({
+          severity: "error",
+          category: "Orphaned relation",
+          message: `"${article.title}" has a ${rel.type} relation to "${rel.targetId}" which doesn't exist`,
+          articleIds: [article.id],
+        });
+      }
+    }
+  }
+
+  // 2. Orphaned @mentions in content
+  for (const article of Object.values(articles)) {
+    const mentionIds = extractMentionIds(article.content);
+    for (const mid of mentionIds) {
+      if (!articleIds.has(mid)) {
+        issues.push({
+          severity: "warning",
+          category: "Orphaned mention",
+          message: `"${article.title}" @mentions "${mid}" which doesn't exist`,
+          articleIds: [article.id],
+        });
+      }
+    }
+  }
+
+  // 3. Duplicate titles
+  const titleMap = new Map<string, string[]>();
+  for (const article of Object.values(articles)) {
+    const key = article.title.toLowerCase().trim();
+    if (!titleMap.has(key)) titleMap.set(key, []);
+    titleMap.get(key)!.push(article.id);
+  }
+  for (const [, ids] of titleMap) {
+    if (ids.length > 1) {
+      issues.push({
+        severity: "warning",
+        category: "Duplicate title",
+        message: `${ids.length} articles share the title "${articles[ids[0]!]?.title}"`,
+        articleIds: ids,
+      });
+    }
+  }
+
+  // 4. Empty content — articles with no body text
+  for (const article of Object.values(articles)) {
+    if (!article.content || article.content === "" || article.content === '{"type":"doc","content":[]}') {
+      if (article.template !== "world_setting") {
+        issues.push({
+          severity: "info",
+          category: "Empty content",
+          message: `"${article.title}" has no body content`,
+          articleIds: [article.id],
+        });
+      }
+    }
+  }
+
+  // 5. Bidirectional relation gaps (ally/rival should be reciprocal)
+  for (const article of Object.values(articles)) {
+    for (const rel of article.relations ?? []) {
+      if (["ally", "rival"].includes(rel.type)) {
+        const target = articles[rel.targetId];
+        if (target) {
+          const reciprocal = (target.relations ?? []).some(
+            (r) => r.targetId === article.id && r.type === rel.type
+          );
+          if (!reciprocal) {
+            issues.push({
+              severity: "info",
+              category: "Missing reciprocal",
+              message: `"${article.title}" is ${rel.type} of "${target.title}" but not vice versa`,
+              articleIds: [article.id, rel.targetId],
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // 6. Timeline events outside era ranges
+  if (lore.timelineEvents && lore.calendarSystems) {
+    const eras = new Map<string, { start: number; end: number }>();
+    for (const cal of lore.calendarSystems) {
+      const sortedEras = [...cal.eras].sort((a, b) => a.startYear - b.startYear);
+      for (let i = 0; i < sortedEras.length; i++) {
+        const era = sortedEras[i]!;
+        const nextStart = sortedEras[i + 1]?.startYear ?? Infinity;
+        eras.set(era.id, { start: era.startYear, end: nextStart - 1 });
+      }
+    }
+    for (const event of lore.timelineEvents) {
+      const eraRange = eras.get(event.eraId);
+      if (eraRange && (event.year < eraRange.start || event.year > eraRange.end)) {
+        issues.push({
+          severity: "warning",
+          category: "Timeline mismatch",
+          message: `Event "${event.title}" (year ${event.year}) is outside its era's range (${eraRange.start}–${eraRange.end})`,
+          articleIds: event.articleId ? [event.articleId] : [],
+        });
+      }
+    }
+  }
+
+  // 7. Orphaned map pins
+  if (lore.maps) {
+    for (const map of lore.maps) {
+      for (const pin of map.pins) {
+        if (pin.articleId && !articleIds.has(pin.articleId)) {
+          issues.push({
+            severity: "warning",
+            category: "Orphaned pin",
+            message: `Pin "${pin.label ?? pin.id}" on map "${map.title}" links to nonexistent article "${pin.articleId}"`,
+            articleIds: [],
+          });
+        }
+      }
+    }
+  }
+
+  // 8. Timeline events referencing nonexistent articles
+  if (lore.timelineEvents) {
+    for (const event of lore.timelineEvents) {
+      if (event.articleId && !articleIds.has(event.articleId)) {
+        issues.push({
+          severity: "warning",
+          category: "Orphaned event link",
+          message: `Timeline event "${event.title}" references nonexistent article "${event.articleId}"`,
+          articleIds: [],
+        });
+      }
+    }
+  }
+
+  // Sort: errors first, then warnings, then info
+  const severityOrder: Record<AuditSeverity, number> = { error: 0, warning: 1, info: 2 };
+  issues.sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]);
+
+  return issues;
+}
+
+function extractMentionIds(content: string): string[] {
+  if (!content || !content.startsWith("{")) return [];
+  const ids: string[] = [];
+  try {
+    const doc = JSON.parse(content);
+    collectMentions(doc, ids);
+  } catch { /* ignore malformed content */ }
+  return ids;
+}
+
+function collectMentions(node: Record<string, unknown>, ids: string[]): void {
+  if (node.type === "mention") {
+    const attrs = node.attrs as Record<string, unknown> | undefined;
+    if (attrs?.id) ids.push(String(attrs.id));
+  }
+  const children = node.content as Record<string, unknown>[] | undefined;
+  if (children) for (const child of children) collectMentions(child, ids);
+}


### PR DESCRIPTION
## Summary
- New `loreAudit.ts` with 8 deterministic checks: orphaned relations, orphaned @mentions, duplicate titles, empty content, missing reciprocal relations, timeline/era mismatches, orphaned map pins, orphaned event links
- `AuditPanel` UI with severity-colored cards, article navigation, dismiss per issue
- Integrated into LoreCodexPanel as collapsible section

Closes #74 (deterministic checks — AI checks can be added later)