### PR TITLE
feat(zones): rename + discoverable create, fix sketch dialog overflow

### DIFF
--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -36,6 +36,7 @@ pub fn run() {
             project::clone_mud_project,
             project::clear_world_zones,
             project::delete_zone_file,
+            project::rename_zone,
             project::read_text_file,
             settings::get_settings,
             settings::save_settings,

--- a/creator/src-tauri/src/project.rs
+++ b/creator/src-tauri/src/project.rs
@@ -535,6 +535,78 @@ pub async fn clear_world_zones(mud_dir: String) -> Result<u32, String> {
     Ok(count)
 }
 
+/// Rename a zone on disk.
+///
+/// For standalone projects, renames `zones/{old_id}/` to `zones/{new_id}/` and
+/// returns the path to the renamed `zone.yaml` inside it.
+///
+/// For legacy projects, renames `{old_id}.yaml` to `{new_id}.yaml` inside the
+/// world directory (derived from `old_file_path`'s parent) and returns the new
+/// file path.
+///
+/// Refuses to rename if a zone with `new_id` already exists at the destination.
+#[tauri::command]
+pub async fn rename_zone(
+    project_dir: String,
+    project_format: String,
+    old_id: String,
+    new_id: String,
+    old_file_path: String,
+) -> Result<String, String> {
+    if new_id.trim().is_empty() {
+        return Err("New zone id must not be empty".to_string());
+    }
+    if old_id == new_id {
+        return Err("New zone id must differ from the old id".to_string());
+    }
+
+    if project_format == "standalone" {
+        let zones_root = PathBuf::from(&project_dir).join("zones");
+        let old_dir = zones_root.join(&old_id);
+        let new_dir = zones_root.join(&new_id);
+
+        if !old_dir.exists() {
+            return Err(format!("Zone directory not found: {old_id}"));
+        }
+        if new_dir.exists() {
+            return Err(format!("Zone directory already exists: {new_id}"));
+        }
+
+        tokio::fs::rename(&old_dir, &new_dir)
+            .await
+            .map_err(|e| format!("Failed to rename zone directory: {e}"))?;
+
+        Ok(new_dir
+            .join("zone.yaml")
+            .to_string_lossy()
+            .to_string())
+    } else {
+        // Legacy format: rename `{old_id}.yaml` → `{new_id}.yaml` in the same
+        // directory as `old_file_path`.
+        let old_path = PathBuf::from(&old_file_path);
+        let parent = old_path
+            .parent()
+            .ok_or_else(|| "Old zone file has no parent directory".to_string())?;
+        let new_path = parent.join(format!("{new_id}.yaml"));
+
+        if !old_path.exists() {
+            return Err(format!("Zone file not found: {old_file_path}"));
+        }
+        if new_path.exists() {
+            return Err(format!(
+                "Zone file already exists: {}",
+                new_path.to_string_lossy()
+            ));
+        }
+
+        tokio::fs::rename(&old_path, &new_path)
+            .await
+            .map_err(|e| format!("Failed to rename zone file: {e}"))?;
+
+        Ok(new_path.to_string_lossy().to_string())
+    }
+}
+
 /// Delete a single zone file.
 #[tauri::command]
 pub async fn delete_zone_file(file_path: String) -> Result<(), String> {

--- a/creator/src/components/RenameZoneDialog.tsx
+++ b/creator/src/components/RenameZoneDialog.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useProjectStore } from "@/stores/projectStore";
+import { useZoneStore } from "@/stores/zoneStore";
+import { useFocusTrap } from "@/lib/useFocusTrap";
+import { saveZone } from "@/lib/saveZone";
+
+interface RenameZoneDialogProps {
+  zoneId: string;
+  onClose: () => void;
+}
+
+export function RenameZoneDialog({ zoneId, onClose }: RenameZoneDialogProps) {
+  const project = useProjectStore((s) => s.project);
+  const openTab = useProjectStore((s) => s.openTab);
+  const closeTab = useProjectStore((s) => s.closeTab);
+  const zones = useZoneStore((s) => s.zones);
+  const renameZoneInStore = useZoneStore((s) => s.renameZone);
+
+  const existing = zones.get(zoneId);
+
+  const [newId, setNewId] = useState(zoneId);
+  const [error, setError] = useState<string | null>(null);
+  const [renaming, setRenaming] = useState(false);
+  const trapRef = useFocusTrap<HTMLDivElement>(onClose);
+
+  const trimmedId = newId.trim().toLowerCase().replace(/\s+/g, "_");
+  const idValid = /^[a-z][a-z0-9_]*$/.test(trimmedId);
+  const idUnchanged = trimmedId === zoneId;
+  const idTaken = !idUnchanged && zones.has(trimmedId);
+
+  const handleRename = async () => {
+    if (!project || !existing || !idValid || idTaken || idUnchanged) return;
+
+    setRenaming(true);
+    setError(null);
+
+    try {
+      // 1. Rename on disk. Backend returns the new absolute file path.
+      const newFilePath = await invoke<string>("rename_zone", {
+        projectDir: project.mudDir,
+        projectFormat: project.format,
+        oldId: zoneId,
+        newId: trimmedId,
+        oldFilePath: existing.filePath,
+      });
+
+      // 2. Re-key the in-memory zone. This also updates `data.zone` and marks
+      // the zone dirty so the next save rewrites the file with the new id.
+      renameZoneInStore(zoneId, trimmedId, newFilePath);
+
+      // 3. Immediately persist so the file on disk matches the store and the
+      // dirty flag clears. Without this, users would have to Ctrl+S to get
+      // the internal `zone:` field rewritten.
+      try {
+        await saveZone(trimmedId);
+      } catch (saveErr) {
+        console.error("Failed to save renamed zone:", saveErr);
+      }
+
+      // 4. Re-point the open tab (if any) to the new id.
+      closeTab(`zone:${zoneId}`);
+      openTab({ id: `zone:${trimmedId}`, kind: "zone", label: trimmedId });
+
+      onClose();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setRenaming(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div ref={trapRef} role="dialog" aria-modal="true" aria-labelledby="rename-zone-dialog-title" className="mx-4 w-96 rounded-lg border border-border-default bg-bg-secondary shadow-xl">
+        <div className="border-b border-border-default px-5 py-3">
+          <h2 id="rename-zone-dialog-title" className="font-display text-sm tracking-wide text-text-primary">
+            Rename Zone
+          </h2>
+        </div>
+
+        <div className="flex flex-col gap-3 px-5 py-4">
+          <div>
+            <label className="mb-1 block text-2xs uppercase tracking-wider text-text-muted">
+              Current ID
+            </label>
+            <div className="h-8 w-full rounded border border-border-default bg-bg-primary px-2 font-mono text-xs leading-8 text-text-muted">
+              {zoneId}
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1 block text-2xs uppercase tracking-wider text-text-muted">
+              New ID
+            </label>
+            <input
+              type="text"
+              value={newId}
+              onChange={(e) => setNewId(e.target.value)}
+              placeholder="e.g. dark_forest"
+              autoFocus
+              aria-describedby={
+                (newId && !idValid) ? "rename-zone-format-error" :
+                idTaken ? "rename-zone-taken-error" :
+                undefined
+              }
+              className="h-8 w-full rounded border border-border-default bg-bg-primary px-2 font-mono text-xs text-text-primary outline-none placeholder:text-text-muted focus:border-accent focus-visible:ring-2 focus-visible:ring-border-active"
+            />
+            {newId && !idValid && (
+              <p id="rename-zone-format-error" className="mt-1 text-2xs text-status-error">
+                Must start with a letter, only lowercase letters, numbers, and underscores.
+              </p>
+            )}
+            {idTaken && (
+              <p id="rename-zone-taken-error" className="mt-1 text-2xs text-status-error">
+                Zone "{trimmedId}" already exists.
+              </p>
+            )}
+          </div>
+
+          <p className="rounded border border-status-warning/30 bg-status-warning/5 px-3 py-2 text-2xs leading-relaxed text-status-warning">
+            Cross-zone references (portal exits, quest links, etc.) that point
+            at <span className="font-mono">{zoneId}</span> will <strong>not</strong> be
+            updated automatically. Review and fix them after renaming.
+          </p>
+
+          {error && (
+            <p className="text-xs text-status-error">{error}</p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-border-default px-5 py-3">
+          <button
+            onClick={onClose}
+            className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleRename}
+            disabled={!idValid || idTaken || idUnchanged || renaming || !project || !existing}
+            className="rounded bg-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {renaming ? "Renaming..." : "Rename Zone"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import { loadCollapsedSections, saveCollapsedSections } from "@/lib/uiPersistenc
 import { ArticleTree } from "./lore/ArticleTree";
 import { BulkActionsBar } from "./lore/BulkActionsBar";
 import { NewZoneDialog } from "./NewZoneDialog";
+import { RenameZoneDialog } from "./RenameZoneDialog";
 import { ConfirmDialog } from "./ConfirmDialog";
 import {
   addRoom,
@@ -85,11 +86,13 @@ function ZoneTree({
   zoneState,
   isActive,
   onDelete,
+  onRename,
 }: {
   zoneId: string;
   zoneState: ZoneState;
   isActive: boolean;
   onDelete: (zoneId: string) => void;
+  onRename: (zoneId: string) => void;
 }) {
   const openTab = useProjectStore((s) => s.openTab);
   const navigateTo = useProjectStore((s) => s.navigateTo);
@@ -154,6 +157,14 @@ function ZoneTree({
           <span className="truncate font-medium" title={zoneState.data.zone || zoneId}>{zoneState.data.zone || zoneId}</span>
           <span className="ml-2 truncate text-2xs text-text-muted" title={zoneId}>{zoneId}</span>
           {zoneState.dirty && <span className="ml-2 shrink-0 text-2xs text-text-dirty">Unsaved</span>}
+        </button>
+        <button
+          onClick={() => onRename(zoneId)}
+          className="shrink-0 rounded-full border border-white/8 px-2.5 py-1.5 text-2xs text-text-muted opacity-0 transition hover:border-accent/40 hover:text-accent focus:opacity-100 group-hover/zone:opacity-100 group-focus-within/zone:opacity-100"
+          title="Rename zone"
+          aria-label="Rename zone"
+        >
+          Rename
         </button>
         <button
           onClick={() => onDelete(zoneId)}
@@ -414,6 +425,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
     useGlobalSearch();
   const searchRef = useRef<HTMLInputElement>(null);
   const [showNewZone, setShowNewZone] = useState(false);
+  const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const hasProject = !!useProjectStore((s) => s.project);
 
@@ -575,9 +587,24 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
               ) : null}
             </div>
             {sortedZones.length === 0 ? (
-              <p className="rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-6 text-sm text-text-muted">
-                Open a world to begin shaping it.
-              </p>
+              <div className="rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-5 text-sm text-text-muted">
+                {hasProject ? (
+                  <>
+                    <p className="mb-3 leading-relaxed">
+                      This world has no zones yet. Create your first zone to
+                      begin shaping it.
+                    </p>
+                    <button
+                      onClick={() => setShowNewZone(true)}
+                      className="focus-ring rounded-full bg-accent px-4 py-1.5 text-2xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110"
+                    >
+                      Create your first zone
+                    </button>
+                  </>
+                ) : (
+                  <p className="leading-relaxed">Open a world to begin shaping it.</p>
+                )}
+              </div>
             ) : (
               <ul className="flex flex-col gap-0.5">
                 {sortedZones.map(([zoneId, zoneState]) => (
@@ -587,6 +614,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
                     zoneState={zoneState}
                     isActive={activeTabId === `zone:${zoneId}`}
                     onDelete={(id) => setDeleteTarget(id)}
+                    onRename={(id) => setRenameTarget(id)}
                   />
                 ))}
               </ul>
@@ -612,6 +640,12 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
       </div>
 
       {showNewZone && <NewZoneDialog onClose={() => setShowNewZone(false)} />}
+      {renameTarget && (
+        <RenameZoneDialog
+          zoneId={renameTarget}
+          onClose={() => setRenameTarget(null)}
+        />
+      )}
       {deleteTarget && (
         <ConfirmDialog
           title="Delete Zone"

--- a/creator/src/components/SketchImportWizard.tsx
+++ b/creator/src/components/SketchImportWizard.tsx
@@ -284,10 +284,10 @@ export function SketchImportWizard({ onClose }: SketchImportWizardProps) {
         role="dialog"
         aria-modal="true"
         aria-labelledby="sketch-wizard-title"
-        className="mx-4 flex w-full max-w-2xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl"
+        className="mx-4 flex max-h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-lg border border-border-default bg-bg-secondary shadow-xl"
       >
         {/* Header */}
-        <div className="border-b border-border-default px-5 py-3">
+        <div className="shrink-0 border-b border-border-default px-5 py-3">
           <h2
             id="sketch-wizard-title"
             className="font-display text-sm tracking-wide text-accent-emphasis"
@@ -606,7 +606,7 @@ export function SketchImportWizard({ onClose }: SketchImportWizardProps) {
         )}
 
         {/* Footer */}
-        <div className="flex justify-end gap-2 border-t border-border-default px-5 py-3">
+        <div className="flex shrink-0 justify-end gap-2 border-t border-border-default px-5 py-3">
           {step === "input" && (
             <button
               onClick={onClose}

--- a/creator/src/stores/zoneStore.ts
+++ b/creator/src/stores/zoneStore.ts
@@ -17,6 +17,12 @@ interface ZoneStore {
   loadZone: (zoneId: string, filePath: string, data: WorldFile) => void;
   updateZone: (zoneId: string, data: WorldFile) => void;
   markClean: (zoneId: string) => void;
+  /**
+   * Re-key a loaded zone from `oldId` to `newId`, updating its file path and
+   * the `zone` field inside its data. Preserves undo/redo history. No-op if
+   * the old zone is missing or the new id already exists.
+   */
+  renameZone: (oldId: string, newId: string, newFilePath: string) => void;
   removeZone: (zoneId: string) => void;
   clearZones: () => void;
   undo: (zoneId: string) => void;
@@ -68,6 +74,31 @@ export const useZoneStore = create<ZoneStore>((set, get) => ({
       const existing = zones.get(zoneId);
       if (existing) {
         zones.set(zoneId, { ...existing, dirty: false });
+      }
+      return { zones };
+    }),
+
+  renameZone: (oldId, newId, newFilePath) =>
+    set((state) => {
+      if (oldId === newId) return state;
+      const existing = state.zones.get(oldId);
+      if (!existing) return state;
+      if (state.zones.has(newId)) return state;
+
+      // Rebuild the Map preserving insertion order so sidebar ordering is
+      // stable (alphabetical sort happens at render time anyway).
+      const zones = new Map<string, ZoneState>();
+      for (const [id, zone] of state.zones) {
+        if (id === oldId) {
+          zones.set(newId, {
+            ...existing,
+            filePath: newFilePath,
+            data: { ...existing.data, zone: newId },
+            dirty: true,
+          });
+        } else {
+          zones.set(id, zone);
+        }
       }
       return { zones };
     }),


### PR DESCRIPTION
## Summary

- **Add zone rename.** New `rename_zone` Tauri command handles both standalone (`zones/{id}/` directory) and legacy (`{id}.yaml`) layouts. `zoneStore.renameZone` re-keys the in-memory Map and updates the internal `data.zone` field; `RenameZoneDialog` drives the flow, saves the YAML so the `zone:` field is persisted, and re-points the open tab. A warning in the dialog notes that cross-zone references are not auto-rewritten. Rename action is wired next to Remove in `ZoneTree`.
- **Make zone creation discoverable.** The empty-state placeholder in the Cartography sidebar section used to say \"Open a world to begin shaping it.\" even when a project was open with zero zones, hiding the tiny \"New zone\" pill up next to the Surfaces heading. Now when a project is loaded but has no zones, the empty state shows a prominent \"Create your first zone\" CTA that opens the existing `NewZoneDialog`.
- **Fix sketch-import dialog overflow.** The confirm/preview dialog container had no max-height, so as parsed rooms/connections accumulated the dialog grew past the viewport and pushed the footer (Import button) off-screen with no scrollbar. Added `max-h-[90vh] overflow-hidden` to the container and `shrink-0` to the header and footer, so the preview body's existing `min-h-0 flex-1 overflow-y-auto` finally has a bound to scroll within.

## Test plan

- [ ] Open an empty standalone project → Cartography section shows \"Create your first zone\" CTA
- [ ] Click CTA → `NewZoneDialog` opens and creates a zone
- [ ] Hover a zone row → Rename + Remove actions appear
- [ ] Rename a zone (standalone) → directory on disk is renamed, YAML `zone:` field updated, tab re-pointed, no dirty flag left
- [ ] Rename a zone (legacy) → `{id}.yaml` file is renamed
- [ ] Attempt to rename to an existing id → error shown, no filesystem change
- [ ] Open sketch import with many rooms → preview dialog scrolls, Import button stays visible, no layout breakage