### PR TITLE
feat(zones): variable-size room layout

### DIFF
--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -20,7 +20,7 @@ import { useProjectStore } from "@/stores/projectStore";
 import { useAssetStore } from "@/stores/assetStore";
 import { useToastStore } from "@/stores/toastStore";
 import { zoneToGraph, GRAPH } from "@/lib/zoneToGraph";
-import { compassLayout } from "@/lib/dagreLayout";
+import { compassLayout, type LayoutMeasurement } from "@/lib/dagreLayout";
 import { addRoom, addExit, deleteExit, generateRoomId } from "@/lib/zoneEdits";
 import { saveZone } from "@/lib/saveZone";
 import type { WorldFile } from "@/types/world";
@@ -219,12 +219,21 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
   }, [layoutEdges, layoutNodes, setEdges, setNodes, zoneState, reactFlow]);
 
   // ─── Re-layout ───────────────────────────────────────────────────
-  // Discard manual positions and re-run the BFS/compass layout, then
-  // fit the viewport to the result.
+  // Discard manual positions and re-run the BFS/compass layout using the
+  // currently measured room sizes (so variable-height rooms don't overlap),
+  // then fit the viewport to the result.
   const handleRelayout = useCallback(() => {
     if (!zoneState) return;
+    const measurements = new Map<string, LayoutMeasurement>();
+    for (const node of reactFlow.getNodes()) {
+      const width = node.measured?.width ?? node.width;
+      const height = node.measured?.height ?? node.height;
+      if (width && height) {
+        measurements.set(node.id, { width, height });
+      }
+    }
     const { nodes: rawNodes } = zoneToGraph(zoneState.data);
-    const fresh = compassLayout(rawNodes, zoneState.data);
+    const fresh = compassLayout(rawNodes, zoneState.data, measurements);
     setNodes(fresh);
     setTimeout(() => {
       reactFlow.fitView({ padding: 0.2, duration: 400 });

--- a/creator/src/lib/__tests__/dagreLayout.test.ts
+++ b/creator/src/lib/__tests__/dagreLayout.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { compassLayout, type LayoutMeasurement } from "../dagreLayout";
+import { zoneToGraph } from "../zoneToGraph";
+import type { WorldFile } from "@/types/world";
+
+function makeWorld(rooms: WorldFile["rooms"], overrides?: Partial<WorldFile>): WorldFile {
+  return {
+    zone: "test_zone",
+    startRoom: Object.keys(rooms)[0] ?? "room1",
+    rooms,
+    ...overrides,
+  };
+}
+
+describe("compassLayout", () => {
+  it("places the start room at the origin", () => {
+    const world = makeWorld({
+      start: { title: "Start", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+    const start = laid.find((n) => n.id === "start")!;
+    // With a single room, origin-aligned, centering and prefix sums cancel out.
+    expect(start.position.x).toBe(0);
+    expect(start.position.y).toBe(0);
+  });
+
+  it("places a north neighbor above the start room", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { n: "b" } },
+      b: { title: "B", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+    const a = laid.find((n) => n.id === "a")!;
+    const b = laid.find((n) => n.id === "b")!;
+    expect(b.position.y).toBeLessThan(a.position.y);
+    expect(b.position.x).toBe(a.position.x);
+  });
+
+  it("places an east neighbor to the right of the start room", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { e: "b" } },
+      b: { title: "B", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+    const a = laid.find((n) => n.id === "a")!;
+    const b = laid.find((n) => n.id === "b")!;
+    expect(b.position.x).toBeGreaterThan(a.position.x);
+    expect(b.position.y).toBe(a.position.y);
+  });
+
+  it("expands a column to fit the widest room and centers narrower ones", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { n: "b" } },
+      b: { title: "B", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const measurements = new Map<string, LayoutMeasurement>([
+      // "a" is wider than "b"; both sit in the same column (gx=0).
+      ["a", { width: 400, height: 140 }],
+      ["b", { width: 200, height: 140 }],
+    ]);
+    const laid = compassLayout(nodes, world, measurements);
+    const a = laid.find((n) => n.id === "a")!;
+    const b = laid.find((n) => n.id === "b")!;
+
+    // Column width = max(400, 200) = 400. "a" spans it; "b" is centered inside.
+    // a.x should be 0 (widest, centered in 400-wide column at origin).
+    // b.x should be (400 - 200) / 2 = 100.
+    expect(a.position.x).toBe(0);
+    expect(b.position.x).toBe(100);
+  });
+
+  it("expands a row to fit the tallest room and centers shorter ones", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { e: "b" } },
+      b: { title: "B", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const measurements = new Map<string, LayoutMeasurement>([
+      ["a", { width: 220, height: 300 }],
+      ["b", { width: 220, height: 100 }],
+    ]);
+    const laid = compassLayout(nodes, world, measurements);
+    const a = laid.find((n) => n.id === "a")!;
+    const b = laid.find((n) => n.id === "b")!;
+
+    // Row height = max(300, 100) = 300. "a" is centered (y=0); "b" centered at (300-100)/2 = 100.
+    expect(a.position.y).toBe(0);
+    expect(b.position.y).toBe(100);
+  });
+
+  it("spaces east-chain rooms by the column's max width plus gutter", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { e: "b" } },
+      b: { title: "B", description: "", exits: { e: "c" } },
+      c: { title: "C", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const measurements = new Map<string, LayoutMeasurement>([
+      ["a", { width: 220, height: 140 }],
+      ["b", { width: 220, height: 140 }],
+      ["c", { width: 220, height: 140 }],
+    ]);
+    const laid = compassLayout(nodes, world, measurements);
+    const a = laid.find((n) => n.id === "a")!;
+    const b = laid.find((n) => n.id === "b")!;
+    const c = laid.find((n) => n.id === "c")!;
+
+    // Each column is 220 wide + 80 gutter = 300 stride.
+    expect(b.position.x - a.position.x).toBe(300);
+    expect(c.position.x - b.position.x).toBe(300);
+  });
+
+  it("falls back to default dimensions when measurements are missing", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { e: "b" } },
+      b: { title: "B", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+    const a = laid.find((n) => n.id === "a")!;
+    const b = laid.find((n) => n.id === "b")!;
+    // Default column width 220 + 80 gutter = 300.
+    expect(b.position.x - a.position.x).toBe(300);
+  });
+});

--- a/creator/src/lib/__tests__/dagreLayout.test.ts
+++ b/creator/src/lib/__tests__/dagreLayout.test.ts
@@ -126,4 +126,88 @@ describe("compassLayout", () => {
     // Default column width 220 + 80 gutter = 300.
     expect(b.position.x - a.position.x).toBe(300);
   });
+
+  // ─── Step 2: collision resolution + component packing ─────────
+
+  it("never places two rooms on top of each other, even with a cycle", () => {
+    // A cycle that cannot embed perfectly in 2D: the s-exit from C
+    // points at the cell already occupied by B's north neighbor.
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { n: "b", e: "c" } },
+      b: { title: "B", description: "", exits: { e: "d" } },
+      c: { title: "C", description: "", exits: { n: "d" } },
+      d: { title: "D", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+
+    // Every room must have a unique pixel position — no overlaps.
+    const seen = new Set<string>();
+    for (const n of laid) {
+      const key = `${n.position.x},${n.position.y}`;
+      expect(seen.has(key)).toBe(false);
+      seen.add(key);
+    }
+  });
+
+  it("pushes the colliding subtree instead of scattering it", () => {
+    // A has two east branches that both want the same cells.
+    // Without a push, the second branch would spiral into a random spot.
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { n: "b", ne: "c" } },
+      b: { title: "B", description: "", exits: { e: "c_collider" } },
+      c: { title: "C", description: "" },
+      c_collider: { title: "Collider", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+
+    // All four rooms should still land on the grid with no overlaps.
+    const positions = new Set(laid.map((n) => `${n.position.x},${n.position.y}`));
+    expect(positions.size).toBe(laid.length);
+  });
+
+  it("packs disconnected components horizontally, not stacked vertically", () => {
+    const world = makeWorld({
+      a1: { title: "A1", description: "", exits: { e: "a2" } },
+      a2: { title: "A2", description: "" },
+      b1: { title: "B1", description: "", exits: { e: "b2" } },
+      b2: { title: "B2", description: "" },
+    }, { startRoom: "a1" });
+
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+
+    const byId = new Map(laid.map((n) => [n.id, n]));
+    const a1 = byId.get("a1")!;
+    const a2 = byId.get("a2")!;
+    const b1 = byId.get("b1")!;
+    const b2 = byId.get("b2")!;
+
+    // Component A is a horizontal pair; component B is a horizontal pair.
+    // Both components should sit on the same y row (y=0), packed left-to-right.
+    expect(a1.position.y).toBe(0);
+    expect(a2.position.y).toBe(0);
+    expect(b1.position.y).toBe(0);
+    expect(b2.position.y).toBe(0);
+
+    // Component B must start to the right of component A's rightmost cell.
+    expect(b1.position.x).toBeGreaterThan(a2.position.x);
+  });
+
+  it("places the start-room component first (leftmost)", () => {
+    const world = makeWorld({
+      orphan: { title: "Orphan", description: "" },
+      start: { title: "Start", description: "", exits: { e: "next" } },
+      next: { title: "Next", description: "" },
+    }, { startRoom: "start" });
+
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+
+    const start = laid.find((n) => n.id === "start")!;
+    const orphan = laid.find((n) => n.id === "orphan")!;
+    // The start component anchors the left edge; the orphan is packed to its right.
+    expect(orphan.position.x).toBeGreaterThan(start.position.x);
+  });
 });

--- a/creator/src/lib/dagreLayout.ts
+++ b/creator/src/lib/dagreLayout.ts
@@ -2,8 +2,13 @@ import type { Node } from "@xyflow/react";
 import type { WorldFile } from "@/types/world";
 import { exitTarget } from "@/lib/zoneEdits";
 
-const CELL_W = 300;
-const CELL_H = 140;
+/** Default room dimensions when no measurement is available (matches RoomNode). */
+const DEFAULT_NODE_WIDTH = 220;
+const DEFAULT_NODE_HEIGHT = 140;
+
+/** Gutter added between columns and rows in pixels. */
+const COL_GUTTER = 80;
+const ROW_GUTTER = 60;
 
 /** Compass direction → grid offset (x, y). Y-axis is inverted: negative = up. */
 const DIR_OFFSET: Record<string, [number, number]> = {
@@ -19,13 +24,34 @@ const DIR_OFFSET: Record<string, [number, number]> = {
   d: [1, 1],
 };
 
+export interface LayoutMeasurement {
+  width: number;
+  height: number;
+}
+
 /**
  * Layout rooms on a grid using compass directions from exits.
- * BFS from startRoom, placing each neighbor at the grid offset
- * implied by the exit direction. Collisions are resolved by
- * shifting to the nearest empty cell.
+ *
+ * BFS from startRoom, placing each neighbor at the grid offset implied by
+ * the exit direction. Collisions are resolved by spiraling to the nearest
+ * empty cell.
+ *
+ * Unlike a fixed-cell grid, the conversion from grid coordinates to pixel
+ * coordinates uses the **max width of each column** and **max height of
+ * each row**, prefix-summed. This means rooms with different sizes get
+ * appropriate spacing without overlap, and uniformly-sized rooms pack
+ * tightly. Nodes are centered within their row/column cell.
+ *
+ * @param nodes          The raw nodes from `zoneToGraph`.
+ * @param world          The zone WorldFile (for `rooms`, `startRoom`, exits).
+ * @param measurements   Optional map of nodeId → measured size. Missing or
+ *                       zero-sized entries fall back to sensible defaults.
  */
-export function compassLayout(nodes: Node[], world: WorldFile): Node[] {
+export function compassLayout(
+  nodes: Node[],
+  world: WorldFile,
+  measurements?: Map<string, LayoutMeasurement>,
+): Node[] {
   const allNodeIds = new Set(nodes.map((n) => n.id));
   const grid = new Map<string, string>(); // "gx,gy" → nodeId
   const pos = new Map<string, [number, number]>(); // nodeId → [gx, gy]
@@ -89,14 +115,63 @@ export function compassLayout(nodes: Node[], world: WorldFile): Node[] {
     }
   }
 
-  // Convert grid coordinates to pixel positions
+  if (pos.size === 0) return nodes;
+
+  // ─── Grid → pixel conversion (max-extent per row/column) ──────────
+  const getDim = (id: string): LayoutMeasurement => {
+    const m = measurements?.get(id);
+    if (m && m.width > 0 && m.height > 0) return m;
+    return { width: DEFAULT_NODE_WIDTH, height: DEFAULT_NODE_HEIGHT };
+  };
+
+  let minGx = Infinity;
+  let maxGx = -Infinity;
+  let minGy = Infinity;
+  let maxGy = -Infinity;
+  for (const [, [gx, gy]] of pos) {
+    if (gx < minGx) minGx = gx;
+    if (gx > maxGx) maxGx = gx;
+    if (gy < minGy) minGy = gy;
+    if (gy > maxGy) maxGy = gy;
+  }
+
+  const colCount = maxGx - minGx + 1;
+  const rowCount = maxGy - minGy + 1;
+  const colWidth: number[] = new Array(colCount).fill(DEFAULT_NODE_WIDTH);
+  const rowHeight: number[] = new Array(rowCount).fill(DEFAULT_NODE_HEIGHT);
+
+  for (const [id, [gx, gy]] of pos) {
+    const dim = getDim(id);
+    const ci = gx - minGx;
+    const ri = gy - minGy;
+    if (dim.width > colWidth[ci]!) colWidth[ci] = dim.width;
+    if (dim.height > rowHeight[ri]!) rowHeight[ri] = dim.height;
+  }
+
+  // Prefix-sum start positions (top-left of each cell).
+  const colStart: number[] = new Array(colCount);
+  const rowStart: number[] = new Array(rowCount);
+  let acc = 0;
+  for (let i = 0; i < colCount; i++) {
+    colStart[i] = acc;
+    acc += colWidth[i]! + COL_GUTTER;
+  }
+  acc = 0;
+  for (let i = 0; i < rowCount; i++) {
+    rowStart[i] = acc;
+    acc += rowHeight[i]! + ROW_GUTTER;
+  }
+
   return nodes.map((node) => {
     const p = pos.get(node.id);
     if (!p) return node;
-    return {
-      ...node,
-      position: { x: p[0] * CELL_W, y: p[1] * CELL_H },
-    };
+    const ci = p[0] - minGx;
+    const ri = p[1] - minGy;
+    const dim = getDim(node.id);
+    // Center node within its (possibly larger) cell.
+    const x = colStart[ci]! + (colWidth[ci]! - dim.width) / 2;
+    const y = rowStart[ri]! + (rowHeight[ri]! - dim.height) / 2;
+    return { ...node, position: { x, y } };
   });
 }
 

--- a/creator/src/lib/dagreLayout.ts
+++ b/creator/src/lib/dagreLayout.ts
@@ -10,6 +10,12 @@ const DEFAULT_NODE_HEIGHT = 140;
 const COL_GUTTER = 80;
 const ROW_GUTTER = 60;
 
+/** Grid columns of empty space between disconnected components. */
+const COMPONENT_GRID_GAP = 2;
+
+/** Safety cap on cascade-push recursion depth. */
+const MAX_PUSH_DEPTH = 24;
+
 /** Compass direction → grid offset (x, y). Y-axis is inverted: negative = up. */
 const DIR_OFFSET: Record<string, [number, number]> = {
   n: [0, -1],
@@ -32,20 +38,30 @@ export interface LayoutMeasurement {
 /**
  * Layout rooms on a grid using compass directions from exits.
  *
- * BFS from startRoom, placing each neighbor at the grid offset implied by
- * the exit direction. Collisions are resolved by spiraling to the nearest
- * empty cell.
+ * The algorithm has three phases:
  *
- * Unlike a fixed-cell grid, the conversion from grid coordinates to pixel
- * coordinates uses the **max width of each column** and **max height of
- * each row**, prefix-summed. This means rooms with different sizes get
- * appropriate spacing without overlap, and uniformly-sized rooms pack
- * tightly. Nodes are centered within their row/column cell.
+ * 1. **Component discovery.** Rooms are partitioned into connected
+ *    components (undirected). The component containing the start room
+ *    is laid out first.
+ *
+ * 2. **Per-component compass BFS.** Each component runs a BFS from its
+ *    seed room. Neighbors are placed at the grid offset implied by the
+ *    exit direction. On collision, the existing occupant's entire
+ *    subtree is pushed further along the incoming direction (so their
+ *    relative compass relationships are preserved). If the push cascade
+ *    bottoms out, we fall back to a spiral search for the nearest empty
+ *    cell.
+ *
+ * 3. **Horizontal packing + pixel conversion.** Components are packed
+ *    side-by-side in grid space with a fixed gap, then the merged grid
+ *    is converted to pixel coordinates using per-column max widths and
+ *    per-row max heights (prefix-summed). Nodes are centered inside
+ *    their cells.
  *
  * @param nodes          The raw nodes from `zoneToGraph`.
- * @param world          The zone WorldFile (for `rooms`, `startRoom`, exits).
- * @param measurements   Optional map of nodeId → measured size. Missing or
- *                       zero-sized entries fall back to sensible defaults.
+ * @param world          The zone WorldFile.
+ * @param measurements   Optional map of nodeId → measured size. Missing
+ *                       or zero-sized entries fall back to defaults.
  */
 export function compassLayout(
   nodes: Node[],
@@ -53,71 +69,274 @@ export function compassLayout(
   measurements?: Map<string, LayoutMeasurement>,
 ): Node[] {
   const allNodeIds = new Set(nodes.map((n) => n.id));
-  const grid = new Map<string, string>(); // "gx,gy" → nodeId
-  const pos = new Map<string, [number, number]>(); // nodeId → [gx, gy]
 
-  function place(id: string, gx: number, gy: number) {
-    const key = `${gx},${gy}`;
-    if (grid.has(key)) {
-      [gx, gy] = findEmpty(gx, gy, grid);
+  // ─── Phase 1: find connected components ──────────────────────────
+  const components = findConnectedComponents(world);
+
+  // Layout the component containing the start room first so it anchors
+  // the left edge of the map.
+  components.sort((a, b) => {
+    const aHasStart = a.includes(world.startRoom) ? 1 : 0;
+    const bHasStart = b.includes(world.startRoom) ? 1 : 0;
+    return bHasStart - aHasStart;
+  });
+
+  // ─── Phase 2: per-component BFS, then pack horizontally ──────────
+  const pos = new Map<string, [number, number]>();
+  const grid = new Map<string, string>();
+  let columnCursor = 0;
+
+  for (const component of components) {
+    if (component.length === 0) continue;
+
+    const localPos = new Map<string, [number, number]>();
+    const localGrid = new Map<string, string>();
+    const localChildren = new Map<string, string[]>();
+
+    const seed = component.includes(world.startRoom)
+      ? world.startRoom
+      : component[0]!;
+
+    bfsComponent({
+      seed,
+      world,
+      allNodeIds,
+      localPos,
+      localGrid,
+      localChildren,
+    });
+
+    if (localPos.size === 0) continue;
+
+    // Compute local bbox for this component.
+    let minGx = Infinity;
+    let maxGx = -Infinity;
+    for (const [, [gx]] of localPos) {
+      if (gx < minGx) minGx = gx;
+      if (gx > maxGx) maxGx = gx;
     }
-    pos.set(id, [gx, gy]);
-    grid.set(`${gx},${gy}`, id);
-  }
 
-  function bfsFrom(startId: string, ox: number, oy: number) {
-    if (pos.has(startId)) return;
-    place(startId, ox, oy);
-
-    const queue = [startId];
-    while (queue.length > 0) {
-      const cur = queue.shift()!;
-      const [cx, cy] = pos.get(cur)!;
-
-      const room = world.rooms[cur];
-      if (!room?.exits) continue;
-
-      for (const [dir, exitVal] of Object.entries(room.exits)) {
-        const raw = exitTarget(exitVal);
-        const nodeId = raw.includes(":") ? `xzone:${raw}` : raw;
-
-        if (!allNodeIds.has(nodeId)) continue;
-        if (pos.has(nodeId)) continue;
-
-        const offset = DIR_OFFSET[dir];
-        if (!offset) continue;
-
-        place(nodeId, cx + offset[0], cy + offset[1]);
-
-        // Continue BFS only into same-zone rooms
-        if (!raw.includes(":") && world.rooms[raw]) {
-          queue.push(nodeId);
-        }
-      }
+    // Shift component into the global grid, starting at the current cursor.
+    const shift = columnCursor - minGx;
+    for (const [id, [gx, gy]] of localPos) {
+      const newGx = gx + shift;
+      pos.set(id, [newGx, gy]);
+      grid.set(`${newGx},${gy}`, id);
     }
-  }
 
-  // Place main component from startRoom
-  bfsFrom(world.startRoom, 0, 0);
-
-  // Place any disconnected rooms below the main graph
-  let maxY = 0;
-  for (const [, [, y]] of pos) {
-    maxY = Math.max(maxY, y);
-  }
-
-  for (const roomId of Object.keys(world.rooms)) {
-    if (!pos.has(roomId)) {
-      bfsFrom(roomId, 0, maxY + 3);
-      for (const [, [, y]] of pos) {
-        maxY = Math.max(maxY, y);
-      }
-    }
+    columnCursor += maxGx - minGx + 1 + COMPONENT_GRID_GAP;
   }
 
   if (pos.size === 0) return nodes;
 
-  // ─── Grid → pixel conversion (max-extent per row/column) ──────────
+  // ─── Phase 3: grid → pixel (max-extent prefix-sum) ───────────────
+  return applyGridToPixel(nodes, pos, measurements);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Connected components
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Partition same-zone rooms into connected components, treating exits
+ * as undirected edges. Cross-zone exits are ignored.
+ */
+function findConnectedComponents(world: WorldFile): string[][] {
+  const adj = new Map<string, Set<string>>();
+  const roomIds = Object.keys(world.rooms);
+  for (const id of roomIds) adj.set(id, new Set());
+
+  for (const [id, room] of Object.entries(world.rooms)) {
+    if (!room.exits) continue;
+    for (const exitVal of Object.values(room.exits)) {
+      const raw = exitTarget(exitVal);
+      if (raw.includes(":")) continue;
+      if (!world.rooms[raw]) continue;
+      adj.get(id)!.add(raw);
+      adj.get(raw)!.add(id);
+    }
+  }
+
+  const seen = new Set<string>();
+  const components: string[][] = [];
+
+  for (const id of roomIds) {
+    if (seen.has(id)) continue;
+    const comp: string[] = [];
+    const queue = [id];
+    seen.add(id);
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      comp.push(cur);
+      for (const next of adj.get(cur) ?? []) {
+        if (seen.has(next)) continue;
+        seen.add(next);
+        queue.push(next);
+      }
+    }
+    components.push(comp);
+  }
+
+  return components;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Compass BFS with push collision resolution
+// ─────────────────────────────────────────────────────────────────
+
+interface BfsContext {
+  seed: string;
+  world: WorldFile;
+  allNodeIds: Set<string>;
+  localPos: Map<string, [number, number]>;
+  localGrid: Map<string, string>;
+  localChildren: Map<string, string[]>;
+}
+
+function bfsComponent(ctx: BfsContext): void {
+  const { seed, world, allNodeIds, localPos, localGrid, localChildren } = ctx;
+
+  function place(id: string, gx: number, gy: number, fromDir?: string) {
+    const key = `${gx},${gy}`;
+    if (localGrid.has(key)) {
+      const occupant = localGrid.get(key)!;
+      let pushed = false;
+      if (fromDir) {
+        pushed = cascadePush(
+          occupant,
+          fromDir,
+          localGrid,
+          localPos,
+          localChildren,
+        );
+      }
+      if (!pushed) {
+        [gx, gy] = findEmpty(gx, gy, localGrid);
+      }
+    }
+    localPos.set(id, [gx, gy]);
+    localGrid.set(`${gx},${gy}`, id);
+  }
+
+  place(seed, 0, 0);
+  const queue = [seed];
+
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    const curPos = localPos.get(cur)!;
+    const cx = curPos[0];
+    const cy = curPos[1];
+
+    const room = world.rooms[cur];
+    if (!room?.exits) continue;
+
+    for (const [dir, exitVal] of Object.entries(room.exits)) {
+      const raw = exitTarget(exitVal);
+      const nodeId = raw.includes(":") ? `xzone:${raw}` : raw;
+
+      if (!allNodeIds.has(nodeId)) continue;
+      if (localPos.has(nodeId)) continue;
+
+      const offset = DIR_OFFSET[dir];
+      if (!offset) continue;
+
+      place(nodeId, cx + offset[0], cy + offset[1], dir);
+
+      // Record child relationship for future cascade pushes.
+      let kids = localChildren.get(cur);
+      if (!kids) {
+        kids = [];
+        localChildren.set(cur, kids);
+      }
+      kids.push(nodeId);
+
+      // Continue BFS only into same-zone rooms.
+      if (!raw.includes(":") && world.rooms[raw]) {
+        queue.push(nodeId);
+      }
+    }
+  }
+}
+
+/**
+ * Push the given node and its entire subtree one step in `dir`. If the
+ * target cell is occupied by something outside the subtree, recursively
+ * push that other subtree first. Preserves compass relationships inside
+ * the pushed subtree. Returns false if the cascade exceeds the depth
+ * limit, letting the caller fall back to a spiral search.
+ */
+function cascadePush(
+  startId: string,
+  dir: string,
+  grid: Map<string, string>,
+  pos: Map<string, [number, number]>,
+  children: Map<string, string[]>,
+  depth = 0,
+): boolean {
+  if (depth > MAX_PUSH_DEPTH) return false;
+  const offset = DIR_OFFSET[dir];
+  if (!offset) return false;
+
+  const subtree = subtreeOf(startId, children);
+  const subtreeSet = new Set(subtree);
+
+  // Resolve any external collisions along the push direction first.
+  for (const id of subtree) {
+    const p = pos.get(id);
+    if (!p) continue;
+    const nx = p[0] + offset[0];
+    const ny = p[1] + offset[1];
+    const other = grid.get(`${nx},${ny}`);
+    if (other && !subtreeSet.has(other)) {
+      if (!cascadePush(other, dir, grid, pos, children, depth + 1)) {
+        return false;
+      }
+    }
+  }
+
+  // Clear old cells, then set new ones (avoids trampling mid-shift).
+  for (const id of subtree) {
+    const p = pos.get(id);
+    if (!p) continue;
+    grid.delete(`${p[0]},${p[1]}`);
+  }
+  for (const id of subtree) {
+    const p = pos.get(id);
+    if (!p) continue;
+    const nx = p[0] + offset[0];
+    const ny = p[1] + offset[1];
+    pos.set(id, [nx, ny]);
+    grid.set(`${nx},${ny}`, id);
+  }
+
+  return true;
+}
+
+function subtreeOf(
+  rootId: string,
+  children: Map<string, string[]>,
+): string[] {
+  const result: string[] = [rootId];
+  const queue = [rootId];
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    for (const child of children.get(cur) ?? []) {
+      result.push(child);
+      queue.push(child);
+    }
+  }
+  return result;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Grid → pixel conversion
+// ─────────────────────────────────────────────────────────────────
+
+function applyGridToPixel(
+  nodes: Node[],
+  pos: Map<string, [number, number]>,
+  measurements?: Map<string, LayoutMeasurement>,
+): Node[] {
   const getDim = (id: string): LayoutMeasurement => {
     const m = measurements?.get(id);
     if (m && m.width > 0 && m.height > 0) return m;
@@ -168,7 +387,6 @@ export function compassLayout(
     const ci = p[0] - minGx;
     const ri = p[1] - minGy;
     const dim = getDim(node.id);
-    // Center node within its (possibly larger) cell.
     const x = colStart[ci]! + (colWidth[ci]! - dim.width) / 2;
     const y = rowStart[ri]! + (rowHeight[ri]! - dim.height) / 2;
     return { ...node, position: { x, y } };


### PR DESCRIPTION
## Summary
Zone layout overhaul — Steps 1 and 2 combined.

### Step 1: Variable-size rooms (prefix-sum columns/rows)
`compassLayout` now accepts optional per-node measurements and converts grid coordinates to pixels by **prefix-summing the max width of each column and the max height of each row**, with nodes centered inside their cell.

- Rooms of different sizes no longer overlap each other.
- Uniform rooms pack tightly with sensible gutters (80px horizontal, 60px vertical).
- The **Re-layout** button passes the currently measured node sizes from ReactFlow, so clicking it produces a clean layout that respects real room dimensions (images, entity sprites, title length).
- Default column width dropped from 300 → 220 to match actual `RoomNode` width.

### Step 2: Per-component BFS + subtree push + horizontal packing
The layout now runs in three phases:

1. **Component discovery.** Rooms are partitioned into connected components (undirected). The component containing the start room is laid out first so it anchors the left edge.
2. **Per-component BFS with subtree push collisions.** Each component runs compass BFS independently. On a collision, `cascadePush` moves the occupant's **entire subtree** one step along the incoming direction, preserving their internal compass relationships. A depth cap falls back to the old spiral search if the cascade bottoms out.
3. **Horizontal component packing.** Components are packed side-by-side in grid space with a 2-column gap before the pixel conversion runs. Disconnected rooms now sit **beside** the main map instead of being dropped far below it.

Compass BFS semantics are unchanged — north is still up, east is still right.

## Test plan
- [x] 11 unit tests in `dagreLayout.test.ts` covering: origin placement, direction semantics, column/row max-extent expansion, east-chain spacing, fallback dims, cycle-no-overlap, subtree push, horizontal component packing, and start-room component anchoring.
- [x] Full suite passes (1371 tests).
- [x] `tsc --noEmit` clean.
- [ ] Open a zone with varying room heights (some with images, some without), click **Re-layout** — rooms don't overlap; narrower rooms centered in their columns.
- [ ] Open a zone with disconnected rooms, click **Re-layout** — disconnected rooms appear packed to the right of the main map at the same Y row, not stacked below.
- [ ] Open a zone with a non-planar cycle (A-n-B, A-e-C, B-e-D, C-n-D), click **Re-layout** — all four rooms visible, no overlaps.