### PR TITLE
Add AI timeline inference from article content

### DIFF
--- a/creator/src/components/lore/TimelineInferencePanel.tsx
+++ b/creator/src/components/lore/TimelineInferencePanel.tsx
@@ -1,0 +1,161 @@
+import { useState, useCallback } from "react";
+import { useLoreStore } from "@/stores/loreStore";
+import {
+  inferTimelineEvents,
+  type TimelineSuggestion,
+  type InferenceProgress,
+} from "@/lib/loreTimelineInference";
+
+export function TimelineInferencePanel() {
+  const lore = useLoreStore((s) => s.lore);
+  const addTimelineEvent = useLoreStore((s) => s.addTimelineEvent);
+  const selectArticle = useLoreStore((s) => s.selectArticle);
+  const [suggestions, setSuggestions] = useState<TimelineSuggestion[]>([]);
+  const [dismissed, setDismissed] = useState<Set<number>>(new Set());
+  const [accepted, setAccepted] = useState<Set<number>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState<InferenceProgress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleInfer = useCallback(async () => {
+    if (!lore) return;
+    setLoading(true);
+    setError(null);
+    setProgress(null);
+    try {
+      const results = await inferTimelineEvents(lore, undefined, setProgress);
+      setSuggestions(results);
+      setDismissed(new Set());
+      setAccepted(new Set());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+      setProgress(null);
+    }
+  }, [lore]);
+
+  const handleAccept = useCallback(
+    (idx: number) => {
+      const s = suggestions[idx];
+      if (!s) return;
+      addTimelineEvent({
+        id: `inferred_${Date.now()}_${idx}`,
+        title: s.title,
+        year: s.year,
+        eraId: s.eraId,
+        calendarId: lore?.calendarSystems?.[0]?.id ?? "",
+        importance: s.importance,
+        articleId: s.articleId,
+        description: s.evidence,
+      });
+      setAccepted((prev) => new Set(prev).add(idx));
+    },
+    [suggestions, lore, addTimelineEvent],
+  );
+
+  const visible = suggestions.filter(
+    (_, i) => !dismissed.has(i) && !accepted.has(i),
+  );
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center gap-3">
+        <button
+          onClick={handleInfer}
+          disabled={!lore || loading || !lore.calendarSystems?.length}
+          className="focus-ring rounded-full border border-accent/30 bg-accent/10 px-4 py-2 text-xs font-medium text-accent transition hover:bg-accent/20 disabled:opacity-40"
+        >
+          {loading ? "Analyzing..." : "Infer Timeline"}
+        </button>
+        {loading && progress && (
+          <span className="text-2xs text-text-muted">
+            Batch {progress.batch} of {progress.totalBatches}
+          </span>
+        )}
+        {!lore?.calendarSystems?.length && (
+          <span className="text-2xs text-text-muted">
+            Add a calendar system first
+          </span>
+        )}
+        {!loading && visible.length > 0 && (
+          <span className="text-2xs text-text-muted">
+            {visible.length} suggestion{visible.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {error && <p className="mb-3 text-xs text-status-danger">{error}</p>}
+
+      {suggestions.length > 0 && visible.length === 0 && !loading && (
+        <p className="rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-6 text-sm text-text-muted">
+          All suggestions processed. {accepted.size} accepted.
+        </p>
+      )}
+
+      {visible.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {suggestions.map((s, i) => {
+            if (dismissed.has(i) || accepted.has(i)) return null;
+            return (
+              <div
+                key={i}
+                className="rounded-xl border border-white/8 bg-black/10 px-4 py-3"
+              >
+                <div className="mb-1 flex flex-wrap items-center gap-2">
+                  <span className="text-xs font-medium text-text-primary">
+                    {s.title}
+                  </span>
+                  <span className="rounded bg-white/10 px-1.5 py-0.5 text-[10px] text-text-muted">
+                    Year {s.year}
+                  </span>
+                  <span className="rounded bg-white/10 px-1.5 py-0.5 text-[10px] text-text-muted">
+                    {s.eraName}
+                  </span>
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-[10px] ${
+                      s.importance === "legendary"
+                        ? "bg-accent/20 text-accent"
+                        : s.importance === "major"
+                          ? "bg-white/10 text-text-primary"
+                          : "bg-white/5 text-text-muted"
+                    }`}
+                  >
+                    {s.importance}
+                  </span>
+                </div>
+                <p className="mb-1 text-2xs italic text-text-secondary">
+                  &ldquo;{s.evidence}&rdquo;
+                </p>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => selectArticle(s.articleId)}
+                    className="text-[11px] text-accent transition-colors hover:text-text-primary"
+                  >
+                    {s.articleTitle}
+                  </button>
+                  <div className="ml-auto flex gap-2">
+                    <button
+                      onClick={() => handleAccept(i)}
+                      className="rounded-full border border-accent/30 bg-accent/10 px-2.5 py-1 text-[11px] text-accent hover:bg-accent/20"
+                    >
+                      Accept
+                    </button>
+                    <button
+                      onClick={() =>
+                        setDismissed((prev) => new Set(prev).add(i))
+                      }
+                      className="rounded-full border border-white/8 px-2.5 py-1 text-[11px] text-text-muted hover:bg-white/8"
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/lore/TimelinePanel.tsx
+++ b/creator/src/components/lore/TimelinePanel.tsx
@@ -12,6 +12,7 @@ import {
   IconButton,
 } from "@/components/ui/FormWidgets";
 import { TimelineView } from "./TimelineView";
+import { TimelineInferencePanel } from "./TimelineInferencePanel";
 
 // Calendar system editor
 
@@ -254,6 +255,11 @@ export function TimelinePanel() {
 
   return (
     <div className="flex flex-col gap-6">
+      {/* AI timeline inference */}
+      <Section title="AI Timeline Inference" defaultExpanded={false}>
+        <TimelineInferencePanel />
+      </Section>
+
       {/* Calendar system editor */}
       <CalendarEditor calendars={calendars} onChange={setCalendars} />
 

--- a/creator/src/lib/loreTimelineInference.ts
+++ b/creator/src/lib/loreTimelineInference.ts
@@ -1,0 +1,156 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { WorldLore, Article } from "@/types/lore";
+
+export interface TimelineSuggestion {
+  title: string;
+  year: number;
+  eraId: string;
+  eraName: string;
+  importance: "minor" | "major" | "legendary";
+  articleId: string;
+  articleTitle: string;
+  evidence: string;
+}
+
+const SYSTEM_PROMPT = `You are a timeline analyst for a fantasy world-building tool. Given articles from a lore corpus and a calendar system, extract temporal references and suggest timeline events.
+
+For each temporal reference found, output a JSON array of objects with:
+- "title": short event title (max 60 chars)
+- "year": numeric year in the calendar
+- "eraId": which era this belongs to (from the provided era list)
+- "importance": "minor", "major", or "legendary"
+- "articleId": ID of the source article
+- "evidence": the exact quote or paraphrase that indicates this temporal reference (max 100 chars)
+
+Rules:
+- Only extract events with specific or inferable dates/years
+- For vague references like "during the Third Age", use the era's start year + a small offset
+- For relative dates like "200 years before X", resolve against known events if possible, otherwise estimate
+- Skip references that are too vague to place on a timeline
+- Do NOT invent events — only extract what's in the text
+- Output ONLY valid JSON array — no markdown, no explanation`;
+
+export interface InferenceProgress {
+  batch: number;
+  totalBatches: number;
+}
+
+export async function inferTimelineEvents(
+  lore: WorldLore,
+  articleIds?: string[],
+  onProgress?: (progress: InferenceProgress) => void,
+): Promise<TimelineSuggestion[]> {
+  const articles: Article[] = articleIds
+    ? articleIds.reduce<Article[]>((acc, id) => {
+        const a = lore.articles[id];
+        if (a) acc.push(a);
+        return acc;
+      }, [])
+    : Object.values(lore.articles).filter((a) => !a.draft);
+
+  if (articles.length === 0) return [];
+
+  const calendars = lore.calendarSystems ?? [];
+  const existingEvents = lore.timelineEvents ?? [];
+
+  // Build calendar context
+  const calendarContext =
+    calendars.length > 0
+      ? calendars
+          .map(
+            (c) =>
+              `Calendar: ${c.name}\nEras: ${c.eras.map((e) => `${e.name} (id: ${e.id}, starts year ${e.startYear})`).join(", ")}`,
+          )
+          .join("\n\n")
+      : "No calendar system defined. Use year numbers directly and eraId 'unknown'.";
+
+  // Build existing events context (so AI doesn't suggest duplicates)
+  const existingContext =
+    existingEvents.length > 0
+      ? `\n\nExisting timeline events (do NOT suggest duplicates):\n${existingEvents.map((e) => `- Year ${e.year}: ${e.title}`).join("\n")}`
+      : "";
+
+  // Process in batches of 10 articles
+  const batchSize = 10;
+  const totalBatches = Math.ceil(articles.length / batchSize);
+  const allSuggestions: TimelineSuggestion[] = [];
+
+  for (let i = 0; i < articles.length; i += batchSize) {
+    const batchIndex = Math.floor(i / batchSize) + 1;
+    onProgress?.({ batch: batchIndex, totalBatches });
+
+    const batch = articles.slice(i, i + batchSize);
+    const articleContext = batch
+      .map((a) => {
+        const plainContent = tiptapToPlain(a.content);
+        const fields = Object.entries(a.fields)
+          .filter(([, v]) => v != null && v !== "")
+          .map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(", ") : v}`)
+          .join("\n");
+        return `--- Article: ${a.title} (id: ${a.id}, template: ${a.template}) ---\nFields:\n${fields}\n\nContent:\n${plainContent.slice(0, 1000)}`;
+      })
+      .join("\n\n");
+
+    const userPrompt = `${calendarContext}${existingContext}\n\n${articleContext}`;
+
+    try {
+      const response = await invoke<string>("llm_complete", {
+        systemPrompt: SYSTEM_PROMPT,
+        userPrompt,
+      });
+
+      // Parse JSON response — strip markdown fences if present
+      const cleaned = response.replace(/```json\n?|\n?```/g, "").trim();
+      const parsed = JSON.parse(cleaned);
+      if (Array.isArray(parsed)) {
+        for (const item of parsed) {
+          const article = batch.find((a) => a.id === item.articleId);
+          allSuggestions.push({
+            title: String(item.title ?? ""),
+            year: Number(item.year ?? 0),
+            eraId: String(item.eraId ?? ""),
+            eraName:
+              calendars
+                .flatMap((c) => c.eras)
+                .find((e) => e.id === item.eraId)?.name ?? item.eraId,
+            importance: ["minor", "major", "legendary"].includes(
+              item.importance,
+            )
+              ? item.importance
+              : "minor",
+            articleId: String(item.articleId ?? ""),
+            articleTitle: article?.title ?? item.articleId,
+            evidence: String(item.evidence ?? ""),
+          });
+        }
+      }
+    } catch (err) {
+      console.warn(`Timeline inference batch failed:`, err);
+    }
+  }
+
+  // Dedup against existing events
+  const existingKeys = new Set(
+    existingEvents.map((e) => `${e.year}:${e.title.toLowerCase()}`),
+  );
+  return allSuggestions.filter(
+    (s) => !existingKeys.has(`${s.year}:${s.title.toLowerCase()}`),
+  );
+}
+
+function tiptapToPlain(content: string): string {
+  if (!content || !content.startsWith("{")) return content ?? "";
+  try {
+    return extractText(JSON.parse(content));
+  } catch {
+    return content;
+  }
+}
+
+function extractText(node: Record<string, unknown>): string {
+  if (node.type === "text") return String(node.text ?? "");
+  if (node.type === "mention")
+    return String((node.attrs as Record<string, unknown>)?.label ?? "");
+  const children = node.content as Record<string, unknown>[] | undefined;
+  return children ? children.map(extractText).join(" ") : "";
+}


### PR DESCRIPTION
## Summary
- New `loreTimelineInference.ts` that sends article batches to LLM to extract temporal references with year, era, importance, and evidence
- `TimelineInferencePanel` UI with progress indicator, accept/dismiss per suggestion
- Deduplicates against existing timeline events
- Integrated into TimelinePanel as collapsible section

Closes #77