### PR TITLE
feat: Art Style editor with AI-assisted generation

### DIFF
--- a/creator/src/components/AssetGenerator.tsx
+++ b/creator/src/components/AssetGenerator.tsx
@@ -87,8 +87,8 @@ export function AssetGenerator() {
     setEnhancing(true);
     setError(null);
     try {
-      const preamble = getPreamble(artStyle);
-      const systemPrompt = getEnhanceSystemPrompt(artStyle);
+      const preamble = getPreamble(artStyle, "worldbuilding");
+      const systemPrompt = getEnhanceSystemPrompt(artStyle, undefined, "worldbuilding");
       const response = await invoke<string>("enhance_prompt", {
         prompt: `${preamble}\n\n${prompt}`,
         systemPrompt,
@@ -106,7 +106,7 @@ export function AssetGenerator() {
     setStage("generating");
     setError(null);
     try {
-      const preamble = getPreamble(artStyle);
+      const preamble = getPreamble(artStyle, "worldbuilding");
       const finalPrompt = useEnhanced && enhancedPrompt ? enhancedPrompt : `${preamble}\n\n${prompt}`;
       const model = IMAGE_MODELS.find((entry) => entry.id === modelId);
       const guidance =

--- a/creator/src/components/CustomAssetStudio.tsx
+++ b/creator/src/components/CustomAssetStudio.tsx
@@ -187,7 +187,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
       setPromptGeneratedByLlm(Boolean(activeVariant.enhanced_prompt));
       return;
     }
-    setPromptDraft(buildCustomAssetPrompt(assetType, description, zoneVibe, artStyle));
+    setPromptDraft(buildCustomAssetPrompt(assetType, description, zoneVibe, artStyle, "worldbuilding"));
     setPromptGeneratedByLlm(false);
   }, [artStyle, assetType, description, variants, zoneVibe]);
 
@@ -212,13 +212,13 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
 
   const generatePrompt = useCallback(async () => {
     if (!description.trim()) return "";
-    const systemPrompt = getCustomAssetSystemPrompt(artStyle);
+    const systemPrompt = getCustomAssetSystemPrompt(artStyle, "worldbuilding");
     const userPrompt = [
       `Format: ${getFormatForAssetType(assetType)}`,
       title.trim() ? `Asset title: ${title.trim()}` : "",
       `User description: ${description.trim()}`,
       zoneVibe ? `Zone atmosphere: ${zoneVibe}` : "",
-      `Required style suffix (adapt and preserve the aesthetic):\n${buildCustomAssetPrompt(assetType, description, zoneVibe, artStyle)}`,
+      `Required style suffix (adapt and preserve the aesthetic):\n${buildCustomAssetPrompt(assetType, description, zoneVibe, artStyle, "worldbuilding")}`,
     ].filter(Boolean).join("\n\n");
 
     return invoke<string>("llm_complete", { systemPrompt, userPrompt });

--- a/creator/src/components/config/panels/AbilitiesPanel.tsx
+++ b/creator/src/components/config/panels/AbilitiesPanel.tsx
@@ -58,7 +58,7 @@ export function renameAbilityDefinition(config: AppConfig, oldId: string, newId:
 }
 
 function abilityPrompt(ability: AbilityDefinitionConfig, style: ArtStyle): string {
-  const preamble = getPreamble(style);
+  const preamble = getPreamble(style, "worldbuilding");
   const effectDesc = ability.effect.type.toLowerCase().replace(/_/g, " ");
   return `${preamble}, a game ability icon for "${ability.displayName}" — ${effectDesc} spell, ${ability.description || "magical ability"}, centered square composition like an RPG ability sprite, iconic symbol rendered as flowing energy, no text, no figures`;
 }
@@ -422,6 +422,7 @@ export function AbilityDetail({
             onAccept={(filePath) => patch({ image: filePath })}
             assetType="ability_icon"
             context={{ zone: "", entity_type: "ability", entity_id: id }}
+            surface="worldbuilding"
           />
         </div>
       </div>

--- a/creator/src/components/config/panels/ClassesPanel.tsx
+++ b/creator/src/components/config/panels/ClassesPanel.tsx
@@ -263,6 +263,7 @@ export function ClassDetail({
           }}
           assetType="class_portrait"
           context={{ zone: "", entity_type: "class", entity_id: id }}
+          surface="worldbuilding"
         />
       </div>
     </>

--- a/creator/src/components/config/panels/PetsPanel.tsx
+++ b/creator/src/components/config/panels/PetsPanel.tsx
@@ -29,7 +29,7 @@ function summarizePet(pet: PetDefinitionConfig): string {
 }
 
 function petPrompt(pet: PetDefinitionConfig, style: ArtStyle): string {
-  const preamble = getPreamble(style);
+  const preamble = getPreamble(style, "worldbuilding");
   return `${preamble}, a summoned companion creature — "${pet.name}", ${pet.description || "a loyal magical pet"}, full body portrait, RPG companion creature, no text`;
 }
 
@@ -157,6 +157,7 @@ function PetDetail({
             onAccept={(filePath) => patch({ image: filePath })}
             assetType="pet"
             context={{ zone: "", entity_type: "pet", entity_id: id }}
+            surface="worldbuilding"
           />
         </div>
       </div>

--- a/creator/src/components/config/panels/RacesPanel.tsx
+++ b/creator/src/components/config/panels/RacesPanel.tsx
@@ -233,6 +233,7 @@ export function RaceDetail({
           }}
           assetType="race_portrait"
           context={{ zone: "", entity_type: "race", entity_id: id }}
+          surface="worldbuilding"
         />
       </div>
     </>

--- a/creator/src/components/editors/EditorShared.tsx
+++ b/creator/src/components/editors/EditorShared.tsx
@@ -159,6 +159,7 @@ export function MediaSection({
             assetType={assetType}
             context={context}
             vibe={vibe}
+            surface="worldbuilding"
           />
         )}
         {onVideoChange && (

--- a/creator/src/components/editors/RecipeEditor.tsx
+++ b/creator/src/components/editors/RecipeEditor.tsx
@@ -208,7 +208,7 @@ export function RecipeEditor({
       </Section>
 
       <MediaSection image={recipe.image} onImageChange={(v) => patch({ image: v })} getPrompt={(style: ArtStyle) => {
-        const preamble = getPreamble(style);
+        const preamble = getPreamble(style, "worldbuilding");
         return style === "gentle_magic"
           ? `${preamble}\n\nStill life of a crafted creation called "${recipe.displayName}" — a warmly glowing artifact resting on a soft surface, gentle ambient light diffusing around it, floating motes of gold, lavender and pale blue tones, dreamlike quality, painterly, centered composition`
           : `${preamble}\n\nStill life of a crafted creation called "${recipe.displayName}" — a luminous artifact emerging from baroque scrollwork, aurum-gold energy threads weaving through its form, deep indigo background, painterly, centered composition`;

--- a/creator/src/components/lore/ArtStylePanel.tsx
+++ b/creator/src/components/lore/ArtStylePanel.tsx
@@ -1,0 +1,565 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useLoreStore } from "@/stores/loreStore";
+import type { ArtStyle } from "@/types/lore";
+import { Section, ActionButton, Spinner } from "@/components/ui/FormWidgets";
+import { ART_STYLE_PRESETS, artStyleFromPreset } from "@/lib/artStylePresets";
+import { generateArtStyle, refineArtStyle } from "@/lib/artStyleGeneration";
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function newStyleId(): string {
+  return `style_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function newEmptyStyle(): ArtStyle {
+  const now = new Date().toISOString();
+  return {
+    id: newStyleId(),
+    name: "Untitled style",
+    description: "",
+    basePrompt: "",
+    surfaces: { worldbuilding: "", lore: "" },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+// ─── Sub: styled textarea ──────────────────────────────────────────
+
+function StyleTextarea({
+  value,
+  onCommit,
+  placeholder,
+  rows = 6,
+}: {
+  value: string;
+  onCommit: (v: string) => void;
+  placeholder?: string;
+  rows?: number;
+}) {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => setDraft(value), [value]);
+  return (
+    <textarea
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => { if (draft !== value) onCommit(draft); }}
+      rows={rows}
+      placeholder={placeholder}
+      className="w-full resize-y rounded border border-border-default bg-bg-primary px-2.5 py-2 text-xs leading-5 text-text-primary outline-none transition focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+    />
+  );
+}
+
+function StyleTextInput({
+  value,
+  onCommit,
+  placeholder,
+}: {
+  value: string;
+  onCommit: (v: string) => void;
+  placeholder?: string;
+}) {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => setDraft(value), [value]);
+  return (
+    <input
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={() => { if (draft !== value) onCommit(draft); }}
+      onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+      placeholder={placeholder}
+      className="w-full rounded border border-border-default bg-bg-primary px-2.5 py-1.5 text-sm text-text-primary outline-none transition focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+    />
+  );
+}
+
+// ─── Create menu ───────────────────────────────────────────────────
+
+function CreateMenu({
+  onEmpty,
+  onPreset,
+  onAi,
+  disabled,
+}: {
+  onEmpty: () => void;
+  onPreset: (key: string) => void;
+  onAi: () => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="relative">
+      <ActionButton
+        variant="primary"
+        size="sm"
+        onClick={() => setOpen((v) => !v)}
+        disabled={disabled}
+      >
+        + New style
+      </ActionButton>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 top-full z-20 mt-1 w-60 overflow-hidden rounded-lg border border-border-default bg-bg-secondary shadow-panel">
+            <button
+              onClick={() => { onAi(); setOpen(false); }}
+              className="block w-full border-b border-border-muted px-3 py-2 text-left text-xs text-text-primary transition hover:bg-bg-hover"
+            >
+              <span className="font-medium text-accent">✦ Generate with AI</span>
+              <span className="mt-0.5 block text-2xs text-text-muted">From a theme prompt</span>
+            </button>
+            {ART_STYLE_PRESETS.map((preset) => (
+              <button
+                key={preset.key}
+                onClick={() => { onPreset(preset.key); setOpen(false); }}
+                className="block w-full border-b border-border-muted px-3 py-2 text-left text-xs text-text-primary transition hover:bg-bg-hover"
+              >
+                <span className="font-medium">{preset.name}</span>
+                <span className="mt-0.5 block text-2xs text-text-muted">{preset.description}</span>
+              </button>
+            ))}
+            <button
+              onClick={() => { onEmpty(); setOpen(false); }}
+              className="block w-full px-3 py-2 text-left text-xs text-text-secondary transition hover:bg-bg-hover"
+            >
+              <span className="font-medium">Empty style</span>
+              <span className="mt-0.5 block text-2xs text-text-muted">Start from scratch</span>
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── AI generate dialog ────────────────────────────────────────────
+
+function AiGenerateDialog({
+  onGenerate,
+  onClose,
+}: {
+  onGenerate: (themePrompt: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [theme, setTheme] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!theme.trim() || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onGenerate(theme.trim());
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="dialog-overlay" role="dialog" aria-modal="true" aria-labelledby="ai-gen-title">
+      <div className="dialog-shell flex w-full max-w-xl flex-col">
+        <div className="dialog-header">
+          <div className="min-w-0 flex-1">
+            <h3 id="ai-gen-title" className="font-display text-base text-text-primary">Generate art style</h3>
+            <p className="mt-0.5 text-2xs text-text-muted">
+              Describe a theme in a sentence. The AI will fill in the base prompt and both surface overrides.
+            </p>
+          </div>
+        </div>
+        <div className="dialog-body flex flex-col gap-3">
+          <textarea
+            value={theme}
+            onChange={(e) => setTheme(e.target.value)}
+            placeholder="e.g. surreal gentle magic, cyberpunk noir, sun-bleached watercolor storybook, obsidian bloom fantasy"
+            rows={3}
+            autoFocus
+            className="w-full resize-y rounded border border-border-default bg-bg-primary px-3 py-2 text-sm text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+          />
+          {error && <p className="text-2xs text-status-error">{error}</p>}
+          <p className="text-2xs text-text-muted/80">
+            Tip: the world's tone (if set in World Setting) is included as context so the style stays on-theme.
+          </p>
+        </div>
+        <div className="dialog-footer">
+          <ActionButton variant="ghost" size="sm" onClick={onClose} disabled={busy}>Cancel</ActionButton>
+          <ActionButton variant="primary" size="sm" onClick={submit} disabled={!theme.trim() || busy}>
+            {busy ? <span className="flex items-center gap-1.5"><Spinner /> Generating</span> : "Generate"}
+          </ActionButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Refine dialog (per-style AI rewrite) ──────────────────────────
+
+function RefineDialog({
+  style,
+  onRefine,
+  onClose,
+}: {
+  style: ArtStyle;
+  onRefine: (instruction: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [instruction, setInstruction] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!instruction.trim() || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onRefine(instruction.trim());
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="dialog-overlay" role="dialog" aria-modal="true" aria-labelledby="refine-title">
+      <div className="dialog-shell flex w-full max-w-xl flex-col">
+        <div className="dialog-header">
+          <div className="min-w-0 flex-1">
+            <h3 id="refine-title" className="font-display text-base text-text-primary">Refine "{style.name}"</h3>
+            <p className="mt-0.5 text-2xs text-text-muted">
+              Describe how you want the style changed. The AI will rewrite the relevant fields.
+            </p>
+          </div>
+        </div>
+        <div className="dialog-body flex flex-col gap-3">
+          <textarea
+            value={instruction}
+            onChange={(e) => setInstruction(e.target.value)}
+            placeholder="e.g. make it darker and more ominous, or push the palette toward warm autumn tones, or add more pixel-art specifics to the worldbuilding surface"
+            rows={4}
+            autoFocus
+            className="w-full resize-y rounded border border-border-default bg-bg-primary px-3 py-2 text-sm text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+          />
+          {error && <p className="text-2xs text-status-error">{error}</p>}
+        </div>
+        <div className="dialog-footer">
+          <ActionButton variant="ghost" size="sm" onClick={onClose} disabled={busy}>Cancel</ActionButton>
+          <ActionButton variant="primary" size="sm" onClick={submit} disabled={!instruction.trim() || busy}>
+            {busy ? <span className="flex items-center gap-1.5"><Spinner /> Refining</span> : "Refine"}
+          </ActionButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main panel ────────────────────────────────────────────────────
+
+export function ArtStylePanel() {
+  const lore = useLoreStore((s) => s.lore);
+  const createArtStyle = useLoreStore((s) => s.createArtStyle);
+  const updateArtStyle = useLoreStore((s) => s.updateArtStyle);
+  const deleteArtStyle = useLoreStore((s) => s.deleteArtStyle);
+  const setActiveArtStyle = useLoreStore((s) => s.setActiveArtStyle);
+
+  const styles = useMemo(() => lore?.artStyles ?? [], [lore?.artStyles]);
+  const activeId = lore?.activeArtStyleId;
+
+  const [selectedId, setSelectedId] = useState<string | null>(activeId ?? styles[0]?.id ?? null);
+  const [showAiDialog, setShowAiDialog] = useState(false);
+  const [showRefineDialog, setShowRefineDialog] = useState(false);
+
+  // Keep selection valid as the list mutates
+  useEffect(() => {
+    if (selectedId && styles.some((s) => s.id === selectedId)) return;
+    setSelectedId(activeId ?? styles[0]?.id ?? null);
+  }, [styles, activeId, selectedId]);
+
+  // ─── Auto-import legacy world_setting.visualStyle on first open ──
+  useEffect(() => {
+    if (!lore || (lore.artStyles && lore.artStyles.length > 0)) return;
+    const ws = Object.values(lore.articles).find((a) => a.template === "world_setting");
+    const legacy = ws && typeof ws.fields.visualStyle === "string" ? ws.fields.visualStyle.trim() : "";
+    if (!legacy) return;
+    const now = new Date().toISOString();
+    createArtStyle({
+      id: `style_imported_${Date.now().toString(36)}`,
+      name: "Imported style",
+      description: "Automatically imported from the legacy World Setting visual-style field",
+      basePrompt: legacy,
+      surfaces: {},
+      createdAt: now,
+      updatedAt: now,
+    });
+  }, [lore, createArtStyle]);
+
+  const selected = styles.find((s) => s.id === selectedId) ?? null;
+
+  const handleCreateEmpty = useCallback(() => {
+    const style = newEmptyStyle();
+    createArtStyle(style);
+    setSelectedId(style.id);
+  }, [createArtStyle]);
+
+  const handleCreatePreset = useCallback((presetKey: string) => {
+    const preset = ART_STYLE_PRESETS.find((p) => p.key === presetKey);
+    if (!preset) return;
+    const style = artStyleFromPreset(preset);
+    createArtStyle(style);
+    setSelectedId(style.id);
+  }, [createArtStyle]);
+
+  const handleAiGenerate = useCallback(async (themePrompt: string) => {
+    const style = await generateArtStyle(themePrompt);
+    createArtStyle(style);
+    setSelectedId(style.id);
+  }, [createArtStyle]);
+
+  const handleRefine = useCallback(async (instruction: string) => {
+    if (!selected) return;
+    const patch = await refineArtStyle(selected, instruction);
+    updateArtStyle(selected.id, patch);
+  }, [selected, updateArtStyle]);
+
+  const handleDelete = useCallback((id: string) => {
+    const style = styles.find((s) => s.id === id);
+    if (!style) return;
+    if (!window.confirm(`Delete art style "${style.name}"?`)) return;
+    deleteArtStyle(id);
+  }, [styles, deleteArtStyle]);
+
+  const handleDuplicate = useCallback((id: string) => {
+    const source = styles.find((s) => s.id === id);
+    if (!source) return;
+    const copy: ArtStyle = {
+      ...source,
+      id: newStyleId(),
+      name: `${source.name} (copy)`,
+      surfaces: source.surfaces ? { ...source.surfaces } : undefined,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    createArtStyle(copy);
+    setSelectedId(copy.id);
+  }, [styles, createArtStyle]);
+
+  // ─── Empty state ──
+  if (styles.length === 0) {
+    return (
+      <>
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col items-center gap-4 rounded-2xl border border-dashed border-border-muted bg-bg-primary/40 px-8 py-16 text-center">
+            <div className="font-display text-lg text-text-primary">No art styles yet</div>
+            <p className="max-w-md text-xs leading-6 text-text-muted">
+              An art style describes how AI should render images for your world. Create one and it will be
+              layered into every image generation prompt — both worldbuilding art (sprites, rooms, icons) and
+              lore art (character portraits, article heroes), with optional surface-specific overrides.
+            </p>
+            <div className="flex gap-2">
+              <ActionButton variant="primary" size="sm" onClick={() => setShowAiDialog(true)}>
+                ✦ Generate with AI
+              </ActionButton>
+              <CreateMenu
+                onEmpty={handleCreateEmpty}
+                onPreset={handleCreatePreset}
+                onAi={() => setShowAiDialog(true)}
+              />
+            </div>
+          </div>
+        </div>
+        {showAiDialog && (
+          <AiGenerateDialog onGenerate={handleAiGenerate} onClose={() => setShowAiDialog(false)} />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-4">
+        {/* Header with create menu */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h2 className="font-display text-lg text-text-primary">Art Style</h2>
+            <p className="mt-0.5 text-2xs text-text-muted">
+              Define how AI renders your world. The active style is layered into every image generation prompt.
+            </p>
+          </div>
+          <CreateMenu
+            onEmpty={handleCreateEmpty}
+            onPreset={handleCreatePreset}
+            onAi={() => setShowAiDialog(true)}
+          />
+        </div>
+
+        {/* List + detail layout */}
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,240px)_1fr]">
+          {/* ─── Style list ─── */}
+          <div className="flex flex-col gap-1.5">
+            {styles.map((style) => {
+              const isSelected = selectedId === style.id;
+              const isActive = activeId === style.id;
+              return (
+                <button
+                  key={style.id}
+                  onClick={() => setSelectedId(style.id)}
+                  className={
+                    "flex flex-col items-start gap-0.5 rounded-lg border px-3 py-2 text-left text-xs transition " +
+                    (isSelected
+                      ? "border-accent/60 bg-bg-tertiary text-text-primary shadow-[inset_0_0_0_1px_rgba(226,188,106,0.15)]"
+                      : "border-border-muted bg-bg-primary/60 text-text-secondary hover:border-border-default hover:bg-bg-primary")
+                  }
+                >
+                  <div className="flex w-full items-center gap-2">
+                    <span className="min-w-0 flex-1 truncate font-medium">{style.name}</span>
+                    {isActive && (
+                      <span className="shrink-0 rounded-full bg-accent/20 px-1.5 py-0.5 text-3xs font-medium uppercase tracking-wide-ui text-accent">
+                        Active
+                      </span>
+                    )}
+                  </div>
+                  {style.description && (
+                    <span className="w-full truncate text-2xs text-text-muted">{style.description}</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* ─── Detail editor ─── */}
+          {selected ? (
+            <div className="flex min-w-0 flex-col gap-4">
+              {/* Activate / refine / delete actions */}
+              <div className="flex flex-wrap items-center gap-2">
+                {activeId === selected.id ? (
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-accent/30 bg-accent/10 px-2.5 py-1 text-2xs font-medium text-accent">
+                    ● Active style
+                  </span>
+                ) : (
+                  <ActionButton variant="primary" size="sm" onClick={() => setActiveArtStyle(selected.id)}>
+                    Set as active
+                  </ActionButton>
+                )}
+                <ActionButton variant="ghost" size="sm" onClick={() => setShowRefineDialog(true)}>
+                  ✦ Refine with AI
+                </ActionButton>
+                <ActionButton variant="ghost" size="sm" onClick={() => handleDuplicate(selected.id)}>
+                  Duplicate
+                </ActionButton>
+                <div className="ml-auto">
+                  <ActionButton variant="danger" size="sm" onClick={() => handleDelete(selected.id)}>
+                    Delete
+                  </ActionButton>
+                </div>
+              </div>
+
+              {/* Identity */}
+              <Section title="Identity">
+                <div className="flex flex-col gap-2">
+                  <label className="flex flex-col gap-1">
+                    <span className="text-2xs uppercase tracking-wide-ui text-text-muted">Name</span>
+                    <StyleTextInput
+                      value={selected.name}
+                      onCommit={(v) => updateArtStyle(selected.id, { name: v || "Untitled style" })}
+                      placeholder="e.g. Surreal Gentle Magic"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="text-2xs uppercase tracking-wide-ui text-text-muted">Description</span>
+                    <StyleTextInput
+                      value={selected.description ?? ""}
+                      onCommit={(v) => updateArtStyle(selected.id, { description: v || undefined })}
+                      placeholder="One-line summary"
+                    />
+                  </label>
+                </div>
+              </Section>
+
+              {/* Base prompt */}
+              <Section title="Base prompt">
+                <p className="mb-2 text-2xs text-text-muted">
+                  The core visual language. Appended to every image generation prompt. Include palette, lighting,
+                  shape language, and forbidden elements. Keep it surface-neutral — per-surface rules go below.
+                </p>
+                <StyleTextarea
+                  value={selected.basePrompt}
+                  onCommit={(v) => updateArtStyle(selected.id, { basePrompt: v })}
+                  placeholder="Describe the style's visual language in concrete, actionable terms..."
+                  rows={10}
+                />
+              </Section>
+
+              {/* Surface overrides */}
+              <Section title="Surface overrides">
+                <p className="mb-3 text-2xs text-text-muted">
+                  Extra directives layered on top of the base prompt for specific kinds of art. Leave blank to
+                  use the base prompt as-is.
+                </p>
+                <div className="flex flex-col gap-4">
+                  <label className="flex flex-col gap-1">
+                    <span className="flex items-center gap-2 text-2xs font-medium uppercase tracking-wide-ui text-text-secondary">
+                      <span className="h-1.5 w-1.5 rounded-full bg-warm" />
+                      Worldbuilding
+                    </span>
+                    <span className="text-2xs text-text-muted">
+                      Sprites, item icons, ability icons, room backgrounds, entity portraits, pets, UI assets.
+                    </span>
+                    <StyleTextarea
+                      value={selected.surfaces?.worldbuilding ?? ""}
+                      onCommit={(v) =>
+                        updateArtStyle(selected.id, {
+                          surfaces: { ...selected.surfaces, worldbuilding: v || undefined },
+                        })
+                      }
+                      placeholder="e.g. pixel-art silhouettes on pale lavender background, readable at 64px..."
+                      rows={5}
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1">
+                    <span className="flex items-center gap-2 text-2xs font-medium uppercase tracking-wide-ui text-text-secondary">
+                      <span className="h-1.5 w-1.5 rounded-full bg-accent" />
+                      Lore
+                    </span>
+                    <span className="text-2xs text-text-muted">
+                      Character portraits, lore article hero images, encyclopedia-style illustrations.
+                    </span>
+                    <StyleTextarea
+                      value={selected.surfaces?.lore ?? ""}
+                      onCommit={(v) =>
+                        updateArtStyle(selected.id, {
+                          surfaces: { ...selected.surfaces, lore: v || undefined },
+                        })
+                      }
+                      placeholder="e.g. high-fantasy oil portraits, faithful anatomy, ornate framing..."
+                      rows={5}
+                    />
+                  </label>
+                </div>
+              </Section>
+            </div>
+          ) : (
+            <div className="flex items-center justify-center rounded-lg border border-dashed border-border-muted bg-bg-primary/40 px-6 py-16 text-sm text-text-muted">
+              Select a style to edit
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showAiDialog && (
+        <AiGenerateDialog onGenerate={handleAiGenerate} onClose={() => setShowAiDialog(false)} />
+      )}
+      {showRefineDialog && selected && (
+        <RefineDialog
+          style={selected}
+          onRefine={handleRefine}
+          onClose={() => setShowRefineDialog(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/creator/src/components/lore/ArticleArtSection.tsx
+++ b/creator/src/components/lore/ArticleArtSection.tsx
@@ -109,6 +109,7 @@ export function ArticleArtSection({
           onAccept={(filePath) => onImageChange(filePath)}
           assetType={assetType}
           context={context}
+          surface="lore"
         />
 
         {/* Gallery */}
@@ -146,6 +147,7 @@ export function ArticleArtSection({
               onAccept={handleAddToGallery}
               assetType={assetType}
               context={galleryContext}
+              surface="lore"
             />
           )}
 

--- a/creator/src/components/lore/LorePanelHost.tsx
+++ b/creator/src/components/lore/LorePanelHost.tsx
@@ -16,6 +16,7 @@ import { DocumentLibraryPanel } from "./DocumentLibraryPanel";
 import { ShowcaseSettingsPanel } from "./ShowcaseSettingsPanel";
 import { TemplateEditorPanel } from "./TemplateEditorPanel";
 import { StoryBrowser } from "./StoryBrowser";
+import { ArtStylePanel } from "./ArtStylePanel";
 
 // Lazy-load MapPanel to isolate Leaflet CSS from the main bundle
 const MapPanel = lazy(() => import("./MapPanel").then(m => ({ default: m.MapPanel })));
@@ -26,6 +27,8 @@ function renderPanel(panelId: string): ReactNode {
       return <ArticleBrowser />;
     case "worldSetting":
       return <WorldSettingPanel />;
+    case "artStyle":
+      return <ArtStylePanel />;
     case "factions":
       return <FactionsPanel />;
     case "codex":

--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -5,6 +5,7 @@ import { useAssetStore } from "@/stores/assetStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { useImageSrc, isLegacyImagePath } from "@/lib/useImageSrc";
 import { getEnhanceSystemPrompt, ART_STYLE_LABELS, UNIVERSAL_NEGATIVE, getStyleSuffix, type ArtStyle } from "@/lib/arcanumPrompts";
+import type { ArtStyleSurface } from "@/lib/loreGeneration";
 import { IMAGE_MODELS, ENTITY_DIMENSIONS, DIMENSION_PRESETS, imageGenerateCommand, resolveImageModel, requestsTransparentBackground } from "@/types/assets";
 import type { AssetContext, GeneratedImage } from "@/types/assets";
 import { VariantStrip } from "./VariantStrip";
@@ -28,6 +29,8 @@ interface EntityArtGeneratorProps {
   context?: AssetContext;
   /** Zone vibe text to inject into LLM prompt generation */
   vibe?: string;
+  /** Which art-style surface to apply — "worldbuilding" for zone/entity/game art, "lore" for lore article illustrations */
+  surface?: ArtStyleSurface;
 }
 
 function computeVariantGroup(context?: AssetContext): string {
@@ -63,6 +66,7 @@ export function EntityArtGenerator({
   assetType,
   context,
   vibe,
+  surface,
 }: EntityArtGeneratorProps) {
   const settings = useAssetStore((s) => s.settings);
   const artStyle = useAssetStore((s) => s.artStyle);
@@ -163,7 +167,7 @@ export function EntityArtGenerator({
 
   /** Enhance a prompt via LLM, injecting entity context, style guide, and zone vibe. */
   const enhancePrompt = async (prompt: string): Promise<string> => {
-    const systemPrompt = getEnhanceSystemPrompt(artStyle, assetType);
+    const systemPrompt = getEnhanceSystemPrompt(artStyle, assetType, surface);
     const parts: string[] = [];
 
     // When we have rich entity context, lead with that so the LLM
@@ -216,7 +220,7 @@ export function EntityArtGenerator({
       }
 
       // Append style suffix to ensure consistent aesthetic
-      const styleSuffix = getStyleSuffix();
+      const styleSuffix = getStyleSuffix(surface);
       if (!finalPrompt.includes(styleSuffix.slice(0, 40))) {
         finalPrompt = `${finalPrompt}\n\n${styleSuffix}`;
       }

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -500,6 +500,7 @@ export function RoomPanel({
             assetType="background"
             context={{ zone: zoneId, entity_type: "room", entity_id: roomId }}
             vibe={vibe}
+            surface="worldbuilding"
           />
           <FieldRow label="Video">
             <TextInput

--- a/creator/src/components/zone/ZoneAssetWorkbench.tsx
+++ b/creator/src/components/zone/ZoneAssetWorkbench.tsx
@@ -275,7 +275,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
 
   const generateEnhancedPrompt = useCallback(async () => {
     if (!selectedTarget) return "";
-    const systemPrompt = getEnhanceSystemPrompt(artStyle);
+    const systemPrompt = getEnhanceSystemPrompt(artStyle, undefined, "worldbuilding");
     const userPrompt = [
       selectedTarget.mode === "default"
         ? `Generate a fallback/default image prompt for this zone asset:\n${buildContext()}`

--- a/creator/src/components/zone/ZoneVibePanel.tsx
+++ b/creator/src/components/zone/ZoneVibePanel.tsx
@@ -160,7 +160,7 @@ export function ZoneVibePanel({ zoneId, world, onWorldChange }: ZoneVibePanelPro
     try {
       let prompt = defaultImagePrompt(kind, currentWorld, vibeText, artStyle);
       if (hasLlmKey) {
-        const systemPrompt = getEnhanceSystemPrompt(artStyle);
+        const systemPrompt = getEnhanceSystemPrompt(artStyle, undefined, "worldbuilding");
         const userPrompt = [
           `Generate a fallback/default image prompt for this zone asset:\n${defaultImageContext(kind, currentWorld)}`,
           vibeText ? `\nZone atmosphere/vibe:\n${vibeText}` : "",

--- a/creator/src/lib/abilityPromptGen.ts
+++ b/creator/src/lib/abilityPromptGen.ts
@@ -85,7 +85,7 @@ Effect type: ${ability.effect.type}
 Level: ${ability.levelRequired}
 
 Required style suffix (include verbatim at the end):
-${getStyleSuffix()}`;
+${getStyleSuffix("worldbuilding")}`;
 
   return invoke<string>("llm_complete", {
     systemPrompt: getAbilitySystemPrompt(),
@@ -114,7 +114,7 @@ Status Effect: ${effect.displayName}
 ${details}
 
 Required style suffix (include verbatim at the end):
-${getStyleSuffix()}`;
+${getStyleSuffix("worldbuilding")}`;
 
   return invoke<string>("llm_complete", {
     systemPrompt: getAbilitySystemPrompt(),
@@ -213,7 +213,7 @@ export function fillAbilityTemplate(
     .replace(/\{class_style\}/g, classStyle)
     .replace(/\{effect_visual\}/g, effectVisual);
 
-  return `${prompt}\n\n${getStyleSuffix()}`;
+  return `${prompt}\n\n${getStyleSuffix("worldbuilding")}`;
 }
 
 /**
@@ -234,7 +234,7 @@ export function fillStatusEffectTemplate(
     .replace(/\{class_style\}/g, classStyle)
     .replace(/\{effect_visual\}/g, effectVisual);
 
-  return `${prompt}\n\n${getStyleSuffix()}`;
+  return `${prompt}\n\n${getStyleSuffix("worldbuilding")}`;
 }
 
 // ─── Per-ability LLM enhancement ─────────────────────────────────────
@@ -263,7 +263,7 @@ Rules:
       systemPrompt,
       userPrompt: `Refine this ability icon generation prompt:\n\n${rawPrompt}`,
     });
-    return `${enhanced.trim()}\n\n${getStyleSuffix()}`;
+    return `${enhanced.trim()}\n\n${getStyleSuffix("worldbuilding")}`;
   } catch {
     return rawPrompt;
   }

--- a/creator/src/lib/arcanumPrompts.ts
+++ b/creator/src/lib/arcanumPrompts.ts
@@ -1,5 +1,5 @@
 import type { AssetType } from "@/types/assets";
-import { buildToneDirective, buildVisualStyleDirective } from "./loreGeneration";
+import { buildToneDirective, buildVisualStyleDirective, type ArtStyleSurface } from "./loreGeneration";
 
 // ─── Art Style System ─────────────────────────────────────────────
 
@@ -63,12 +63,15 @@ export const GENTLE_MAGIC_PREAMBLE = `Surreal Gentle Magic style (surreal_softma
 const GENERIC_STYLE_FALLBACK = `Rendered as a digital fantasy illustration — painterly, detailed, atmospheric. NOT a photograph, NOT a 3D render. Visible brushwork with textured rendering throughout. NO readable text, words, letters, or legible writing in the image.`;
 
 /**
- * Dynamic style suffix — uses the world's visual style if defined,
- * otherwise falls back to a minimal generic fantasy illustration style.
- * Appended to all image generation prompts.
+ * Dynamic style suffix — uses the active art style (optionally with a per-surface
+ * override) if defined, otherwise falls back to a minimal generic fantasy
+ * illustration style. Appended to all image generation prompts.
+ *
+ * Pass `surface` to layer worldbuilding-specific or lore-specific directives on
+ * top of the base style.
  */
-export function getStyleSuffix(): string {
-  const visualStyle = buildVisualStyleDirective();
+export function getStyleSuffix(surface?: ArtStyleSurface): string {
+  const visualStyle = buildVisualStyleDirective(surface);
   if (visualStyle) {
     return `Rendered in the following visual style: ${visualStyle}\n\nNO readable text, words, letters, or legible writing in the image.`;
   }
@@ -156,8 +159,8 @@ NO readable text, words, letters, runes, or glyphs — no watermarks, no logos, 
 FORBIDDEN: photorealism, neon colors, modern technology, flat design, cartoon, anime, studio lighting, stock photo aesthetic, harsh edges, brutalist shapes`;
 
 /** Get the preamble for image prompts — uses world visual style if defined, falls back to art style constant */
-export function getPreamble(style: ArtStyle): string {
-  const visualStyle = buildVisualStyleDirective();
+export function getPreamble(style: ArtStyle, surface?: ArtStyleSurface): string {
+  const visualStyle = buildVisualStyleDirective(surface);
   if (visualStyle) return visualStyle;
   return style === "arcanum" ? ARCANUM_PREAMBLE : GENTLE_MAGIC_PREAMBLE;
 }
@@ -489,8 +492,8 @@ EFFECT COLOR MODIFIERS:
 - Debuffs: descending spirals, dark mists, weakening auras`;
 
 /** Get the system prompt for prompt enhancement — defers to world visual style when defined */
-export function getEnhanceSystemPrompt(style: ArtStyle, assetType?: string): string {
-  const visualStyle = buildVisualStyleDirective();
+export function getEnhanceSystemPrompt(style: ArtStyle, assetType?: string, surface?: ArtStyleSurface): string {
+  const visualStyle = buildVisualStyleDirective(surface);
   const tone = buildToneDirective();
 
   // If the world defines a visual style, use a generic enhancer that defers to it
@@ -544,8 +547,8 @@ Rules:
 
 Output ONLY the finished prompt text — no explanation, no labels, no markdown.`;
 
-export function getCustomAssetSystemPrompt(style: ArtStyle): string {
-  const visualStyle = buildVisualStyleDirective();
+export function getCustomAssetSystemPrompt(style: ArtStyle, surface?: ArtStyleSurface): string {
+  const visualStyle = buildVisualStyleDirective(surface);
   const tone = buildToneDirective();
 
   if (visualStyle || tone) {
@@ -579,16 +582,17 @@ export function buildCustomAssetPrompt(
   description: string,
   zoneVibe?: string | null,
   style: ArtStyle = "gentle_magic",
+  surface?: ArtStyleSurface,
 ): string {
   const formatSpec = getFormatForAssetType(assetType);
   const vibeSection = zoneVibe ? `\nZone atmosphere: ${zoneVibe}` : "";
-  const preamble = getPreamble(style);
+  const preamble = getPreamble(style, surface);
 
   return `${formatSpec}. ${preamble}
 
 User brief: ${description}${vibeSection}
 
-${getStyleSuffix()}`;
+${getStyleSuffix(surface)}`;
 }
 
 /** Compose a full prompt from template + context */

--- a/creator/src/lib/artStyleGeneration.ts
+++ b/creator/src/lib/artStyleGeneration.ts
@@ -1,0 +1,138 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { ArtStyle } from "@/types/lore";
+import { buildToneDirective } from "./loreGeneration";
+import { parseLlmJson } from "./arcanumPrompts";
+
+// ─── AI-assisted art style generation ───────────────────────────────
+//
+// One-shot: user types a theme ("surreal gentle magic", "cyberpunk noir",
+// "watercolor storybook"), LLM returns a fully-populated ArtStyle with a
+// name, description, base prompt, and both surface overrides.
+
+const SYSTEM_PROMPT = `You are an expert AI art director specializing in crafting visual style guides for fantasy worldbuilding tools. Your job is to take a short theme prompt and turn it into a rich, specific, actionable style guide that an image generation AI can use to produce consistent art.
+
+A "style guide" in this context has four parts:
+
+1. **name**: A short, memorable name for the style (2-5 words). E.g. "Surreal Gentle Magic", "Arcanum", "Obsidian Bloom".
+
+2. **description**: A one-line hook describing the style's emotional feel and dominant palette. Max 12 words. E.g. "Baroque cosmic gold-and-indigo — the Creator's instrument".
+
+3. **basePrompt**: A 100-300 word paragraph describing the visual language the image generator should use. Cover color palette (specific hex codes when useful), lighting behavior, shape language, texture, and compositional rules. Include forbidden elements. This paragraph is appended to EVERY image generation prompt, so it must feel self-contained. Use concrete, actionable language — no vague adjectives. Do NOT include surface-specific rules here.
+
+4. **surfaces**: Two short additional directives, each 1-3 sentences:
+   - **worldbuilding**: Extra rules for game-facing art — sprites, item icons, ability icons, room backgrounds, entity portraits. Focus on readability-at-small-sizes, silhouette clarity, and in-game asset conventions.
+   - **lore**: Extra rules for codex/lore-book illustrations — character portraits, lore article hero images, encyclopedia-style artwork. Focus on faithful subject depiction, compositional framing, and narrative evocativeness.
+
+These surface directives should LAYER on top of the basePrompt — they give surface-specific guidance without contradicting the base style.
+
+Output ONLY valid JSON with this exact shape — no markdown fences, no commentary:
+{
+  "name": "string",
+  "description": "string",
+  "basePrompt": "string",
+  "worldbuilding": "string",
+  "lore": "string"
+}`;
+
+/**
+ * Generate a complete ArtStyle from a short theme prompt.
+ * Uses the world tone directive (if any) as context so the style stays on-theme.
+ */
+export async function generateArtStyle(themePrompt: string): Promise<ArtStyle> {
+  const tone = buildToneDirective();
+  const toneBlock = tone ? `\n\nWorld context (stay consistent with this):\n${tone}` : "";
+
+  const userPrompt = `Design a visual style guide for this theme: "${themePrompt}"${toneBlock}
+
+Output the JSON now.`;
+
+  const response = await invoke<string>("llm_complete", {
+    systemPrompt: SYSTEM_PROMPT,
+    userPrompt,
+    maxTokens: 2048,
+  });
+
+  const parsed = parseLlmJson(response, "art-style-generation") as {
+    name?: unknown;
+    description?: unknown;
+    basePrompt?: unknown;
+    worldbuilding?: unknown;
+    lore?: unknown;
+  };
+
+  const name = typeof parsed.name === "string" ? parsed.name.trim() : "";
+  const basePrompt = typeof parsed.basePrompt === "string" ? parsed.basePrompt.trim() : "";
+  if (!name || !basePrompt) {
+    throw new Error("AI response missing required fields (name and basePrompt).");
+  }
+
+  const now = new Date().toISOString();
+  return {
+    id: `style_${Date.now().toString(36)}`,
+    name,
+    description: typeof parsed.description === "string" ? parsed.description.trim() : undefined,
+    basePrompt,
+    surfaces: {
+      worldbuilding: typeof parsed.worldbuilding === "string" ? parsed.worldbuilding.trim() : undefined,
+      lore: typeof parsed.lore === "string" ? parsed.lore.trim() : undefined,
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Rewrite/refine an existing ArtStyle based on a user instruction.
+ * Returns a patch that can be passed to updateArtStyle.
+ */
+export async function refineArtStyle(
+  style: ArtStyle,
+  instruction: string,
+): Promise<Partial<ArtStyle>> {
+  const tone = buildToneDirective();
+  const toneBlock = tone ? `\n\nWorld context (preserve consistency with this):\n${tone}` : "";
+
+  const userPrompt = `Existing style:
+Name: ${style.name}
+Description: ${style.description ?? ""}
+Base prompt: ${style.basePrompt}
+Worldbuilding override: ${style.surfaces?.worldbuilding ?? ""}
+Lore override: ${style.surfaces?.lore ?? ""}
+
+User instruction: ${instruction}${toneBlock}
+
+Rewrite the style per the instruction. Output the JSON now with all five fields — include fields unchanged if the instruction doesn't touch them.`;
+
+  const response = await invoke<string>("llm_complete", {
+    systemPrompt: SYSTEM_PROMPT,
+    userPrompt,
+    maxTokens: 2048,
+  });
+
+  const parsed = parseLlmJson(response, "art-style-refinement") as {
+    name?: unknown;
+    description?: unknown;
+    basePrompt?: unknown;
+    worldbuilding?: unknown;
+    lore?: unknown;
+  };
+
+  const patch: Partial<ArtStyle> = {};
+  if (typeof parsed.name === "string" && parsed.name.trim()) patch.name = parsed.name.trim();
+  if (typeof parsed.description === "string") patch.description = parsed.description.trim() || undefined;
+  if (typeof parsed.basePrompt === "string" && parsed.basePrompt.trim()) patch.basePrompt = parsed.basePrompt.trim();
+
+  const surfaces: ArtStyle["surfaces"] = { ...style.surfaces };
+  let surfacesChanged = false;
+  if (typeof parsed.worldbuilding === "string") {
+    surfaces.worldbuilding = parsed.worldbuilding.trim() || undefined;
+    surfacesChanged = true;
+  }
+  if (typeof parsed.lore === "string") {
+    surfaces.lore = parsed.lore.trim() || undefined;
+    surfacesChanged = true;
+  }
+  if (surfacesChanged) patch.surfaces = surfaces;
+
+  return patch;
+}

--- a/creator/src/lib/artStylePresets.ts
+++ b/creator/src/lib/artStylePresets.ts
@@ -1,0 +1,80 @@
+import type { ArtStyle } from "@/types/lore";
+
+// ─── Built-in art style presets ─────────────────────────────────────
+//
+// These are offered as starting points in the "Create style" menu.
+// Users can pick a preset, rename it, then edit freely. The base prompts
+// are extracted from the legacy ARCANUM_PREAMBLE and GENTLE_MAGIC_PREAMBLE
+// constants in arcanumPrompts.ts so no aesthetic is lost in migration.
+
+export interface ArtStylePresetTemplate {
+  /** Stable id for UI selection — not used as the ArtStyle id. */
+  key: string;
+  name: string;
+  description: string;
+  basePrompt: string;
+  worldbuilding: string;
+  lore: string;
+}
+
+/** The two starter presets available in the "Create style" menu. */
+export const ART_STYLE_PRESETS: ArtStylePresetTemplate[] = [
+  {
+    key: "arcanum",
+    name: "Arcanum",
+    description: "Baroque cosmic gold-and-indigo — the Creator's instrument",
+    basePrompt: `Digital fantasy painting with deep cosmic indigo and abyssal navy backgrounds, baroque rococo light scrollwork rendered as glowing energy threads, warm aurum-gold as the primary accent against cool blue-violet atmospheric fill, sweeping spiral arms of light, fractaline structures, slow cosmological scale.
+
+Color and light:
+- Deep cosmic indigo (#080c1c to #1a2040) and abyssal navy as primary backgrounds
+- Warm aurum-gold (#c8972e, #e2bc6a) as the primary accent — concentrated light with 20-40px feathered bloom
+- Cool blue-violet atmospheric fill in shadows and ambient spaces
+- No harsh shadows, no spotlights — light dissolves gradually into darkness
+
+Shape and form:
+- Baroque C-curves and S-curves — borders and ornaments terminate in curls, never hard stops
+- Acanthus-leaf spirals, flowing filigree of light, fractaline structures
+- Cosmological scale — slow, vast, contemplative
+
+Visible painterly oil-painting texture throughout. NO runes, text, or neon colors.`,
+    worldbuilding: `For sprites, items, and icons: centered compositions, clear silhouettes readable at small sizes, aurum-gold highlights on key features, solid dark indigo backgrounds. For room backgrounds: wide landscape framing, baroque architectural silhouettes dissolving at the edges.`,
+    lore: `For portraits and lore article illustrations: depict subjects faithfully with literal anatomy and appearance. Frame figures with baroque ornamentation — scrollwork borders, spiral light-threads — without obscuring the subject. Dramatic chiaroscuro lighting with aurum-gold rim-light, deep indigo shadow fill. Oil-painting technique, jewel-like detail.`,
+  },
+  {
+    key: "gentle_magic",
+    name: "Surreal Gentle Magic",
+    description: "Soft dreamlike lavender — emotionally safe storybook illustration",
+    basePrompt: `Digital fantasy painting in the style of a dreamy storybook illustration. Soft lavender and pale blue undertones suffusing every surface, ambient diffused lighting with NO clear source point — light feels source-ambiguous and magical, never like realistic sunlight or artificial lamps. Gentle atmospheric haze with floating motes of light and faint magical particles drifting in the air.
+
+Color and light:
+- Cool undertones dominate — lavender, pale blue, dusty rose, moss green
+- Warm accents (dusty rose, soft gold) used sparingly for balance
+- Soft bloom around windows and light sources, ground-level magical glow (glowing moss, luminous plants)
+
+Shape and form:
+- Gentle curves over hard angles — nothing perfectly straight, micro-warping on all edges
+- Slightly elongated organic forms (trees, towers, figures, architecture, furniture)
+- Organic lived-in quality — nothing feels industrial, nothing feels mechanical
+
+Visible painterly brushwork with soft textured rendering throughout. NO photorealism, neon colors, harsh edges, or readable text.`,
+    worldbuilding: `For sprites, items, and icons: gently curved silhouettes against solid pale lavender (#d8d0e8) backgrounds, soft bloom around edges, dusty rose and moss green accents. For room backgrounds: wide dreamy landscapes with atmospheric haze, floating light motes, slightly elongated organic architecture.`,
+    lore: `For portraits and lore article illustrations: depict subjects faithfully — the dreamlike quality enhances the character, it doesn't replace them. Soft ambient light with no harsh shadows, faint halo of pale golden glow, floating motes of light in the atmosphere. Slightly elongated proportions give an ethereal quality. The image should feel kind, approachable, and emotionally warm.`,
+  },
+];
+
+/** Build an ArtStyle object from a preset template. */
+export function artStyleFromPreset(preset: ArtStylePresetTemplate): ArtStyle {
+  const now = new Date().toISOString();
+  return {
+    id: `style_${preset.key}_${Date.now().toString(36)}`,
+    name: preset.name,
+    description: preset.description,
+    basePrompt: preset.basePrompt,
+    surfaces: {
+      worldbuilding: preset.worldbuilding,
+      lore: preset.lore,
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/creator/src/lib/batchArt.ts
+++ b/creator/src/lib/batchArt.ts
@@ -174,7 +174,7 @@ export async function runBatchArtGeneration(
 
         let finalPrompt = basePrompt;
         try {
-          const systemPrompt = getEnhanceSystemPrompt(artStyle);
+          const systemPrompt = getEnhanceSystemPrompt(artStyle, undefined, "worldbuilding");
           let userPrompt: string;
           if (context) {
             const parts = [

--- a/creator/src/lib/entityPrompts.ts
+++ b/creator/src/lib/entityPrompts.ts
@@ -98,7 +98,7 @@ export function defaultImageContext(kind: DefaultImageKind, world: WorldFile): s
 
 /** Build a full prompt for a room image. */
 export function roomPrompt(_roomId: string, room: RoomFile, style: ArtStyle = "gentle_magic"): string {
-  const preamble = getPreamble(style);
+  const preamble = getPreamble(style, "worldbuilding");
   const setting = room.description
     ? `A place called "${room.title}": ${room.description}.`
     : `A chamber known as "${room.title}".`;
@@ -112,7 +112,7 @@ export function roomPrompt(_roomId: string, room: RoomFile, style: ArtStyle = "g
 
 ${setting}${station} Rendered as a dreamlike interior space — soft lavender and pale blue ambient light diffusing through gentle atmospheric haze, floating motes of warm light drifting lazily, organic curves and lived-in details, moss green and dusty rose accents on natural surfaces, soft gold highlights on magical elements, painterly, luminous, breathable
 
-${getStyleSuffix()}`;
+${getStyleSuffix("worldbuilding")}`;
   }
 
   return `${preamble}
@@ -122,7 +122,7 @@ ${setting}${station} Rendered as a baroque cosmic interior — deep indigo shado
 
 /** Build a full prompt for a mob portrait. */
 export function mobPrompt(_mobId: string, mob: MobFile, style: ArtStyle = "gentle_magic"): string {
-  const preamble = getPreamble(style);
+  const preamble = getPreamble(style, "worldbuilding");
   const tier = mob.tier ?? "standard";
   const level = mob.level ?? 1;
   const mobDesc = mob.description ? ` ${mob.description}.` : "";
@@ -140,7 +140,7 @@ export function mobPrompt(_mobId: string, mob: MobFile, style: ArtStyle = "gentl
 
 Portrait of ${desc} known as "${mob.name}", level ${level}.${mobDesc} Depicted with soft organic forms and gentle curves, ambient lavender and pale blue light diffusing around the figure, floating motes of warm gold light, subtle magical glow emanating naturally from within, dreamlike atmospheric haze, dusty rose and moss green accents, painterly, luminous
 
-${getStyleSuffix()}`;
+${getStyleSuffix("worldbuilding")}`;
   }
 
   const tierDesc: Record<string, string> = {
@@ -158,7 +158,7 @@ Portrait of ${desc} known as "${mob.name}", level ${level}.${mobDesc} Rendered w
 
 /** Build a full prompt for an item image. */
 export function itemPrompt(_itemId: string, item: ItemFile, style: ArtStyle = "gentle_magic"): string {
-  const preamble = getPreamble(style);
+  const preamble = getPreamble(style, "worldbuilding");
   const slotDesc = item.slot
     ? ` worn in the ${item.slot.toLowerCase()} slot`
     : "";
@@ -180,7 +180,7 @@ export function itemPrompt(_itemId: string, item: ItemFile, style: ArtStyle = "g
 
 Still life of ${typeHint} called "${item.displayName}"${slotDesc}.${desc} Rendered as a gently luminous object resting on a soft surface, ambient lavender and pale blue light diffusing around it, subtle floating motes of warm gold, soft atmospheric haze, organic gentle forms, dreamlike quality, painterly
 
-${getStyleSuffix()}`;
+${getStyleSuffix("worldbuilding")}`;
   }
 
   const typeHint = isWeapon
@@ -196,14 +196,14 @@ Still life of ${typeHint} called "${item.displayName}"${slotDesc}.${desc} Render
 
 /** Build a full prompt for a shop image. */
 export function shopPrompt(_shopId: string, shop: ShopFile, style: ArtStyle = "gentle_magic"): string {
-  const preamble = getPreamble(style);
+  const preamble = getPreamble(style, "worldbuilding");
 
   if (style === "gentle_magic") {
     return `${FORMAT_BY_TYPE.room}. ${preamble}
 
 A gentle magical marketplace called "${shop.name}" — cozy shelves and display cases holding softly glowing artifacts, warm ambient light filtering through atmospheric haze, floating motes of gold drifting between items, lavender and pale blue tones in the shadows, dusty rose accents on wooden surfaces, a sense of wonder and quiet abundance, organic curves and lived-in warmth, painterly, luminous
 
-${getStyleSuffix()}`;
+${getStyleSuffix("worldbuilding")}`;
   }
 
   return `${preamble}
@@ -213,7 +213,7 @@ An arcane marketplace called "${shop.name}" — baroque display cases of glowing
 
 /** Build a full prompt for a trainer image. */
 export function trainerPrompt(_trainerId: string, trainer: TrainerFile, style: ArtStyle = "gentle_magic"): string {
-  const preamble = getPreamble(style);
+  const preamble = getPreamble(style, "worldbuilding");
   const cls = trainer.class?.toLowerCase() ?? "warrior";
 
   if (style === "gentle_magic") {
@@ -221,7 +221,7 @@ export function trainerPrompt(_trainerId: string, trainer: TrainerFile, style: A
 
 A gentle magical portrait of a ${cls} class trainer called "${trainer.name}" — a wise mentor figure in soft flowing robes or battle-worn attire appropriate for a ${cls}, warm ambient light, floating motes of gold, lavender and pale blue tones, a sense of knowledge and patient guidance, painterly, luminous
 
-${getStyleSuffix()}`;
+${getStyleSuffix("worldbuilding")}`;
   }
 
   return `${preamble}
@@ -248,9 +248,9 @@ export function entityPrompt(
     case "trainer":
       return trainerPrompt(id, entity as TrainerFile, style);
     default: {
-      const preamble = getPreamble(style);
+      const preamble = getPreamble(style, "worldbuilding");
       return style === "gentle_magic"
-        ? `${preamble}\n\nDreamlike portrait of a ${kind} entity called "${id}", rendered in soft magical style, lavender and pale blue tones, gentle ambient glow, floating motes of warm light, painterly, luminous\n\n${getStyleSuffix()}`
+        ? `${preamble}\n\nDreamlike portrait of a ${kind} entity called "${id}", rendered in soft magical style, lavender and pale blue tones, gentle ambient glow, floating motes of warm light, painterly, luminous\n\n${getStyleSuffix("worldbuilding")}`
         : `${preamble}\n\nArcane portrait of a ${kind} entity called "${id}", rendered in baroque cosmic style, aurum-gold highlights, deep indigo background, painterly, luminous`;
     }
   }
@@ -262,7 +262,7 @@ export function defaultImagePrompt(
   zoneVibe: string,
   style: ArtStyle = "gentle_magic",
 ): string {
-  const preamble = getPreamble(style);
+  const preamble = getPreamble(style, "worldbuilding");
   const zoneSummary = buildZoneSummary(world);
   const vibeSection = zoneVibe
     ? `Zone atmosphere: ${zoneVibe}`
@@ -278,7 +278,7 @@ ${zoneSummary}
 
 No named characters, no specific plot moment, and no readable text. Focus on an atmospheric establishing scene that can gracefully stand in for any unillustrated room in the zone. Painterly, luminous, softly enchanted, emotionally safe.
 
-${getStyleSuffix()}`;
+${getStyleSuffix("worldbuilding")}`;
       case "mob":
         return `${FORMAT_BY_TYPE.mob}. ${preamble}
 
@@ -287,7 +287,7 @@ ${zoneSummary}
 
 Depict a generic inhabitant or creature archetype that feels native to the zone without representing any named NPC. The figure should feel characterful and approachable, with subtle magical details and a soft ambient glow.
 
-${getStyleSuffix()}`;
+${getStyleSuffix("worldbuilding")}`;
       case "item":
         return `${FORMAT_BY_TYPE.item}. ${preamble}
 
@@ -296,7 +296,7 @@ ${zoneSummary}
 
 Depict a generic magical object or artifact that could plausibly belong anywhere in this zone. Keep the silhouette clear, the materials handcrafted, and the enchantment subtle but visible.
 
-${getStyleSuffix()}`;
+${getStyleSuffix("worldbuilding")}`;
     }
   }
 

--- a/creator/src/lib/loreGeneration.ts
+++ b/creator/src/lib/loreGeneration.ts
@@ -35,18 +35,38 @@ export function buildToneDirective(): string {
   return parts.join(" ");
 }
 
+/** Which surface an image is being generated for. Controls which per-surface override is appended. */
+export type ArtStyleSurface = "worldbuilding" | "lore";
+
 /**
  * Build a visual style directive for AI image generation prompts.
- * Returns the world's visual style description, or a minimal generic fallback.
- * Injected into image generation prompts as the style suffix.
+ *
+ * Resolution order:
+ *   1. The active ArtStyle's basePrompt (+ optional surface override)
+ *   2. The legacy `world_setting.visualStyle` field (fallback for pre-art-style worlds)
+ *   3. Empty string (callers fall back to a generic style)
+ *
+ * Pass `surface` when the call site knows which kind of art is being generated —
+ * "worldbuilding" for sprites/rooms/entities/abilities/icons, "lore" for portraits
+ * and lore article illustrations. Omit for surface-neutral callers.
  */
-export function buildVisualStyleDirective(): string {
+export function buildVisualStyleDirective(surface?: ArtStyleSurface): string {
   const lore = useLoreStore.getState().lore;
   if (!lore) return "";
 
+  // Prefer the active ArtStyle
+  const active = (lore.artStyles ?? []).find((s) => s.id === lore.activeArtStyleId);
+  if (active) {
+    const base = active.basePrompt.trim();
+    const override = surface ? active.surfaces?.[surface]?.trim() : "";
+    if (base && override) return `${base}\n\n${override}`;
+    if (base) return base;
+    if (override) return override;
+  }
+
+  // Legacy fallback: world_setting.visualStyle
   const ws = Object.values(lore.articles).find((a) => a.template === "world_setting");
   if (!ws) return "";
-
   const visualStyle = typeof ws.fields.visualStyle === "string" ? ws.fields.visualStyle.trim() : "";
   return visualStyle;
 }

--- a/creator/src/lib/lorePersistence.ts
+++ b/creator/src/lib/lorePersistence.ts
@@ -2,7 +2,7 @@ import { exists, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { parseDocument, stringify } from "yaml";
 import { useLoreStore } from "@/stores/loreStore";
 import { DEFAULT_WORLD_LORE } from "@/types/lore";
-import type { WorldLore, WorldLoreV1, Article, ArticleRelation, ArticleTemplate, LoreDocument, TemplateOverrides, ShowcaseSettings } from "@/types/lore";
+import type { WorldLore, WorldLoreV1, Article, ArticleRelation, ArticleTemplate, LoreDocument, TemplateOverrides, ShowcaseSettings, CustomTemplateDefinition, ArtStyle } from "@/types/lore";
 import type { Project } from "@/types/project";
 import { CODEX_CATEGORY_TO_TEMPLATE } from "@/lib/loreTemplates";
 
@@ -42,6 +42,9 @@ export async function loadLore(project: Project): Promise<WorldLore> {
         showcaseSettings: raw.showcaseSettings && typeof raw.showcaseSettings === "object"
           ? (raw.showcaseSettings as ShowcaseSettings)
           : undefined,
+        customTemplates: Array.isArray(raw.customTemplates) ? (raw.customTemplates as CustomTemplateDefinition[]) : undefined,
+        artStyles: Array.isArray(raw.artStyles) ? (raw.artStyles as ArtStyle[]) : undefined,
+        activeArtStyleId: typeof raw.activeArtStyleId === "string" ? raw.activeArtStyleId : undefined,
       };
     }
 

--- a/creator/src/lib/panelRegistry.ts
+++ b/creator/src/lib/panelRegistry.ts
@@ -29,12 +29,26 @@ export interface PanelDef {
 
 // ─── Studio panels ──────────────────────────────────────────────────
 
+// Art Style panel is shared between Studio (worldmaker) and Lore sidebars.
+// MainArea routes on `host: "lore"` regardless of which sidebar group listed it.
+const ART_STYLE_PANEL: PanelDef = {
+  id: "artStyle",
+  label: "Art Style",
+  group: "studio",
+  host: "lore",
+  kicker: "Studio",
+  title: "Art style",
+  description: "Named art styles with base + per-surface overrides. AI-assisted generation and refinement.",
+  maxWidth: "max-w-5xl",
+};
+
 const STUDIO_PANELS: PanelDef[] = [
   { id: "art", label: "Art", group: "studio", host: "studio", kicker: "Studio", title: "Art", description: "Zone vibes, entity art, defaults, and free-form generation.", maxWidth: "max-w-7xl" },
   { id: "media", label: "Media", group: "studio", host: "studio", kicker: "Studio", title: "Media", description: "Music, ambience, and cinematic staging.", maxWidth: "max-w-7xl" },
   { id: "portraits", label: "Portraits", group: "studio", host: "studio", kicker: "Studio", title: "Portraits", description: "Race and class portrait creation.", maxWidth: "max-w-7xl" },
   { id: "studioAbilities", label: "Icons", group: "studio", host: "studio", kicker: "Studio", title: "Icons", description: "Ability and status-effect icon generation.", maxWidth: "max-w-7xl" },
   { id: "sprites", label: "Player Sprites", group: "studio", host: "command", kicker: "Studio", title: "Player sprites", description: "Visible identity, unlockable variants, and portrait logic.", maxWidth: "max-w-7xl" },
+  ART_STYLE_PANEL,
 ];
 
 // ─── Character panels (includes former Ability panels) ─────────────
@@ -81,6 +95,7 @@ const SYSTEMS_PANELS: PanelDef[] = [
 const LORE_PANELS: PanelDef[] = [
   { id: "lore", label: "Articles", group: "lore", host: "lore", kicker: "Codex", title: "World lore", description: "All world-building articles — characters, locations, factions, and more.", maxWidth: "max-w-7xl" },
   { id: "worldSetting", label: "World Setting", group: "lore", host: "lore", kicker: "Foundation", title: "World setting", description: "Name, overview, history, themes, geography, and magic system.", maxWidth: "max-w-5xl" },
+  { ...ART_STYLE_PANEL, group: "lore", kicker: "Foundation" },
   { id: "factions", label: "Factions", group: "lore", host: "lore", kicker: "Politics", title: "Factions & organizations", description: "Political groups, guilds, and power structures.", maxWidth: "max-w-5xl" },
   { id: "codex", label: "Codex", group: "lore", host: "lore", kicker: "Reference", title: "Lore codex", description: "Wiki-style articles for places, legends, creatures, deities, and more.", maxWidth: "max-w-5xl" },
   { id: "loreMaps", label: "Maps", group: "lore", host: "lore", kicker: "Cartography", title: "World maps", description: "Upload maps, place pins, and link locations to lore articles.", maxWidth: "max-w-7xl" },
@@ -111,15 +126,26 @@ const COMMAND_PANELS: PanelDef[] = [
 
 // ─── Aggregate ──────────────────────────────────────────────────────
 
-export const ALL_PANELS: PanelDef[] = [
-  ...STUDIO_PANELS,
-  ...CHARACTER_PANELS,
-  ...WORLD_PANELS,
-  ...SYSTEMS_PANELS,
-  ...LORE_PANELS,
-  ...OPERATIONS_PANELS,
-  ...COMMAND_PANELS,
-];
+// Deduped by id — a panel listed in multiple sidebar groups (e.g. artStyle
+// appears in both Studio and Lore) only produces one entry here.
+export const ALL_PANELS: PanelDef[] = (() => {
+  const seen = new Set<string>();
+  const out: PanelDef[] = [];
+  for (const p of [
+    ...STUDIO_PANELS,
+    ...CHARACTER_PANELS,
+    ...WORLD_PANELS,
+    ...SYSTEMS_PANELS,
+    ...LORE_PANELS,
+    ...OPERATIONS_PANELS,
+    ...COMMAND_PANELS,
+  ]) {
+    if (seen.has(p.id)) continue;
+    seen.add(p.id);
+    out.push(p);
+  }
+  return out;
+})();
 
 export const PANEL_MAP: Record<string, PanelDef> = Object.fromEntries(
   ALL_PANELS.map((p) => [p.id, p]),

--- a/creator/src/lib/portraitPromptGen.ts
+++ b/creator/src/lib/portraitPromptGen.ts
@@ -31,7 +31,7 @@ const CLASS_FORMAT_SPEC =
   "2:3 portrait orientation action portrait of a fantasy race character (race varies per class). Mid-shot framing, dynamic or atmospheric pose, richly detailed painterly environment background";
 
 function getPortraitPromptPrefix(): string {
-  const vs = buildVisualStyleDirective();
+  const vs = buildVisualStyleDirective("worldbuilding");
   if (vs) {
     return `${vs}. NOT a photograph, NOT a 3D render, NOT concept art. 2:3 portrait orientation.`;
   }
@@ -67,7 +67,7 @@ export async function generatePortraitTemplate(
     .join("\n");
 
   const toneDirective = buildToneDirective();
-  const visualStyle = buildVisualStyleDirective();
+  const visualStyle = buildVisualStyleDirective("worldbuilding");
   const toneBlock = toneDirective ? `\nWorld context: ${toneDirective}` : "";
   const styleBlock = visualStyle
     ? `\nWorld visual style: ${visualStyle}\nAll generated imagery must conform to this visual style.`
@@ -141,7 +141,7 @@ export function fillPortraitTemplate(
       .replace(/\{race\}/g, dimensions.key)
       .replace(/\{race_description\}/g, raceDesc);
 
-    return `${getPortraitPromptPrefix()}\n\n${filled}\n\n${getStyleSuffix()}`;
+    return `${getPortraitPromptPrefix()}\n\n${filled}\n\n${getStyleSuffix("worldbuilding")}`;
   }
 
   // Class portrait — uses a curated race for each class to showcase diversity
@@ -157,5 +157,5 @@ export function fillPortraitTemplate(
     .replace(/\{class\}/g, dimensions.key)
     .replace(/\{class_outfit\}/g, classOutfit);
 
-  return `${getPortraitPromptPrefix()}\n\n${filled}\n\n${getStyleSuffix()}`;
+  return `${getPortraitPromptPrefix()}\n\n${filled}\n\n${getStyleSuffix("worldbuilding")}`;
 }

--- a/creator/src/lib/spritePromptGen.ts
+++ b/creator/src/lib/spritePromptGen.ts
@@ -199,7 +199,7 @@ export function fillSpriteTemplate(
   template: SpritePromptTemplate,
   dimensions: SpriteDimensions,
 ): string {
-  return `${resolveSpritePromptBody(template, dimensions)}\n\n${getStyleSuffix()}`;
+  return `${resolveSpritePromptBody(template, dimensions)}\n\n${getStyleSuffix("worldbuilding")}`;
 }
 
 function resolveSpritePromptBody(
@@ -256,7 +256,7 @@ export function buildSpritePrompt(
 ): string {
   const resolvedTemplate = template ?? fallbackSpriteTemplate();
   const promptBody = resolveSpritePromptBody(resolvedTemplate, dimensions, extraContext);
-  return `${promptBody}\n\n${getStyleSuffix()}`;
+  return `${promptBody}\n\n${getStyleSuffix("worldbuilding")}`;
 }
 
 // ─── Per-sprite LLM enhancement ─────────────────────────────────────
@@ -288,7 +288,7 @@ Rules:
       userPrompt: `Refine this sprite generation prompt:\n\n${rawPrompt}`,
     });
     // Re-append style suffix since the LLM was told not to include it
-    return `${enhanced.trim()}\n\n${getStyleSuffix()}`;
+    return `${enhanced.trim()}\n\n${getStyleSuffix("worldbuilding")}`;
   } catch {
     return rawPrompt;
   }

--- a/creator/src/stores/loreStore.ts
+++ b/creator/src/stores/loreStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { WorldLore, Article, ArticleTemplate, ColorLabel, LoreMap, MapPin, CalendarSystem, TimelineEvent, LoreDocument, TemplateOverrides, ShowcaseSettings, CustomTemplateDefinition } from "@/types/lore";
+import type { WorldLore, Article, ArticleTemplate, ColorLabel, LoreMap, MapPin, CalendarSystem, TimelineEvent, LoreDocument, TemplateOverrides, ShowcaseSettings, CustomTemplateDefinition, ArtStyle } from "@/types/lore";
 
 const MAX_LORE_HISTORY = 50;
 
@@ -108,6 +108,12 @@ interface LoreStore extends LoreState {
   addCustomTemplate: (template: CustomTemplateDefinition) => void;
   updateCustomTemplate: (id: string, template: CustomTemplateDefinition) => void;
   deleteCustomTemplate: (id: string) => void;
+
+  // Art style operations
+  createArtStyle: (style: ArtStyle) => void;
+  updateArtStyle: (id: string, patch: Partial<ArtStyle>) => void;
+  deleteArtStyle: (id: string) => void;
+  setActiveArtStyle: (id: string | null) => void;
 
   // Undo/redo
   undoLore: () => void;
@@ -712,6 +718,62 @@ export const useLoreStore = create<LoreStore>((set, get) => ({
       return {
         ...snapshotLore(s),
         lore: { ...s.lore, customTemplates: templates, articles },
+        dirty: true,
+      };
+    }),
+
+  // ─── Art style operations ────────────────────────────────────────
+
+  createArtStyle: (style) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const existing = s.lore.artStyles ?? [];
+      const styles = [...existing, style];
+      // Auto-activate the first style created
+      const activeArtStyleId = s.lore.activeArtStyleId ?? style.id;
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, artStyles: styles, activeArtStyleId },
+        dirty: true,
+      };
+    }),
+
+  updateArtStyle: (id, patch) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const styles = (s.lore.artStyles ?? []).map((style) =>
+        style.id === id
+          ? { ...style, ...patch, updatedAt: new Date().toISOString() }
+          : style,
+      );
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, artStyles: styles },
+        dirty: true,
+      };
+    }),
+
+  deleteArtStyle: (id) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const styles = (s.lore.artStyles ?? []).filter((style) => style.id !== id);
+      const activeArtStyleId = s.lore.activeArtStyleId === id
+        ? styles[0]?.id
+        : s.lore.activeArtStyleId;
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, artStyles: styles, activeArtStyleId },
+        dirty: true,
+      };
+    }),
+
+  setActiveArtStyle: (id) =>
+    set((s) => {
+      if (!s.lore) return s;
+      if (id !== null && !(s.lore.artStyles ?? []).some((style) => style.id === id)) return s;
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, activeArtStyleId: id ?? undefined },
         dirty: true,
       };
     }),

--- a/creator/src/types/lore.ts
+++ b/creator/src/types/lore.ts
@@ -154,6 +154,34 @@ export interface ShowcaseSettings {
   footerText?: string;
 }
 
+// ─── Art styles ────────────────────────────────────────────────────
+
+/** Per-surface prompt overrides appended after the base prompt. */
+export interface ArtStyleSurfaces {
+  /** Appended when generating worldbuilding art (sprites, rooms, entities, abilities, icons). */
+  worldbuilding?: string;
+  /** Appended when generating lore art (portraits, lore article illustrations). */
+  lore?: string;
+}
+
+/**
+ * A named, reusable art style definition. The active style's base prompt is
+ * appended to every image generation prompt via `buildVisualStyleDirective()`,
+ * with the matching surface override appended when a surface is provided.
+ */
+export interface ArtStyle {
+  id: string;
+  name: string;
+  /** Short one-line summary, shown in the list. */
+  description?: string;
+  /** The core style prose. Appended to every image generation prompt. */
+  basePrompt: string;
+  /** Optional per-surface directives layered on top of basePrompt. */
+  surfaces?: ArtStyleSurfaces;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // ─── Top-level lore container ──────────────────────────────────────
 
 export interface WorldLore {
@@ -167,6 +195,8 @@ export interface WorldLore {
   templateOverrides?: Partial<Record<ArticleTemplate, TemplateOverrides>>;
   showcaseSettings?: ShowcaseSettings;
   customTemplates?: CustomTemplateDefinition[];
+  artStyles?: ArtStyle[];
+  activeArtStyleId?: string;
 }
 
 export const DEFAULT_WORLD_LORE: WorldLore = {


### PR DESCRIPTION
## Summary

Adds a first-class **Art Style** concept to the project — a library of named styles that get layered into every AI image generation prompt, with optional per-surface overrides for worldbuilding vs lore art and one-shot AI generation from a theme prompt.

Replaces the buried single-string \`world_setting.visualStyle\` field with a real editor.

### What it does

- **Library of named styles** on \`WorldLore\` with one marked active. Full CRUD (create / update / delete / duplicate / activate) hooked into the existing lore undo/redo snapshot system.
- **Per-surface overrides** — each style has an optional \`worldbuilding\` directive (sprites, rooms, entities, abilities, icons, pets, portrait studio) and \`lore\` directive (lore article hero images and galleries). Base prompt is always appended; surface overrides layer on top.
- **AI one-shot generation** — type a theme like \"surreal gentle magic\" or \"cyberpunk noir\" and the LLM returns a fully populated style (name, description, base prompt, both surface overrides). Uses the world's tone directive as context so the style stays on-theme.
- **AI refinement** — per-style \"refine with AI\" dialog accepts freeform instructions (e.g. \"make it darker\", \"push toward warm autumn tones\").
- **Two built-in presets** — Arcanum and Surreal Gentle Magic, extracted verbatim from the existing hardcoded preambles so no aesthetic is lost. Available alongside \"Empty\" and \"AI generate\" in the \`+ New style\` menu.
- **Auto-migration** — on first open, if \`world_setting.visualStyle\` is set but \`artStyles\` is empty, it's imported as an \"Imported style\" and activated. Legacy field is kept as a fallback.
- **Panel placement** — \"Art Style\" appears in **both** the Studio (worldmaker) and Lore sidebar groups. Same component, shared lore state, routed through \`LorePanelHost\` so lore auto-save handles persistence.

### Surface routing

| Surface | Call sites |
|---|---|
| \`worldbuilding\` | sprites, rooms, mobs, items, shops, trainers, abilities, status effects, pets, portrait studio (race/class), free-form AssetGenerator, CustomAssetStudio, batch art, zone vibe panel, zone asset workbench |
| \`lore\` | lore article primary image + gallery (\`ArticleArtSection\`) |

### Files touched

**Data + persistence**
- \`types/lore.ts\` — new \`ArtStyle\` interface, \`artStyles[]\` and \`activeArtStyleId\` on \`WorldLore\`
- \`stores/loreStore.ts\` — \`createArtStyle\`, \`updateArtStyle\`, \`deleteArtStyle\`, \`setActiveArtStyle\` (snapshot-aware)
- \`lib/lorePersistence.ts\` — round-trip new fields (also picks up \`customTemplates\`, which was missing from the loader)

**Prompt pipeline**
- \`lib/loreGeneration.ts\` — \`buildVisualStyleDirective(surface?)\` prefers active style, falls back to legacy field
- \`lib/arcanumPrompts.ts\` — surface param threaded through \`getStyleSuffix\` / \`getPreamble\` / \`getEnhanceSystemPrompt\` / \`getCustomAssetSystemPrompt\` / \`buildCustomAssetPrompt\`
- ~15 call sites updated to pass the right surface

**New files**
- \`lib/artStylePresets.ts\` — Arcanum + Surreal Gentle Magic presets
- \`lib/artStyleGeneration.ts\` — \`generateArtStyle()\` and \`refineArtStyle()\` LLM helpers
- \`components/lore/ArtStylePanel.tsx\` — list + detail editor with create menu, AI dialogs, surface overrides

**Wiring**
- \`lib/panelRegistry.ts\` — new \`artStyle\` panel in both sidebars; \`ALL_PANELS\` deduped by id
- \`components/lore/LorePanelHost.tsx\` — route \`artStyle\` panel id

### Verification

- TypeScript clean (\`bunx tsc --noEmit\`)
- Rust clean (\`cargo check\` — only pre-existing warnings)
- All 1,325 Vitest data-layer tests pass

### Deferred

- Live preview / test-render inside the editor (users can already test via the existing AssetGenerator panel after activating a style)

## Test plan

- [ ] Open the panel from the Studio sidebar (worldmaker workspace) and confirm the empty state renders
- [ ] Open the panel from the Lore sidebar and confirm the same component appears
- [ ] Click \`+ New style\` → \`Arcanum\` preset, confirm it lands in the list and is auto-activated
- [ ] Click \`+ New style\` → \`✦ Generate with AI\`, type a theme prompt, confirm the LLM returns a populated style and it lands in the list
- [ ] Open an existing style and click \`Refine with AI\`, type an instruction, confirm relevant fields update
- [ ] Edit name, description, base prompt, and both surface overrides — confirm auto-save fires (Save Lore button appears)
- [ ] Generate a room background or mob portrait from the Worldmaker side and confirm the worldbuilding override is appended
- [ ] Generate art for a lore article and confirm the lore override is appended
- [ ] Open a project that has \`world_setting.visualStyle\` set but no \`artStyles\` — confirm it auto-imports as \"Imported style\" and is marked active
- [ ] Set Active on a different style, then delete the active style — confirm activation falls through to another style
- [ ] Undo/redo across art-style mutations