### PR TITLE
Story editor: lore links, story metadata, custom templates, AI tools

### DIFF
--- a/creator/src/components/lore/CinematicRenderer.tsx
+++ b/creator/src/components/lore/CinematicRenderer.tsx
@@ -14,6 +14,8 @@ interface CinematicRendererProps {
   onComplete?: () => void;
   onSceneChange?: (index: number) => void;
   narrationSpeed?: NarrationSpeed;
+  /** Render ambient lore badges (year, mini-map, article chips, title card) over the scene. */
+  showBadges?: boolean;
   resolvedSceneData: Array<{
     sceneId: string;
     roomImageSrc?: string;
@@ -33,6 +35,7 @@ export function CinematicRenderer({
   playing,
   onComplete,
   narrationSpeed,
+  showBadges,
   resolvedSceneData,
 }: CinematicRendererProps) {
   // ─── Current scene ─────────────────────────────────────────────
@@ -83,6 +86,7 @@ export function CinematicRenderer({
             resolvedEntities={resolved?.entities ?? []}
             roomImageSrc={resolved?.roomImageSrc}
             onAnimationsComplete={onComplete}
+            showBadges={showBadges}
           />
         </AnimatePresence>
       </LazyMotion>

--- a/creator/src/components/lore/CinematicScene.tsx
+++ b/creator/src/components/lore/CinematicScene.tsx
@@ -3,6 +3,7 @@ import { m } from "motion/react";
 import { isBackRow } from "@/lib/sceneLayout";
 import { AnimatedEntity } from "./AnimatedEntity";
 import { TypewriterNarration } from "./TypewriterNarration";
+import { SceneInfoBadges } from "./SceneInfoBadges";
 import type { Scene, SceneEntity, TransitionConfig } from "@/types/story";
 import type { NarrationSpeed } from "@/lib/narrationSpeed";
 
@@ -20,6 +21,8 @@ interface CinematicSceneProps {
   }>;
   roomImageSrc?: string;
   onAnimationsComplete?: () => void;
+  /** When true, render the ambient lore badges (year, mini-map, article chips, title card). */
+  showBadges?: boolean;
 }
 
 // ─── Easing ────────────────────────────────────────────────────────
@@ -36,6 +39,7 @@ export function CinematicScene({
   resolvedEntities,
   roomImageSrc,
   onAnimationsComplete: _onAnimationsComplete,
+  showBadges = false,
 }: CinematicSceneProps) {
   // ─── Transition duration ───────────────────────────────────────
 
@@ -132,6 +136,9 @@ export function CinematicScene({
           </div>
         </div>
       )}
+
+      {/* Layer 4: Ambient lore badges (z-35, toggleable) */}
+      {showBadges && <SceneInfoBadges scene={scene} mode="playback" />}
     </m.div>
   );
 }

--- a/creator/src/components/lore/EffectsEditor.tsx
+++ b/creator/src/components/lore/EffectsEditor.tsx
@@ -1,0 +1,113 @@
+// ─── EffectsEditor ──────────────────────────────────────────────────
+// Edits Scene.effects (particles, parallaxLayers, parallaxDepth).
+// The Scene.effects field has been on the data model — this exposes it
+// in the UI. Particle preset names are advisory; runtime rendering is
+// out of scope for this commit.
+
+import { useStoryStore } from "@/stores/storyStore";
+import type { Scene, EffectConfig } from "@/types/story";
+
+const PARTICLE_PRESETS: { value: string; label: string }[] = [
+  { value: "embers", label: "Embers" },
+  { value: "dust", label: "Dust motes" },
+  { value: "mist", label: "Drifting mist" },
+  { value: "snow", label: "Snowfall" },
+  { value: "leaves", label: "Falling leaves" },
+  { value: "aurora", label: "Aurora" },
+  { value: "sparks", label: "Magic sparks" },
+];
+
+interface EffectsEditorProps {
+  storyId: string;
+  scene: Scene;
+}
+
+export function EffectsEditor({ storyId, scene }: EffectsEditorProps) {
+  const updateScene = useStoryStore((s) => s.updateScene);
+  const fx = scene.effects ?? {};
+
+  const patch = (next: Partial<EffectConfig>) => {
+    const merged = { ...fx, ...next };
+    // Strip empty/zero values so we don't store noise
+    const clean: EffectConfig = {};
+    if (merged.particles) clean.particles = merged.particles;
+    if (merged.parallaxLayers && merged.parallaxLayers > 0) clean.parallaxLayers = merged.parallaxLayers;
+    if (merged.parallaxDepth && merged.parallaxDepth > 0) clean.parallaxDepth = merged.parallaxDepth;
+    updateScene(storyId, scene.id, {
+      effects: Object.keys(clean).length > 0 ? clean : undefined,
+    });
+  };
+
+  return (
+    <details className="group rounded-lg border border-border-muted bg-bg-primary/50 p-3">
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-xs font-display uppercase tracking-[0.15em] text-text-secondary">
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 12 12"
+          fill="none"
+          className="transform transition-transform group-open:rotate-90"
+        >
+          <path d="M5 3l3 3-3 3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        Effects
+        {(fx.particles || fx.parallaxLayers) && (
+          <span className="ml-2 normal-case tracking-normal text-2xs text-text-muted">
+            {[fx.particles, fx.parallaxLayers && `${fx.parallaxLayers}-layer parallax`]
+              .filter(Boolean)
+              .join(" · ")}
+          </span>
+        )}
+      </summary>
+
+      <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div className="flex flex-col gap-1">
+          <label className="font-display text-2xs uppercase tracking-[0.15em] text-text-muted">
+            Particles
+          </label>
+          <select
+            value={fx.particles ?? ""}
+            onChange={(e) => patch({ particles: e.target.value || undefined })}
+            className="rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-secondary outline-none focus:border-accent/50"
+          >
+            <option value="">— none —</option>
+            {PARTICLE_PRESETS.map((p) => (
+              <option key={p.value} value={p.value}>{p.label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="font-display text-2xs uppercase tracking-[0.15em] text-text-muted">
+            Parallax layers
+          </label>
+          <input
+            type="number"
+            min={0}
+            max={5}
+            step={1}
+            value={fx.parallaxLayers ?? 0}
+            onChange={(e) => patch({ parallaxLayers: Number(e.target.value) || undefined })}
+            className="rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent/50"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="font-display text-2xs uppercase tracking-[0.15em] text-text-muted">
+            Parallax depth
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={5}
+            value={fx.parallaxDepth ?? 0}
+            onChange={(e) => patch({ parallaxDepth: Number(e.target.value) || undefined })}
+            className="accent-accent"
+          />
+          <span className="text-2xs text-text-muted">{fx.parallaxDepth ?? 0}%</span>
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/creator/src/components/lore/LoreLinkPicker.tsx
+++ b/creator/src/components/lore/LoreLinkPicker.tsx
@@ -1,0 +1,398 @@
+// ─── LoreLinkPicker ─────────────────────────────────────────────────
+// Reusable pickers for linking scenes/stories to lore articles, map pins,
+// and timeline events. Pulls all data from the lore store.
+
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useLoreStore, selectArticles, selectMaps, selectEvents, selectCalendars } from "@/stores/loreStore";
+import { useImageSrc } from "@/lib/useImageSrc";
+import type { ArticleTemplate } from "@/types/lore";
+
+// ─── Shared chip/popover styles ────────────────────────────────────
+
+const POPOVER_CLASS =
+  "absolute z-50 mt-1 max-h-72 w-72 overflow-y-auto rounded-lg border border-border-default bg-bg-elevated shadow-2xl";
+
+const CHIP_CLASS =
+  "inline-flex items-center gap-1.5 rounded-full border border-accent/30 bg-accent/10 px-2 py-0.5 text-2xs text-accent";
+
+const REMOVE_BTN_CLASS =
+  "leading-none text-accent/80 hover:text-status-error";
+
+// ─── Article chip with image ───────────────────────────────────────
+
+function ArticleChip({
+  articleId,
+  onRemove,
+  onClick,
+}: {
+  articleId: string;
+  onRemove?: () => void;
+  onClick?: () => void;
+}) {
+  const article = useLoreStore((s) => s.lore?.articles[articleId]);
+  const src = useImageSrc(article?.image);
+  if (!article) {
+    return (
+      <span className={CHIP_CLASS}>
+        <span className="italic text-text-muted">missing</span>
+        {onRemove && (
+          <button type="button" onClick={onRemove} className={REMOVE_BTN_CLASS} aria-label="Remove link">
+            &times;
+          </button>
+        )}
+      </span>
+    );
+  }
+  return (
+    <span className={CHIP_CLASS}>
+      {src ? (
+        <img src={src} alt="" className="h-4 w-4 rounded-sm object-cover" />
+      ) : (
+        <span className="h-4 w-4 rounded-sm bg-bg-tertiary" />
+      )}
+      <button
+        type="button"
+        onClick={onClick}
+        className="max-w-[120px] truncate hover:underline"
+        title={article.title}
+      >
+        {article.title}
+      </button>
+      {onRemove && (
+        <button type="button" onClick={onRemove} className={REMOVE_BTN_CLASS} aria-label="Remove link">
+          &times;
+        </button>
+      )}
+    </span>
+  );
+}
+
+// ─── Hook: outside-click ───────────────────────────────────────────
+
+function useOutsideClick(ref: React.RefObject<HTMLElement | null>, onClose: () => void, open: boolean) {
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    }
+    window.addEventListener("mousedown", handler);
+    return () => window.removeEventListener("mousedown", handler);
+  }, [ref, onClose, open]);
+}
+
+// ─── Multi-article picker ──────────────────────────────────────────
+
+interface ArticleMultiPickerProps {
+  selected: string[];
+  onChange: (ids: string[]) => void;
+  /** Filter to a single template (e.g. only characters). Optional. */
+  templateFilter?: ArticleTemplate;
+  placeholder?: string;
+}
+
+export function ArticleMultiPicker({
+  selected,
+  onChange,
+  templateFilter,
+  placeholder,
+}: ArticleMultiPickerProps) {
+  const articles = useLoreStore(selectArticles);
+  const selectArticle = useLoreStore((s) => s.selectArticle);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  useOutsideClick(wrapperRef, () => setOpen(false), open);
+
+  const candidates = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return Object.values(articles)
+      .filter((a) => !a.draft)
+      .filter((a) => !templateFilter || a.template === templateFilter)
+      .filter((a) => !selected.includes(a.id))
+      .filter((a) => !q || a.title.toLowerCase().includes(q))
+      .sort((a, b) => a.title.localeCompare(b.title))
+      .slice(0, 25);
+  }, [articles, query, selected, templateFilter]);
+
+  const add = useCallback(
+    (id: string) => {
+      onChange([...selected, id]);
+      setQuery("");
+    },
+    [onChange, selected],
+  );
+
+  const remove = useCallback(
+    (id: string) => {
+      onChange(selected.filter((s) => s !== id));
+    },
+    [onChange, selected],
+  );
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <div className="flex flex-wrap items-center gap-1">
+        {selected.map((id) => (
+          <ArticleChip
+            key={id}
+            articleId={id}
+            onRemove={() => remove(id)}
+            onClick={() => selectArticle(id)}
+          />
+        ))}
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="rounded-full border border-dashed border-border-default px-2 py-0.5 text-2xs text-text-muted hover:border-accent/40 hover:text-accent"
+        >
+          + {placeholder ?? "Link article"}
+        </button>
+      </div>
+
+      {open && (
+        <div className={POPOVER_CLASS}>
+          <div className="sticky top-0 border-b border-border-muted bg-bg-elevated p-2">
+            <input
+              autoFocus
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={templateFilter ? `Search ${templateFilter}...` : "Search articles..."}
+              className="w-full rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent/50"
+            />
+          </div>
+          {candidates.length === 0 ? (
+            <div className="px-3 py-4 text-center text-2xs text-text-muted">
+              {query ? "No matches" : "No more articles to link"}
+            </div>
+          ) : (
+            <ul>
+              {candidates.map((a) => (
+                <li key={a.id}>
+                  <button
+                    type="button"
+                    onClick={() => add(a.id)}
+                    className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover"
+                  >
+                    <span className="flex-1 truncate">{a.title}</span>
+                    <span className="text-2xs text-text-muted">{a.template}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Single-article picker ─────────────────────────────────────────
+
+interface ArticleSinglePickerProps {
+  value: string | undefined;
+  onChange: (id: string | undefined) => void;
+  templateFilter?: ArticleTemplate;
+  placeholder?: string;
+}
+
+export function ArticleSinglePicker({
+  value,
+  onChange,
+  templateFilter,
+  placeholder,
+}: ArticleSinglePickerProps) {
+  const articles = useLoreStore(selectArticles);
+  const selectArticle = useLoreStore((s) => s.selectArticle);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  useOutsideClick(wrapperRef, () => setOpen(false), open);
+
+  const candidates = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return Object.values(articles)
+      .filter((a) => !a.draft)
+      .filter((a) => !templateFilter || a.template === templateFilter)
+      .filter((a) => !q || a.title.toLowerCase().includes(q))
+      .sort((a, b) => a.title.localeCompare(b.title))
+      .slice(0, 25);
+  }, [articles, query, templateFilter]);
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      {value ? (
+        <ArticleChip
+          articleId={value}
+          onRemove={() => onChange(undefined)}
+          onClick={() => selectArticle(value)}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="rounded-full border border-dashed border-border-default px-2 py-0.5 text-2xs text-text-muted hover:border-accent/40 hover:text-accent"
+        >
+          + {placeholder ?? "Link article"}
+        </button>
+      )}
+
+      {open && (
+        <div className={POPOVER_CLASS}>
+          <div className="sticky top-0 border-b border-border-muted bg-bg-elevated p-2">
+            <input
+              autoFocus
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={templateFilter ? `Search ${templateFilter}...` : "Search articles..."}
+              className="w-full rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent/50"
+            />
+          </div>
+          {candidates.length === 0 ? (
+            <div className="px-3 py-4 text-center text-2xs text-text-muted">No matches</div>
+          ) : (
+            <ul>
+              {candidates.map((a) => (
+                <li key={a.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onChange(a.id);
+                      setOpen(false);
+                      setQuery("");
+                    }}
+                    className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-text-secondary hover:bg-bg-hover"
+                  >
+                    <span className="flex-1 truncate">{a.title}</span>
+                    <span className="text-2xs text-text-muted">{a.template}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Map + pin picker ──────────────────────────────────────────────
+
+interface MapPinPickerProps {
+  mapId: string | undefined;
+  pinId: string | undefined;
+  onChange: (mapId: string | undefined, pinId: string | undefined) => void;
+}
+
+export function MapPinPicker({ mapId, pinId, onChange }: MapPinPickerProps) {
+  const maps = useLoreStore(selectMaps);
+  const map = useMemo(() => maps.find((m) => m.id === mapId), [maps, mapId]);
+  const pin = useMemo(() => map?.pins.find((p) => p.id === pinId), [map, pinId]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <select
+        className="rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-secondary outline-none focus:border-accent/50"
+        value={mapId ?? ""}
+        onChange={(e) => onChange(e.target.value || undefined, undefined)}
+      >
+        <option value="">— map —</option>
+        {maps.map((m) => (
+          <option key={m.id} value={m.id}>
+            {m.title}
+          </option>
+        ))}
+      </select>
+
+      {map && map.pins.length > 0 && (
+        <select
+          className="rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-secondary outline-none focus:border-accent/50"
+          value={pinId ?? ""}
+          onChange={(e) => onChange(mapId, e.target.value || undefined)}
+        >
+          <option value="">— pin (optional) —</option>
+          {map.pins.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.label ?? p.id}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {map && map.pins.length === 0 && (
+        <span className="text-2xs italic text-text-muted">No pins on this map yet</span>
+      )}
+
+      {(mapId || pinId) && (
+        <button
+          type="button"
+          onClick={() => onChange(undefined, undefined)}
+          className="text-2xs text-text-muted hover:text-status-error"
+        >
+          clear
+        </button>
+      )}
+
+      {pin?.label && (
+        <span className="text-2xs text-accent/80" title={`Lat ${pin.position[0]}, Lng ${pin.position[1]}`}>
+          → {pin.label}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ─── Timeline event picker ─────────────────────────────────────────
+
+interface TimelineEventPickerProps {
+  value: string | undefined;
+  onChange: (id: string | undefined) => void;
+}
+
+export function TimelineEventPicker({ value, onChange }: TimelineEventPickerProps) {
+  const events = useLoreStore(selectEvents);
+  const calendars = useLoreStore(selectCalendars);
+
+  const sorted = useMemo(
+    () => [...events].sort((a, b) => a.year - b.year),
+    [events],
+  );
+
+  const eraName = useCallback(
+    (calendarId: string, eraId: string): string | undefined => {
+      const cal = calendars.find((c) => c.id === calendarId);
+      return cal?.eras.find((e) => e.id === eraId)?.name;
+    },
+    [calendars],
+  );
+
+  return (
+    <div className="flex items-center gap-2">
+      <select
+        className="rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-secondary outline-none focus:border-accent/50"
+        value={value ?? ""}
+        onChange={(e) => onChange(e.target.value || undefined)}
+      >
+        <option value="">— timeline event —</option>
+        {sorted.map((ev) => {
+          const era = eraName(ev.calendarId, ev.eraId);
+          return (
+            <option key={ev.id} value={ev.id}>
+              {ev.year}{era ? ` ${era}` : ""} — {ev.title}
+            </option>
+          );
+        })}
+      </select>
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange(undefined)}
+          className="text-2xs text-text-muted hover:text-status-error"
+        >
+          clear
+        </button>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/lore/LorePanelHost.tsx
+++ b/creator/src/components/lore/LorePanelHost.tsx
@@ -15,6 +15,7 @@ import { RelationGraphPanel } from "./RelationGraphPanel";
 import { DocumentLibraryPanel } from "./DocumentLibraryPanel";
 import { ShowcaseSettingsPanel } from "./ShowcaseSettingsPanel";
 import { TemplateEditorPanel } from "./TemplateEditorPanel";
+import { SceneTemplateEditorPanel } from "./SceneTemplateEditorPanel";
 import { StoryBrowser } from "./StoryBrowser";
 import { ArtStylePanel } from "./ArtStylePanel";
 
@@ -45,6 +46,8 @@ function renderPanel(panelId: string): ReactNode {
       return <ShowcaseSettingsPanel />;
     case "templates":
       return <TemplateEditorPanel />;
+    case "sceneTemplates":
+      return <SceneTemplateEditorPanel />;
     case "storyEditor":
       return <StoryBrowser />;
     default:

--- a/creator/src/components/lore/PresentationMode.tsx
+++ b/creator/src/components/lore/PresentationMode.tsx
@@ -46,6 +46,7 @@ export function PresentationMode({
   const [dmNotesVisible, setDmNotesVisible] = useState(false);
   const [hudVisible, setHudVisible] = useState(true);
   const [cursorVisible, setCursorVisible] = useState(true);
+  const [badgesVisible, setBadgesVisible] = useState(false);
 
   // ─── Timer refs ───────────────────────────────────────────────
 
@@ -208,6 +209,13 @@ export function PresentationMode({
           break;
         }
 
+        case "i":
+        case "I": {
+          e.preventDefault();
+          setBadgesVisible((prev) => !prev);
+          break;
+        }
+
         default:
           break;
       }
@@ -261,6 +269,7 @@ export function PresentationMode({
           narrationSpeed={narrationSpeed}
           resolvedSceneData={resolvedSceneData}
           onComplete={handleAnimationComplete}
+          showBadges={badgesVisible}
         />
 
         {/* HUD overlay -- inside renderer container for positioning */}

--- a/creator/src/components/lore/SceneContextMenu.tsx
+++ b/creator/src/components/lore/SceneContextMenu.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { SCENE_TEMPLATE_PRESETS } from "@/lib/sceneTemplates";
-import type { SceneTemplate } from "@/types/story";
+import { useLoreStore } from "@/stores/loreStore";
+import { getAllSceneTemplates } from "@/lib/sceneTemplates";
+import type { SceneTemplateId } from "@/types/story";
 
 interface SceneContextMenuProps {
   x: number;
   y: number;
   sceneId: string;
-  currentTemplate?: SceneTemplate;
+  currentTemplate?: SceneTemplateId;
   onDuplicate: (sceneId: string) => void;
   onDelete: (sceneId: string) => void;
-  onApplyTemplate: (sceneId: string, template: SceneTemplate) => void;
+  onApplyTemplate: (sceneId: string, template: SceneTemplateId) => void;
   onClearTemplate: (sceneId: string) => void;
   onClose: () => void;
 }
@@ -68,6 +69,8 @@ export function SceneContextMenu({
 }: SceneContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [showTemplateSubmenu, setShowTemplateSubmenu] = useState(false);
+  const customTemplates = useLoreStore((s) => s.lore?.customSceneTemplates);
+  const templates = getAllSceneTemplates(customTemplates);
 
   // Dismiss on outside click or Escape
   useEffect(() => {
@@ -134,21 +137,26 @@ export function SceneContextMenu({
             className="absolute left-full top-0 bg-bg-elevated border border-border-default rounded-lg backdrop-blur-sm min-w-[180px] py-1 shadow-[var(--shadow-panel)]"
             style={{ zIndex: 61 }}
           >
-            {Object.values(SCENE_TEMPLATE_PRESETS).map((preset) => (
+            {templates.map((tpl) => (
               <button
-                key={preset.id}
+                key={tpl.id}
                 type="button"
                 className={menuItemClass}
                 onClick={() => {
-                  onApplyTemplate(sceneId, preset.id);
+                  onApplyTemplate(sceneId, tpl.id);
                   onClose();
                 }}
               >
                 <span
                   className="inline-block w-1.5 h-1.5 rounded-full"
-                  style={{ backgroundColor: preset.badgeColor }}
+                  style={{ backgroundColor: tpl.badgeColor }}
                 />
-                {preset.label}
+                {tpl.label}
+                {tpl.isCustom && (
+                  <span className="ml-auto text-[8px] uppercase tracking-wider text-text-muted">
+                    custom
+                  </span>
+                )}
               </button>
             ))}
 

--- a/creator/src/components/lore/SceneDetailEditor.tsx
+++ b/creator/src/components/lore/SceneDetailEditor.tsx
@@ -8,6 +8,9 @@ import { EntityPicker } from "./EntityPicker";
 import { TransitionDropdown } from "./TransitionDropdown";
 import { PathPresetPicker } from "./PathPresetPicker";
 import { NarrationSpeedSelector } from "./NarrationSpeedSelector";
+import { SceneLinksSection } from "./SceneLinksSection";
+import { TitleCardEditor } from "./TitleCardEditor";
+import { EffectsEditor } from "./EffectsEditor";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { EditableField } from "@/components/ui/FormWidgets";
 import { applyTemplate, isSceneEmpty } from "@/lib/sceneTemplates";
@@ -141,6 +144,15 @@ export function SceneDetailEditor({ storyId, scene, zoneId }: SceneDetailEditorP
             onUpdateEntity={handleUpdateEntity}
           />
         )}
+
+        {/* Section 7: Linked Lore (articles, location, map, timeline) */}
+        <SceneLinksSection storyId={storyId} scene={scene} />
+
+        {/* Section 8: Title Card overlay */}
+        <TitleCardEditor storyId={storyId} scene={scene} />
+
+        {/* Section 9: Effects (particles, parallax) */}
+        <EffectsEditor storyId={storyId} scene={scene} />
 
         {/* Confirm dialog for template replacement (D-13) */}
         {pendingTemplate && (

--- a/creator/src/components/lore/SceneDetailEditor.tsx
+++ b/creator/src/components/lore/SceneDetailEditor.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useStoryStore } from "@/stores/storyStore";
+import { useLoreStore } from "@/stores/loreStore";
 import { LoreEditor } from "./LoreEditor";
 import { DmNotesSection } from "./DmNotesSection";
 import { TemplatePicker } from "./TemplatePicker";
@@ -14,7 +15,7 @@ import { EffectsEditor } from "./EffectsEditor";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { EditableField } from "@/components/ui/FormWidgets";
 import { applyTemplate, isSceneEmpty } from "@/lib/sceneTemplates";
-import type { Scene, SceneTemplate, TransitionType, SceneEntity } from "@/types/story";
+import type { Scene, SceneTemplateId, TransitionType, SceneEntity } from "@/types/story";
 import type { NarrationSpeed } from "@/lib/narrationSpeed";
 
 interface SceneDetailEditorProps {
@@ -25,7 +26,8 @@ interface SceneDetailEditorProps {
 
 export function SceneDetailEditor({ storyId, scene, zoneId }: SceneDetailEditorProps) {
   const updateScene = useStoryStore((s) => s.updateScene);
-  const [pendingTemplate, setPendingTemplate] = useState<SceneTemplate | null>(
+  const customTemplates = useLoreStore((s) => s.lore?.customSceneTemplates);
+  const [pendingTemplate, setPendingTemplate] = useState<SceneTemplateId | null>(
     null,
   );
   const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
@@ -64,22 +66,22 @@ export function SceneDetailEditor({ storyId, scene, zoneId }: SceneDetailEditorP
   );
 
   const handleApplyTemplate = useCallback(
-    (template: SceneTemplate) => {
+    (template: SceneTemplateId) => {
       if (isSceneEmpty(scene)) {
-        updateScene(storyId, scene.id, applyTemplate(template));
+        updateScene(storyId, scene.id, applyTemplate(template, customTemplates));
       } else {
         setPendingTemplate(template);
       }
     },
-    [scene, storyId, updateScene],
+    [scene, storyId, updateScene, customTemplates],
   );
 
   const handleConfirmTemplate = useCallback(() => {
     if (pendingTemplate) {
-      updateScene(storyId, scene.id, applyTemplate(pendingTemplate));
+      updateScene(storyId, scene.id, applyTemplate(pendingTemplate, customTemplates));
     }
     setPendingTemplate(null);
-  }, [pendingTemplate, storyId, scene.id, updateScene]);
+  }, [pendingTemplate, storyId, scene.id, updateScene, customTemplates]);
 
   return (
     <div key={scene.id} className="flex gap-4 flex-1 min-h-0">

--- a/creator/src/components/lore/SceneInfoBadges.tsx
+++ b/creator/src/components/lore/SceneInfoBadges.tsx
@@ -1,0 +1,212 @@
+// ─── SceneInfoBadges ────────────────────────────────────────────────
+// Subtle, ambient overlays for a scene during preview/playback:
+//   - Top-left:   year/era badge (resolved from linkedTimelineEventId)
+//   - Top-right:  mini-map thumbnail with pulsing pin
+//   - Top-center: title card text overlay
+//   - Bottom:     featured-article chips
+//
+// All four are individually optional. The `mode` prop controls visual
+// intensity: "ambient" (low opacity, always-on for editing) vs "playback"
+// (full opacity, toggleable in presentation mode).
+
+import { useMemo } from "react";
+import { useLoreStore, selectMaps, selectEvents, selectCalendars } from "@/stores/loreStore";
+import { useImageSrc } from "@/lib/useImageSrc";
+import type { Scene } from "@/types/story";
+
+interface SceneInfoBadgesProps {
+  scene: Scene;
+  mode?: "ambient" | "playback";
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function useTimelineLabel(eventId: string | undefined) {
+  const events = useLoreStore(selectEvents);
+  const calendars = useLoreStore(selectCalendars);
+  return useMemo(() => {
+    if (!eventId) return null;
+    const ev = events.find((e) => e.id === eventId);
+    if (!ev) return null;
+    const cal = calendars.find((c) => c.id === ev.calendarId);
+    const era = cal?.eras.find((e) => e.id === ev.eraId);
+    return {
+      year: ev.year,
+      era: era?.name,
+      title: ev.title,
+      color: era?.color,
+    };
+  }, [events, calendars, eventId]);
+}
+
+function useMapPin(mapId: string | undefined, pinId: string | undefined) {
+  const maps = useLoreStore(selectMaps);
+  return useMemo(() => {
+    if (!mapId) return null;
+    const m = maps.find((x) => x.id === mapId);
+    if (!m) return null;
+    const pin = pinId ? m.pins.find((p) => p.id === pinId) : undefined;
+    return { map: m, pin };
+  }, [maps, mapId, pinId]);
+}
+
+// ─── Mini-map thumbnail ────────────────────────────────────────────
+
+function MiniMap({
+  mapAsset,
+  mapWidth,
+  mapHeight,
+  pinX,
+  pinY,
+  pinColor,
+}: {
+  mapAsset: string;
+  mapWidth: number;
+  mapHeight: number;
+  pinX?: number;
+  pinY?: number;
+  pinColor?: string;
+}) {
+  const src = useImageSrc(mapAsset);
+  if (!src) return null;
+  // Convert leaflet CRS.Simple coords (lat=Y from bottom, lng=X) to %.
+  // pinX is lng, pinY is lat — convert to top-down percent.
+  const xPct = pinX !== undefined && mapWidth > 0 ? (pinX / mapWidth) * 100 : null;
+  const yPct = pinY !== undefined && mapHeight > 0
+    ? ((mapHeight - pinY) / mapHeight) * 100
+    : null;
+
+  return (
+    <div className="relative h-20 w-28 overflow-hidden rounded border border-white/20 shadow-lg">
+      <img src={src} alt="" className="h-full w-full object-cover" draggable={false} />
+      {xPct !== null && yPct !== null && (
+        <span
+          className="absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full ring-2 ring-white/70 animate-pulse"
+          style={{
+            left: `${xPct}%`,
+            top: `${yPct}%`,
+            backgroundColor: pinColor ?? "#fbbf24",
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Article chip (badge variant — image only) ────────────────────
+
+function ArticleBadgeChip({ articleId }: { articleId: string }) {
+  const article = useLoreStore((s) => s.lore?.articles[articleId]);
+  const src = useImageSrc(article?.image);
+  if (!article) return null;
+  return (
+    <div
+      className="flex items-center gap-1.5 rounded-full border border-white/20 bg-black/50 px-2 py-0.5 backdrop-blur-sm"
+      title={article.title}
+    >
+      {src ? (
+        <img src={src} alt="" className="h-4 w-4 rounded-full object-cover" />
+      ) : (
+        <span className="h-4 w-4 rounded-full bg-white/20" />
+      )}
+      <span className="max-w-[100px] truncate text-2xs text-white/90">{article.title}</span>
+    </div>
+  );
+}
+
+// ─── Title card text styling ───────────────────────────────────────
+
+function TitleCardOverlay({ scene }: { scene: Scene }) {
+  const card = scene.titleCard;
+  if (!card?.text) return null;
+  const isYear = card.style === "year";
+  const isLocation = card.style === "location";
+  const isCharacter = card.style === "character";
+  return (
+    <div
+      className={[
+        "rounded backdrop-blur-sm px-4 py-1.5",
+        "font-display tracking-[0.25em] uppercase",
+        isYear ? "text-base text-warm border border-warm/30 bg-black/50" : "",
+        isLocation ? "text-sm text-white border-b border-white/30 bg-transparent" : "",
+        isCharacter ? "text-sm text-accent border border-accent/30 bg-black/50" : "",
+        !isYear && !isLocation && !isCharacter ? "text-xs text-white/90 bg-black/40" : "",
+      ].join(" ")}
+      style={{ textShadow: "0 1px 4px rgba(0,0,0,0.7)" }}
+    >
+      {card.text}
+    </div>
+  );
+}
+
+// ─── Main component ────────────────────────────────────────────────
+
+export function SceneInfoBadges({ scene, mode = "ambient" }: SceneInfoBadgesProps) {
+  const timeline = useTimelineLabel(scene.linkedTimelineEventId);
+  const mapInfo = useMapPin(scene.linkedMapId, scene.linkedPinId);
+  const articleIds = scene.linkedArticleIds ?? [];
+
+  const opacity = mode === "ambient" ? "opacity-65" : "opacity-100";
+
+  // Nothing to render → don't add overlay layers
+  if (!timeline && !mapInfo && articleIds.length === 0 && !scene.titleCard?.text) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`pointer-events-none absolute inset-0 ${opacity}`}
+      style={{ zIndex: 35 }}
+      aria-hidden="true"
+    >
+      {/* Top-left: year/era badge */}
+      {timeline && (
+        <div className="absolute left-3 top-3 flex flex-col items-start gap-0.5 rounded border border-warm/40 bg-black/55 px-2 py-1 backdrop-blur-sm">
+          <span
+            className="font-display text-base leading-none tracking-[0.18em] text-warm"
+            style={{ textShadow: "0 1px 3px rgba(0,0,0,0.6)" }}
+          >
+            {timeline.year}
+            {timeline.era && <span className="ml-1 text-2xs uppercase tracking-[0.2em]">{timeline.era}</span>}
+          </span>
+          <span className="max-w-[180px] truncate text-2xs text-white/70">{timeline.title}</span>
+        </div>
+      )}
+
+      {/* Top-right: mini-map */}
+      {mapInfo && (
+        <div className="absolute right-3 top-3">
+          <MiniMap
+            mapAsset={mapInfo.map.imageAsset}
+            mapWidth={mapInfo.map.width}
+            mapHeight={mapInfo.map.height}
+            pinX={mapInfo.pin?.position[1]}
+            pinY={mapInfo.pin?.position[0]}
+            pinColor={mapInfo.pin?.color}
+          />
+          {mapInfo.pin?.label && (
+            <div className="mt-1 max-w-[112px] truncate text-right text-2xs text-white/80" style={{ textShadow: "0 1px 2px rgba(0,0,0,0.7)" }}>
+              {mapInfo.pin.label}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Top-center: title card */}
+      {scene.titleCard?.text && (
+        <div className="absolute left-1/2 top-6 -translate-x-1/2">
+          <TitleCardOverlay scene={scene} />
+        </div>
+      )}
+
+      {/* Bottom: article chips (above the narration overlay if both exist) */}
+      {articleIds.length > 0 && (
+        <div className="absolute inset-x-0 bottom-24 flex flex-wrap items-center justify-center gap-1.5 px-4">
+          {articleIds.slice(0, 6).map((id) => (
+            <ArticleBadgeChip key={id} articleId={id} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/lore/SceneLinksSection.tsx
+++ b/creator/src/components/lore/SceneLinksSection.tsx
@@ -1,0 +1,85 @@
+// ─── SceneLinksSection ──────────────────────────────────────────────
+// Per-scene lore links: location article, featured articles, map+pin,
+// and timeline event. Lives below DM Notes in SceneDetailEditor.
+
+import { useStoryStore } from "@/stores/storyStore";
+import { ArticleSinglePicker, ArticleMultiPicker, MapPinPicker, TimelineEventPicker } from "./LoreLinkPicker";
+import type { Scene } from "@/types/story";
+
+interface SceneLinksSectionProps {
+  storyId: string;
+  scene: Scene;
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="font-display text-2xs uppercase tracking-[0.15em] text-text-muted">
+        {label}
+        {hint && <span className="ml-2 normal-case tracking-normal text-text-muted/70">{hint}</span>}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+export function SceneLinksSection({ storyId, scene }: SceneLinksSectionProps) {
+  const updateScene = useStoryStore((s) => s.updateScene);
+
+  return (
+    <details className="group rounded-lg border border-border-muted bg-bg-primary/50 p-3" open>
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-xs font-display uppercase tracking-[0.15em] text-text-secondary">
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 12 12"
+          fill="none"
+          className="transform transition-transform group-open:rotate-90"
+        >
+          <path d="M5 3l3 3-3 3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        Linked Lore
+      </summary>
+
+      <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+        <Field label="Location article" hint="(single)">
+          <ArticleSinglePicker
+            value={scene.linkedLocationArticleId}
+            onChange={(id) => updateScene(storyId, scene.id, { linkedLocationArticleId: id })}
+            templateFilter="location"
+            placeholder="Link location"
+          />
+        </Field>
+
+        <Field label="Timeline event">
+          <TimelineEventPicker
+            value={scene.linkedTimelineEventId}
+            onChange={(id) => updateScene(storyId, scene.id, { linkedTimelineEventId: id })}
+          />
+        </Field>
+
+        <Field label="Map + pin">
+          <MapPinPicker
+            mapId={scene.linkedMapId}
+            pinId={scene.linkedPinId}
+            onChange={(mapId, pinId) =>
+              updateScene(storyId, scene.id, { linkedMapId: mapId, linkedPinId: pinId })
+            }
+          />
+        </Field>
+
+        <Field label="Featured articles" hint="(any kind)">
+          <ArticleMultiPicker
+            selected={scene.linkedArticleIds ?? []}
+            onChange={(ids) =>
+              updateScene(storyId, scene.id, {
+                linkedArticleIds: ids.length > 0 ? ids : undefined,
+              })
+            }
+            placeholder="Link article"
+          />
+        </Field>
+      </div>
+    </details>
+  );
+}

--- a/creator/src/components/lore/ScenePreview.tsx
+++ b/creator/src/components/lore/ScenePreview.tsx
@@ -9,6 +9,7 @@ import { EntityOverlay } from "./EntityOverlay";
 import { AnimatedEntity } from "./AnimatedEntity";
 import { TypewriterNarration } from "./TypewriterNarration";
 import { PreviewPlayback } from "./PreviewPlayback";
+import { SceneInfoBadges } from "./SceneInfoBadges";
 import type { Scene, SceneEntity } from "@/types/story";
 import type { ZoneState } from "@/stores/zoneStore";
 
@@ -222,6 +223,9 @@ export function ScenePreview({ scene, storyId, zoneId }: ScenePreviewProps) {
 
       {/* Preview playback button (z-40) */}
       <PreviewPlayback playing={previewPlaying} onToggle={handlePreviewToggle} />
+
+      {/* Ambient lore badges (z-35, always-on at low opacity) */}
+      <SceneInfoBadges scene={scene} mode="ambient" />
 
       {previewPlaying ? (
         /* ─── Animated preview mode ────────────────────────────── */

--- a/creator/src/components/lore/SceneTemplateEditorPanel.tsx
+++ b/creator/src/components/lore/SceneTemplateEditorPanel.tsx
@@ -1,0 +1,245 @@
+// ─── SceneTemplateEditorPanel ───────────────────────────────────────
+// Manage user-defined scene templates that appear alongside the built-in
+// presets in the story editor's TemplatePicker and SceneContextMenu.
+
+import { useState, useCallback } from "react";
+import { useLoreStore } from "@/stores/loreStore";
+import { SCENE_TEMPLATE_PRESETS } from "@/lib/sceneTemplates";
+import { plainTextToTiptap, tiptapToPlainText } from "@/lib/loreRelations";
+import { Section, ActionButton } from "@/components/ui/FormWidgets";
+import type { CustomSceneTemplate } from "@/types/lore";
+
+const PALETTE = [
+  "#a897d2", "#8caec9", "#bea873", "#a3c48e", "#c4956a",
+  "#b88faa", "#95a0bf", "#d4c8a0", "#7a8a6e", "#6e5a8a",
+];
+
+function generateId(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_|_$/g, "")
+    || `scene_template_${Date.now()}`;
+}
+
+function emptyTemplate(): CustomSceneTemplate {
+  return {
+    id: `scene_tpl_${Date.now()}`,
+    label: "",
+    badgeColor: PALETTE[0]!,
+    defaultTitle: "",
+    defaultNarration: JSON.stringify({
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    }),
+  };
+}
+
+// ─── Built-in templates display (read-only) ────────────────────────
+
+function BuiltInTemplates() {
+  return (
+    <Section title="Built-in templates" defaultExpanded={false}>
+      <div className="flex flex-col gap-2 p-3">
+        <p className="text-2xs italic text-text-muted">
+          The three built-in scene templates are baked into the editor and cannot be modified.
+          Add your own custom templates below to extend the picker.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {Object.values(SCENE_TEMPLATE_PRESETS).map((p) => (
+            <span
+              key={p.id}
+              className="inline-flex items-center gap-1.5 rounded-full border border-border-muted bg-bg-tertiary px-2.5 py-1 text-2xs"
+              style={{ color: p.badgeColor }}
+            >
+              <span
+                className="inline-block h-1.5 w-1.5 rounded-full"
+                style={{ backgroundColor: p.badgeColor }}
+              />
+              {p.label}
+            </span>
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Single template editor row ────────────────────────────────────
+
+function TemplateEditor({
+  template,
+  onChange,
+  onDelete,
+}: {
+  template: CustomSceneTemplate;
+  onChange: (patch: Partial<CustomSceneTemplate>) => void;
+  onDelete: () => void;
+}) {
+  // Render narration as plain text for editing simplicity; convert back on commit.
+  const plain = tiptapToPlainText(template.defaultNarration);
+  return (
+    <div className="rounded-lg border border-border-default bg-bg-primary p-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          value={template.label}
+          onChange={(e) => onChange({ label: e.target.value })}
+          onBlur={(e) => {
+            // Auto-derive a stable id from label if id is still the placeholder
+            if (template.id.startsWith("scene_tpl_") && e.target.value.trim()) {
+              onChange({ id: generateId(e.target.value) });
+            }
+          }}
+          placeholder="Template name (e.g. Boss Reveal)"
+          className="min-w-0 flex-1 rounded border border-border-default bg-bg-primary px-2 py-1.5 text-sm text-text-primary outline-none focus:border-accent/50"
+        />
+        <button
+          type="button"
+          onClick={onDelete}
+          aria-label="Delete template"
+          className="rounded border border-border-default px-2 py-1 text-2xs text-text-muted hover:border-status-error/50 hover:text-status-error"
+        >
+          Delete
+        </button>
+      </div>
+
+      <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+        <div className="flex flex-col gap-1">
+          <label className="font-display text-2xs uppercase tracking-[0.15em] text-text-muted">
+            Default scene title
+          </label>
+          <input
+            value={template.defaultTitle}
+            onChange={(e) => onChange({ defaultTitle: e.target.value })}
+            placeholder="A Sudden Confrontation"
+            className="rounded border border-border-default bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="font-display text-2xs uppercase tracking-[0.15em] text-text-muted">
+            Badge color
+          </label>
+          <div className="flex flex-wrap gap-1">
+            {PALETTE.map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => onChange({ badgeColor: c })}
+                aria-label={`Use color ${c}`}
+                aria-pressed={template.badgeColor === c}
+                className="h-6 w-6 rounded-full border-2 transition-transform hover:scale-110"
+                style={{
+                  backgroundColor: c,
+                  borderColor: template.badgeColor === c ? "white" : "transparent",
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-1">
+        <label className="font-display text-2xs uppercase tracking-[0.15em] text-text-muted">
+          Default narration
+        </label>
+        <textarea
+          value={plain}
+          onChange={(e) => {
+            const json = plainTextToTiptap(e.target.value);
+            onChange({ defaultNarration: json });
+          }}
+          rows={4}
+          placeholder="The narrator falls silent. The world holds its breath..."
+          className="rounded border border-border-default bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50 resize-y font-sans"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── Main panel ────────────────────────────────────────────────────
+
+export function SceneTemplateEditorPanel() {
+  const customTemplates = useLoreStore((s) => s.lore?.customSceneTemplates ?? []);
+  const addCustomSceneTemplate = useLoreStore((s) => s.addCustomSceneTemplate);
+  const updateCustomSceneTemplate = useLoreStore((s) => s.updateCustomSceneTemplate);
+  const deleteCustomSceneTemplate = useLoreStore((s) => s.deleteCustomSceneTemplate);
+
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+
+  const handleAdd = useCallback(() => {
+    addCustomSceneTemplate(emptyTemplate());
+  }, [addCustomSceneTemplate]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <header>
+        <h1 className="font-display text-2xl tracking-[0.5px] text-text-primary">
+          Scene Templates
+        </h1>
+        <p className="mt-1 text-sm text-text-muted">
+          Define reusable scene presets that appear in the story editor's template picker.
+          Each template provides a default title and narration that scenes can be initialised from.
+        </p>
+      </header>
+
+      <BuiltInTemplates />
+
+      <Section title="Custom templates" defaultExpanded>
+        <div className="flex flex-col gap-3 p-3">
+          {customTemplates.length === 0 ? (
+            <p className="rounded border border-dashed border-border-muted px-4 py-6 text-center text-2xs italic text-text-muted">
+              No custom scene templates yet. Add one to extend the picker.
+            </p>
+          ) : (
+            customTemplates.map((tpl) =>
+              pendingDelete === tpl.id ? (
+                <div
+                  key={tpl.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-status-error/40 bg-status-error/5 p-3 text-xs text-text-secondary"
+                >
+                  <span>
+                    Delete "<span className="font-medium">{tpl.label || tpl.id}</span>"? Scenes already
+                    using this template will keep their content but lose the template tag.
+                  </span>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        deleteCustomSceneTemplate(tpl.id);
+                        setPendingDelete(null);
+                      }}
+                      className="rounded border border-status-error/60 bg-status-error/10 px-2 py-1 text-2xs text-status-error hover:bg-status-error/20"
+                    >
+                      Delete
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setPendingDelete(null)}
+                      className="rounded border border-border-default px-2 py-1 text-2xs text-text-muted hover:bg-bg-tertiary"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <TemplateEditor
+                  key={tpl.id}
+                  template={tpl}
+                  onChange={(patch) => updateCustomSceneTemplate(tpl.id, patch)}
+                  onDelete={() => setPendingDelete(tpl.id)}
+                />
+              ),
+            )
+          )}
+
+          <div>
+            <ActionButton variant="primary" onClick={handleAdd}>
+              + Add scene template
+            </ActionButton>
+          </div>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/creator/src/components/lore/SceneTimeline.tsx
+++ b/creator/src/components/lore/SceneTimeline.tsx
@@ -16,7 +16,8 @@ import {
   arrayMove,
 } from "@dnd-kit/sortable";
 import { useStoryStore, generateSceneId } from "@/stores/storyStore";
-import type { Scene, SceneTemplate } from "@/types/story";
+import { useLoreStore } from "@/stores/loreStore";
+import type { Scene, SceneTemplateId } from "@/types/story";
 import { SceneCard } from "./SceneCard";
 import { SceneContextMenu } from "./SceneContextMenu";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -51,8 +52,10 @@ export function SceneTimeline({
   const [confirmAction, setConfirmAction] = useState<{
     type: "delete" | "template";
     sceneId: string;
-    template?: SceneTemplate;
+    template?: SceneTemplateId;
   } | null>(null);
+
+  const customTemplates = useLoreStore((s) => s.lore?.customSceneTemplates);
 
   // Scroll fade state
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -137,16 +140,16 @@ export function SceneTimeline({
   }, []);
 
   const handleContextApplyTemplate = useCallback(
-    (sceneId: string, template: SceneTemplate) => {
+    (sceneId: string, template: SceneTemplateId) => {
       const scene = scenes.find((s) => s.id === sceneId);
       if (!scene) return;
       if (isSceneEmpty(scene)) {
-        updateScene(storyId, sceneId, applyTemplate(template));
+        updateScene(storyId, sceneId, applyTemplate(template, customTemplates));
       } else {
         setConfirmAction({ type: "template", sceneId, template });
       }
     },
-    [scenes, storyId, updateScene],
+    [scenes, storyId, updateScene, customTemplates],
   );
 
   const handleContextClearTemplate = useCallback(
@@ -164,11 +167,11 @@ export function SceneTimeline({
       updateScene(
         storyId,
         confirmAction.sceneId,
-        applyTemplate(confirmAction.template),
+        applyTemplate(confirmAction.template, customTemplates),
       );
     }
     setConfirmAction(null);
-  }, [confirmAction, storyId, removeScene, updateScene]);
+  }, [confirmAction, storyId, removeScene, updateScene, customTemplates]);
 
   const activeDragScene = activeDragId
     ? scenes.find((s) => s.id === activeDragId)

--- a/creator/src/components/lore/StoryAIToolbar.tsx
+++ b/creator/src/components/lore/StoryAIToolbar.tsx
@@ -1,0 +1,242 @@
+// ─── StoryAIToolbar ─────────────────────────────────────────────────
+// Three story-level AI tools:
+//   - Outline:   synopsis -> 4-7 scene stubs (replaces existing scenes after confirmation)
+//   - Next:      generate the next scene continuing the existing arc
+//   - Synopsis:  reverse — fill story.synopsis from current scenes
+
+import { useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useStoryStore, generateSceneId } from "@/stores/storyStore";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { plainTextToTiptap } from "@/lib/loreRelations";
+import {
+  getStoryOutlineSystemPrompt,
+  buildStoryOutlineUserPrompt,
+  parseOutlineResponse,
+  getNextSceneSystemPrompt,
+  buildNextSceneUserPrompt,
+  parseNextSceneResponse,
+  getSynopsisSystemPrompt,
+  buildSynopsisUserPrompt,
+} from "@/lib/storyPrompts";
+import type { Story, Scene } from "@/types/story";
+
+interface StoryAIToolbarProps {
+  story: Story;
+}
+
+type LoadingState = null | "outline" | "next" | "synopsis";
+
+// ─── Sparkle icon ─────────────────────────────────────────────────
+
+function SparkleIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="M8 1l1.5 4.5L14 7l-4.5 1.5L8 13l-1.5-4.5L2 7l4.5-1.5L8 1z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// ─── Main toolbar ─────────────────────────────────────────────────
+
+export function StoryAIToolbar({ story }: StoryAIToolbarProps) {
+  const updateStory = useStoryStore((s) => s.updateStory);
+  const addScene = useStoryStore((s) => s.addScene);
+  const setActiveScene = useStoryStore((s) => s.setActiveScene);
+  const removeScene = useStoryStore((s) => s.removeScene);
+
+  const [loading, setLoading] = useState<LoadingState>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmReplace, setConfirmReplace] = useState<
+    null | { scenes: { title: string; narration: string }[] }
+  >(null);
+
+  const sortedScenes = [...story.scenes].sort((a, b) => a.sortOrder - b.sortOrder);
+
+  // ─── Outline ──────────────────────────────────────────────────
+
+  const handleOutline = useCallback(async () => {
+    if (!story.synopsis?.trim()) {
+      setError("Add a synopsis first — outline needs something to expand from.");
+      return;
+    }
+    setError(null);
+    setLoading("outline");
+    try {
+      const result = await invoke<string>("llm_complete", {
+        systemPrompt: getStoryOutlineSystemPrompt(),
+        userPrompt: buildStoryOutlineUserPrompt(story),
+      });
+      const parsed = parseOutlineResponse(result);
+      if (parsed.length === 0) {
+        setError("AI returned no usable scenes — try again or rewrite the synopsis.");
+        return;
+      }
+      if (sortedScenes.length === 0) {
+        // No scenes to replace — apply directly
+        applyOutline(parsed);
+      } else {
+        setConfirmReplace({ scenes: parsed });
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [story, sortedScenes.length]);
+
+  const applyOutline = useCallback(
+    (outline: { title: string; narration: string }[]) => {
+      // Wipe existing scenes (confirmed via dialog)
+      sortedScenes.forEach((s) => removeScene(story.id, s.id));
+      // Add new scenes in order
+      outline.forEach((s, i) => {
+        const newScene: Scene = {
+          id: generateSceneId(),
+          title: s.title || `Scene ${i + 1}`,
+          sortOrder: i,
+          narration: plainTextToTiptap(s.narration),
+        };
+        addScene(story.id, newScene);
+      });
+      setConfirmReplace(null);
+    },
+    [story.id, sortedScenes, addScene, removeScene],
+  );
+
+  const handleConfirmReplace = useCallback(() => {
+    if (confirmReplace) applyOutline(confirmReplace.scenes);
+  }, [confirmReplace, applyOutline]);
+
+  // ─── Next scene ────────────────────────────────────────────────
+
+  const handleNextScene = useCallback(async () => {
+    if (sortedScenes.length === 0) {
+      setError("Need at least one existing scene to continue from.");
+      return;
+    }
+    setError(null);
+    setLoading("next");
+    try {
+      const result = await invoke<string>("llm_complete", {
+        systemPrompt: getNextSceneSystemPrompt(),
+        userPrompt: buildNextSceneUserPrompt(story, sortedScenes),
+      });
+      const parsed = parseNextSceneResponse(result);
+      if (!parsed) {
+        setError("AI returned no usable scene — try again.");
+        return;
+      }
+      const newScene: Scene = {
+        id: generateSceneId(),
+        title: parsed.title || `Scene ${sortedScenes.length + 1}`,
+        sortOrder: sortedScenes.length,
+        narration: plainTextToTiptap(parsed.narration),
+      };
+      addScene(story.id, newScene);
+      setActiveScene(newScene.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(null);
+    }
+  }, [story, sortedScenes, addScene, setActiveScene]);
+
+  // ─── Synopsis from scenes ─────────────────────────────────────
+
+  const handleSynopsis = useCallback(async () => {
+    if (sortedScenes.length === 0) {
+      setError("Need at least one scene to summarise.");
+      return;
+    }
+    setError(null);
+    setLoading("synopsis");
+    try {
+      const result = await invoke<string>("llm_complete", {
+        systemPrompt: getSynopsisSystemPrompt(),
+        userPrompt: buildSynopsisUserPrompt(story, sortedScenes),
+      });
+      const synopsis = result.trim();
+      if (!synopsis) {
+        setError("AI returned no synopsis — try again.");
+        return;
+      }
+      updateStory(story.id, { synopsis });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(null);
+    }
+  }, [story, sortedScenes, updateStory]);
+
+  // ─── Render ────────────────────────────────────────────────────
+
+  const btn = (active: boolean) =>
+    [
+      "flex items-center gap-1 rounded-full border px-2.5 py-1 text-2xs font-sans transition-colors",
+      active
+        ? "border-accent/50 bg-accent/10 text-accent"
+        : "border-border-default text-text-muted hover:border-accent/40 hover:text-accent",
+      "disabled:opacity-40 disabled:cursor-not-allowed",
+    ].join(" ");
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={handleOutline}
+          disabled={loading !== null}
+          className={btn(loading === "outline")}
+          title="Generate scene stubs from the synopsis"
+        >
+          <SparkleIcon />
+          {loading === "outline" ? "Outlining..." : "Outline"}
+        </button>
+        <button
+          type="button"
+          onClick={handleNextScene}
+          disabled={loading !== null}
+          className={btn(loading === "next")}
+          title="Append a new scene continuing the story"
+        >
+          <SparkleIcon />
+          {loading === "next" ? "Writing..." : "Next scene"}
+        </button>
+        <button
+          type="button"
+          onClick={handleSynopsis}
+          disabled={loading !== null}
+          className={btn(loading === "synopsis")}
+          title="Fill the synopsis from existing scenes"
+        >
+          <SparkleIcon />
+          {loading === "synopsis" ? "Summarising..." : "Synopsise"}
+        </button>
+      </div>
+      {error && (
+        <span role="alert" className="max-w-xs text-right text-2xs text-status-error">
+          {error}
+        </span>
+      )}
+
+      {confirmReplace && (
+        <ConfirmDialog
+          title="Replace All Scenes?"
+          message={`This will delete the ${sortedScenes.length} existing scene${sortedScenes.length === 1 ? "" : "s"} and replace them with ${confirmReplace.scenes.length} new scene${confirmReplace.scenes.length === 1 ? "" : "s"} from the AI outline. You can undo.`}
+          confirmLabel="Replace"
+          cancelLabel="Keep current"
+          destructive
+          onConfirm={handleConfirmReplace}
+          onCancel={() => setConfirmReplace(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/lore/StoryEditorPanel.tsx
+++ b/creator/src/components/lore/StoryEditorPanel.tsx
@@ -10,6 +10,7 @@ import { SceneTimeline } from "./SceneTimeline";
 import { SceneDetailEditor } from "./SceneDetailEditor";
 import { PresentationMode } from "./PresentationMode";
 import { StorySettingsSection } from "./StorySettingsSection";
+import { StoryAIToolbar } from "./StoryAIToolbar";
 
 interface StoryEditorPanelProps {
   storyId: string;
@@ -243,6 +244,9 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
           </ActionButton>
         </div>
       </div>
+
+      {/* Section 0.5: AI tools (between header and settings) */}
+      <StoryAIToolbar story={story} />
 
       {/* Section 1: Story Settings (cover, synopsis, tags, lore links) */}
       <StorySettingsSection story={story} />

--- a/creator/src/components/lore/StoryEditorPanel.tsx
+++ b/creator/src/components/lore/StoryEditorPanel.tsx
@@ -5,43 +5,14 @@ import { useLoreStore } from "@/stores/loreStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { loadStory, saveStory } from "@/lib/storyPersistence";
-import { useImageSrc } from "@/lib/useImageSrc";
 import { ActionButton, Spinner, EditableField } from "@/components/ui/FormWidgets";
-import { AssetPickerModal } from "@/components/ui/AssetPickerModal";
 import { SceneTimeline } from "./SceneTimeline";
 import { SceneDetailEditor } from "./SceneDetailEditor";
 import { PresentationMode } from "./PresentationMode";
+import { StorySettingsSection } from "./StorySettingsSection";
 
 interface StoryEditorPanelProps {
   storyId: string;
-}
-
-/** Renders a cover image thumbnail with loading state. */
-function CoverImage({
-  fileName,
-  onChangeClick,
-}: {
-  fileName: string;
-  onChangeClick: () => void;
-}) {
-  const src = useImageSrc(fileName);
-  return (
-    <button
-      onClick={onChangeClick}
-      className="group relative w-[240px] overflow-hidden rounded-xl border border-border-default"
-    >
-      {src ? (
-        <img src={src} alt="Story cover" className="w-full object-cover" />
-      ) : (
-        <div className="flex h-[160px] w-full items-center justify-center">
-          <Spinner />
-        </div>
-      )}
-      <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
-        <span className="text-sm font-medium text-white">Change</span>
-      </div>
-    </button>
-  );
 }
 
 export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
@@ -59,8 +30,6 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
 
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState(false);
-  const [showAssetPicker, setShowAssetPicker] = useState(false);
-  const [showSettings, setShowSettings] = useState(false);
   const [isPresenting, setIsPresenting] = useState(false);
 
   // Derive zone name from zoneStore
@@ -155,19 +124,6 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
         title: newTitle.trim(),
         updatedAt: new Date().toISOString(),
       });
-    },
-    [storyId, updateStory],
-  );
-
-  // Cover image selection handler -- syncs story and lore article
-  const handleCoverImageSelect = useCallback(
-    (fileName: string) => {
-      updateStory(storyId, { coverImage: fileName });
-      useLoreStore.getState().updateArticle(storyId, {
-        image: fileName,
-        updatedAt: new Date().toISOString(),
-      });
-      setShowAssetPicker(false);
     },
     [storyId, updateStory],
   );
@@ -288,49 +244,8 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
         </div>
       </div>
 
-      {/* Section 1: Collapsible Story Settings (D-04) */}
-      <div>
-        <button
-          type="button"
-          onClick={() => setShowSettings(!showSettings)}
-          aria-expanded={showSettings}
-          className="flex items-center gap-2 text-2xs text-text-muted hover:text-text-primary transition-colors"
-        >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            className={`transform transition-transform duration-200 ${showSettings ? "rotate-180" : ""}`}
-          >
-            <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-          Story Settings
-        </button>
-
-        <div
-          className={`overflow-hidden transition-[max-height] duration-300 ${
-            showSettings ? "max-h-[400px]" : "max-h-0"
-          }`}
-          style={{ transitionTimingFunction: "var(--ease-unfurl)" }}
-        >
-          <div className="pt-3">
-            {story.coverImage ? (
-              <CoverImage
-                fileName={story.coverImage}
-                onChangeClick={() => setShowAssetPicker(true)}
-              />
-            ) : (
-              <button
-                onClick={() => setShowAssetPicker(true)}
-                className="flex h-[160px] w-[240px] cursor-pointer items-center justify-center rounded-xl border-2 border-dashed border-border-default transition-colors hover:border-accent/40 hover:bg-bg-tertiary"
-              >
-                <span className="text-sm text-text-muted">Add a cover image</span>
-              </button>
-            )}
-          </div>
-        </div>
-      </div>
+      {/* Section 1: Story Settings (cover, synopsis, tags, lore links) */}
+      <StorySettingsSection story={story} />
 
       {/* Section 2: SceneTimeline (D-01) */}
       <SceneTimeline
@@ -354,14 +269,6 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
         </span>
         <span className="ml-auto font-mono text-2xs text-text-muted">{story.id}</span>
       </div>
-
-      {/* Asset Picker Modal */}
-      {showAssetPicker && (
-        <AssetPickerModal
-          onSelect={handleCoverImageSelect}
-          onClose={() => setShowAssetPicker(false)}
-        />
-      )}
 
       {/* Presentation Mode (portal to body for fullscreen overlay) */}
       {isPresenting && story && createPortal(

--- a/creator/src/components/lore/StorySettingsSection.tsx
+++ b/creator/src/components/lore/StorySettingsSection.tsx
@@ -1,0 +1,298 @@
+// ─── StorySettingsSection ────────────────────────────────────────────
+// Story-level metadata: cover, synopsis, tags, draft, lore links,
+// featured characters, primary map, primary calendar.
+
+import { useState, useCallback } from "react";
+import { useStoryStore } from "@/stores/storyStore";
+import { useLoreStore, selectMaps, selectCalendars } from "@/stores/loreStore";
+import { useImageSrc } from "@/lib/useImageSrc";
+import { AssetPickerModal } from "@/components/ui/AssetPickerModal";
+import { Spinner } from "@/components/ui/FormWidgets";
+import { ArticleMultiPicker } from "./LoreLinkPicker";
+import type { Story } from "@/types/story";
+
+// ─── Cover image thumbnail (mirrors StoryEditorPanel) ──────────────
+
+function CoverImage({
+  fileName,
+  onChangeClick,
+}: {
+  fileName: string;
+  onChangeClick: () => void;
+}) {
+  const src = useImageSrc(fileName);
+  return (
+    <button
+      type="button"
+      onClick={onChangeClick}
+      className="group relative w-[200px] overflow-hidden rounded-xl border border-border-default"
+    >
+      {src ? (
+        <img src={src} alt="Story cover" className="w-full object-cover" />
+      ) : (
+        <div className="flex h-[140px] w-full items-center justify-center">
+          <Spinner />
+        </div>
+      )}
+      <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+        <span className="text-sm font-medium text-white">Change</span>
+      </div>
+    </button>
+  );
+}
+
+// ─── Inline tag list ───────────────────────────────────────────────
+
+function TagList({
+  items,
+  onChange,
+}: {
+  items: string[];
+  onChange: (next: string[]) => void;
+}) {
+  const [draft, setDraft] = useState("");
+
+  const add = useCallback(() => {
+    const v = draft.trim();
+    if (!v || items.includes(v)) return;
+    onChange([...items, v]);
+    setDraft("");
+  }, [draft, items, onChange]);
+
+  return (
+    <div>
+      {items.length > 0 && (
+        <div className="mb-1.5 flex flex-wrap gap-1">
+          {items.map((t, i) => (
+            <span
+              key={i}
+              className="inline-flex items-center gap-0.5 rounded-full border border-border-muted bg-bg-tertiary px-2 py-0.5 text-2xs text-text-secondary"
+            >
+              {t}
+              <button
+                type="button"
+                onClick={() => onChange(items.filter((_, j) => j !== i))}
+                className="ml-0.5 leading-none text-text-muted hover:text-status-error"
+                aria-label={`Remove ${t}`}
+              >
+                &times;
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="flex gap-1.5">
+        <input
+          className="flex-1 rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent/50"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && add()}
+          placeholder="Add tag and press Enter..."
+        />
+        <button
+          type="button"
+          onClick={add}
+          disabled={!draft.trim()}
+          className="rounded border border-border-default px-2 py-0.5 text-xs text-text-secondary hover:bg-bg-tertiary disabled:opacity-40"
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Field row ─────────────────────────────────────────────────────
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="font-display text-2xs uppercase tracking-[0.15em] text-text-muted">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+// ─── Main component ────────────────────────────────────────────────
+
+interface StorySettingsSectionProps {
+  story: Story;
+}
+
+export function StorySettingsSection({ story }: StorySettingsSectionProps) {
+  const updateStory = useStoryStore((s) => s.updateStory);
+  const maps = useLoreStore(selectMaps);
+  const calendars = useLoreStore(selectCalendars);
+
+  const [showSettings, setShowSettings] = useState(false);
+  const [showAssetPicker, setShowAssetPicker] = useState(false);
+
+  // ─── Handlers ──────────────────────────────────────────────────
+
+  const handleCoverImageSelect = useCallback(
+    (fileName: string) => {
+      updateStory(story.id, { coverImage: fileName });
+      useLoreStore.getState().updateArticle(story.id, {
+        image: fileName,
+        updatedAt: new Date().toISOString(),
+      });
+      setShowAssetPicker(false);
+    },
+    [story.id, updateStory],
+  );
+
+  const patch = useCallback(
+    (p: Partial<Story>) => updateStory(story.id, p),
+    [story.id, updateStory],
+  );
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setShowSettings(!showSettings)}
+        aria-expanded={showSettings}
+        className="flex items-center gap-2 text-2xs text-text-muted hover:text-text-primary transition-colors"
+      >
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          className={`transform transition-transform duration-200 ${showSettings ? "rotate-180" : ""}`}
+        >
+          <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        Story Settings
+        {story.draft && (
+          <span className="rounded-full border border-warm/30 bg-warm/10 px-1.5 py-0 text-[9px] uppercase tracking-wider text-warm">
+            draft
+          </span>
+        )}
+      </button>
+
+      <div
+        className={`grid overflow-hidden transition-[grid-template-rows] duration-300 ${
+          showSettings ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        }`}
+        style={{ transitionTimingFunction: "var(--ease-unfurl)" }}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="grid grid-cols-1 gap-4 pt-3 md:grid-cols-[200px,1fr]">
+            {/* Cover image */}
+            <div>
+              {story.coverImage ? (
+                <CoverImage
+                  fileName={story.coverImage}
+                  onChangeClick={() => setShowAssetPicker(true)}
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setShowAssetPicker(true)}
+                  className="flex h-[140px] w-[200px] cursor-pointer items-center justify-center rounded-xl border-2 border-dashed border-border-default transition-colors hover:border-accent/40 hover:bg-bg-tertiary"
+                >
+                  <span className="text-sm text-text-muted">Add a cover image</span>
+                </button>
+              )}
+            </div>
+
+            {/* Right column: synopsis + meta + lore links */}
+            <div className="flex flex-col gap-3">
+              <Field label="Synopsis">
+                <textarea
+                  value={story.synopsis ?? ""}
+                  onChange={(e) => patch({ synopsis: e.target.value || undefined })}
+                  placeholder="A short logline or pitch for this story..."
+                  rows={3}
+                  className="rounded border border-border-default bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50 resize-none"
+                />
+              </Field>
+
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                <Field label="Tags">
+                  <TagList
+                    items={story.tags ?? []}
+                    onChange={(tags) => patch({ tags: tags.length > 0 ? tags : undefined })}
+                  />
+                </Field>
+
+                <div className="flex flex-col gap-3">
+                  <label className="flex items-center gap-2 text-xs text-text-secondary">
+                    <input
+                      type="checkbox"
+                      checked={story.draft ?? false}
+                      onChange={(e) => patch({ draft: e.target.checked || undefined })}
+                      className="rounded border-border-default"
+                    />
+                    Draft (excluded from showcase)
+                  </label>
+
+                  <Field label="Primary map">
+                    <select
+                      className="rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-secondary outline-none focus:border-accent/50"
+                      value={story.primaryMapId ?? ""}
+                      onChange={(e) => patch({ primaryMapId: e.target.value || undefined })}
+                    >
+                      <option value="">— none —</option>
+                      {maps.map((m) => (
+                        <option key={m.id} value={m.id}>
+                          {m.title}
+                        </option>
+                      ))}
+                    </select>
+                  </Field>
+
+                  <Field label="Primary calendar">
+                    <select
+                      className="rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-secondary outline-none focus:border-accent/50"
+                      value={story.primaryCalendarId ?? ""}
+                      onChange={(e) => patch({ primaryCalendarId: e.target.value || undefined })}
+                    >
+                      <option value="">— none —</option>
+                      {calendars.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.name}
+                        </option>
+                      ))}
+                    </select>
+                  </Field>
+                </div>
+              </div>
+
+              <Field label="Featured characters">
+                <ArticleMultiPicker
+                  selected={story.featuredCharacterIds ?? []}
+                  onChange={(ids) =>
+                    patch({ featuredCharacterIds: ids.length > 0 ? ids : undefined })
+                  }
+                  templateFilter="character"
+                  placeholder="Add character"
+                />
+              </Field>
+
+              <Field label="Featured lore">
+                <ArticleMultiPicker
+                  selected={story.linkedArticleIds ?? []}
+                  onChange={(ids) =>
+                    patch({ linkedArticleIds: ids.length > 0 ? ids : undefined })
+                  }
+                  placeholder="Link article"
+                />
+              </Field>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {showAssetPicker && (
+        <AssetPickerModal
+          onSelect={handleCoverImageSelect}
+          onClose={() => setShowAssetPicker(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/lore/TemplateBadge.tsx
+++ b/creator/src/components/lore/TemplateBadge.tsx
@@ -1,5 +1,6 @@
-import type { SceneTemplate } from "@/types/story";
-import { SCENE_TEMPLATE_PRESETS } from "@/lib/sceneTemplates";
+import { useLoreStore } from "@/stores/loreStore";
+import type { SceneTemplateId } from "@/types/story";
+import { resolveSceneTemplate } from "@/lib/sceneTemplates";
 
 function hexToRgba(hex: string, alpha: number): string {
   const r = parseInt(hex.slice(1, 3), 16);
@@ -8,17 +9,19 @@ function hexToRgba(hex: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-export function TemplateBadge({ template }: { template: SceneTemplate }) {
-  const preset = SCENE_TEMPLATE_PRESETS[template];
+export function TemplateBadge({ template }: { template: SceneTemplateId }) {
+  const customTemplates = useLoreStore((s) => s.lore?.customSceneTemplates);
+  const resolved = resolveSceneTemplate(template, customTemplates);
+  if (!resolved) return null;
   return (
     <span
       className="rounded-full px-2 py-1 text-3xs uppercase tracking-[0.18em]"
       style={{
-        backgroundColor: hexToRgba(preset.badgeColor, 0.18),
-        color: preset.badgeColor,
+        backgroundColor: hexToRgba(resolved.badgeColor, 0.18),
+        color: resolved.badgeColor,
       }}
     >
-      {preset.label}
+      {resolved.label}
     </span>
   );
 }

--- a/creator/src/components/lore/TemplatePicker.tsx
+++ b/creator/src/components/lore/TemplatePicker.tsx
@@ -1,9 +1,10 @@
-import { SCENE_TEMPLATE_PRESETS } from "@/lib/sceneTemplates";
-import type { SceneTemplate } from "@/types/story";
+import { useLoreStore } from "@/stores/loreStore";
+import { getAllSceneTemplates } from "@/lib/sceneTemplates";
+import type { SceneTemplateId } from "@/types/story";
 
 interface TemplatePickerProps {
-  activeTemplate?: SceneTemplate;
-  onApply: (template: SceneTemplate) => void;
+  activeTemplate?: SceneTemplateId;
+  onApply: (template: SceneTemplateId) => void;
   onClear: () => void;
 }
 
@@ -12,22 +13,28 @@ export function TemplatePicker({
   onApply,
   onClear,
 }: TemplatePickerProps) {
+  const customTemplates = useLoreStore((s) => s.lore?.customSceneTemplates);
+  const templates = getAllSceneTemplates(customTemplates);
+
   return (
     <div className="flex gap-2 items-center flex-wrap">
-      {Object.values(SCENE_TEMPLATE_PRESETS).map((preset) => (
+      {templates.map((tpl) => (
         <button
-          key={preset.id}
+          key={tpl.id}
           type="button"
           className="segmented-button px-3 py-1.5 flex items-center gap-2"
-          data-active={activeTemplate === preset.id ? "true" : "false"}
-          aria-pressed={activeTemplate === preset.id}
-          onClick={() => onApply(preset.id)}
+          data-active={activeTemplate === tpl.id ? "true" : "false"}
+          aria-pressed={activeTemplate === tpl.id}
+          onClick={() => onApply(tpl.id)}
         >
           <span
             className="inline-block w-1.5 h-1.5 rounded-full"
-            style={{ backgroundColor: preset.badgeColor }}
+            style={{ backgroundColor: tpl.badgeColor }}
           />
-          <span className="text-2xs">{preset.label}</span>
+          <span className="text-2xs">{tpl.label}</span>
+          {tpl.isCustom && (
+            <span className="text-[8px] uppercase tracking-wider text-text-muted">custom</span>
+          )}
         </button>
       ))}
 

--- a/creator/src/components/lore/TitleCardEditor.tsx
+++ b/creator/src/components/lore/TitleCardEditor.tsx
@@ -1,0 +1,88 @@
+// ─── TitleCardEditor ────────────────────────────────────────────────
+// Optional top-center text overlay distinct from bottom narration.
+// Used for location labels, year stamps, character reveals, subtitles.
+
+import { useStoryStore } from "@/stores/storyStore";
+import type { Scene, TitleCardStyle } from "@/types/story";
+
+const STYLE_OPTIONS: { value: TitleCardStyle; label: string }[] = [
+  { value: "location", label: "Location" },
+  { value: "year", label: "Year / Era" },
+  { value: "subtitle", label: "Subtitle" },
+  { value: "character", label: "Character" },
+];
+
+interface TitleCardEditorProps {
+  storyId: string;
+  scene: Scene;
+}
+
+export function TitleCardEditor({ storyId, scene }: TitleCardEditorProps) {
+  const updateScene = useStoryStore((s) => s.updateScene);
+  const card = scene.titleCard;
+
+  const setText = (text: string) => {
+    if (!text.trim()) {
+      updateScene(storyId, scene.id, { titleCard: undefined });
+      return;
+    }
+    updateScene(storyId, scene.id, {
+      titleCard: { ...(card ?? {}), text, style: card?.style ?? "subtitle" },
+    });
+  };
+
+  const setStyle = (style: TitleCardStyle) => {
+    updateScene(storyId, scene.id, {
+      titleCard: { text: card?.text ?? "", style },
+    });
+  };
+
+  return (
+    <details className="group rounded-lg border border-border-muted bg-bg-primary/50 p-3">
+      <summary className="flex cursor-pointer list-none items-center gap-2 text-xs font-display uppercase tracking-[0.15em] text-text-secondary">
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 12 12"
+          fill="none"
+          className="transform transition-transform group-open:rotate-90"
+        >
+          <path d="M5 3l3 3-3 3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+        Title Card
+        {card?.text && (
+          <span className="ml-2 max-w-[200px] truncate normal-case tracking-normal text-2xs text-text-muted">
+            "{card.text}"
+          </span>
+        )}
+      </summary>
+
+      <div className="mt-3 flex flex-col gap-2">
+        <input
+          type="text"
+          value={card?.text ?? ""}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="e.g. The Black Spire — 1247 A.M."
+          className="rounded border border-border-default bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50"
+        />
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-display text-2xs uppercase tracking-[0.15em] text-text-muted">Style</span>
+          {STYLE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setStyle(opt.value)}
+              className={`rounded-full border px-2 py-0.5 text-2xs transition-colors ${
+                card?.style === opt.value
+                  ? "border-accent/60 bg-accent/15 text-accent"
+                  : "border-border-default text-text-muted hover:border-accent/40 hover:text-accent"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/creator/src/lib/exportShowcase.ts
+++ b/creator/src/lib/exportShowcase.ts
@@ -191,6 +191,18 @@ export interface ShowcaseScene {
   transition?: { type: "crossfade" | "fade_black" };
   narrationSpeed?: "slow" | "normal" | "fast";
   entities: ShowcaseSceneEntity[];
+
+  // ─── Lore links (showcase resolves these against its own article list) ──
+  /** Featured article IDs — showcase looks them up in `articles[]`. */
+  linkedArticleIds?: string[];
+  linkedLocationArticleId?: string;
+  linkedMapId?: string;
+  linkedPinId?: string;
+  linkedTimelineEventId?: string;
+
+  // ─── Visual overlays ──────────────────────────────────────────────────
+  titleCard?: { text: string; style?: "location" | "year" | "subtitle" | "character" };
+  effects?: { particles?: string; parallaxLayers?: number; parallaxDepth?: number };
 }
 
 export interface ShowcaseStory {
@@ -204,6 +216,17 @@ export interface ShowcaseStory {
   narrationSpeed?: "slow" | "normal" | "fast";
   createdAt: string;
   updatedAt: string;
+
+  // ─── Story metadata ──────────────────────────────────────────────────
+  synopsis?: string;
+  tags?: string[];
+  // draft is excluded from showcase by definition
+
+  // ─── Story-level lore links ──────────────────────────────────────────
+  linkedArticleIds?: string[];
+  featuredCharacterIds?: string[];
+  primaryMapId?: string;
+  primaryCalendarId?: string;
 }
 
 // ─── Story export context ─────────────────────────────────────────
@@ -229,45 +252,61 @@ export function exportStories(
     return `${baseUrl}/${filename}`;
   }
 
-  return contexts.map(({ story, zoneName, resolveRoomImage, resolveEntityName, resolveEntityImage }) => {
-    const scenes: ShowcaseScene[] = story.scenes
-      .slice()
-      .sort((a, b) => a.sortOrder - b.sortOrder)
-      .map((scene) => ({
-        id: scene.id,
-        title: scene.title,
-        sortOrder: scene.sortOrder,
-        roomImageUrl: scene.roomId ? resolveImageUrl(resolveRoomImage(scene.roomId)) : undefined,
-        narration: scene.narration,
-        narrationHtml: scene.narration ? tiptapToHtml(scene.narration) : undefined,
-        transition: scene.transition ? { type: scene.transition.type } : undefined,
-        narrationSpeed: scene.narrationSpeed,
-        entities: (scene.entities ?? []).map((e) => ({
-          id: e.id,
-          entityType: e.entityType,
-          entityId: e.entityId,
-          name: resolveEntityName(e.entityType, e.entityId),
-          imageUrl: resolveImageUrl(resolveEntityImage(e.entityType, e.entityId)),
-          slot: e.slot,
-          position: e.position,
-          entrancePath: e.entrancePath,
-          exitPath: e.exitPath,
-        })),
-      }));
+  return contexts
+    .filter(({ story }) => !story.draft) // Exclude drafts from showcase
+    .map(({ story, zoneName, resolveRoomImage, resolveEntityName, resolveEntityImage }) => {
+      const scenes: ShowcaseScene[] = story.scenes
+        .slice()
+        .sort((a, b) => a.sortOrder - b.sortOrder)
+        .map((scene) => ({
+          id: scene.id,
+          title: scene.title,
+          sortOrder: scene.sortOrder,
+          roomImageUrl: scene.roomId ? resolveImageUrl(resolveRoomImage(scene.roomId)) : undefined,
+          narration: scene.narration,
+          narrationHtml: scene.narration ? tiptapToHtml(scene.narration) : undefined,
+          transition: scene.transition ? { type: scene.transition.type } : undefined,
+          narrationSpeed: scene.narrationSpeed,
+          entities: (scene.entities ?? []).map((e) => ({
+            id: e.id,
+            entityType: e.entityType,
+            entityId: e.entityId,
+            name: resolveEntityName(e.entityType, e.entityId),
+            imageUrl: resolveImageUrl(resolveEntityImage(e.entityType, e.entityId)),
+            slot: e.slot,
+            position: e.position,
+            entrancePath: e.entrancePath,
+            exitPath: e.exitPath,
+          })),
+          // Lore links — showcase resolves IDs against articles[]/maps[]/timelineEvents[]
+          linkedArticleIds: scene.linkedArticleIds,
+          linkedLocationArticleId: scene.linkedLocationArticleId,
+          linkedMapId: scene.linkedMapId,
+          linkedPinId: scene.linkedPinId,
+          linkedTimelineEventId: scene.linkedTimelineEventId,
+          titleCard: scene.titleCard,
+          effects: scene.effects,
+        }));
 
-    return {
-      id: story.id,
-      title: story.title,
-      zoneId: story.zoneId,
-      zoneName,
-      coverImageUrl: resolveImageUrl(story.coverImage),
-      sceneCount: scenes.length,
-      scenes,
-      narrationSpeed: story.narrationSpeed,
-      createdAt: story.createdAt,
-      updatedAt: story.updatedAt,
-    };
-  });
+      return {
+        id: story.id,
+        title: story.title,
+        zoneId: story.zoneId,
+        zoneName,
+        coverImageUrl: resolveImageUrl(story.coverImage),
+        sceneCount: scenes.length,
+        scenes,
+        narrationSpeed: story.narrationSpeed,
+        createdAt: story.createdAt,
+        updatedAt: story.updatedAt,
+        synopsis: story.synopsis,
+        tags: story.tags,
+        linkedArticleIds: story.linkedArticleIds,
+        featuredCharacterIds: story.featuredCharacterIds,
+        primaryMapId: story.primaryMapId,
+        primaryCalendarId: story.primaryCalendarId,
+      };
+    });
 }
 
 // ─── Export pipeline ───────────────────────────────────────────────

--- a/creator/src/lib/lorePersistence.ts
+++ b/creator/src/lib/lorePersistence.ts
@@ -2,7 +2,7 @@ import { exists, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { parseDocument, stringify } from "yaml";
 import { useLoreStore } from "@/stores/loreStore";
 import { DEFAULT_WORLD_LORE } from "@/types/lore";
-import type { WorldLore, WorldLoreV1, Article, ArticleRelation, ArticleTemplate, LoreDocument, TemplateOverrides, ShowcaseSettings, CustomTemplateDefinition, ArtStyle } from "@/types/lore";
+import type { WorldLore, WorldLoreV1, Article, ArticleRelation, ArticleTemplate, LoreDocument, TemplateOverrides, ShowcaseSettings, CustomTemplateDefinition, CustomSceneTemplate, ArtStyle } from "@/types/lore";
 import type { Project } from "@/types/project";
 import { CODEX_CATEGORY_TO_TEMPLATE } from "@/lib/loreTemplates";
 
@@ -43,6 +43,7 @@ export async function loadLore(project: Project): Promise<WorldLore> {
           ? (raw.showcaseSettings as ShowcaseSettings)
           : undefined,
         customTemplates: Array.isArray(raw.customTemplates) ? (raw.customTemplates as CustomTemplateDefinition[]) : undefined,
+        customSceneTemplates: Array.isArray(raw.customSceneTemplates) ? (raw.customSceneTemplates as CustomSceneTemplate[]) : undefined,
         artStyles: Array.isArray(raw.artStyles) ? (raw.artStyles as ArtStyle[]) : undefined,
         activeArtStyleId: typeof raw.activeArtStyleId === "string" ? raw.activeArtStyleId : undefined,
       };

--- a/creator/src/lib/panelRegistry.ts
+++ b/creator/src/lib/panelRegistry.ts
@@ -104,6 +104,7 @@ const LORE_PANELS: PanelDef[] = [
   { id: "loreDocuments", label: "Documents", group: "lore", host: "lore", kicker: "Archive", title: "Document library", description: "Internal notes, lore bibles, and reference documents.", maxWidth: "max-w-5xl" },
   { id: "showcaseSettings", label: "Showcase", group: "lore", host: "lore", kicker: "Publication", title: "Showcase settings", description: "Branding and appearance for the published showcase site.", maxWidth: "max-w-5xl" },
   { id: "templates", label: "Templates", group: "lore", host: "lore", kicker: "Lore structure", title: "Templates", description: "Create and customize article template types and their fields.", maxWidth: "max-w-5xl" },
+  { id: "sceneTemplates", label: "Scene Templates", group: "lore", host: "lore", kicker: "Narrative", title: "Scene templates", description: "Custom scene presets that appear in the story editor's template picker.", maxWidth: "max-w-5xl" },
   { id: "storyEditor", label: "Story Editor", group: "lore", host: "lore", kicker: "Narrative", title: "Story editor", description: "Compose cinematic zone stories with scenes and narration.", maxWidth: "max-w-7xl" },
 ];
 

--- a/creator/src/lib/sceneTemplates.ts
+++ b/creator/src/lib/sceneTemplates.ts
@@ -1,4 +1,5 @@
-import type { Scene, SceneTemplate } from "@/types/story";
+import type { Scene, SceneTemplate, SceneTemplateId } from "@/types/story";
+import type { CustomSceneTemplate } from "@/types/lore";
 
 // ─── Scene template preset definitions ──────────────────────────────
 
@@ -81,12 +82,71 @@ const DEFAULT_TITLES = new Set(
   Object.values(SCENE_TEMPLATE_PRESETS).map((p) => p.defaultTitle),
 );
 
-/** Returns a Partial<Scene> patch with the template's default title, narration, and template type. */
-export function applyTemplate(template: SceneTemplate): Partial<Scene> {
-  const preset = SCENE_TEMPLATE_PRESETS[template];
+/** Resolved scene template (built-in or custom), unified shape. */
+export interface ResolvedSceneTemplate {
+  id: string;
+  label: string;
+  badgeColor: string;
+  defaultTitle: string;
+  defaultNarration: string;
+  isCustom: boolean;
+}
+
+/** Convert built-in preset to resolved shape. */
+function presetToResolved(preset: SceneTemplatePreset): ResolvedSceneTemplate {
   return {
-    title: preset.defaultTitle,
-    narration: preset.defaultNarration,
+    id: preset.id,
+    label: preset.label,
+    badgeColor: preset.badgeColor,
+    defaultTitle: preset.defaultTitle,
+    defaultNarration: preset.defaultNarration,
+    isCustom: false,
+  };
+}
+
+/** Convert custom template to resolved shape. */
+function customToResolved(c: CustomSceneTemplate): ResolvedSceneTemplate {
+  return {
+    id: c.id,
+    label: c.label,
+    badgeColor: c.badgeColor,
+    defaultTitle: c.defaultTitle,
+    defaultNarration: c.defaultNarration,
+    isCustom: true,
+  };
+}
+
+/** Look up a scene template by ID, checking built-ins first then custom. */
+export function resolveSceneTemplate(
+  id: SceneTemplateId | undefined,
+  custom?: CustomSceneTemplate[],
+): ResolvedSceneTemplate | undefined {
+  if (!id) return undefined;
+  const builtIn = (SCENE_TEMPLATE_PRESETS as Record<string, SceneTemplatePreset | undefined>)[id];
+  if (builtIn) return presetToResolved(builtIn);
+  const found = custom?.find((c) => c.id === id);
+  return found ? customToResolved(found) : undefined;
+}
+
+/** Return a flat list of all scene templates (built-in + custom). */
+export function getAllSceneTemplates(
+  custom?: CustomSceneTemplate[],
+): ResolvedSceneTemplate[] {
+  const builtIn = Object.values(SCENE_TEMPLATE_PRESETS).map(presetToResolved);
+  const customResolved = (custom ?? []).map(customToResolved);
+  return [...builtIn, ...customResolved];
+}
+
+/** Returns a Partial<Scene> patch with the template's default title, narration, and template type. */
+export function applyTemplate(
+  template: SceneTemplateId,
+  custom?: CustomSceneTemplate[],
+): Partial<Scene> {
+  const resolved = resolveSceneTemplate(template, custom);
+  if (!resolved) return { template };
+  return {
+    title: resolved.defaultTitle,
+    narration: resolved.defaultNarration,
     template,
   };
 }

--- a/creator/src/lib/storyPrompts.ts
+++ b/creator/src/lib/storyPrompts.ts
@@ -1,0 +1,139 @@
+// ─── Story-level AI prompts ─────────────────────────────────────────
+// Used by StoryAIToolbar to drive Outline, Next-scene, and Synopsis tools.
+
+import { buildToneDirective } from "./loreGeneration";
+import { tiptapToPlainText } from "./loreRelations";
+import type { Story, Scene } from "@/types/story";
+
+function toneBlock(): string {
+  const directive = buildToneDirective();
+  return directive ? ` ${directive}` : "";
+}
+
+// ─── Outline a story from a synopsis ───────────────────────────────
+
+export interface OutlineScene {
+  title: string;
+  narration: string;
+}
+
+export function getStoryOutlineSystemPrompt(): string {
+  return (
+    "You are a cinematic storyteller for a fantasy MUD." +
+    toneBlock() +
+    " Given a story synopsis, produce a structured outline of 4-7 scenes. " +
+    "Each scene must have: a short evocative title (2-6 words) and a brief " +
+    "narration paragraph (2-4 sentences) written in second-person, present tense, " +
+    "vivid and atmospheric. Output ONLY a JSON array with this exact shape: " +
+    `[{"title": "...", "narration": "..."}, ...] — no markdown fences, no explanation.`
+  );
+}
+
+export function buildStoryOutlineUserPrompt(story: Story): string {
+  const parts: string[] = [];
+  parts.push(`Story title: ${story.title || "Untitled"}`);
+  if (story.synopsis) parts.push(`Synopsis: ${story.synopsis}`);
+  if (story.tags && story.tags.length > 0) parts.push(`Tags: ${story.tags.join(", ")}`);
+  parts.push("\nProduce the JSON outline now.");
+  return parts.join("\n");
+}
+
+/** Parse the outline LLM response, tolerating common formatting issues. */
+export function parseOutlineResponse(raw: string): OutlineScene[] {
+  // Strip code fences if present
+  let cleaned = raw.trim();
+  if (cleaned.startsWith("```")) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, "").replace(/```$/, "").trim();
+  }
+  // Find first [ and last ] in case the model added explanatory prose
+  const start = cleaned.indexOf("[");
+  const end = cleaned.lastIndexOf("]");
+  if (start >= 0 && end > start) cleaned = cleaned.slice(start, end + 1);
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((s): s is { title: unknown; narration: unknown } => !!s && typeof s === "object")
+      .map((s) => ({
+        title: typeof s.title === "string" ? s.title : "",
+        narration: typeof s.narration === "string" ? s.narration : "",
+      }))
+      .filter((s) => s.title || s.narration);
+  } catch {
+    return [];
+  }
+}
+
+// ─── Next scene continuation ───────────────────────────────────────
+
+export function getNextSceneSystemPrompt(): string {
+  return (
+    "You are a cinematic storyteller for a fantasy MUD." +
+    toneBlock() +
+    " Given a story's existing scenes (in order), generate the NEXT scene that " +
+    "naturally continues the narrative arc. Maintain voice, tone, and pacing. " +
+    "Output ONLY a JSON object with this exact shape: " +
+    `{"title": "...", "narration": "..."} — no markdown fences, no explanation. ` +
+    "Narration should be 2-4 sentences, second-person present tense."
+  );
+}
+
+export function buildNextSceneUserPrompt(story: Story, priorScenes: Scene[]): string {
+  const parts: string[] = [];
+  if (story.synopsis) parts.push(`Story synopsis: ${story.synopsis}`);
+  parts.push(`Story title: ${story.title || "Untitled"}`);
+  parts.push("\nExisting scenes (in order):");
+  priorScenes.forEach((s, i) => {
+    const text = tiptapToPlainText(s.narration ?? "").trim();
+    parts.push(`\n${i + 1}. ${s.title || "Untitled"}`);
+    if (text) parts.push(`   ${text}`);
+  });
+  parts.push("\nGenerate the next scene as JSON now.");
+  return parts.join("\n");
+}
+
+export function parseNextSceneResponse(raw: string): { title: string; narration: string } | null {
+  let cleaned = raw.trim();
+  if (cleaned.startsWith("```")) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, "").replace(/```$/, "").trim();
+  }
+  const start = cleaned.indexOf("{");
+  const end = cleaned.lastIndexOf("}");
+  if (start >= 0 && end > start) cleaned = cleaned.slice(start, end + 1);
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (!parsed || typeof parsed !== "object") return null;
+    const obj = parsed as { title?: unknown; narration?: unknown };
+    const title = typeof obj.title === "string" ? obj.title : "";
+    const narration = typeof obj.narration === "string" ? obj.narration : "";
+    if (!title && !narration) return null;
+    return { title, narration };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Synopsis from scenes ──────────────────────────────────────────
+
+export function getSynopsisSystemPrompt(): string {
+  return (
+    "You are a story editor for a fantasy MUD." +
+    toneBlock() +
+    " Read the following scene-by-scene narration and produce a single concise " +
+    "synopsis paragraph (3-5 sentences) capturing the story's arc, stakes, and " +
+    "tone. Output ONLY the synopsis — no quotes, no preamble, no markdown."
+  );
+}
+
+export function buildSynopsisUserPrompt(story: Story, scenes: Scene[]): string {
+  const parts: string[] = [];
+  parts.push(`Story title: ${story.title || "Untitled"}`);
+  parts.push("\nScenes (in order):");
+  scenes.forEach((s, i) => {
+    const text = tiptapToPlainText(s.narration ?? "").trim();
+    parts.push(`\n${i + 1}. ${s.title || "Untitled"}`);
+    if (text) parts.push(`   ${text}`);
+  });
+  parts.push("\nWrite the synopsis paragraph now.");
+  return parts.join("\n");
+}

--- a/creator/src/stores/loreStore.ts
+++ b/creator/src/stores/loreStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { WorldLore, Article, ArticleTemplate, ColorLabel, LoreMap, MapPin, CalendarSystem, TimelineEvent, LoreDocument, TemplateOverrides, ShowcaseSettings, CustomTemplateDefinition, ArtStyle } from "@/types/lore";
+import type { WorldLore, Article, ArticleTemplate, ColorLabel, LoreMap, MapPin, CalendarSystem, TimelineEvent, LoreDocument, TemplateOverrides, ShowcaseSettings, CustomTemplateDefinition, CustomSceneTemplate, ArtStyle } from "@/types/lore";
 
 const MAX_LORE_HISTORY = 50;
 
@@ -108,6 +108,11 @@ interface LoreStore extends LoreState {
   addCustomTemplate: (template: CustomTemplateDefinition) => void;
   updateCustomTemplate: (id: string, template: CustomTemplateDefinition) => void;
   deleteCustomTemplate: (id: string) => void;
+
+  // Custom scene template operations
+  addCustomSceneTemplate: (template: CustomSceneTemplate) => void;
+  updateCustomSceneTemplate: (id: string, patch: Partial<CustomSceneTemplate>) => void;
+  deleteCustomSceneTemplate: (id: string) => void;
 
   // Art style operations
   createArtStyle: (style: ArtStyle) => void;
@@ -718,6 +723,43 @@ export const useLoreStore = create<LoreStore>((set, get) => ({
       return {
         ...snapshotLore(s),
         lore: { ...s.lore, customTemplates: templates, articles },
+        dirty: true,
+      };
+    }),
+
+  // ─── Custom scene template operations ───────────────────────────
+
+  addCustomSceneTemplate: (template) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const templates = [...(s.lore.customSceneTemplates ?? []), template];
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, customSceneTemplates: templates },
+        dirty: true,
+      };
+    }),
+
+  updateCustomSceneTemplate: (id, patch) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const templates = (s.lore.customSceneTemplates ?? []).map((t) =>
+        t.id === id ? { ...t, ...patch } : t,
+      );
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, customSceneTemplates: templates },
+        dirty: true,
+      };
+    }),
+
+  deleteCustomSceneTemplate: (id) =>
+    set((s) => {
+      if (!s.lore) return s;
+      const templates = (s.lore.customSceneTemplates ?? []).filter((t) => t.id !== id);
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, customSceneTemplates: templates },
         dirty: true,
       };
     }),

--- a/creator/src/types/lore.ts
+++ b/creator/src/types/lore.ts
@@ -154,6 +154,21 @@ export interface ShowcaseSettings {
   footerText?: string;
 }
 
+// ─── Custom scene templates ────────────────────────────────────────
+
+/**
+ * User-defined scene template. Mirrors the built-in scene template presets
+ * (creator/src/lib/sceneTemplates.ts) but is editable from the lore tools.
+ * The narration field stores TipTap JSON as a string.
+ */
+export interface CustomSceneTemplate {
+  id: string;
+  label: string;
+  badgeColor: string;
+  defaultTitle: string;
+  defaultNarration: string;
+}
+
 // ─── Art styles ────────────────────────────────────────────────────
 
 /** Per-surface prompt overrides appended after the base prompt. */
@@ -195,6 +210,7 @@ export interface WorldLore {
   templateOverrides?: Partial<Record<ArticleTemplate, TemplateOverrides>>;
   showcaseSettings?: ShowcaseSettings;
   customTemplates?: CustomTemplateDefinition[];
+  customSceneTemplates?: CustomSceneTemplate[];
   artStyles?: ArtStyle[];
   activeArtStyleId?: string;
 }

--- a/creator/src/types/story.ts
+++ b/creator/src/types/story.ts
@@ -4,7 +4,14 @@
 
 import type { NarrationSpeed } from "@/lib/narrationSpeed";
 
+/**
+ * Built-in scene template IDs. User-defined custom templates store their own
+ * IDs as plain strings, so `Scene.template` is widened to `SceneTemplateId`.
+ */
 export type SceneTemplate = "establishing_shot" | "encounter" | "discovery";
+
+/** ID for either a built-in or custom scene template (lives in WorldLore.customSceneTemplates). */
+export type SceneTemplateId = SceneTemplate | string;
 
 /** Preset slot positions for entity placement in a scene. */
 export type EntitySlot =
@@ -57,7 +64,7 @@ export interface Scene {
   backgroundOverride?: string;
   narration?: string; // TipTap JSON string
   dmNotes?: string;
-  template?: SceneTemplate;
+  template?: SceneTemplateId;
   entities?: SceneEntity[];
   transition?: TransitionConfig;
   effects?: EffectConfig;

--- a/creator/src/types/story.ts
+++ b/creator/src/types/story.ts
@@ -40,6 +40,14 @@ export interface EffectConfig {
   parallaxDepth?: number;
 }
 
+/** Title card overlay shown above the scene (distinct from bottom narration). */
+export type TitleCardStyle = "location" | "year" | "subtitle" | "character";
+
+export interface TitleCard {
+  text: string;
+  style?: TitleCardStyle;
+}
+
 export interface Scene {
   id: string;
   title: string;
@@ -54,6 +62,22 @@ export interface Scene {
   transition?: TransitionConfig;
   effects?: EffectConfig;
   narrationSpeed?: NarrationSpeed;
+
+  // ─── Lore links ──────────────────────────────────────────────────
+  /** Featured lore article IDs for this scene (characters, items, etc). */
+  linkedArticleIds?: string[];
+  /** Article ID for the location this scene depicts. */
+  linkedLocationArticleId?: string;
+  /** Map ID this scene is positioned on. */
+  linkedMapId?: string;
+  /** Pin ID on the linked map. */
+  linkedPinId?: string;
+  /** Timeline event ID this scene depicts. */
+  linkedTimelineEventId?: string;
+
+  // ─── Visual overlays ──────────────────────────────────────────────
+  /** Title card text overlay (top-center, distinct from narration). */
+  titleCard?: TitleCard;
 }
 
 export interface Story {
@@ -65,4 +89,22 @@ export interface Story {
   createdAt: string; // ISO 8601
   updatedAt: string; // ISO 8601
   narrationSpeed?: NarrationSpeed; // Story-level default, defaults to "normal"
+
+  // ─── Story metadata ──────────────────────────────────────────────
+  /** Short logline / pitch for this story. */
+  synopsis?: string;
+  /** Free-form tags for organization. */
+  tags?: string[];
+  /** Draft stories are excluded from the showcase export. */
+  draft?: boolean;
+
+  // ─── Story-level lore links ──────────────────────────────────────
+  /** Featured lore article IDs for the story as a whole. */
+  linkedArticleIds?: string[];
+  /** Article IDs of characters featured in this story. */
+  featuredCharacterIds?: string[];
+  /** Primary map for the story (e.g. world map for context). */
+  primaryMapId?: string;
+  /** Primary calendar system to drive timeline display. */
+  primaryCalendarId?: string;
 }

--- a/showcase/src/components/player/CinematicRenderer.tsx
+++ b/showcase/src/components/player/CinematicRenderer.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { AnimatePresence, LazyMotion } from "motion/react";
 import { loadMotionFeatures } from "@/lib/motionFeatures";
 import { CinematicScene } from "./CinematicScene";
+import { SceneInfoBadges } from "./SceneInfoBadges";
 import type { ShowcaseScene } from "@/types/showcase";
 import type { NarrationSpeed } from "@/lib/narrationSpeed";
 import type { SceneEntity } from "@/types/story";
@@ -104,6 +105,9 @@ export function CinematicRenderer({
           />
         </AnimatePresence>
       </LazyMotion>
+
+      {/* Lore badges sit above the cinematic layers (z-35 inside) */}
+      <SceneInfoBadges scene={scene} />
     </div>
   );
 }

--- a/showcase/src/components/player/SceneInfoBadges.tsx
+++ b/showcase/src/components/player/SceneInfoBadges.tsx
@@ -1,0 +1,191 @@
+// ─── SceneInfoBadges ────────────────────────────────────────────────
+// Subtle, ambient overlays for a scene during showcase playback.
+// Mirrors creator/src/components/lore/SceneInfoBadges.tsx but resolves
+// data from the showcase DataContext.
+
+import { useMemo } from "react";
+import { useShowcase } from "@/lib/DataContext";
+import type { ShowcaseScene } from "@/types/showcase";
+
+interface SceneInfoBadgesProps {
+  scene: ShowcaseScene;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function useTimelineLabel(eventId: string | undefined) {
+  const { data } = useShowcase();
+  return useMemo(() => {
+    if (!eventId || !data) return null;
+    const ev = data.timelineEvents?.find((e) => e.id === eventId);
+    if (!ev) return null;
+    const cal = data.calendarSystems?.find((c) => c.id === ev.calendarId);
+    const era = cal?.eras.find((e) => e.id === ev.eraId);
+    return { year: ev.year, era: era?.name, title: ev.title };
+  }, [data, eventId]);
+}
+
+function useMapPin(mapId: string | undefined, pinId: string | undefined) {
+  const { data } = useShowcase();
+  return useMemo(() => {
+    if (!mapId || !data) return null;
+    const m = data.maps.find((x) => x.id === mapId);
+    if (!m) return null;
+    const pin = pinId ? m.pins.find((p) => p.id === pinId) : undefined;
+    return { map: m, pin };
+  }, [data, mapId, pinId]);
+}
+
+// ─── Mini-map thumbnail ────────────────────────────────────────────
+
+function MiniMap({
+  imageUrl,
+  mapWidth,
+  mapHeight,
+  pinX,
+  pinY,
+  pinColor,
+}: {
+  imageUrl: string;
+  mapWidth: number;
+  mapHeight: number;
+  pinX?: number;
+  pinY?: number;
+  pinColor?: string;
+}) {
+  if (!imageUrl) return null;
+  const xPct = pinX !== undefined && mapWidth > 0 ? (pinX / mapWidth) * 100 : null;
+  const yPct = pinY !== undefined && mapHeight > 0
+    ? ((mapHeight - pinY) / mapHeight) * 100
+    : null;
+  return (
+    <div className="relative h-20 w-28 overflow-hidden rounded border border-white/20 shadow-lg">
+      <img src={imageUrl} alt="" className="h-full w-full object-cover" draggable={false} />
+      {xPct !== null && yPct !== null && (
+        <span
+          className="absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full ring-2 ring-white/70 animate-pulse"
+          style={{
+            left: `${xPct}%`,
+            top: `${yPct}%`,
+            backgroundColor: pinColor ?? "#fbbf24",
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Article badge chip ────────────────────────────────────────────
+
+function ArticleBadgeChip({ articleId }: { articleId: string }) {
+  const { articleById } = useShowcase();
+  const article = articleById.get(articleId);
+  if (!article) return null;
+  return (
+    <div
+      className="flex items-center gap-1.5 rounded-full border border-white/20 bg-black/50 px-2 py-0.5 backdrop-blur-sm"
+      title={article.title}
+    >
+      {article.imageUrl ? (
+        <img src={article.imageUrl} alt="" className="h-4 w-4 rounded-full object-cover" />
+      ) : (
+        <span className="h-4 w-4 rounded-full bg-white/20" />
+      )}
+      <span className="max-w-[100px] truncate text-[10px] text-white/90">{article.title}</span>
+    </div>
+  );
+}
+
+// ─── Title card overlay ────────────────────────────────────────────
+
+function TitleCardOverlay({ scene }: { scene: ShowcaseScene }) {
+  const card = scene.titleCard;
+  if (!card?.text) return null;
+  const isYear = card.style === "year";
+  const isLocation = card.style === "location";
+  const isCharacter = card.style === "character";
+  return (
+    <div
+      className={[
+        "rounded backdrop-blur-sm px-4 py-1.5",
+        "font-display tracking-[0.25em] uppercase",
+        isYear ? "text-base text-amber-300 border border-amber-400/30 bg-black/50" : "",
+        isLocation ? "text-sm text-white border-b border-white/30 bg-transparent" : "",
+        isCharacter ? "text-sm text-violet-300 border border-violet-400/30 bg-black/50" : "",
+        !isYear && !isLocation && !isCharacter ? "text-xs text-white/90 bg-black/40" : "",
+      ].join(" ")}
+      style={{ textShadow: "0 1px 4px rgba(0,0,0,0.7)" }}
+    >
+      {card.text}
+    </div>
+  );
+}
+
+// ─── Main component ────────────────────────────────────────────────
+
+export function SceneInfoBadges({ scene }: SceneInfoBadgesProps) {
+  const timeline = useTimelineLabel(scene.linkedTimelineEventId);
+  const mapInfo = useMapPin(scene.linkedMapId, scene.linkedPinId);
+  const articleIds = scene.linkedArticleIds ?? [];
+
+  if (!timeline && !mapInfo && articleIds.length === 0 && !scene.titleCard?.text) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-0"
+      style={{ zIndex: 35 }}
+      aria-hidden="true"
+    >
+      {/* Top-left: year/era badge */}
+      {timeline && (
+        <div className="absolute left-3 top-3 flex flex-col items-start gap-0.5 rounded border border-amber-400/40 bg-black/55 px-2 py-1 backdrop-blur-sm">
+          <span
+            className="font-display text-base leading-none tracking-[0.18em] text-amber-300"
+            style={{ textShadow: "0 1px 3px rgba(0,0,0,0.6)" }}
+          >
+            {timeline.year}
+            {timeline.era && <span className="ml-1 text-[10px] uppercase tracking-[0.2em]">{timeline.era}</span>}
+          </span>
+          <span className="max-w-[180px] truncate text-[10px] text-white/70">{timeline.title}</span>
+        </div>
+      )}
+
+      {/* Top-right: mini-map */}
+      {mapInfo && (
+        <div className="absolute right-3 top-3">
+          <MiniMap
+            imageUrl={mapInfo.map.imageUrl}
+            mapWidth={mapInfo.map.width}
+            mapHeight={mapInfo.map.height}
+            pinX={mapInfo.pin?.position[1]}
+            pinY={mapInfo.pin?.position[0]}
+            pinColor={mapInfo.pin?.color}
+          />
+          {mapInfo.pin?.label && (
+            <div className="mt-1 max-w-[112px] truncate text-right text-[10px] text-white/80" style={{ textShadow: "0 1px 2px rgba(0,0,0,0.7)" }}>
+              {mapInfo.pin.label}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Top-center: title card */}
+      {scene.titleCard?.text && (
+        <div className="absolute left-1/2 top-6 -translate-x-1/2">
+          <TitleCardOverlay scene={scene} />
+        </div>
+      )}
+
+      {/* Bottom: article chips */}
+      {articleIds.length > 0 && (
+        <div className="absolute inset-x-0 bottom-24 flex flex-wrap items-center justify-center gap-1.5 px-4">
+          {articleIds.slice(0, 6).map((id) => (
+            <ArticleBadgeChip key={id} articleId={id} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/showcase/src/components/player/ScrollModeContainer.tsx
+++ b/showcase/src/components/player/ScrollModeContainer.tsx
@@ -6,6 +6,7 @@ import { useRef, useState, useEffect, useCallback } from "react";
 import { LazyMotion } from "motion/react";
 import { loadMotionFeatures } from "@/lib/motionFeatures";
 import { CinematicScene } from "./CinematicScene";
+import { SceneInfoBadges } from "./SceneInfoBadges";
 import type { ShowcaseStory } from "@/types/showcase";
 import type { SceneEntity, TransitionConfig } from "@/types/story";
 import type { NarrationSpeed } from "@/lib/narrationSpeed";
@@ -147,6 +148,7 @@ export function ScrollModeContainer({ story }: ScrollModeContainerProps) {
                 roomImageSrc={scene.roomImageUrl}
               />
             </LazyMotion>
+            <SceneInfoBadges scene={scene} />
           </div>
         );
       })}

--- a/showcase/src/pages/ArticlePage.tsx
+++ b/showcase/src/pages/ArticlePage.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import DOMPurify from "dompurify";
 import { useShowcase } from "@/lib/DataContext";
 import { TEMPLATE_LABELS, TEMPLATE_COLORS } from "@/lib/templates";
-import type { ShowcaseArticle } from "@/types/showcase";
+import type { ShowcaseArticle, ShowcaseStory } from "@/types/showcase";
 
 const RELATION_TYPE_LABELS: Record<string, string> = {
   ally: "Allies",
@@ -200,6 +200,55 @@ function ArticleGallery({ images, title }: { images: string[]; title: string }) 
   );
 }
 
+// ─── Featured-in-stories sidebar section ────────────────────────────
+
+function FeaturedInStories({ stories, color }: { stories: ShowcaseStory[]; color: string }) {
+  if (stories.length === 0) return null;
+  return (
+    <div className="rounded-xl overflow-hidden border-t-2" style={{ borderTopColor: `${color}30` }}>
+      <div className="px-5 py-3 bg-bg-tertiary/40">
+        <h3 className="font-display text-[11px] tracking-[0.2em] uppercase" style={{ color }}>
+          Featured In Stories
+        </h3>
+      </div>
+      <ul className="px-3 py-2 bg-bg-secondary/30 space-y-1">
+        {stories.map((s) => (
+          <li key={s.id}>
+            <Link
+              to={`/stories/${encodeURIComponent(s.id)}`}
+              className="flex items-center gap-2 rounded px-2 py-1.5 text-xs text-text-secondary hover:bg-bg-hover hover:text-text-primary transition-colors"
+            >
+              {s.coverImageUrl ? (
+                <img src={s.coverImageUrl} alt="" className="h-8 w-12 rounded object-cover" />
+              ) : (
+                <span className="h-8 w-12 rounded bg-bg-tertiary" />
+              )}
+              <span className="flex-1 truncate">{s.title}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/** Find every story that references the given article ID at story or scene level. */
+function findStoriesFeaturingArticle(
+  stories: ShowcaseStory[] | undefined,
+  articleId: string,
+): ShowcaseStory[] {
+  if (!stories) return [];
+  return stories.filter((s) => {
+    if (s.linkedArticleIds?.includes(articleId)) return true;
+    if (s.featuredCharacterIds?.includes(articleId)) return true;
+    return s.scenes.some(
+      (sc) =>
+        sc.linkedArticleIds?.includes(articleId) ||
+        sc.linkedLocationArticleId === articleId,
+    );
+  });
+}
+
 export function ArticlePage() {
   const { id } = useParams<{ id: string }>();
   const { data, articleById } = useShowcase();
@@ -262,6 +311,12 @@ export function ArticlePage() {
           }))
       );
   }, [data, article.id, articleById]);
+
+  // Stories that feature this article (story-level or scene-level linked)
+  const featuredInStories = useMemo(
+    () => findStoriesFeaturingArticle(data?.stories, article.id),
+    [data?.stories, article.id],
+  );
 
   // Merge forward and reverse, deduplicating by targetId+type
   const allRelations = useMemo(() => {
@@ -414,6 +469,8 @@ export function ArticlePage() {
           )}
 
           <ConnectionsSection relations={allRelations} color={color} />
+
+          <FeaturedInStories stories={featuredInStories} color={color} />
         </aside>
       </div>
     </div>

--- a/showcase/src/types/showcase.ts
+++ b/showcase/src/types/showcase.ts
@@ -94,6 +94,8 @@ export interface ShowcaseBranding {
   footerText?: string;
 }
 
+export type TitleCardStyle = "location" | "year" | "subtitle" | "character";
+
 export interface ShowcaseScene {
   id: string;
   title: string;
@@ -114,6 +116,15 @@ export interface ShowcaseScene {
     entrancePath?: string;
     exitPath?: string;
   }>;
+  // ─── Lore links ──────────────────────────────────────────────────
+  linkedArticleIds?: string[];
+  linkedLocationArticleId?: string;
+  linkedMapId?: string;
+  linkedPinId?: string;
+  linkedTimelineEventId?: string;
+  // ─── Visual overlays ─────────────────────────────────────────────
+  titleCard?: { text: string; style?: TitleCardStyle };
+  effects?: { particles?: string; parallaxLayers?: number; parallaxDepth?: number };
 }
 
 export interface ShowcaseStory {
@@ -127,6 +138,14 @@ export interface ShowcaseStory {
   narrationSpeed?: "slow" | "normal" | "fast";
   createdAt: string;
   updatedAt: string;
+  // ─── Story metadata ──────────────────────────────────────────────
+  synopsis?: string;
+  tags?: string[];
+  // ─── Story-level lore links ──────────────────────────────────────
+  linkedArticleIds?: string[];
+  featuredCharacterIds?: string[];
+  primaryMapId?: string;
+  primaryCalendarId?: string;
 }
 
 export interface ShowcaseData {


### PR DESCRIPTION
## Summary

Power-user pass on the story editor. Adds first-class linking to lore articles, maps, and timeline events, plus story-level metadata, custom scene templates, ambient playback overlays, AI assists, and full showcase parity.

### Story-level
- Synopsis textarea, tag list, draft toggle (drafts excluded from showcase)
- Featured-characters picker (filtered to character articles), featured-lore picker (any article)
- Primary map and primary calendar pickers
- AI tools toolbar: **Outline** (synopsis → 4–7 scene stubs), **Next scene** (continues the arc), **Synopsise** (reverse: scenes → synopsis)

### Scene-level
- **Linked Lore** section: location article, featured articles, map+pin, timeline event
- **Title Card** editor (text + style: location / year / subtitle / character)
- **Effects** editor (particles preset, parallax layers, parallax depth — exposes the previously-hidden `Scene.effects` field)

### Custom scene templates
- New `WorldLore.customSceneTemplates` collection persisted in `lore.yaml`
- New **Lore → Scene Templates** panel for managing them
- `TemplatePicker`, `SceneContextMenu`, and `applyTemplate` resolve built-in + custom uniformly

### Playback / preview
- New `SceneInfoBadges` component renders subtle ambient overlays:
  - Top-left: year + era badge resolved from linked timeline event
  - Top-right: mini-map thumbnail with pulsing pin
  - Top-center: title card text overlay (style-aware)
  - Bottom: featured-article chips
- Always-on at 65% opacity in `ScenePreview` while editing
- Toggleable in `PresentationMode` via the **I** key

### Showcase parity
- New fields flow through `exportShowcase.ts` → `showcase.json`
- Drafts excluded from export
- Showcase `CinematicRenderer` and `ScrollModeContainer` render the badges
- Article pages get a new **Featured In Stories** sidebar section linking back to stories that reference the article (story-level or any scene)

### Files
32 files changed, ~2,460 insertions, ~180 deletions. New components: `LoreLinkPicker`, `StorySettingsSection`, `SceneLinksSection`, `TitleCardEditor`, `EffectsEditor`, `SceneInfoBadges`, `SceneTemplateEditorPanel`, `StoryAIToolbar` (creator) and `SceneInfoBadges` (showcase). New lib: `storyPrompts.ts`.

## Test plan

- [ ] Open a story → Story Settings → fill synopsis/tags/draft, link characters and lore articles, pick primary map + calendar
- [ ] Open a scene → Linked Lore → set location article, featured articles, map+pin, timeline event
- [ ] Add a Title Card (try each style) and verify it appears in the preview top-center
- [ ] Add Effects (particles/parallax) and verify they round-trip through save/load
- [ ] Lore → Scene Templates → create a custom template, then apply it from the story editor's TemplatePicker
- [ ] Story AI Toolbar:
  - [ ] Add a synopsis, click **Outline**, confirm scene stubs replace correctly
  - [ ] Click **Next scene**, confirm a new scene appends
  - [ ] Click **Synopsise**, confirm story.synopsis populates
- [ ] Press **F5** to enter presentation, press **I** to toggle the badges, verify year/mini-map/chips/title card render
- [ ] Mark a story as draft, publish lore, confirm it does NOT appear in the showcase
- [ ] Publish a non-draft story and view it in the showcase player; badges should render in both click and scroll modes
- [ ] Visit an article page in the showcase that's referenced by a story; verify "Featured In Stories" sidebar appears
- [ ] `bun run test` (creator) — 1325 tests should pass
- [ ] `bunx tsc --noEmit` (creator) and `npm run typecheck` (showcase) — both clean