### PR TITLE
Add vision-powered map analysis

### DIFF
--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -43,6 +43,7 @@ pub fn run() {
             deepinfra::enhance_prompt,
             deepinfra::read_image_data_url,
             llm::llm_complete,
+            llm::llm_complete_with_vision,
             runware::runware_generate_image,
             openai_images::openai_generate_image,
             runware::runware_generate_audio,

--- a/creator/src-tauri/src/llm.rs
+++ b/creator/src-tauri/src/llm.rs
@@ -112,3 +112,39 @@ pub async fn llm_complete(
     let s = settings::get_settings(app.clone()).await?;
     complete_from_settings(&s, &system_prompt, &user_prompt, max_tokens).await
 }
+
+/// Vision-enabled LLM completion using the Anthropic API.
+/// Accepts a data URL (e.g. "data:image/png;base64,...") and parses it into
+/// the base64 payload and media type required by the Anthropic vision API.
+#[tauri::command]
+pub async fn llm_complete_with_vision(
+    app: AppHandle,
+    system_prompt: String,
+    user_prompt: String,
+    image_data_url: String,
+) -> Result<String, String> {
+    let s = settings::get_settings(app).await?;
+
+    if s.anthropic_api_key.is_empty() {
+        return Err("Anthropic API key required for vision analysis. Set it in Settings.".to_string());
+    }
+
+    // Parse "data:<media_type>;base64,<data>" format
+    let rest = image_data_url
+        .strip_prefix("data:")
+        .ok_or("Invalid image data URL: missing 'data:' prefix")?;
+    let (media_type, base64_data) = rest
+        .split_once(";base64,")
+        .ok_or("Invalid image data URL: missing ';base64,' delimiter")?;
+
+    anthropic::complete_with_vision(
+        &s.anthropic_api_key,
+        "claude-sonnet-4-20250514",
+        &system_prompt,
+        &user_prompt,
+        base64_data,
+        media_type,
+        4096,
+    )
+    .await
+}

--- a/creator/src/components/lore/MapAnalysisPanel.tsx
+++ b/creator/src/components/lore/MapAnalysisPanel.tsx
@@ -1,0 +1,163 @@
+import { useState, useCallback } from "react";
+import { useLoreStore } from "@/stores/loreStore";
+import { analyzeMap, type MapFeatureSuggestion } from "@/lib/loreMapAnalysis";
+import type { LoreMap } from "@/types/lore";
+
+export function MapAnalysisPanel({
+  map,
+  imageDataUrl,
+}: {
+  map: LoreMap;
+  imageDataUrl: string;
+}) {
+  const lore = useLoreStore((s) => s.lore);
+  const addPin = useLoreStore((s) => s.addPin);
+  const [suggestions, setSuggestions] = useState<MapFeatureSuggestion[]>([]);
+  const [dismissed, setDismissed] = useState<Set<number>>(new Set());
+  const [accepted, setAccepted] = useState<Set<number>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAnalyze = useCallback(async () => {
+    if (!lore || !imageDataUrl) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const results = await analyzeMap(map, imageDataUrl, lore);
+      setSuggestions(results);
+      setDismissed(new Set());
+      setAccepted(new Set());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [map, imageDataUrl, lore]);
+
+  const handleAccept = useCallback(
+    (idx: number) => {
+      const s = suggestions[idx];
+      if (!s) return;
+      addPin(map.id, {
+        id: `pin_${Date.now()}_${idx}`,
+        position: [s.y, s.x],
+        label: s.label,
+        articleId: s.matchedArticleId,
+      });
+      setAccepted((prev) => new Set(prev).add(idx));
+    },
+    [suggestions, map.id, addPin],
+  );
+
+  const handleAcceptAll = useCallback(() => {
+    suggestions.forEach((s, i) => {
+      if (dismissed.has(i) || accepted.has(i)) return;
+      addPin(map.id, {
+        id: `pin_${Date.now()}_${i}`,
+        position: [s.y, s.x],
+        label: s.label,
+        articleId: s.matchedArticleId,
+      });
+    });
+    setAccepted(
+      new Set(
+        suggestions
+          .map((_, i) => i)
+          .filter((i) => !dismissed.has(i)),
+      ),
+    );
+  }, [suggestions, dismissed, accepted, map.id, addPin]);
+
+  const visible = suggestions.filter(
+    (_, i) => !dismissed.has(i) && !accepted.has(i),
+  );
+
+  return (
+    <div className="rounded-xl border border-white/8 bg-black/10 p-4">
+      <div className="mb-3 flex items-center gap-3">
+        <button
+          onClick={handleAnalyze}
+          disabled={loading || !imageDataUrl}
+          className="focus-ring rounded-full border border-accent/30 bg-accent/10 px-4 py-2 text-xs font-medium text-accent transition hover:bg-accent/20 disabled:opacity-40"
+        >
+          {loading ? "Analyzing..." : "Analyze Map"}
+        </button>
+        {visible.length > 0 && (
+          <>
+            <span className="text-2xs text-text-muted">
+              {visible.length} feature{visible.length !== 1 ? "s" : ""} found
+            </span>
+            <button
+              onClick={handleAcceptAll}
+              className="rounded-full border border-accent/20 px-3 py-1 text-[10px] text-accent hover:bg-accent/10"
+            >
+              Pin All
+            </button>
+          </>
+        )}
+      </div>
+
+      {error && <p className="mb-3 text-xs text-status-danger">{error}</p>}
+
+      {suggestions.length > 0 && visible.length === 0 && !loading && (
+        <p className="text-2xs text-text-muted">
+          All features processed. {accepted.size} pin
+          {accepted.size !== 1 ? "s" : ""} added.
+        </p>
+      )}
+
+      {visible.length > 0 && (
+        <div className="flex max-h-60 flex-col gap-1.5 overflow-y-auto">
+          {suggestions.map((s, i) => {
+            if (dismissed.has(i) || accepted.has(i)) return null;
+            return (
+              <div
+                key={i}
+                className="flex items-center gap-2 rounded-lg border border-white/6 bg-black/10 px-3 py-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <span className="text-xs text-text-primary">{s.label}</span>
+                  {s.matchedArticleTitle && (
+                    <span className="ml-2 text-[10px] text-accent">
+                      &rarr; {s.matchedArticleTitle}
+                    </span>
+                  )}
+                  {s.suggestNewArticle && (
+                    <span className="ml-2 text-[10px] italic text-text-muted">
+                      new
+                    </span>
+                  )}
+                </div>
+                <span
+                  className={`rounded-full px-1.5 py-0.5 text-[9px] ${
+                    s.confidence === "high"
+                      ? "bg-accent/15 text-accent"
+                      : s.confidence === "medium"
+                        ? "bg-white/8 text-text-secondary"
+                        : "bg-white/5 text-text-muted"
+                  }`}
+                >
+                  {s.confidence}
+                </span>
+                <button
+                  onClick={() => handleAccept(i)}
+                  className="rounded-full border border-accent/30 px-2 py-0.5 text-[10px] text-accent hover:bg-accent/10"
+                >
+                  Pin
+                </button>
+                <button
+                  onClick={() =>
+                    setDismissed((prev) => new Set(prev).add(i))
+                  }
+                  className="rounded-full border border-white/8 px-2 py-0.5 text-[10px] text-text-muted hover:bg-white/8"
+                >
+                  Skip
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/lore/MapPanel.tsx
+++ b/creator/src/components/lore/MapPanel.tsx
@@ -8,6 +8,7 @@ import { TEMPLATE_SCHEMAS } from "@/lib/loreTemplates";
 import { ActionButton, FieldRow, TextInput } from "@/components/ui/FormWidgets";
 import { MapViewer } from "./MapViewer";
 import { MapEnhancer } from "./MapEnhancer";
+import { MapAnalysisPanel } from "./MapAnalysisPanel";
 
 // ─── Map image hook ─────────────────────────────────────────────────
 
@@ -642,6 +643,11 @@ export function MapPanel() {
         <div className="flex h-64 items-center justify-center rounded-lg border border-dashed border-border-muted text-sm text-text-muted">
           Select a map or upload a new one to get started.
         </div>
+      )}
+
+      {/* Vision-powered map analysis */}
+      {selectedMap && mapImage && (
+        <MapAnalysisPanel map={selectedMap} imageDataUrl={mapImage} />
       )}
 
       {/* Map enhancer dialog */}

--- a/creator/src/lib/loreMapAnalysis.ts
+++ b/creator/src/lib/loreMapAnalysis.ts
@@ -1,0 +1,103 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { WorldLore, LoreMap } from "@/types/lore";
+
+export interface MapFeatureSuggestion {
+  label: string;
+  x: number;
+  y: number;
+  matchedArticleId?: string;
+  matchedArticleTitle?: string;
+  suggestNewArticle: boolean;
+  confidence: "high" | "medium" | "low";
+}
+
+const SYSTEM_PROMPT = `You are a cartographer AI analyzing a fantasy world map image. Your task is to identify labeled locations, notable geographic features, and points of interest.
+
+For each feature you identify, estimate its pixel coordinates within the image. The image dimensions are provided — use them to estimate x (horizontal, from left) and y (vertical, from top) positions.
+
+Also provided is a list of existing lore articles. Match identified features to article titles where possible.
+
+Output a JSON array of objects with:
+- "label": the name/label of the feature (as readable text from the map, or a descriptive name for unlabeled features)
+- "x": estimated x pixel coordinate (from left edge)
+- "y": estimated y pixel coordinate (from top edge)
+- "matchedArticle": title of the matching lore article, or null if no match
+- "confidence": "high" (clearly labeled text), "medium" (partially readable or geographic feature), "low" (inferred/uncertain)
+- "type": "city", "region", "mountain", "river", "forest", "landmark", or "other"
+
+Focus on:
+1. Readable text labels on the map (highest priority)
+2. Major geographic features (mountain ranges, rivers, coastlines, forests)
+3. Notable structures or landmarks
+
+Output ONLY valid JSON array — no markdown, no explanation.`;
+
+export async function analyzeMap(
+  map: LoreMap,
+  imageDataUrl: string,
+  lore: WorldLore,
+): Promise<MapFeatureSuggestion[]> {
+  const articleTitles = Object.values(lore.articles)
+    .filter((a) => !a.draft)
+    .map((a) => ({ id: a.id, title: a.title, template: a.template }));
+
+  const existingPins = map.pins.map((p) => p.label ?? p.id).join(", ");
+
+  const userPrompt = `Map: "${map.title}" (${map.width}×${map.height} pixels)
+
+Existing pins: ${existingPins || "none"}
+
+Lore articles to match against:
+${articleTitles.map((a) => `- ${a.title} (${a.template})`).join("\n")}
+
+Identify features on this map and estimate their pixel coordinates.`;
+
+  const response = await invoke<string>("llm_complete_with_vision", {
+    systemPrompt: SYSTEM_PROMPT,
+    userPrompt,
+    imageDataUrl,
+  });
+
+  // Parse JSON response — strip markdown fences if present
+  const cleaned = response.replace(/```json\n?|\n?```/g, "").trim();
+  const parsed = JSON.parse(cleaned);
+
+  if (!Array.isArray(parsed)) return [];
+
+  // Build title→id lookup (case-insensitive)
+  const titleToId = new Map<string, string>();
+  const titleToOriginal = new Map<string, string>();
+  for (const a of articleTitles) {
+    titleToId.set(a.title.toLowerCase(), a.id);
+    titleToOriginal.set(a.title.toLowerCase(), a.title);
+  }
+
+  return parsed.map((item: Record<string, unknown>) => {
+    const matchTitle =
+      typeof item.matchedArticle === "string"
+        ? item.matchedArticle.toLowerCase()
+        : undefined;
+    const matchId = matchTitle ? titleToId.get(matchTitle) : undefined;
+    const matchOriginal = matchTitle
+      ? titleToOriginal.get(matchTitle)
+      : undefined;
+
+    // Convert pixel coords to Leaflet CRS.Simple: lat = height - y, lng = x
+    const lng = Number(item.x ?? 0);
+    const lat = map.height - Number(item.y ?? 0);
+
+    return {
+      label: String(item.label ?? "Unknown"),
+      x: lng,
+      y: lat,
+      matchedArticleId: matchId,
+      matchedArticleTitle: matchOriginal,
+      suggestNewArticle: !matchId,
+      confidence: ["high", "medium", "low"].includes(
+        item.confidence as string,
+      )
+        ? (item.confidence as "high" | "medium" | "low")
+        : "medium",
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- New `llm_complete_with_vision` Rust command exposing Claude's vision API
- `loreMapAnalysis.ts` sends map image + lore articles to vision API, identifies features with estimated coordinates
- `MapAnalysisPanel` UI with analyze button, feature list with confidence badges, accept/skip per feature, "Pin All" batch action
- Integrated into MapPanel below the map viewer
- Coordinates converted to Leaflet CRS.Simple format

Closes #78