### PR TITLE
fix: streamline AI generation workflow UX (#126)

### DIFF
--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -80,6 +80,9 @@ export function EntityArtGenerator({
   const [customModel, setCustomModel] = useState("");
   // Track the final prompt that was actually sent to the image model
   const [lastEnhancedPrompt, setLastEnhancedPrompt] = useState<string | null>(null);
+  // Whether the current prompt has been LLM-enhanced (skip re-enhancement during generation)
+  const [enhanced, setEnhanced] = useState(false);
+  const [removingBg, setRemovingBg] = useState(false);
 
   // Refs to track pending results across unmount — auto-accept if user navigates away
   const pendingResultRef = useRef<GeneratedImage | null>(null);
@@ -197,11 +200,13 @@ export function EntityArtGenerator({
         throw new Error(`No models available for provider: ${imageProvider}`);
       }
 
-      // Auto-enhance via LLM if available — this is the key change.
-      // The LLM gets the entity description, style guide, and zone vibe
-      // and crafts a proper image prompt from all three.
+      // If the prompt was already enhanced via the Enhance button, send it as-is.
+      // Otherwise auto-enhance via LLM when available — the LLM gets the entity
+      // description, style guide, and zone vibe and crafts a proper image prompt.
       let finalPrompt = activePrompt;
-      if (hasLlmKey) {
+      if (enhanced) {
+        setLastEnhancedPrompt(activePrompt);
+      } else if (hasLlmKey) {
         try {
           finalPrompt = await enhancePrompt(activePrompt);
           setLastEnhancedPrompt(finalPrompt);
@@ -259,8 +264,9 @@ export function EntityArtGenerator({
     setEnhancing(true);
     setError(null);
     try {
-      const enhanced = await enhancePrompt(activePrompt);
-      setEditedPrompt(enhanced);
+      const enhancedText = await enhancePrompt(activePrompt);
+      setEditedPrompt(enhancedText);
+      setEnhanced(true);
     } catch (e) {
       setError(String(e));
     } finally {
@@ -300,19 +306,28 @@ export function EntityArtGenerator({
     pendingResultRef.current = null;
     pendingPromptRef.current = null;
     const fileName = result.file_path.split(/[\\/]/).pop() ?? result.hash;
+    const needsBgRemoval = !!(settings?.auto_remove_bg && assetType && shouldRemoveBg(assetType) && result.data_url);
+    const savedDataUrl = result.data_url;
     onAccept(fileName);
     if (assetType) {
       await acceptAsset(result, assetType, lastEnhancedPrompt ?? undefined, context, variantGroup, true).catch(() => {});
-
-      // Auto-remove background for sprite asset types
-      if (settings?.auto_remove_bg && shouldRemoveBg(assetType) && result.data_url) {
-        const entry = await removeBgAndSave(result.data_url, assetType, context, variantGroup).catch(() => null);
-        if (entry) await useAssetStore.getState().loadAssets();
-      }
     }
     setStage("idle");
     setResult(null);
     setLastEnhancedPrompt(null);
+    setEnhanced(false);
+
+    // Run BG removal after returning to idle so the user can keep working,
+    // but show an inline spinner so they know the operation isn't actually done.
+    if (needsBgRemoval && savedDataUrl && assetType) {
+      setRemovingBg(true);
+      try {
+        const entry = await removeBgAndSave(savedDataUrl, assetType, context, variantGroup).catch(() => null);
+        if (entry) await useAssetStore.getState().loadAssets();
+      } finally {
+        setRemovingBg(false);
+      }
+    }
   };
 
   const handleReject = () => {
@@ -418,14 +433,15 @@ export function EntityArtGenerator({
             {hasApiKey && (
               <button
                 onClick={handleGenerate}
-                className="flex-1 rounded bg-accent/15 px-2 py-1 text-2xs font-medium text-accent transition-colors hover:bg-accent/25"
+                disabled={removingBg}
+                className="flex-1 rounded bg-accent/15 px-2 py-1 text-2xs font-medium text-accent transition-colors hover:bg-accent/25 disabled:opacity-50"
               >
                 Generate Art
               </button>
             )}
             <button
               onClick={handlePickImage}
-              disabled={importing}
+              disabled={importing || removingBg}
               className="flex-1 rounded bg-bg-elevated px-2 py-1 text-2xs font-medium text-text-secondary transition-colors hover:bg-bg-hover hover:text-text-primary disabled:opacity-50"
             >
               {importing ? "Importing..." : "Pick Image"}
@@ -448,17 +464,25 @@ export function EntityArtGenerator({
                 rows={4}
                 className="w-full resize-y rounded border border-border-default bg-bg-primary px-2 py-1 font-mono text-2xs leading-relaxed text-text-secondary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
               />
-              <div className="flex gap-1">
+              <div className="flex items-center gap-1">
                 <button
                   onClick={handleEnhance}
                   disabled={enhancing}
                   className="rounded px-1.5 py-0.5 text-2xs text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
                 >
-                  {enhancing ? "..." : "Enhance"}
+                  {enhancing ? "..." : enhanced ? "Re-enhance" : "Enhance"}
                 </button>
+                {enhanced && (
+                  <span className="rounded bg-accent/15 px-1.5 py-0.5 text-2xs font-medium text-accent">
+                    Enhanced
+                  </span>
+                )}
                 {editedPrompt && (
                   <button
-                    onClick={() => setEditedPrompt(null)}
+                    onClick={() => {
+                      setEditedPrompt(null);
+                      setEnhanced(false);
+                    }}
                     className="rounded px-1.5 py-0.5 text-2xs text-text-muted transition-colors hover:text-text-secondary"
                   >
                     Reset
@@ -467,9 +491,11 @@ export function EntityArtGenerator({
               </div>
               {(entityContext || vibe) && (
                 <p className="text-2xs italic text-text-muted">
-                  {hasLlmKey
-                    ? "Entity details + zone vibe auto-injected during generation"
-                    : "Configure an LLM provider to enable auto-enhanced prompts"}
+                  {!hasLlmKey
+                    ? "Configure an LLM provider to enable auto-enhanced prompts"
+                    : enhanced
+                      ? "Prompt already enhanced — will be sent as-is during generation"
+                      : "Entity details + zone vibe auto-injected during generation"}
                 </p>
               )}
             </div>
@@ -481,8 +507,15 @@ export function EntityArtGenerator({
         <div className="flex items-center gap-2 py-2">
           <div className="h-4 w-4 rounded-full border-2 border-accent border-t-transparent animate-spin" />
           <span className="text-2xs text-text-secondary">
-            {hasLlmKey ? "Crafting prompt & generating..." : "Generating..."}
+            {hasLlmKey && !enhanced ? "Crafting prompt & generating..." : "Generating..."}
           </span>
+        </div>
+      )}
+
+      {removingBg && stage === "idle" && (
+        <div className="flex items-center gap-2 py-1">
+          <div className="h-3 w-3 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+          <span className="text-2xs text-text-secondary">Removing background...</span>
         </div>
       )}
 

--- a/creator/src/components/zone/ZoneAssetWorkbench.tsx
+++ b/creator/src/components/zone/ZoneAssetWorkbench.tsx
@@ -173,7 +173,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
   const [previewEntry, setPreviewEntry] = useState<AssetEntry | null>(null);
   const [generatingPrompt, setGeneratingPrompt] = useState(false);
   const [generatingImage, setGeneratingImage] = useState(false);
-  const [batchGenerating, setBatchGenerating] = useState(false);
+  const [batchCount, setBatchCount] = useState(1);
   const [importing, setImporting] = useState(false);
   const [removingBg, setRemovingBg] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -331,41 +331,50 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
     }
   };
 
-  const handleGenerateImage = async () => {
-    if (!selectedTarget || !hasImageKey) return;
+  const handleGenerate = async () => {
+    if (!selectedTarget || !hasImageKey || !selectedKind) return;
+    const count = Math.max(1, Math.min(8, batchCount));
     setGeneratingImage(true);
     setError(null);
     try {
-      const image = await runGeneration(promptDraft, true);
-      if (image) {
-        persistImageSelection(image.file_path.split(/[\\/]/).pop() ?? image.hash);
-        await loadAssets();
-        await refreshVariants();
+      let firstImage: GeneratedImage | null = null;
+      for (let i = 0; i < count; i += 1) {
+        const image = await runGeneration(promptDraft, i === 0);
+        if (i === 0) firstImage = image;
+      }
+      if (firstImage) {
+        persistImageSelection(firstImage.file_path.split(/[\\/]/).pop() ?? firstImage.hash);
+      }
+      await loadAssets();
+      await refreshVariants();
+
+      // Auto-run background removal for sprite asset types after generation.
+      // The spinner stays visible the whole time so the user knows work is
+      // still happening even after the new variant appears.
+      const assetType = assetTypeForKind(selectedKind);
+      if (firstImage?.data_url && shouldRemoveBg(assetType) && settings?.auto_remove_bg) {
+        setRemovingBg(true);
+        try {
+          const entry = await removeBgAndSave(
+            firstImage.data_url,
+            assetType,
+            selectedContext,
+            selectedVariantGroup,
+          ).catch(() => null);
+          if (entry && selectedVariantGroup) {
+            await setActiveVariant(selectedVariantGroup, entry.id);
+            persistImageSelection(entry.file_name);
+            await loadAssets();
+            await refreshVariants();
+          }
+        } finally {
+          setRemovingBg(false);
+        }
       }
     } catch (err) {
       setError(String(err));
     } finally {
       setGeneratingImage(false);
-    }
-  };
-
-  const handleGenerateFour = async () => {
-    if (!selectedTarget || !hasImageKey) return;
-    setBatchGenerating(true);
-    setError(null);
-    try {
-      for (let i = 0; i < 4; i += 1) {
-        const image = await runGeneration(promptDraft, i === 0);
-        if (i === 0 && image) {
-          persistImageSelection(image.file_path.split(/[\\/]/).pop() ?? image.hash);
-        }
-      }
-      await loadAssets();
-      await refreshVariants();
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setBatchGenerating(false);
     }
   };
 
@@ -582,7 +591,30 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
               <div className="mb-3 text-2xs uppercase tracking-ui text-text-muted">Prompt engineering</div>
 
               <div className="grid gap-4 lg:grid-cols-[1fr_1fr]">
-                <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <span className="text-2xs uppercase tracking-ui text-text-muted">Step 1 · Prompt</span>
+                      {promptGeneratedByLlm && (
+                        <span className="rounded-full bg-accent/15 px-2 py-0.5 text-2xs font-medium text-accent">
+                          Enhanced
+                        </span>
+                      )}
+                    </div>
+                    <button
+                      onClick={handleGeneratePrompt}
+                      disabled={!hasLlmKey || generatingPrompt || generatingImage || removingBg}
+                      className="rounded-full border border-white/10 bg-white/6 px-3 py-1 text-2xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+                    >
+                      {generatingPrompt ? (
+                        <span className="flex items-center gap-1.5"><Spinner />Enhancing</span>
+                      ) : promptGeneratedByLlm ? (
+                        "Re-enhance"
+                      ) : (
+                        "Enhance prompt"
+                      )}
+                    </button>
+                  </div>
                   <textarea
                     value={promptDraft}
                     onChange={(event) => {
@@ -591,7 +623,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                     }}
                     rows={8}
                     className="w-full flex-1 resize-y rounded-2xl border border-white/10 bg-surface-scrim px-4 py-3 font-mono text-xs leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
-                    placeholder={selectedTarget.mode === "default" ? "Generate a fallback prompt for this zone asset..." : "Generate a prompt for this entity..."}
+                    placeholder={selectedTarget.mode === "default" ? "Describe the fallback for this zone asset, then click Enhance prompt..." : "Describe this entity, then click Enhance prompt..."}
                   />
                 </div>
 
@@ -611,38 +643,49 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                 </div>
               </div>
 
-              <div className="mt-4 flex flex-wrap gap-2">
-                <button
-                  onClick={handleGeneratePrompt}
-                  disabled={!hasLlmKey || generatingPrompt || generatingImage || batchGenerating}
-                  className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+              <div className="mt-4 flex flex-wrap items-center gap-2">
+                <span className="text-2xs uppercase tracking-ui text-text-muted">Step 2 · Generate</span>
+                <select
+                  value={batchCount}
+                  onChange={(event) => setBatchCount(Number(event.target.value))}
+                  disabled={!hasImageKey || generatingPrompt || generatingImage || removingBg}
+                  aria-label="Number of variants to generate"
+                  className="rounded-full border border-white/10 bg-white/6 px-3 py-2 text-xs font-medium text-text-primary outline-none transition focus-visible:ring-2 focus-visible:ring-border-active disabled:opacity-50"
                 >
-                  {generatingPrompt ? <span className="flex items-center gap-1.5"><Spinner />Generating prompt</span> : "Generate prompt"}
-                </button>
+                  <option value={1} className="bg-bg-primary">×1</option>
+                  <option value={2} className="bg-bg-primary">×2</option>
+                  <option value={4} className="bg-bg-primary">×4</option>
+                  <option value={8} className="bg-bg-primary">×8</option>
+                </select>
                 <button
-                  onClick={handleGenerateImage}
-                  disabled={!hasImageKey || generatingPrompt || generatingImage || batchGenerating}
+                  onClick={handleGenerate}
+                  disabled={!hasImageKey || generatingPrompt || generatingImage || removingBg}
                   className="rounded-full border border-[var(--border-accent-subtle)] bg-gradient-active-strong px-4 py-2 text-xs font-medium text-text-primary transition hover:brightness-110 disabled:opacity-50"
                 >
-                  {generatingImage ? <span className="flex items-center gap-1.5"><Spinner />Generating image</span> : "Generate image"}
+                  {generatingImage ? (
+                    <span className="flex items-center gap-1.5">
+                      <Spinner />
+                      {batchCount > 1 ? `Generating ×${batchCount}` : "Generating image"}
+                    </span>
+                  ) : removingBg ? (
+                    <span className="flex items-center gap-1.5"><Spinner />Removing background</span>
+                  ) : batchCount > 1 ? (
+                    `Generate ×${batchCount}`
+                  ) : (
+                    "Generate image"
+                  )}
                 </button>
-                <button
-                  onClick={handleGenerateFour}
-                  disabled={!hasImageKey || generatingPrompt || generatingImage || batchGenerating}
-                  className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
-                >
-                  {batchGenerating ? <span className="flex items-center gap-1.5"><Spinner />Generating 4</span> : "Generate 4"}
-                </button>
+                <span className="mx-1 h-6 w-px bg-white/10" aria-hidden="true" />
                 <button
                   onClick={handleImport}
-                  disabled={importing || generatingPrompt || generatingImage || batchGenerating}
+                  disabled={importing || generatingPrompt || generatingImage || removingBg}
                   className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
                 >
                   {importing ? <span className="flex items-center gap-1.5"><Spinner />Importing</span> : "Import image"}
                 </button>
                 <button
                   onClick={handleRemoveBg}
-                  disabled={removingBg || !previewEntry || !selectedSrc || !selectedKind || !shouldRemoveBg(assetTypeForKind(selectedKind))}
+                  disabled={removingBg || generatingImage || !previewEntry || !selectedSrc || !selectedKind || !shouldRemoveBg(assetTypeForKind(selectedKind))}
                   className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
                 >
                   {removingBg ? <span className="flex items-center gap-1.5"><Spinner />Removing BG</span> : "Remove BG"}
@@ -651,7 +694,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
 
               {error && (
                 <div className="mt-4">
-                  <InlineError error={error} onDismiss={() => setError(null)} onRetry={handleGenerateImage} />
+                  <InlineError error={error} onDismiss={() => setError(null)} onRetry={handleGenerate} />
                 </div>
               )}
             </div>


### PR DESCRIPTION
Closes #126 (which consolidates #120 and #112).

## Summary
- **EntityArtGenerator**: added a persistent `enhanced` flag so the Enhance button now acts as a true preview of what will be sent to the image model. Generation skips re-enhancement when the prompt is already enhanced. Shows an "Enhanced" pill, the button flips to "Re-enhance", and Reset clears it.
- **EntityArtGenerator**: fixed the background-removal indicator (#112) — a `removingBg` state keeps an inline spinner visible under the entity image until BG removal actually completes. Generate / Pick Image are disabled in that window.
- **ZoneAssetWorkbench**: clearer two-step workflow (#120) — promoted "Generate prompt" up to a small toolbar above the textarea as "Enhance prompt", with an "Enhanced" badge when active. Bottom action row is labeled "Step 2 · Generate".
- **ZoneAssetWorkbench**: replaced the dedicated "Generate 4" button with a ×1/×2/×4/×8 selector next to "Generate image". Both old handlers collapsed into one.
- **ZoneAssetWorkbench**: auto-runs background removal after generation for sprite asset types (when the user has opted in). The Generate button label flips to "Removing background" so the spinner stays visible until removal completes.

## Test plan
- [ ] Open an entity editor (mob/item) and click Generate Art — confirm the spinner stays visible through both image generation and background removal
- [ ] Open the prompt panel on an entity, click Enhance, verify "Enhanced" badge appears and the button changes to "Re-enhance"
- [ ] After enhancing, click Generate Art and confirm it sends the enhanced prompt directly without re-enhancing (check generating spinner text)
- [ ] In the Zone Asset Workbench, verify "Step 1 · Prompt" and "Step 2 · Generate" labels read clearly
- [ ] Try the ×1/×2/×4/×8 variant selector and confirm the right number of variants appears
- [ ] Generate a mob/item in the workbench with auto BG removal enabled and verify the spinner persists until BG removal finishes
- [ ] Run \`bun run test\` — 1325 tests should pass