### PR TITLE
Add bulk article operations

### DIFF
--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import type { WorldFile } from "@/types/world";
 import { useGlobalSearch, ENTITY_TYPE_LABELS } from "@/lib/useGlobalSearch";
 import { PANEL_MAP, WORLDMAKER_GROUPS, LORE_GROUPS, panelTab, type Workspace } from "@/lib/panelRegistry";
 import { ArticleTree } from "./lore/ArticleTree";
+import { BulkActionsBar } from "./lore/BulkActionsBar";
 import { NewZoneDialog } from "./NewZoneDialog";
 import { ConfirmDialog } from "./ConfirmDialog";
 import {
@@ -539,6 +540,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
                 <span className="ml-2 text-[10px] font-normal text-text-muted">{articleCount}</span>
               </h2>
             </div>
+            <BulkActionsBar />
             <ArticleTree />
           </div>
         )}

--- a/creator/src/components/lore/ArticleTree.tsx
+++ b/creator/src/components/lore/ArticleTree.tsx
@@ -60,13 +60,26 @@ function buildTree(articles: Record<string, Article>): TreeNode[] {
 function Node({ node, style, dragHandle }: NodeRendererProps<TreeNode>) {
   const selectedArticleId = useLoreStore((s) => s.selectedArticleId);
   const selectArticle = useLoreStore((s) => s.selectArticle);
+  const selectedArticleIds = useLoreStore((s) => s.selectedArticleIds);
+  const toggleArticleSelection = useLoreStore((s) => s.toggleArticleSelection);
   const openTab = useProjectStore((s) => s.openTab);
   const isSelected = selectedArticleId === node.data.id;
+  const isMultiSelected = selectedArticleIds.has(node.data.id);
+  const multiSelectActive = selectedArticleIds.size > 0;
   const dotColor = TEMPLATE_DOT_COLORS[node.data.template];
 
-  const handleSelect = () => {
+  const handleSelect = (e: React.MouseEvent) => {
+    if (e.ctrlKey || e.metaKey) {
+      toggleArticleSelection(node.data.id);
+      return;
+    }
     selectArticle(node.data.id);
     openTab(panelTab("lore"));
+  };
+
+  const handleCheckbox = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    toggleArticleSelection(node.data.id);
   };
 
   return (
@@ -74,22 +87,42 @@ function Node({ node, style, dragHandle }: NodeRendererProps<TreeNode>) {
       ref={dragHandle}
       style={style}
       role="treeitem"
-      aria-selected={isSelected}
+      aria-selected={isSelected || isMultiSelected}
       aria-expanded={node.children && node.children.length > 0 ? node.isOpen : undefined}
       tabIndex={0}
       className={`flex cursor-pointer items-center gap-1.5 rounded px-2 py-1.5 text-xs transition-colors focus-visible:ring-1 focus-visible:ring-accent/50 ${
-        isSelected
-          ? "bg-accent/15 text-text-primary"
-          : "text-text-secondary hover:bg-bg-tertiary"
+        isMultiSelected
+          ? "bg-accent/10 text-text-primary ring-1 ring-accent/25"
+          : isSelected
+            ? "bg-accent/15 text-text-primary"
+            : "text-text-secondary hover:bg-bg-tertiary"
       }`}
       onClick={handleSelect}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          handleSelect();
+          if (e.ctrlKey || e.metaKey) {
+            toggleArticleSelection(node.data.id);
+          } else {
+            selectArticle(node.data.id);
+            openTab(panelTab("lore"));
+          }
         }
       }}
     >
+      {multiSelectActive && (
+        <span
+          onClick={handleCheckbox}
+          className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border text-[10px] transition ${
+            isMultiSelected
+              ? "border-accent/50 bg-accent/20 text-accent"
+              : "border-white/20 bg-white/5 text-transparent hover:border-white/30"
+          }`}
+          aria-label={isMultiSelected ? "Deselect" : "Select"}
+        >
+          {isMultiSelected ? "\u2713" : ""}
+        </span>
+      )}
       {node.children && node.children.length > 0 ? (
         <button
           onClick={(e) => {

--- a/creator/src/components/lore/BulkActionsBar.tsx
+++ b/creator/src/components/lore/BulkActionsBar.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { useLoreStore } from "@/stores/loreStore";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+
+export function BulkActionsBar() {
+  const selectedIds = useLoreStore((s) => s.selectedArticleIds);
+  const clearSelection = useLoreStore((s) => s.clearArticleSelection);
+  const bulkDelete = useLoreStore((s) => s.bulkDelete);
+  const bulkSetDraft = useLoreStore((s) => s.bulkSetDraft);
+  const bulkAddTags = useLoreStore((s) => s.bulkAddTags);
+  const [showDelete, setShowDelete] = useState(false);
+  const [showTag, setShowTag] = useState(false);
+  const [tagInput, setTagInput] = useState("");
+
+  const ids = [...selectedIds];
+  if (ids.length < 2) return null;
+
+  return (
+    <div className="relative mb-2 flex flex-wrap items-center gap-1.5 rounded-lg border border-accent/20 bg-accent/5 px-3 py-2">
+      <span className="text-2xs font-medium text-accent">
+        {ids.length} selected
+      </span>
+
+      <button
+        onClick={() => bulkSetDraft(ids, true)}
+        className="rounded-full border border-white/8 px-2 py-0.5 text-[10px] text-text-secondary hover:bg-white/8"
+      >
+        Draft
+      </button>
+      <button
+        onClick={() => bulkSetDraft(ids, false)}
+        className="rounded-full border border-white/8 px-2 py-0.5 text-[10px] text-text-secondary hover:bg-white/8"
+      >
+        Publish
+      </button>
+      <button
+        onClick={() => setShowTag(true)}
+        className="rounded-full border border-white/8 px-2 py-0.5 text-[10px] text-text-secondary hover:bg-white/8"
+      >
+        Tag
+      </button>
+      <button
+        onClick={() => setShowDelete(true)}
+        className="rounded-full border border-white/8 px-2 py-0.5 text-[10px] text-status-danger hover:bg-status-danger/10"
+      >
+        Delete
+      </button>
+      <button
+        onClick={clearSelection}
+        className="ml-auto text-[10px] text-text-muted hover:text-text-primary"
+      >
+        Clear
+      </button>
+
+      {showTag && (
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-white/10 bg-bg-primary p-3 shadow-lg">
+          <div className="flex gap-1.5">
+            <input
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              placeholder="Tag to add..."
+              className="ornate-input min-w-0 flex-1 rounded px-2 py-1 text-xs"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && tagInput.trim()) {
+                  bulkAddTags(ids, [tagInput.trim()]);
+                  setTagInput("");
+                  setShowTag(false);
+                }
+                if (e.key === "Escape") setShowTag(false);
+              }}
+              autoFocus
+            />
+            <button
+              onClick={() => {
+                if (tagInput.trim()) {
+                  bulkAddTags(ids, [tagInput.trim()]);
+                  setTagInput("");
+                }
+                setShowTag(false);
+              }}
+              className="rounded-full border border-accent/30 bg-accent/10 px-2 py-1 text-[10px] text-accent"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showDelete && (
+        <ConfirmDialog
+          title="Delete Articles"
+          message={`Delete ${ids.length} articles? This cannot be undone.`}
+          confirmLabel={`Delete ${ids.length}`}
+          destructive
+          onConfirm={() => {
+            bulkDelete(ids);
+            setShowDelete(false);
+          }}
+          onCancel={() => setShowDelete(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/creator/src/stores/loreStore.ts
+++ b/creator/src/stores/loreStore.ts
@@ -38,6 +38,7 @@ interface LoreState {
   loreFuture: WorldLore[];
   selectedArticleId: string | null;
   selectedMapId: string | null;
+  selectedArticleIds: Set<string>;
 }
 
 interface LoreStore extends LoreState {
@@ -49,6 +50,18 @@ interface LoreStore extends LoreState {
   duplicateArticle: (id: string) => void;
   moveArticle: (id: string, newParentId: string | undefined, sortOrder: number) => void;
   selectArticle: (id: string | null) => void;
+
+  // Multi-select operations
+  toggleArticleSelection: (id: string) => void;
+  selectAllArticles: () => void;
+  clearArticleSelection: () => void;
+
+  // Bulk mutation operations
+  bulkDelete: (ids: string[]) => void;
+  bulkSetDraft: (ids: string[], draft: boolean) => void;
+  bulkAddTags: (ids: string[], tags: string[]) => void;
+  bulkRemoveTags: (ids: string[], tags: string[]) => void;
+  bulkReparent: (ids: string[], parentId: string | undefined) => void;
 
   /** Bulk-replace all articles of a given template (used by legacy panel adapters). */
   replaceArticlesByTemplate: (
@@ -105,8 +118,9 @@ export const useLoreStore = create<LoreStore>((set, get) => ({
   loreFuture: [],
   selectedArticleId: null,
   selectedMapId: null,
+  selectedArticleIds: new Set(),
 
-  setLore: (lore) => set({ lore, dirty: false, lorePast: [], loreFuture: [] }),
+  setLore: (lore) => set({ lore, dirty: false, lorePast: [], loreFuture: [], selectedArticleIds: new Set() }),
 
   createArticle: (article) =>
     set((s) => {
@@ -259,6 +273,123 @@ export const useLoreStore = create<LoreStore>((set, get) => ({
     }),
 
   selectArticle: (id) => set({ selectedArticleId: id }),
+
+  // ─── Multi-select operations ──────────────────────────────────
+  toggleArticleSelection: (id) =>
+    set((s) => {
+      const next = new Set(s.selectedArticleIds);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return { selectedArticleIds: next };
+    }),
+
+  selectAllArticles: () =>
+    set((s) => ({
+      selectedArticleIds: new Set(Object.keys(s.lore?.articles ?? {})),
+    })),
+
+  clearArticleSelection: () => set({ selectedArticleIds: new Set() }),
+
+  // ─── Bulk mutation operations ─────────────────────────────────
+  bulkDelete: (ids) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const articles = { ...s.lore.articles };
+      for (const id of ids) delete articles[id];
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, articles },
+        dirty: true,
+        selectedArticleIds: new Set(),
+        selectedArticleId:
+          ids.includes(s.selectedArticleId ?? "") ? null : s.selectedArticleId,
+      };
+    }),
+
+  bulkSetDraft: (ids, draft) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const articles = { ...s.lore.articles };
+      const now = new Date().toISOString();
+      for (const id of ids) {
+        const a = articles[id];
+        if (a) articles[id] = { ...a, draft, updatedAt: now };
+      }
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, articles },
+        dirty: true,
+      };
+    }),
+
+  bulkAddTags: (ids, tags) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const articles = { ...s.lore.articles };
+      const now = new Date().toISOString();
+      for (const id of ids) {
+        const a = articles[id];
+        if (a) {
+          const existing = new Set(a.tags ?? []);
+          for (const t of tags) existing.add(t);
+          articles[id] = { ...a, tags: [...existing], updatedAt: now };
+        }
+      }
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, articles },
+        dirty: true,
+      };
+    }),
+
+  bulkRemoveTags: (ids, tags) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const articles = { ...s.lore.articles };
+      const now = new Date().toISOString();
+      const tagSet = new Set(tags);
+      for (const id of ids) {
+        const a = articles[id];
+        if (a && a.tags) {
+          articles[id] = {
+            ...a,
+            tags: a.tags.filter((t) => !tagSet.has(t)),
+            updatedAt: now,
+          };
+        }
+      }
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, articles },
+        dirty: true,
+      };
+    }),
+
+  bulkReparent: (ids, parentId) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const articles = { ...s.lore.articles };
+      const now = new Date().toISOString();
+      // Find the max sortOrder among existing children of the target parent
+      let maxSort = 0;
+      for (const a of Object.values(articles)) {
+        if (a.parentId === parentId && (a.sortOrder ?? 0) > maxSort) {
+          maxSort = a.sortOrder ?? 0;
+        }
+      }
+      for (const id of ids) {
+        const a = articles[id];
+        if (a) {
+          maxSort++;
+          articles[id] = { ...a, parentId, sortOrder: maxSort, updatedAt: now };
+        }
+      }
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, articles },
+        dirty: true,
+      };
+    }),
 
   replaceArticlesByTemplate: (template, articles) =>
     set((s) => {
@@ -543,5 +674,5 @@ export const useLoreStore = create<LoreStore>((set, get) => ({
   canRedoLore: () => get().loreFuture.length > 0,
 
   markClean: () => set({ dirty: false }),
-  clearLore: () => set({ lore: null, dirty: false, lorePast: [], loreFuture: [], selectedArticleId: null, selectedMapId: null }),
+  clearLore: () => set({ lore: null, dirty: false, lorePast: [], loreFuture: [], selectedArticleId: null, selectedMapId: null, selectedArticleIds: new Set() }),
 }));


### PR DESCRIPTION
## Summary
- Multi-select in ArticleTree via Ctrl+Click with checkboxes
- Bulk store methods: delete, draft/publish, add/remove tags, reparent — all with undo/redo support
- BulkActionsBar floating toolbar with selection count and action buttons
- Inline tag input, delete confirmation dialog
- Integrated into sidebar lore workspace

Closes #86