### PR TITLE
Add Obsidian/Markdown import wizard

### DIFF
--- a/creator/src/components/lore/DocumentLibraryPanel.tsx
+++ b/creator/src/components/lore/DocumentLibraryPanel.tsx
@@ -6,6 +6,7 @@ import { useLoreStore, selectDocuments } from "@/stores/loreStore";
 import type { LoreDocument } from "@/types/lore";
 import { Section, CommitTextarea } from "@/components/ui/FormWidgets";
 import { exportLoreBible } from "@/lib/exportLoreBible";
+import { ImportWizard } from "./ImportWizard";
 
 function LoreBibleExport() {
   const lore = useLoreStore((s) => s.lore);
@@ -79,6 +80,7 @@ export function DocumentLibraryPanel() {
   const deleteDocument = useLoreStore((s) => s.deleteDocument);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [newTitle, setNewTitle] = useState("");
+  const [showImportWizard, setShowImportWizard] = useState(false);
 
   const selected = selectedId ? documents.find((d) => d.id === selectedId) ?? null : null;
 
@@ -95,7 +97,7 @@ export function DocumentLibraryPanel() {
 
       const content = await invoke<string>("read_text_file", { filePath: String(filePath) });
       const filename = filePath.split(/[/\\]/).pop() ?? "document.md";
-      const title = filename.replace(/\.\w+$/, "").replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+      const title = filename.replace(/\.\w+$/, "").replace(/[-_]/g, " ").replace(/\b\w/g, (c: string) => c.toUpperCase());
       const now = new Date().toISOString();
       const doc: LoreDocument = {
         id: `doc_${Date.now()}`,
@@ -133,12 +135,18 @@ export function DocumentLibraryPanel() {
     <div className="flex gap-6">
       {/* Sidebar list */}
       <div className="w-64 shrink-0 space-y-3">
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <button
             onClick={handleImport}
             className="rounded-full border border-[rgba(184,216,232,0.28)] bg-gradient-active-strong px-3 py-1.5 text-xs text-text-primary transition hover:shadow-glow-sm"
           >
             Import .md
+          </button>
+          <button
+            onClick={() => setShowImportWizard(true)}
+            className="focus-ring rounded-full border border-white/10 px-3 py-1.5 text-xs font-medium text-text-secondary transition hover:bg-white/8 hover:text-text-primary"
+          >
+            Import Markdown
           </button>
           <button
             onClick={handleCreate}
@@ -218,6 +226,9 @@ export function DocumentLibraryPanel() {
         )}
       </div>
     </div>
+      {showImportWizard && (
+        <ImportWizard onClose={() => setShowImportWizard(false)} />
+      )}
     </div>
   );
 }

--- a/creator/src/components/lore/ImportWizard.tsx
+++ b/creator/src/components/lore/ImportWizard.tsx
@@ -1,0 +1,292 @@
+import { useState, useCallback } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { readDir, readTextFile } from "@tauri-apps/plugin-fs";
+import { useLoreStore } from "@/stores/loreStore";
+import { useFocusTrap } from "@/lib/useFocusTrap";
+import { parseMarkdownFile, type ImportCandidate } from "@/lib/loreImport";
+import type { ArticleTemplate } from "@/types/lore";
+import { TEMPLATE_SCHEMAS } from "@/lib/loreTemplates";
+
+type WizardStep = "select" | "review" | "done";
+
+/** Recursively collect all .md files from a directory tree. */
+async function collectMarkdownFiles(
+  dir: string,
+  rootDir: string,
+): Promise<{ relativePath: string; fullPath: string }[]> {
+  const results: { relativePath: string; fullPath: string }[] = [];
+  try {
+    const entries = await readDir(dir);
+    for (const entry of entries) {
+      if (!entry.name) continue;
+      const fullPath = `${dir}/${entry.name}`;
+      if (entry.isDirectory) {
+        // Recurse into subdirectories (skip hidden folders like .obsidian)
+        if (!entry.name.startsWith(".")) {
+          const nested = await collectMarkdownFiles(fullPath, rootDir);
+          results.push(...nested);
+        }
+      } else if (entry.name.endsWith(".md")) {
+        // Build a relative path from the root folder
+        const relative = fullPath.slice(rootDir.length + 1).replace(/\\/g, "/");
+        results.push({ relativePath: relative, fullPath });
+      }
+    }
+  } catch (err) {
+    console.warn(`Failed to read directory ${dir}:`, err);
+  }
+  return results;
+}
+
+export function ImportWizard({ onClose }: { onClose: () => void }) {
+  const [step, setStep] = useState<WizardStep>("select");
+  const [candidates, setCandidates] = useState<ImportCandidate[]>([]);
+  const [importedCount, setImportedCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const createArticle = useLoreStore((s) => s.createArticle);
+  const articles = useLoreStore((s) => s.lore?.articles ?? {});
+  const trapRef = useFocusTrap<HTMLDivElement>(onClose);
+
+  const handleSelectFolder = useCallback(async () => {
+    const folder = await open({
+      directory: true,
+      title: "Select Markdown folder",
+    });
+    if (!folder || typeof folder !== "string") return;
+
+    setLoading(true);
+    try {
+      const files = await collectMarkdownFiles(folder, folder);
+      const parsed: ImportCandidate[] = [];
+      for (const file of files) {
+        try {
+          const content = await readTextFile(file.fullPath);
+          parsed.push(parseMarkdownFile(file.relativePath, content));
+        } catch (err) {
+          console.warn(`Failed to read ${file.relativePath}:`, err);
+        }
+      }
+      setCandidates(parsed);
+      setStep("review");
+    } catch (err) {
+      console.error("Failed to scan folder:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleImport = useCallback(() => {
+    const selected = candidates.filter((c) => c.selected);
+    const now = new Date().toISOString();
+    // Snapshot current article IDs plus any we create during this loop
+    const usedIds = new Set(Object.keys(articles));
+    let count = 0;
+
+    for (const candidate of selected) {
+      let id = candidate.title
+        .toLowerCase()
+        .replace(/\s+/g, "_")
+        .replace(/[^a-z0-9_]/g, "");
+      if (!id) id = "untitled";
+
+      // Avoid duplicates
+      if (usedIds.has(id)) {
+        let suffix = 2;
+        while (usedIds.has(`${id}_${suffix}`)) suffix++;
+        id = `${id}_${suffix}`;
+      }
+      usedIds.add(id);
+
+      createArticle({
+        id,
+        template: candidate.template,
+        title: candidate.title,
+        fields: candidate.fields,
+        content: candidate.tiptapContent,
+        tags: candidate.tags.length > 0 ? candidate.tags : undefined,
+        draft: true,
+        createdAt: now,
+        updatedAt: now,
+      });
+      count++;
+    }
+
+    setImportedCount(count);
+    setStep("done");
+  }, [candidates, articles, createArticle]);
+
+  const toggleCandidate = (idx: number) => {
+    setCandidates((prev) =>
+      prev.map((c, i) =>
+        i === idx ? { ...c, selected: !c.selected } : c,
+      ),
+    );
+  };
+
+  const setTemplate = (idx: number, template: ArticleTemplate) => {
+    setCandidates((prev) =>
+      prev.map((c, i) => (i === idx ? { ...c, template } : c)),
+    );
+  };
+
+  const toggleAll = () => {
+    const allSelected = candidates.every((c) => c.selected);
+    setCandidates((prev) => prev.map((c) => ({ ...c, selected: !allSelected })));
+  };
+
+  const templateOptions = Object.entries(TEMPLATE_SCHEMAS).map(([key, s]) => ({
+    value: key,
+    label: s.label,
+  }));
+  const selectedCount = candidates.filter((c) => c.selected).length;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div
+        ref={trapRef}
+        className="relative flex w-full max-w-2xl max-h-[80vh] flex-col overflow-hidden rounded-2xl border border-white/10 bg-bg-primary shadow-[0_24px_80px_rgba(8,10,18,0.6)]"
+      >
+        {/* Header */}
+        <div className="shrink-0 border-b border-white/8 px-6 py-4">
+          <h2 className="font-display text-lg text-text-primary">
+            Import Markdown
+          </h2>
+          <p className="mt-1 text-2xs text-text-secondary">
+            {step === "select" &&
+              "Select a folder of Markdown files to import as lore articles."}
+            {step === "review" &&
+              `${candidates.length} file${candidates.length !== 1 ? "s" : ""} found. Review and import.`}
+            {step === "done" &&
+              `${importedCount} article${importedCount !== 1 ? "s" : ""} imported as drafts.`}
+          </p>
+        </div>
+
+        {/* Body */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
+          {step === "select" && (
+            <div className="flex flex-col items-center gap-4 py-12">
+              <p className="text-sm text-text-muted">
+                Supports Obsidian vaults, plain Markdown, and Notion exports.
+              </p>
+              <button
+                onClick={handleSelectFolder}
+                disabled={loading}
+                className="focus-ring rounded-full border border-accent/30 bg-accent/10 px-6 py-3 text-sm font-medium text-accent transition hover:bg-accent/20 disabled:opacity-40"
+              >
+                {loading ? "Scanning..." : "Choose Folder"}
+              </button>
+            </div>
+          )}
+
+          {step === "review" && (
+            <div className="flex flex-col gap-2">
+              {candidates.length > 1 && (
+                <button
+                  onClick={toggleAll}
+                  className="mb-1 self-start text-2xs text-text-muted hover:text-text-secondary transition"
+                >
+                  {candidates.every((c) => c.selected)
+                    ? "Deselect all"
+                    : "Select all"}
+                </button>
+              )}
+              {candidates.map((c, i) => (
+                <div
+                  key={c.filePath}
+                  className={`flex items-center gap-3 rounded-xl border px-4 py-3 ${
+                    c.selected
+                      ? "border-accent/20 bg-accent/5"
+                      : "border-white/6 bg-black/10 opacity-50"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={c.selected}
+                    onChange={() => toggleCandidate(i)}
+                    className="accent-accent"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <span className="block truncate text-sm text-text-primary">
+                      {c.title}
+                    </span>
+                    <span className="block truncate text-[10px] text-text-muted">
+                      {c.filePath}
+                    </span>
+                    {c.tags.length > 0 && (
+                      <span className="block truncate text-[10px] text-text-muted/60">
+                        {c.tags.join(", ")}
+                      </span>
+                    )}
+                  </div>
+                  <select
+                    value={c.template}
+                    onChange={(e) =>
+                      setTemplate(i, e.target.value as ArticleTemplate)
+                    }
+                    className="ornate-input rounded px-2 py-1 text-xs"
+                  >
+                    {templateOptions.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ))}
+              {candidates.length === 0 && (
+                <p className="py-6 text-center text-sm text-text-muted">
+                  No .md files found in the selected folder.
+                </p>
+              )}
+            </div>
+          )}
+
+          {step === "done" && (
+            <div className="flex flex-col items-center gap-4 py-12">
+              <p className="font-display text-lg text-accent">
+                {importedCount} article{importedCount !== 1 ? "s" : ""} imported
+              </p>
+              <p className="text-sm text-text-secondary">
+                All imported articles are marked as drafts for review.
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="shrink-0 border-t border-white/8 px-6 py-3 flex items-center justify-between">
+          <button
+            onClick={onClose}
+            className="text-xs text-text-muted hover:text-text-primary transition"
+          >
+            {step === "done" ? "Close" : "Cancel"}
+          </button>
+          <div className="flex gap-2">
+            {step === "review" && candidates.length === 0 && (
+              <button
+                onClick={() => setStep("select")}
+                className="text-xs text-text-muted hover:text-text-primary transition"
+              >
+                Back
+              </button>
+            )}
+            {step === "review" && (
+              <button
+                onClick={handleImport}
+                disabled={selectedCount === 0}
+                className="focus-ring rounded-full border border-accent/30 bg-accent/10 px-5 py-2 text-xs font-medium text-accent transition hover:bg-accent/20 disabled:opacity-40"
+              >
+                Import {selectedCount} article
+                {selectedCount !== 1 ? "s" : ""}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/lib/loreImport.ts
+++ b/creator/src/lib/loreImport.ts
@@ -1,0 +1,366 @@
+import type { ArticleTemplate } from "@/types/lore";
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export interface ImportCandidate {
+  /** Relative file path within the selected folder */
+  filePath: string;
+  /** Parsed title (from front-matter or filename) */
+  title: string;
+  /** Auto-detected template */
+  template: ArticleTemplate;
+  /** Front-matter fields mapped to article fields */
+  fields: Record<string, unknown>;
+  /** Markdown body (raw, pre-conversion) */
+  markdownBody: string;
+  /** TipTap JSON content (converted from markdown) */
+  tiptapContent: string;
+  /** Tags from front-matter */
+  tags: string[];
+  /** Whether to import (user can toggle) */
+  selected: boolean;
+}
+
+// ─── Public API ─────────────────────────────────────────────────────
+
+/** Parse a markdown file with optional YAML front-matter. */
+export function parseMarkdownFile(
+  filename: string,
+  content: string,
+): ImportCandidate {
+  let fields: Record<string, unknown> = {};
+  let body = content;
+  let tags: string[] = [];
+  let title = filename.replace(/\.md$/i, "").replace(/.*[/\\]/, "");
+
+  // Parse YAML front-matter delimited by --- ... ---
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (fmMatch) {
+    const fmText = fmMatch[1] ?? "";
+    body = fmMatch[2] ?? "";
+
+    let currentListKey: string | undefined;
+    const listValues: Record<string, string[]> = {};
+
+    for (const line of fmText.split(/\r?\n/)) {
+      // Key: value pair
+      const kv = line.match(/^(\w[\w-]*)\s*:\s*(.+)$/);
+      if (kv) {
+        currentListKey = undefined;
+        const key = kv[1]!;
+        const value = kv[2]!;
+        const trimmed = value.trim().replace(/^["']|["']$/g, "");
+        if (key === "title") {
+          title = trimmed;
+        } else if (key === "tags" || key === "aliases") {
+          // Inline array: tags: [a, b, c]
+          if (trimmed.startsWith("[")) {
+            const parsed = trimmed
+              .replace(/^\[|\]$/g, "")
+              .split(",")
+              .map((t) => t.trim().replace(/^["']|["']$/g, ""))
+              .filter(Boolean);
+            if (key === "tags") tags = parsed;
+            else fields[key.toLowerCase()] = parsed;
+          } else {
+            // Could be a single value or start of a YAML list
+            currentListKey = key;
+            listValues[key] = [trimmed].filter(Boolean);
+          }
+        } else {
+          fields[key.toLowerCase()] = trimmed;
+        }
+        continue;
+      }
+
+      // Key with empty value (start of a YAML list)
+      const emptyKey = line.match(/^(\w[\w-]*)\s*:\s*$/);
+      if (emptyKey) {
+        currentListKey = emptyKey[1]!;
+        listValues[currentListKey] = [];
+        continue;
+      }
+
+      // YAML list item
+      const listItem = line.match(/^\s*-\s+(.+)$/);
+      const listArr = currentListKey ? listValues[currentListKey] : undefined;
+      if (listItem && listArr) {
+        listArr.push(listItem[1]!.trim().replace(/^["']|["']$/g, ""));
+      }
+    }
+
+    // Apply collected list values
+    if (listValues.tags && listValues.tags.length > 0) {
+      tags = listValues.tags;
+    }
+    for (const [key, values] of Object.entries(listValues)) {
+      if (key !== "tags" && values.length > 0) {
+        fields[key.toLowerCase()] = values;
+      }
+    }
+  }
+
+  const template = detectTemplate(fields, filename);
+  const tiptapContent = markdownToTiptap(body);
+
+  return {
+    filePath: filename,
+    title,
+    template,
+    fields,
+    markdownBody: body,
+    tiptapContent,
+    tags,
+    selected: true,
+  };
+}
+
+// ─── Template detection ─────────────────────────────────────────────
+
+function detectTemplate(
+  fields: Record<string, unknown>,
+  path: string,
+): ArticleTemplate {
+  const type = String(fields.type ?? fields.category ?? "").toLowerCase();
+  const pathLower = path.toLowerCase();
+
+  if (
+    type.includes("character") ||
+    type.includes("npc") ||
+    type.includes("person") ||
+    pathLower.includes("/characters/")
+  )
+    return "character";
+  if (
+    type.includes("location") ||
+    type.includes("place") ||
+    pathLower.includes("/locations/") ||
+    pathLower.includes("/places/")
+  )
+    return "location";
+  if (
+    type.includes("organization") ||
+    type.includes("faction") ||
+    pathLower.includes("/factions/") ||
+    pathLower.includes("/organizations/")
+  )
+    return "organization";
+  if (
+    type.includes("species") ||
+    type.includes("race") ||
+    type.includes("creature") ||
+    pathLower.includes("/species/")
+  )
+    return "species";
+  if (
+    type.includes("item") ||
+    type.includes("artifact") ||
+    pathLower.includes("/items/")
+  )
+    return "item";
+  if (
+    type.includes("event") ||
+    pathLower.includes("/events/") ||
+    pathLower.includes("/history/")
+  )
+    return "event";
+  if (type.includes("language") || pathLower.includes("/languages/"))
+    return "language";
+  if (
+    type.includes("profession") ||
+    type.includes("class") ||
+    pathLower.includes("/classes/")
+  )
+    return "profession";
+  if (
+    type.includes("ability") ||
+    type.includes("spell") ||
+    pathLower.includes("/abilities/")
+  )
+    return "ability";
+
+  return "freeform";
+}
+
+// ─── Markdown → TipTap JSON ────────────────────────────────────────
+
+/** Convert markdown text to a TipTap-compatible JSON string. */
+function markdownToTiptap(md: string): string {
+  const nodes: Record<string, unknown>[] = [];
+  const lines = md.split(/\r?\n/);
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+
+    // Headings
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      nodes.push({
+        type: "heading",
+        attrs: { level: headingMatch[1]!.length },
+        content: parseInline(headingMatch[2]!),
+      });
+      i++;
+      continue;
+    }
+
+    // Horizontal rule
+    if (/^(-{3,}|\*{3,}|_{3,})$/.test(line.trim())) {
+      nodes.push({ type: "horizontalRule" });
+      i++;
+      continue;
+    }
+
+    // Blockquote (collect consecutive > lines)
+    if (line.startsWith("> ") || line === ">") {
+      const quoteLines: string[] = [];
+      while (
+        i < lines.length &&
+        (lines[i]!.startsWith("> ") || lines[i] === ">")
+      ) {
+        quoteLines.push(lines[i]!.replace(/^>\s?/, ""));
+        i++;
+      }
+      nodes.push({
+        type: "blockquote",
+        content: [
+          {
+            type: "paragraph",
+            content: parseInline(quoteLines.join(" ")),
+          },
+        ],
+      });
+      continue;
+    }
+
+    // Unordered list
+    if (/^\s*[-*+]\s/.test(line)) {
+      const listItems: Record<string, unknown>[] = [];
+      while (i < lines.length && /^\s*[-*+]\s/.test(lines[i]!)) {
+        const text = lines[i]!.replace(/^\s*[-*+]\s+/, "");
+        listItems.push({
+          type: "listItem",
+          content: [{ type: "paragraph", content: parseInline(text) }],
+        });
+        i++;
+      }
+      nodes.push({ type: "bulletList", content: listItems });
+      continue;
+    }
+
+    // Ordered list
+    if (/^\s*\d+\.\s/.test(line)) {
+      const listItems: Record<string, unknown>[] = [];
+      while (i < lines.length && /^\s*\d+\.\s/.test(lines[i]!)) {
+        const text = lines[i]!.replace(/^\s*\d+\.\s+/, "");
+        listItems.push({
+          type: "listItem",
+          content: [{ type: "paragraph", content: parseInline(text) }],
+        });
+        i++;
+      }
+      nodes.push({ type: "orderedList", content: listItems });
+      continue;
+    }
+
+    // Empty line — skip
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    // Paragraph — collect until a block boundary or empty line
+    const paraLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i]!.trim() !== "" &&
+      !lines[i]!.match(/^#{1,6}\s/) &&
+      !lines[i]!.match(/^\s*[-*+]\s/) &&
+      !lines[i]!.match(/^\s*\d+\.\s/) &&
+      !lines[i]!.startsWith("> ") &&
+      !/^(-{3,}|\*{3,}|_{3,})$/.test(lines[i]!.trim())
+    ) {
+      paraLines.push(lines[i]!);
+      i++;
+    }
+    if (paraLines.length > 0) {
+      nodes.push({
+        type: "paragraph",
+        content: parseInline(paraLines.join(" ")),
+      });
+    }
+  }
+
+  if (nodes.length === 0) {
+    return "";
+  }
+
+  return JSON.stringify({ type: "doc", content: nodes });
+}
+
+// ─── Inline markdown parsing ────────────────────────────────────────
+
+/**
+ * Parse inline markdown (bold, italic, code, wiki-links) into
+ * TipTap-compatible text/mark/mention nodes.
+ */
+function parseInline(text: string): Record<string, unknown>[] {
+  const nodes: Record<string, unknown>[] = [];
+  // Matches: **bold**, *italic*, `code`, [[wiki-link]], [[target|display]]
+  const regex =
+    /(\*\*(.+?)\*\*|\*(.+?)\*|`(.+?)`|\[\[([^|\]]+?)(?:\|([^\]]+?))?\]\])/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(text)) !== null) {
+    // Text before this match
+    if (match.index > lastIndex) {
+      nodes.push({ type: "text", text: text.slice(lastIndex, match.index) });
+    }
+
+    if (match[2] != null) {
+      // **bold**
+      nodes.push({
+        type: "text",
+        text: match[2],
+        marks: [{ type: "bold" }],
+      });
+    } else if (match[3] != null) {
+      // *italic*
+      nodes.push({
+        type: "text",
+        text: match[3],
+        marks: [{ type: "italic" }],
+      });
+    } else if (match[4] != null) {
+      // `code`
+      nodes.push({
+        type: "text",
+        text: match[4],
+        marks: [{ type: "code" }],
+      });
+    } else if (match[5] != null) {
+      // [[wiki-link]] or [[target|display]]
+      const targetTitle = match[5].trim();
+      const displayName = (match[6] ?? match[5]).trim();
+      const id = targetTitle
+        .toLowerCase()
+        .replace(/\s+/g, "_")
+        .replace(/[^a-z0-9_]/g, "");
+      nodes.push({
+        type: "mention",
+        attrs: { id, label: displayName },
+      });
+    }
+
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Remaining text
+  if (lastIndex < text.length) {
+    nodes.push({ type: "text", text: text.slice(lastIndex) });
+  }
+
+  return nodes.length > 0 ? nodes : [{ type: "text", text }];
+}


### PR DESCRIPTION
## Summary
- New `loreImport.ts` with Markdown parsing, YAML front-matter extraction, template auto-detection, and Markdown→TipTap JSON conversion (headings, lists, bold, italic, code, `[[wiki-links]]`→@mentions)
- `ImportWizard` three-step modal: folder selection, review with template overrides, bulk import as drafts
- Recursive folder scanning, skips hidden dirs (.obsidian), handles edge cases
- Integrated into DocumentLibraryPanel

Closes #85