### PR TITLE
Story → cinematic video export

### DIFF
--- a/creator/src-tauri/Cargo.lock
+++ b/creator/src-tauri/Cargo.lock
@@ -48,11 +48,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arcanum"
 version = "1.0.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "ffmpeg-sidecar",
  "hex",
  "hmac",
  "image",
@@ -71,6 +81,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tokio",
  "uuid",
+ "which",
  "windows-sys 0.59.0",
 ]
 
@@ -540,6 +551,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +766,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ffmpeg-sidecar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bc8b8df567bc8a9dcf9004a22be12c4e0766649b2116b2397dd04f25c8f2fe"
+dependencies = [
+ "anyhow",
+ "tar",
+ "ureq",
+ "xz2",
+ "zip",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +786,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -761,6 +813,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1289,6 +1342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1827,8 +1889,17 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1862,6 +1933,17 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "mac"
@@ -2313,7 +2395,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2481,6 +2563,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -2852,6 +2940,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3044,6 +3141,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3051,7 +3161,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3061,6 +3171,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3525,7 +3636,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -3735,6 +3846,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4059,7 +4181,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4499,6 +4621,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4528,6 +4679,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4847,6 +5004,18 @@ dependencies = [
  "thiserror 2.0.18",
  "windows",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
 ]
 
 [[package]]
@@ -5323,6 +5492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5483,6 +5658,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5586,10 +5780,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/creator/src-tauri/Cargo.toml
+++ b/creator/src-tauri/Cargo.toml
@@ -32,6 +32,8 @@ tauri-plugin-window-state = "2.4.1"
 imagesize = "0.13"
 regex = "1"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
+ffmpeg-sidecar = "2"
+which = "6"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/creator/src-tauri/src/audio_mix.rs
+++ b/creator/src-tauri/src/audio_mix.rs
@@ -1,0 +1,761 @@
+// ─── Story Audio Mixer ───────────────────────────────────────────
+// Builds an ffmpeg filter_complex for the story → video export
+// pipeline. Mixes per-scene narration MP3s (delayed to their absolute
+// timeline offsets) with optional zone music (looped, sidechain-ducked
+// under narration) and zone ambient (looped, low-volume bed).
+//
+// Architecture:
+//   - `build_mix_command()` is a PURE function that turns a MixInput
+//     into the exact ffmpeg argv. Unit-tested without invoking ffmpeg.
+//   - `mix_audio()` is the async wrapper that resolves the ffmpeg
+//     binary, spawns it, waits for completion, and returns the output
+//     file metadata. Used by the export orchestrator (PR 7).
+//
+// Filtergraph shape (4 narrations + music + ambient):
+//
+//   [0:a]adelay=1000|1000[n0];
+//   [1:a]adelay=8500|8500[n1];
+//   [2:a]adelay=16000|16000[n2];
+//   [3:a]adelay=22000|22000[n3];
+//   [n0][n1][n2][n3]amix=inputs=4:duration=longest:normalize=0[narr];
+//   [4:a]volume=0.55[music_raw];
+//   [music_raw][narr]sidechaincompress=threshold=0.04:ratio=6:attack=15:release=400[music_d];
+//   [5:a]volume=0.22[ambient];
+//   [music_d][narr][ambient]amix=inputs=3:duration=first:normalize=0[out]
+//
+// All four major shapes are supported:
+//   - narrations + music + ambient
+//   - narrations + music (no ambient)
+//   - narrations only
+//   - music + ambient with no narrations (silent story with ambient bed)
+//
+// Returns an error if there is nothing to mix at all.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+use crate::ffmpeg;
+use tauri::AppHandle;
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/// One scene's narration audio with its absolute placement in the
+/// final video timeline.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NarrationTrack {
+    pub file_path: String,
+    /// Absolute start time in the final video, in milliseconds.
+    pub offset_ms: u64,
+}
+
+/// Mix request: zero or more narration tracks plus optional music
+/// and ambient backing tracks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioMixInput {
+    pub narrations: Vec<NarrationTrack>,
+    pub music_path: Option<String>,
+    pub ambient_path: Option<String>,
+    /// Total story duration in milliseconds. Output is clamped to this
+    /// length so looping music/ambient don't run forever.
+    pub total_duration_ms: u64,
+    /// Audio bitrate in kbps for the AAC encoder.
+    pub audio_bitrate_kbps: u32,
+}
+
+/// Result of a successful mix.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioMixOutput {
+    pub file_path: String,
+    pub duration_ms: u64,
+}
+
+// ─── Volume + dynamics constants ─────────────────────────────────
+
+/// Music background volume (linear, 0..1) before sidechain ducking.
+const MUSIC_VOLUME: f32 = 0.55;
+/// Ambient bed volume (linear, 0..1).
+const AMBIENT_VOLUME: f32 = 0.22;
+
+// Sidechain compressor settings — chosen for music ducking under
+// dialogue. Tuned to be audible but not aggressive.
+const DUCK_THRESHOLD: f32 = 0.04;
+const DUCK_RATIO: u32 = 6;
+const DUCK_ATTACK_MS: u32 = 15;
+const DUCK_RELEASE_MS: u32 = 400;
+
+// ─── Pure command builder ────────────────────────────────────────
+
+/// The pure result of building an ffmpeg invocation. Doesn't actually
+/// run ffmpeg — `mix_audio` is the function that spawns the process.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AudioMixCommand {
+    /// Full argv (excluding the ffmpeg binary path itself). Pass this
+    /// to `Command::args`.
+    pub args: Vec<String>,
+}
+
+/// Builds the ffmpeg argument vector for an audio mix.
+///
+/// Returns an error when the input has nothing to mix (no narrations,
+/// no music, no ambient) or when total_duration_ms is zero.
+pub fn build_mix_command(
+    input: &AudioMixInput,
+    output_path: &Path,
+) -> Result<AudioMixCommand, String> {
+    if input.total_duration_ms == 0 {
+        return Err("Cannot mix audio: total duration is zero.".to_string());
+    }
+
+    let has_narrations = !input.narrations.is_empty();
+    let has_music = input.music_path.is_some();
+    let has_ambient = input.ambient_path.is_some();
+
+    if !has_narrations && !has_music && !has_ambient {
+        return Err(
+            "Cannot mix audio: no narrations, music, or ambient tracks provided."
+                .to_string(),
+        );
+    }
+
+    let mut args: Vec<String> = Vec::new();
+    // Overwrite output without prompting + suppress noisy banner.
+    args.push("-y".to_string());
+    args.push("-hide_banner".to_string());
+    args.push("-loglevel".to_string());
+    args.push("error".to_string());
+
+    // ─── Inputs (in declared order, indexed for the filter) ──
+    let mut next_index: usize = 0;
+    let mut narration_indexes: Vec<usize> = Vec::with_capacity(input.narrations.len());
+
+    for narration in &input.narrations {
+        if narration.file_path.is_empty() {
+            return Err("Narration track has empty file_path".to_string());
+        }
+        args.push("-i".to_string());
+        args.push(narration.file_path.clone());
+        narration_indexes.push(next_index);
+        next_index += 1;
+    }
+
+    let music_index = if let Some(music) = input.music_path.as_ref() {
+        // Loop the music input infinitely; the -t flag at the end
+        // clamps total duration so we don't render forever.
+        args.push("-stream_loop".to_string());
+        args.push("-1".to_string());
+        args.push("-i".to_string());
+        args.push(music.clone());
+        let idx = next_index;
+        next_index += 1;
+        Some(idx)
+    } else {
+        None
+    };
+
+    let ambient_index = if let Some(ambient) = input.ambient_path.as_ref() {
+        args.push("-stream_loop".to_string());
+        args.push("-1".to_string());
+        args.push("-i".to_string());
+        args.push(ambient.clone());
+        // Last input — no further increment needed.
+        Some(next_index)
+    } else {
+        None
+    };
+
+    // ─── Filter complex ──────────────────────────────────────
+    let filter = build_filter_complex(
+        &narration_indexes,
+        &input.narrations,
+        music_index,
+        ambient_index,
+    );
+    args.push("-filter_complex".to_string());
+    args.push(filter);
+
+    args.push("-map".to_string());
+    args.push("[out]".to_string());
+
+    // ─── Duration clamp + encoder settings ───────────────────
+    let total_seconds = format_seconds(input.total_duration_ms);
+    args.push("-t".to_string());
+    args.push(total_seconds);
+
+    args.push("-c:a".to_string());
+    args.push("aac".to_string());
+    args.push("-b:a".to_string());
+    args.push(format!("{}k", input.audio_bitrate_kbps.max(64)));
+
+    args.push(output_path.to_string_lossy().to_string());
+
+    Ok(AudioMixCommand { args })
+}
+
+/// Formats a millisecond duration as a decimal seconds string with
+/// 3-digit precision: 1500 → "1.500".
+fn format_seconds(ms: u64) -> String {
+    let seconds = ms / 1000;
+    let millis = ms % 1000;
+    format!("{seconds}.{millis:03}")
+}
+
+/// Constructs the filter_complex value. Handles every combination of
+/// narration / music / ambient presence.
+fn build_filter_complex(
+    narration_indexes: &[usize],
+    narrations: &[NarrationTrack],
+    music_index: Option<usize>,
+    ambient_index: Option<usize>,
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    // ─── Narration delay + mix → [narr] ──────────────────────
+    let narr_label: Option<&str> = if narration_indexes.is_empty() {
+        None
+    } else {
+        for (i, &input_idx) in narration_indexes.iter().enumerate() {
+            let offset = narrations[i].offset_ms;
+            // adelay default unit is milliseconds. Pipe-separate the
+            // value once per channel (we use stereo, so 2 values).
+            parts.push(format!(
+                "[{input_idx}:a]adelay={offset}|{offset}[n{i}]",
+            ));
+        }
+        if narration_indexes.len() == 1 {
+            // Rename to [narr] for consistency with the multi-narration path.
+            parts.push("[n0]anull[narr]".to_string());
+        } else {
+            let labels: String = (0..narration_indexes.len())
+                .map(|i| format!("[n{i}]"))
+                .collect::<Vec<_>>()
+                .join("");
+            parts.push(format!(
+                "{labels}amix=inputs={count}:duration=longest:normalize=0[narr]",
+                count = narration_indexes.len(),
+            ));
+        }
+        Some("narr")
+    };
+
+    // ─── Music: volume + optional sidechain duck → [music_out] ──
+    let music_label: Option<String> = if let Some(idx) = music_index {
+        parts.push(format!("[{idx}:a]volume={MUSIC_VOLUME}[music_raw]"));
+        if narr_label.is_some() {
+            // Duck music under narration via sidechain compress. We
+            // need a copy of the narration signal as the sidechain,
+            // so split it into two outputs first.
+            parts.push("[narr]asplit=2[narr_main][narr_sc]".to_string());
+            parts.push(format!(
+                "[music_raw][narr_sc]sidechaincompress=threshold={DUCK_THRESHOLD}:ratio={DUCK_RATIO}:attack={DUCK_ATTACK_MS}:release={DUCK_RELEASE_MS}[music_out]",
+            ));
+            Some("music_out".to_string())
+        } else {
+            // No narration → no need to duck.
+            Some("music_raw".to_string())
+        }
+    } else {
+        None
+    };
+
+    // ─── Ambient: volume only → [ambient_out] ────────────────
+    let ambient_label: Option<String> = ambient_index.map(|idx| {
+        parts.push(format!("[{idx}:a]volume={AMBIENT_VOLUME}[ambient_out]"));
+        "ambient_out".to_string()
+    });
+
+    // ─── Final mix → [out] ───────────────────────────────────
+    // Pick the narration label (split-main if music ducked it, else raw).
+    let narr_for_final: Option<String> = match (narr_label, music_label.as_deref()) {
+        (Some(_), Some("music_out")) => Some("narr_main".to_string()),
+        (Some(label), _) => Some(label.to_string()),
+        (None, _) => None,
+    };
+
+    let mut final_inputs: Vec<String> = Vec::new();
+    if let Some(label) = music_label.as_ref() {
+        final_inputs.push(format!("[{label}]"));
+    }
+    if let Some(label) = narr_for_final.as_ref() {
+        final_inputs.push(format!("[{label}]"));
+    }
+    if let Some(label) = ambient_label.as_ref() {
+        final_inputs.push(format!("[{label}]"));
+    }
+
+    if final_inputs.len() == 1 {
+        // Single source — just rename it to [out].
+        let only = &final_inputs[0];
+        parts.push(format!("{only}anull[out]"));
+    } else {
+        let count = final_inputs.len();
+        // amix `duration=first` makes the output as long as the FIRST
+        // input. We list narration first when present (so the mix is
+        // narration-length-driven), or music first as fallback. The
+        // outer -t clamp on the CLI is the real safety net.
+        let joined = final_inputs.join("");
+        parts.push(format!(
+            "{joined}amix=inputs={count}:duration=longest:normalize=0[out]",
+        ));
+    }
+
+    parts.join(";")
+}
+
+// ─── Async runner ────────────────────────────────────────────────
+
+/// Mixes audio for a story by spawning ffmpeg with the args from
+/// `build_mix_command`. Resolves ffmpeg from the bundled cache or
+/// system PATH (must already be available — call `ensure_ffmpeg_ready`
+/// from the frontend before invoking this).
+#[allow(dead_code)] // consumed by the export orchestrator (PR 7)
+pub async fn mix_audio(
+    app: &AppHandle,
+    input: AudioMixInput,
+    output_path: PathBuf,
+) -> Result<AudioMixOutput, String> {
+    let ffmpeg_path = ffmpeg::ffmpeg_binary_path(app).await?;
+    let cmd = build_mix_command(&input, &output_path)?;
+
+    if let Some(parent) = output_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Failed to create output directory: {e}"))?;
+    }
+
+    let output = Command::new(&ffmpeg_path)
+        .args(&cmd.args)
+        .output()
+        .await
+        .map_err(|e| format!("Failed to spawn ffmpeg: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "ffmpeg audio mix failed (exit {}): {}",
+            output.status.code().unwrap_or(-1),
+            stderr.trim(),
+        ));
+    }
+
+    Ok(AudioMixOutput {
+        file_path: output_path.to_string_lossy().to_string(),
+        duration_ms: input.total_duration_ms,
+    })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn narration(file: &str, offset_ms: u64) -> NarrationTrack {
+        NarrationTrack {
+            file_path: file.to_string(),
+            offset_ms,
+        }
+    }
+
+    fn input_with(narrations: Vec<NarrationTrack>) -> AudioMixInput {
+        AudioMixInput {
+            narrations,
+            music_path: None,
+            ambient_path: None,
+            total_duration_ms: 30_000,
+            audio_bitrate_kbps: 192,
+        }
+    }
+
+    fn output() -> PathBuf {
+        PathBuf::from("/tmp/output.m4a")
+    }
+
+    // ─── format_seconds ──────────────────────────────────────
+
+    #[test]
+    fn formats_zero_seconds() {
+        assert_eq!(format_seconds(0), "0.000");
+    }
+
+    #[test]
+    fn formats_round_seconds() {
+        assert_eq!(format_seconds(5_000), "5.000");
+    }
+
+    #[test]
+    fn formats_sub_second_precision() {
+        assert_eq!(format_seconds(1_234), "1.234");
+        assert_eq!(format_seconds(60_500), "60.500");
+        assert_eq!(format_seconds(123_001), "123.001");
+    }
+
+    // ─── error cases ─────────────────────────────────────────
+
+    #[test]
+    fn errors_when_total_duration_is_zero() {
+        let mut input = input_with(vec![]);
+        input.total_duration_ms = 0;
+        assert!(build_mix_command(&input, &output()).is_err());
+    }
+
+    #[test]
+    fn errors_when_no_audio_sources() {
+        let input = input_with(vec![]);
+        let result = build_mix_command(&input, &output());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("no narrations"));
+    }
+
+    #[test]
+    fn errors_when_narration_has_empty_path() {
+        let input = input_with(vec![narration("", 0)]);
+        assert!(build_mix_command(&input, &output()).is_err());
+    }
+
+    // ─── argv structure ──────────────────────────────────────
+
+    #[test]
+    fn includes_overwrite_and_loglevel_flags() {
+        let input = input_with(vec![narration("/n0.mp3", 0)]);
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        assert_eq!(cmd.args[0], "-y");
+        assert!(cmd.args.contains(&"-hide_banner".to_string()));
+        assert!(cmd.args.contains(&"-loglevel".to_string()));
+    }
+
+    #[test]
+    fn includes_total_duration_clamp() {
+        let mut input = input_with(vec![narration("/n0.mp3", 0)]);
+        input.total_duration_ms = 12_500;
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let t_idx = cmd.args.iter().position(|a| a == "-t").unwrap();
+        assert_eq!(cmd.args[t_idx + 1], "12.500");
+    }
+
+    #[test]
+    fn includes_aac_encoder_with_bitrate() {
+        let mut input = input_with(vec![narration("/n0.mp3", 0)]);
+        input.audio_bitrate_kbps = 256;
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let codec_idx = cmd.args.iter().position(|a| a == "-c:a").unwrap();
+        assert_eq!(cmd.args[codec_idx + 1], "aac");
+        let bitrate_idx = cmd.args.iter().position(|a| a == "-b:a").unwrap();
+        assert_eq!(cmd.args[bitrate_idx + 1], "256k");
+    }
+
+    #[test]
+    fn clamps_low_bitrate_to_64k_minimum() {
+        let mut input = input_with(vec![narration("/n0.mp3", 0)]);
+        input.audio_bitrate_kbps = 32;
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let bitrate_idx = cmd.args.iter().position(|a| a == "-b:a").unwrap();
+        assert_eq!(cmd.args[bitrate_idx + 1], "64k");
+    }
+
+    #[test]
+    fn output_path_is_the_last_arg() {
+        let input = input_with(vec![narration("/n0.mp3", 0)]);
+        let cmd = build_mix_command(&input, &PathBuf::from("/out/mix.m4a")).unwrap();
+        assert_eq!(cmd.args.last().unwrap(), "/out/mix.m4a");
+    }
+
+    // ─── input args ──────────────────────────────────────────
+
+    #[test]
+    fn narration_inputs_use_plain_i_flag() {
+        let input = input_with(vec![narration("/n0.mp3", 0), narration("/n1.mp3", 5000)]);
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        // Two narration -i flags, no -stream_loop in front of them
+        let n0_idx = cmd.args.iter().position(|a| a == "/n0.mp3").unwrap();
+        assert_eq!(cmd.args[n0_idx - 1], "-i");
+        // Check it's NOT preceded by -stream_loop
+        if n0_idx >= 2 {
+            assert_ne!(cmd.args[n0_idx - 2], "-stream_loop");
+        }
+    }
+
+    #[test]
+    fn music_input_uses_stream_loop() {
+        let mut input = input_with(vec![narration("/n0.mp3", 0)]);
+        input.music_path = Some("/music.mp3".to_string());
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let music_idx = cmd.args.iter().position(|a| a == "/music.mp3").unwrap();
+        assert_eq!(cmd.args[music_idx - 1], "-i");
+        assert_eq!(cmd.args[music_idx - 2], "-1");
+        assert_eq!(cmd.args[music_idx - 3], "-stream_loop");
+    }
+
+    #[test]
+    fn ambient_input_uses_stream_loop() {
+        let mut input = input_with(vec![narration("/n0.mp3", 0)]);
+        input.ambient_path = Some("/ambient.mp3".to_string());
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let amb_idx = cmd.args.iter().position(|a| a == "/ambient.mp3").unwrap();
+        assert_eq!(cmd.args[amb_idx - 3], "-stream_loop");
+    }
+
+    // ─── filter_complex content ──────────────────────────────
+
+    fn extract_filter(cmd: &AudioMixCommand) -> String {
+        let idx = cmd
+            .args
+            .iter()
+            .position(|a| a == "-filter_complex")
+            .expect("filter_complex flag missing");
+        cmd.args[idx + 1].clone()
+    }
+
+    #[test]
+    fn single_narration_uses_anull_rename() {
+        let input = input_with(vec![narration("/n0.mp3", 1000)]);
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(filter.contains("[0:a]adelay=1000|1000[n0]"));
+        assert!(filter.contains("[n0]anull[narr]"));
+        // No amix for single narration
+        assert!(!filter.contains("inputs=1:duration=longest"));
+    }
+
+    #[test]
+    fn multiple_narrations_are_amixed() {
+        let input = input_with(vec![
+            narration("/n0.mp3", 1000),
+            narration("/n1.mp3", 8500),
+            narration("/n2.mp3", 16000),
+        ]);
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(filter.contains("[0:a]adelay=1000|1000[n0]"));
+        assert!(filter.contains("[1:a]adelay=8500|8500[n1]"));
+        assert!(filter.contains("[2:a]adelay=16000|16000[n2]"));
+        assert!(filter.contains("[n0][n1][n2]amix=inputs=3:duration=longest:normalize=0[narr]"));
+    }
+
+    #[test]
+    fn music_only_skips_sidechain_when_no_narration() {
+        let mut input = input_with(vec![]);
+        input.music_path = Some("/music.mp3".to_string());
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(filter.contains("volume=0.55"));
+        assert!(!filter.contains("sidechaincompress"));
+    }
+
+    #[test]
+    fn music_with_narration_applies_sidechain_duck() {
+        let mut input = input_with(vec![narration("/n0.mp3", 1000)]);
+        input.music_path = Some("/music.mp3".to_string());
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let filter = extract_filter(&cmd);
+        // Narration is split so one branch goes to the sidechain
+        assert!(filter.contains("[narr]asplit=2[narr_main][narr_sc]"));
+        // Music is ducked using narr_sc as the sidechain
+        assert!(filter.contains("[music_raw][narr_sc]sidechaincompress"));
+        // Final mix uses narr_main, not narr (the split branch)
+        assert!(filter.contains("[narr_main]"));
+    }
+
+    #[test]
+    fn ambient_uses_low_volume_only() {
+        let mut input = input_with(vec![narration("/n0.mp3", 0)]);
+        input.ambient_path = Some("/ambient.mp3".to_string());
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(filter.contains("volume=0.22"));
+        assert!(filter.contains("[ambient_out]"));
+        // Ambient is NOT ducked by narration
+        assert!(!filter.contains("ambient_out]sidechain"));
+    }
+
+    #[test]
+    fn full_mix_includes_all_three_sources_in_final_amix() {
+        let mut input = input_with(vec![narration("/n0.mp3", 0)]);
+        input.music_path = Some("/music.mp3".to_string());
+        input.ambient_path = Some("/ambient.mp3".to_string());
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let filter = extract_filter(&cmd);
+        // Final amix should have 3 inputs: ducked music + narration main + ambient
+        assert!(filter.contains("amix=inputs=3"));
+        assert!(filter.ends_with("[out]"));
+    }
+
+    #[test]
+    fn narration_only_renames_narr_to_out() {
+        let input = input_with(vec![narration("/n0.mp3", 0)]);
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let filter = extract_filter(&cmd);
+        // Single source: should anull-rename narr to out
+        assert!(filter.contains("[narr]anull[out]"));
+    }
+
+    #[test]
+    fn music_only_renames_to_out_no_amix() {
+        let mut input = input_with(vec![]);
+        input.music_path = Some("/music.mp3".to_string());
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(filter.contains("[music_raw]anull[out]"));
+        assert!(!filter.contains("amix=inputs"));
+    }
+
+    #[test]
+    fn input_indexes_match_filter_references() {
+        // narration0=0, narration1=1, music=2, ambient=3
+        let mut input = input_with(vec![
+            narration("/n0.mp3", 0),
+            narration("/n1.mp3", 5000),
+        ]);
+        input.music_path = Some("/music.mp3".to_string());
+        input.ambient_path = Some("/ambient.mp3".to_string());
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(filter.contains("[0:a]adelay")); // narration 0
+        assert!(filter.contains("[1:a]adelay")); // narration 1
+        assert!(filter.contains("[2:a]volume=0.55")); // music
+        assert!(filter.contains("[3:a]volume=0.22")); // ambient
+    }
+
+    #[test]
+    fn output_label_is_always_out() {
+        let input = input_with(vec![narration("/n0.mp3", 0)]);
+        let cmd = build_mix_command(&input, &output()).unwrap();
+        let map_idx = cmd.args.iter().position(|a| a == "-map").unwrap();
+        assert_eq!(cmd.args[map_idx + 1], "[out]");
+    }
+
+    // ─── Integration test: real ffmpeg mix ──────────────────────
+    //
+    // Generates synthetic narration + music tones via ffmpeg's
+    // built-in `sine` source, mixes them with our filtergraph, and
+    // verifies the output exists and has the expected duration.
+    //
+    // Marked `#[ignore]` so it only runs when explicitly requested:
+    //
+    //   cargo test audio_mix::tests::mixes_real_audio_via_ffmpeg \
+    //     -- --ignored --nocapture
+    //
+    // Requires the ffmpeg-sidecar download cache to already be
+    // populated (run the ffmpeg integration test once first), or
+    // ffmpeg installed on PATH.
+    #[test]
+    #[ignore]
+    fn mixes_real_audio_via_ffmpeg() {
+        use std::process::Command as StdCommand;
+
+        // Locate ffmpeg: prefer PATH; otherwise download a fresh copy
+        // into a tempdir via the same path the runtime uses on first
+        // export. Either way the test ends up with a working binary.
+        let tmp = std::env::temp_dir().join(format!(
+            "arcanum-audio-mix-test-{}",
+            std::process::id(),
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let ffmpeg_bin = match which::which("ffmpeg") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("ffmpeg not on PATH; downloading via ffmpeg-sidecar...");
+                crate::ffmpeg::download_ffmpeg_blocking(&tmp)
+                    .expect("downloading ffmpeg should succeed")
+            }
+        };
+
+        // 1) Generate two synthetic narration tones (440 Hz and 660 Hz).
+        let n0 = tmp.join("n0.mp3");
+        let n1 = tmp.join("n1.mp3");
+        let music = tmp.join("music.mp3");
+
+        for (path, freq, duration) in [
+            (&n0, 440, "2"),
+            (&n1, 660, "2"),
+            (&music, 220, "10"),
+        ] {
+            let status = StdCommand::new(&ffmpeg_bin)
+                .args([
+                    "-y",
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    &format!("sine=frequency={freq}:duration={duration}"),
+                    path.to_str().unwrap(),
+                ])
+                .status()
+                .unwrap();
+            assert!(status.success(), "failed to generate {path:?}");
+        }
+
+        // 2) Build the mix command and run it.
+        let out_path = tmp.join("mixed.m4a");
+        let input = AudioMixInput {
+            narrations: vec![
+                NarrationTrack {
+                    file_path: n0.to_string_lossy().to_string(),
+                    offset_ms: 0,
+                },
+                NarrationTrack {
+                    file_path: n1.to_string_lossy().to_string(),
+                    offset_ms: 4000,
+                },
+            ],
+            music_path: Some(music.to_string_lossy().to_string()),
+            ambient_path: None,
+            total_duration_ms: 8000,
+            audio_bitrate_kbps: 128,
+        };
+        let cmd = build_mix_command(&input, &out_path).unwrap();
+
+        let mix_output = StdCommand::new(&ffmpeg_bin)
+            .args(&cmd.args)
+            .output()
+            .unwrap();
+        if !mix_output.status.success() {
+            let stderr = String::from_utf8_lossy(&mix_output.stderr);
+            panic!("ffmpeg mix failed: {stderr}");
+        }
+
+        // 3) Verify output exists and is non-trivial.
+        let metadata = std::fs::metadata(&out_path).unwrap();
+        assert!(metadata.is_file());
+        assert!(
+            metadata.len() > 1000,
+            "output file is suspiciously small: {} bytes",
+            metadata.len(),
+        );
+
+        // 4) Probe duration via ffprobe (when available) — best-effort.
+        // Most users have it next to ffmpeg.
+        if let Some(ffprobe_bin) = which::which("ffprobe").ok() {
+            let probe = StdCommand::new(&ffprobe_bin)
+                .args([
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    out_path.to_str().unwrap(),
+                ])
+                .output()
+                .unwrap();
+            let duration_str = String::from_utf8_lossy(&probe.stdout);
+            let duration_sec: f64 = duration_str.trim().parse().unwrap_or(0.0);
+            // Should be ~8 seconds (the total_duration_ms clamp).
+            assert!(
+                (7.5..=8.5).contains(&duration_sec),
+                "expected ~8s output, got {duration_sec}s",
+            );
+            eprintln!("Mixed audio duration: {duration_sec}s");
+        }
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/creator/src-tauri/src/ffmpeg.rs
+++ b/creator/src-tauri/src/ffmpeg.rs
@@ -144,12 +144,16 @@ pub async fn resolve_ffmpeg(app: &AppHandle) -> FfmpegStatus {
 
 // ─── Download ────────────────────────────────────────────────────
 
-/// Downloads and unpacks ffmpeg into `app_data_dir/bin/`. Blocks the
+/// Downloads and unpacks ffmpeg into the given directory. Blocks the
 /// calling task (use `tokio::task::spawn_blocking` from async callers).
 ///
 /// This is intentionally synchronous because `ffmpeg-sidecar` does
 /// blocking I/O internally — wrapping it is the caller's responsibility.
-fn download_ffmpeg_blocking(dest_dir: &Path) -> Result<PathBuf, String> {
+///
+/// Visible to other modules in the crate so integration tests in
+/// sibling modules (e.g. `audio_mix`) can self-bootstrap ffmpeg
+/// without requiring it on PATH.
+pub(crate) fn download_ffmpeg_blocking(dest_dir: &Path) -> Result<PathBuf, String> {
     use ffmpeg_sidecar::download::{
         download_ffmpeg_package, ffmpeg_download_url, unpack_ffmpeg,
     };

--- a/creator/src-tauri/src/ffmpeg.rs
+++ b/creator/src-tauri/src/ffmpeg.rs
@@ -1,0 +1,352 @@
+// ─── FFmpeg Resolution & Download ────────────────────────────────
+// Finds ffmpeg for the story → video export pipeline.
+//
+// Resolution order:
+//   1. Cached binary under `app_data_dir/bin/ffmpeg(.exe)` — downloaded
+//      by this module on first export.
+//   2. System-installed ffmpeg (via PATH).
+//   3. None → caller invokes `ensure_ffmpeg_ready` to download.
+//
+// We deliberately prefer the cached binary over the system one so
+// exports stay reproducible across machines (same ffmpeg version).
+// System PATH is a fallback for users who want to point at their own
+// build — e.g. with hardware encoder support — or who pre-placed a
+// binary before first launch.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use tauri::{AppHandle, Manager};
+
+// ─── Types ───────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FfmpegSource {
+    /// Downloaded by this app into `app_data_dir/bin/`.
+    Bundled,
+    /// Resolved via the system PATH (user-installed).
+    System,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FfmpegStatus {
+    /// Whether ffmpeg is currently usable.
+    pub available: bool,
+    /// Which source was resolved. `None` when unavailable.
+    pub source: Option<FfmpegSource>,
+    /// Absolute path to the binary. `None` when unavailable.
+    pub path: Option<String>,
+    /// Parsed version string (e.g. "6.1.1"). `None` when unavailable
+    /// or when parsing failed.
+    pub version: Option<String>,
+}
+
+impl FfmpegStatus {
+    fn missing() -> Self {
+        Self {
+            available: false,
+            source: None,
+            path: None,
+            version: None,
+        }
+    }
+}
+
+// ─── Paths ───────────────────────────────────────────────────────
+
+fn bin_filename() -> &'static str {
+    if cfg!(windows) {
+        "ffmpeg.exe"
+    } else {
+        "ffmpeg"
+    }
+}
+
+fn bundled_bin_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+        .join("bin");
+    Ok(dir)
+}
+
+fn bundled_ffmpeg_path(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(bundled_bin_dir(app)?.join(bin_filename()))
+}
+
+// ─── Probing ─────────────────────────────────────────────────────
+
+/// Runs `ffmpeg -version` against the given binary and returns the
+/// parsed version string on success. Returns `None` on any failure
+/// (binary missing, non-zero exit, unparseable output).
+async fn probe_ffmpeg(path: &Path) -> Option<String> {
+    let output = tokio::process::Command::new(path)
+        .arg("-version")
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_ffmpeg_version(&stdout)
+}
+
+/// Parses the first line of `ffmpeg -version` output into a version
+/// string. Typical format: `ffmpeg version 6.1.1 Copyright ...`.
+///
+/// Returns the third whitespace-delimited token or `None` if the line
+/// doesn't start with the expected prefix.
+fn parse_ffmpeg_version(text: &str) -> Option<String> {
+    let first_line = text.lines().next()?.trim();
+    let rest = first_line.strip_prefix("ffmpeg version ")?;
+    let token = rest.split_whitespace().next()?;
+    Some(token.to_string())
+}
+
+// ─── Resolution ──────────────────────────────────────────────────
+
+/// Attempts to find ffmpeg in the bundled location first, then on
+/// the system PATH. Returns the first working source (probed via
+/// `ffmpeg -version`).
+pub async fn resolve_ffmpeg(app: &AppHandle) -> FfmpegStatus {
+    // ─── Bundled cache ───────────────────────────────────────
+    if let Ok(bundled) = bundled_ffmpeg_path(app) {
+        if bundled.exists() {
+            if let Some(version) = probe_ffmpeg(&bundled).await {
+                return FfmpegStatus {
+                    available: true,
+                    source: Some(FfmpegSource::Bundled),
+                    path: Some(bundled.to_string_lossy().to_string()),
+                    version: Some(version),
+                };
+            }
+        }
+    }
+
+    // ─── System PATH ─────────────────────────────────────────
+    if let Ok(system_path) = which::which("ffmpeg") {
+        if let Some(version) = probe_ffmpeg(&system_path).await {
+            return FfmpegStatus {
+                available: true,
+                source: Some(FfmpegSource::System),
+                path: Some(system_path.to_string_lossy().to_string()),
+                version: Some(version),
+            };
+        }
+    }
+
+    FfmpegStatus::missing()
+}
+
+// ─── Download ────────────────────────────────────────────────────
+
+/// Downloads and unpacks ffmpeg into `app_data_dir/bin/`. Blocks the
+/// calling task (use `tokio::task::spawn_blocking` from async callers).
+///
+/// This is intentionally synchronous because `ffmpeg-sidecar` does
+/// blocking I/O internally — wrapping it is the caller's responsibility.
+fn download_ffmpeg_blocking(dest_dir: &Path) -> Result<PathBuf, String> {
+    use ffmpeg_sidecar::download::{
+        download_ffmpeg_package, ffmpeg_download_url, unpack_ffmpeg,
+    };
+
+    std::fs::create_dir_all(dest_dir)
+        .map_err(|e| format!("Failed to create ffmpeg dir: {e}"))?;
+
+    // Keep only the ffmpeg binary; skip ffplay and ffprobe to shave
+    // a few MB off the download. Our pipeline only needs ffmpeg itself.
+    std::env::set_var("FFMPEG_SIDECAR_KEEP_ONLY_FFMPEG", "1");
+
+    let url = ffmpeg_download_url()
+        .map_err(|e| format!("Failed to resolve ffmpeg download URL: {e}"))?;
+    let archive_path = download_ffmpeg_package(url, dest_dir)
+        .map_err(|e| format!("Failed to download ffmpeg: {e}"))?;
+    unpack_ffmpeg(&archive_path, dest_dir)
+        .map_err(|e| format!("Failed to unpack ffmpeg: {e}"))?;
+
+    let final_path = dest_dir.join(bin_filename());
+    if !final_path.exists() {
+        return Err(format!(
+            "ffmpeg binary not found at expected path after unpack: {}",
+            final_path.display(),
+        ));
+    }
+    Ok(final_path)
+}
+
+// ─── Commands ────────────────────────────────────────────────────
+
+/// Fast status check. Does not download anything. Returns the current
+/// resolution state so the UI can show "ready" vs. "needs install".
+#[tauri::command]
+pub async fn check_ffmpeg_status(app: AppHandle) -> Result<FfmpegStatus, String> {
+    Ok(resolve_ffmpeg(&app).await)
+}
+
+/// Ensures ffmpeg is available, downloading it into `app_data_dir/bin/`
+/// if needed. Returns the final status (with path + version).
+///
+/// On success, subsequent calls short-circuit via the bundled cache.
+/// On failure, returns an error describing the step that failed
+/// (resolve URL / download / unpack / post-unpack probe).
+#[tauri::command]
+pub async fn ensure_ffmpeg_ready(app: AppHandle) -> Result<FfmpegStatus, String> {
+    // If ffmpeg is already resolvable, short-circuit.
+    let status = resolve_ffmpeg(&app).await;
+    if status.available {
+        return Ok(status);
+    }
+
+    let dest_dir = bundled_bin_dir(&app)?;
+
+    // ffmpeg-sidecar is blocking; run it on the blocking pool so we
+    // don't wedge the async runtime while downloading ~30MB.
+    let dest_for_blocking = dest_dir.clone();
+    let downloaded = tokio::task::spawn_blocking(move || {
+        download_ffmpeg_blocking(&dest_for_blocking)
+    })
+    .await
+    .map_err(|e| format!("ffmpeg download task panicked: {e}"))??;
+
+    // Confirm the just-downloaded binary works.
+    let version = probe_ffmpeg(&downloaded).await.ok_or_else(|| {
+        format!(
+            "Downloaded ffmpeg at {} did not respond to -version",
+            downloaded.display(),
+        )
+    })?;
+
+    Ok(FfmpegStatus {
+        available: true,
+        source: Some(FfmpegSource::Bundled),
+        path: Some(downloaded.to_string_lossy().to_string()),
+        version: Some(version),
+    })
+}
+
+// ─── Internal helper for the encoder PR ──────────────────────────
+
+/// Returns the path to an ffmpeg binary that is known to work, or an
+/// error if one is not available. Tries the cache + PATH; does NOT
+/// trigger a download (callers that want download-on-demand should use
+/// `ensure_ffmpeg_ready` via IPC first).
+///
+/// Used by the video export pipeline when it needs to spawn ffmpeg.
+#[allow(dead_code)] // consumed by a later PR in the feature branch
+pub async fn ffmpeg_binary_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let status = resolve_ffmpeg(app).await;
+    match status.path {
+        Some(p) => Ok(PathBuf::from(p)),
+        None => Err(
+            "ffmpeg is not available. Call ensure_ffmpeg_ready first to download it."
+                .to_string(),
+        ),
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_standard_version_line() {
+        let sample = "ffmpeg version 6.1.1 Copyright (c) 2000-2023 the FFmpeg developers\n\
+                      built with gcc 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)";
+        assert_eq!(parse_ffmpeg_version(sample), Some("6.1.1".to_string()));
+    }
+
+    #[test]
+    fn parses_git_version_line() {
+        let sample = "ffmpeg version n6.0-gfedcba Copyright (c) 2000-2023 the FFmpeg developers";
+        assert_eq!(parse_ffmpeg_version(sample), Some("n6.0-gfedcba".to_string()));
+    }
+
+    #[test]
+    fn parses_windows_build_version() {
+        let sample = "ffmpeg version 2024-01-15-git-6b6b9c4e5e-full_build-www.gyan.dev Copyright (c) 2000-2024";
+        assert_eq!(
+            parse_ffmpeg_version(sample),
+            Some("2024-01-15-git-6b6b9c4e5e-full_build-www.gyan.dev".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_non_ffmpeg_output() {
+        assert_eq!(parse_ffmpeg_version(""), None);
+        assert_eq!(parse_ffmpeg_version("not ffmpeg"), None);
+        assert_eq!(parse_ffmpeg_version("bash: ffmpeg: command not found"), None);
+    }
+
+    #[test]
+    fn returns_none_for_partial_version_line() {
+        // "ffmpeg version" with nothing after
+        assert_eq!(parse_ffmpeg_version("ffmpeg version "), None);
+        assert_eq!(parse_ffmpeg_version("ffmpeg version"), None);
+    }
+
+    #[test]
+    fn ignores_lines_after_the_first() {
+        let sample = "ffmpeg version 7.0.0 Copyright\nrandom second line\n6.1.1 trailing";
+        assert_eq!(parse_ffmpeg_version(sample), Some("7.0.0".to_string()));
+    }
+
+    #[test]
+    fn bin_filename_is_platform_specific() {
+        if cfg!(windows) {
+            assert_eq!(bin_filename(), "ffmpeg.exe");
+        } else {
+            assert_eq!(bin_filename(), "ffmpeg");
+        }
+    }
+
+    #[test]
+    fn missing_status_has_no_path_or_version() {
+        let missing = FfmpegStatus::missing();
+        assert!(!missing.available);
+        assert!(missing.source.is_none());
+        assert!(missing.path.is_none());
+        assert!(missing.version.is_none());
+    }
+
+    // ─── Integration test: real ffmpeg download ─────────────────
+    //
+    // Exercises the full download → unpack → probe pipeline against
+    // the real ffmpeg-sidecar CDN. Marked `#[ignore]` so it only runs
+    // when explicitly requested:
+    //
+    //   cargo test ffmpeg::tests::downloads_and_probes_real_ffmpeg \
+    //     -- --ignored --nocapture
+    //
+    // Takes ~30 seconds on a reasonable connection. Downloads ~30 MB.
+    #[test]
+    #[ignore]
+    fn downloads_and_probes_real_ffmpeg() {
+        let tmp = std::env::temp_dir().join(format!(
+            "arcanum-ffmpeg-test-{}",
+            std::process::id(),
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let bin = download_ffmpeg_blocking(&tmp)
+            .expect("download should succeed");
+        assert!(bin.exists(), "downloaded binary should exist at {}", bin.display());
+
+        // Sync version probe (the async helper needs tokio).
+        let output = std::process::Command::new(&bin)
+            .arg("-version")
+            .output()
+            .expect("spawning downloaded ffmpeg should succeed");
+        assert!(output.status.success(), "ffmpeg -version should exit 0");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let version = parse_ffmpeg_version(&stdout).expect("should parse version");
+        eprintln!("Downloaded ffmpeg version: {version}");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod project_settings;
 mod settings;
 mod sketch;
 mod video_encode;
+mod video_export;
 mod vibes;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -57,6 +58,10 @@ pub fn run() {
             runware::runware_generate_image,
             ffmpeg::check_ffmpeg_status,
             ffmpeg::ensure_ffmpeg_ready,
+            video_export::save_video_frame,
+            video_export::cleanup_video_export_session,
+            video_export::resolve_first_existing_path,
+            video_export::export_story_video,
             openai_images::openai_generate_image,
             openai_tts::openai_tts_generate,
             runware::runware_generate_audio,

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod admin;
 mod anthropic;
 mod arcanum_meta;
 mod assets;
+mod audio_mix;
 mod deepinfra;
 mod ffmpeg;
 mod git;

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod git;
 mod generation;
 mod llm;
 mod openai_images;
+mod openai_tts;
 mod openrouter;
 mod project;
 mod r2;
@@ -52,6 +53,7 @@ pub fn run() {
             llm::llm_complete_with_vision,
             runware::runware_generate_image,
             openai_images::openai_generate_image,
+            openai_tts::openai_tts_generate,
             runware::runware_generate_audio,
             runware::runware_generate_video,
             assets::accept_asset,

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod anthropic;
 mod arcanum_meta;
 mod assets;
 mod deepinfra;
+mod ffmpeg;
 mod git;
 mod generation;
 mod llm;
@@ -52,6 +53,8 @@ pub fn run() {
             llm::llm_complete,
             llm::llm_complete_with_vision,
             runware::runware_generate_image,
+            ffmpeg::check_ffmpeg_status,
+            ffmpeg::ensure_ffmpeg_ready,
             openai_images::openai_generate_image,
             openai_tts::openai_tts_generate,
             runware::runware_generate_audio,

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod runware;
 mod project_settings;
 mod settings;
 mod sketch;
+mod video_encode;
 mod vibes;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -92,6 +92,7 @@ pub fn run() {
             r2::deploy_achievements_to_r2,
             r2::deploy_zones_to_r2,
             r2::deploy_showcase_to_r2,
+            r2::deploy_story_video_to_r2,
             vibes::save_zone_vibe,
             vibes::load_zone_vibe,
             arcanum_meta::load_arcanum_meta,

--- a/creator/src-tauri/src/openai_tts.rs
+++ b/creator/src-tauri/src/openai_tts.rs
@@ -1,0 +1,290 @@
+// ─── OpenAI Text-to-Speech ──────────────────────────────────────
+// Narration synthesis for the story → video export pipeline.
+// Uses the existing `openai_api_key` from Settings.
+//
+// Output files are content-addressed by SHA256(text + voice + model + speed)
+// so identical narration doesn't re-synthesize on every export. Cached
+// MP3s live under `app_data_dir/assets/narration/<hash>.mp3`.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager};
+
+use crate::settings;
+
+const API_URL: &str = "https://api.openai.com/v1/audio/speech";
+
+/// Supported OpenAI TTS voices. Passed through to the API as-is.
+/// Keep in sync with the frontend voice picker.
+const SUPPORTED_VOICES: &[&str] = &[
+    "alloy", "echo", "fable", "onyx", "nova", "shimmer",
+];
+
+/// Supported OpenAI TTS models. `tts-1` is fast/cheap, `tts-1-hd` is
+/// higher quality at 2x the cost.
+const SUPPORTED_MODELS: &[&str] = &["tts-1", "tts-1-hd"];
+
+#[derive(Debug, Serialize)]
+struct OpenAiTtsRequest {
+    model: String,
+    input: String,
+    voice: String,
+    response_format: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    speed: Option<f32>,
+}
+
+/// Result returned to the frontend.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NarrationAudio {
+    /// Absolute filesystem path to the cached MP3.
+    pub file_path: String,
+    /// Content hash (also the filename stem).
+    pub hash: String,
+    /// Bytes of the generated audio.
+    pub size_bytes: u64,
+    /// Whether the file came from cache (true) or was freshly synthesized (false).
+    pub cached: bool,
+}
+
+// ─── Input validation ────────────────────────────────────────────
+
+fn validate_voice(voice: &str) -> Result<String, String> {
+    if SUPPORTED_VOICES.contains(&voice) {
+        Ok(voice.to_string())
+    } else {
+        Err(format!(
+            "Unsupported TTS voice '{voice}'. Supported: {}",
+            SUPPORTED_VOICES.join(", ")
+        ))
+    }
+}
+
+fn validate_model(model: Option<&str>) -> Result<String, String> {
+    let m = model.unwrap_or("tts-1");
+    if SUPPORTED_MODELS.contains(&m) {
+        Ok(m.to_string())
+    } else {
+        Err(format!(
+            "Unsupported TTS model '{m}'. Supported: {}",
+            SUPPORTED_MODELS.join(", ")
+        ))
+    }
+}
+
+/// Clamp speed to the API's supported range [0.25, 4.0]. None means "default".
+fn validate_speed(speed: Option<f32>) -> Option<f32> {
+    speed.map(|s| s.clamp(0.25, 4.0))
+}
+
+// ─── Cache key ───────────────────────────────────────────────────
+
+fn cache_hash(text: &str, voice: &str, model: &str, speed: Option<f32>) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    hasher.update(b"|");
+    hasher.update(voice.as_bytes());
+    hasher.update(b"|");
+    hasher.update(model.as_bytes());
+    hasher.update(b"|");
+    // Serialize speed with 2-decimal precision so 1.0 and 1.00 map to the
+    // same key.
+    match speed {
+        Some(s) => hasher.update(format!("{s:.2}").as_bytes()),
+        None => hasher.update(b"default"),
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+async fn narration_dir(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+        .join("assets")
+        .join("narration");
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| format!("Failed to create narration dir: {e}"))?;
+    Ok(dir)
+}
+
+// ─── Public command ──────────────────────────────────────────────
+
+/// Synthesize narration audio via OpenAI's TTS API.
+///
+/// Returns a cached file path when the same (text, voice, model, speed)
+/// combination has been generated before. Otherwise calls the API,
+/// saves the MP3 under `app_data_dir/assets/narration/<hash>.mp3`,
+/// and returns the new path.
+///
+/// Empty or whitespace-only input is rejected (the API would 400 anyway).
+#[tauri::command]
+pub async fn openai_tts_generate(
+    app: AppHandle,
+    text: String,
+    voice: String,
+    model: Option<String>,
+    speed: Option<f32>,
+) -> Result<NarrationAudio, String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Err("TTS input text is empty.".to_string());
+    }
+
+    let voice = validate_voice(&voice)?;
+    let model = validate_model(model.as_deref())?;
+    let speed = validate_speed(speed);
+
+    // ─── Cache lookup ────────────────────────────────────────
+    let hash = cache_hash(trimmed, &voice, &model, speed);
+    let dir = narration_dir(&app).await?;
+    let file_path = dir.join(format!("{hash}.mp3"));
+
+    if let Ok(metadata) = tokio::fs::metadata(&file_path).await {
+        if metadata.is_file() && metadata.len() > 0 {
+            return Ok(NarrationAudio {
+                file_path: file_path.to_string_lossy().to_string(),
+                hash,
+                size_bytes: metadata.len(),
+                cached: true,
+            });
+        }
+    }
+
+    // ─── API key check ───────────────────────────────────────
+    let settings = settings::get_settings(app.clone()).await?;
+    if settings.openai_api_key.is_empty() {
+        return Err("OpenAI API key not configured. Set it in Settings.".to_string());
+    }
+
+    // ─── Request ─────────────────────────────────────────────
+    let body = OpenAiTtsRequest {
+        model: model.clone(),
+        input: trimmed.to_string(),
+        voice: voice.clone(),
+        response_format: "mp3".to_string(),
+        speed,
+    };
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(API_URL)
+        .header("Authorization", format!("Bearer {}", settings.openai_api_key))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("OpenAI TTS request failed: {e}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("OpenAI TTS error ({status}): {text}"));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read TTS response bytes: {e}"))?;
+
+    if bytes.is_empty() {
+        return Err("OpenAI TTS returned an empty audio body.".to_string());
+    }
+
+    // ─── Write to cache ──────────────────────────────────────
+    tokio::fs::write(&file_path, &bytes)
+        .await
+        .map_err(|e| format!("Failed to write narration audio: {e}"))?;
+
+    Ok(NarrationAudio {
+        file_path: file_path.to_string_lossy().to_string(),
+        hash,
+        size_bytes: bytes.len() as u64,
+        cached: false,
+    })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_hash_is_deterministic() {
+        let a = cache_hash("hello", "onyx", "tts-1", Some(1.0));
+        let b = cache_hash("hello", "onyx", "tts-1", Some(1.0));
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn cache_hash_varies_with_text() {
+        let a = cache_hash("hello", "onyx", "tts-1", Some(1.0));
+        let b = cache_hash("world", "onyx", "tts-1", Some(1.0));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_hash_varies_with_voice() {
+        let a = cache_hash("hello", "onyx", "tts-1", Some(1.0));
+        let b = cache_hash("hello", "nova", "tts-1", Some(1.0));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_hash_varies_with_model() {
+        let a = cache_hash("hello", "onyx", "tts-1", Some(1.0));
+        let b = cache_hash("hello", "onyx", "tts-1-hd", Some(1.0));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cache_hash_varies_with_speed() {
+        let slow = cache_hash("hello", "onyx", "tts-1", Some(0.85));
+        let fast = cache_hash("hello", "onyx", "tts-1", Some(1.15));
+        assert_ne!(slow, fast);
+    }
+
+    #[test]
+    fn cache_hash_default_speed_is_stable() {
+        let a = cache_hash("hello", "onyx", "tts-1", None);
+        let b = cache_hash("hello", "onyx", "tts-1", None);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn validate_voice_accepts_supported_voices() {
+        for voice in SUPPORTED_VOICES {
+            assert!(validate_voice(voice).is_ok(), "{voice} should be valid");
+        }
+    }
+
+    #[test]
+    fn validate_voice_rejects_unknown() {
+        assert!(validate_voice("deepvoice").is_err());
+        assert!(validate_voice("").is_err());
+    }
+
+    #[test]
+    fn validate_model_defaults_to_tts1() {
+        assert_eq!(validate_model(None).unwrap(), "tts-1");
+    }
+
+    #[test]
+    fn validate_model_rejects_unknown() {
+        assert!(validate_model(Some("gpt-4")).is_err());
+    }
+
+    #[test]
+    fn validate_speed_clamps_extremes() {
+        assert_eq!(validate_speed(Some(0.1)), Some(0.25));
+        assert_eq!(validate_speed(Some(10.0)), Some(4.0));
+        assert_eq!(validate_speed(Some(1.5)), Some(1.5));
+    }
+
+    #[test]
+    fn validate_speed_passes_through_none() {
+        assert_eq!(validate_speed(None), None);
+    }
+}

--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -1086,6 +1086,70 @@ pub async fn resolve_asset_url(app: AppHandle, file_name: String) -> Result<Stri
     Ok(format!("{domain}/{file_name}"))
 }
 
+/// Deploys a story's exported MP4 cinematic to R2 under
+/// `showcase/videos/<story_id>.mp4`. Returns the public URL so the
+/// caller can stamp it onto the story's metadata for inclusion in
+/// the next showcase JSON deploy.
+#[tauri::command]
+pub async fn deploy_story_video_to_r2(
+    app: AppHandle,
+    story_id: String,
+    file_path: String,
+) -> Result<String, String> {
+    let s = settings::get_settings(app).await?;
+    if s.r2_account_id.is_empty()
+        || s.r2_access_key_id.is_empty()
+        || s.r2_secret_access_key.is_empty()
+        || s.r2_bucket.is_empty()
+    {
+        return Err("R2 credentials not configured. Set them in Settings.".to_string());
+    }
+    if s.r2_custom_domain.is_empty() {
+        return Err(
+            "R2 custom domain not configured — showcase URLs need it to be reachable."
+                .to_string(),
+        );
+    }
+
+    // Only allow alphanumeric + dash/underscore for the story ID so a
+    // malicious input can't escape the expected key prefix.
+    if story_id.is_empty()
+        || story_id
+            .chars()
+            .any(|c| !c.is_ascii_alphanumeric() && c != '-' && c != '_')
+    {
+        return Err(format!(
+            "Invalid story_id '{story_id}' — alphanumeric + dash/underscore only"
+        ));
+    }
+
+    let bytes = tokio::fs::read(&file_path)
+        .await
+        .map_err(|e| format!("Failed to read cinematic file '{file_path}': {e}"))?;
+
+    if bytes.is_empty() {
+        return Err("Cinematic file is empty".to_string());
+    }
+
+    let client = reqwest::Client::new();
+    let object_key = format!("showcase/videos/{story_id}.mp4");
+
+    upload_object(
+        &client,
+        &s.r2_account_id,
+        &s.r2_bucket,
+        &s.r2_access_key_id,
+        &s.r2_secret_access_key,
+        &object_key,
+        bytes,
+        "video/mp4",
+    )
+    .await?;
+
+    let domain = s.r2_custom_domain.trim_end_matches('/');
+    Ok(format!("{domain}/{object_key}"))
+}
+
 /// Deploy showcase JSON to R2 so the lore site can fetch it.
 #[tauri::command]
 pub async fn deploy_showcase_to_r2(

--- a/creator/src-tauri/src/video_encode.rs
+++ b/creator/src-tauri/src/video_encode.rs
@@ -1,0 +1,905 @@
+// ─── Story Video Encoder ─────────────────────────────────────────
+// Encodes a sequence of pre-rendered scene PNGs (one per scene, at
+// the preset's target dimensions) into a silent H.264 video, then
+// muxes the resulting video with the audio track from audio_mix.rs.
+//
+// Architecture mirrors audio_mix.rs:
+//   - `build_video_encode_command()` and `build_mux_command()` are
+//     PURE functions returning ffmpeg argv. Unit-tested without
+//     spawning ffmpeg.
+//   - `encode_video_segments()` and `mux_video_and_audio()` are async
+//     wrappers that resolve the ffmpeg binary, spawn it, wait for
+//     completion. Used by the export orchestrator (PR 8).
+//
+// Filtergraph for crossfade-chained scenes (3 scenes, 0.5s xfade):
+//
+//   [0:v]format=yuv420p[s0];
+//   [1:v]format=yuv420p[s1];
+//   [2:v]format=yuv420p[s2];
+//   [s0][s1]xfade=transition=fade:duration=0.500:offset=5.000[v1];
+//   [v1][s2]xfade=transition=fade:duration=0.500:offset=12.500[out]
+//
+// xfade offsets accumulate: each crossfade shortens the running chain
+// length by `crossfade_ms`, so the offset is the cumulative duration
+// minus the crossfade. The encoder validates this is positive — a
+// scene shorter than the crossfade would corrupt the chain.
+//
+// For hard cuts (crossfade_ms = None or 0), the filtergraph collapses
+// to a `concat` filter which is simpler and faster.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+use crate::ffmpeg;
+use tauri::AppHandle;
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/// One scene's pre-rendered PNG plus how long it should hold on screen.
+/// Crossfade durations are global (set on `VideoEncodeInput`), not
+/// per-scene, in this PR — per-scene transitions can come later.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SceneFrame {
+    pub png_path: String,
+    /// Total time this scene occupies in the final video (including
+    /// any portion of the next crossfade). Milliseconds.
+    pub duration_ms: u64,
+}
+
+/// H.264 codec profile — drives the `-profile:v` flag. Lower profiles
+/// are more compatible with older players (in_game preset uses baseline).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum H264Profile {
+    Baseline,
+    Main,
+    High,
+}
+
+impl H264Profile {
+    fn as_arg(self) -> &'static str {
+        match self {
+            Self::Baseline => "baseline",
+            Self::Main => "main",
+            Self::High => "high",
+        }
+    }
+}
+
+/// Video encode request: ordered scene frames + preset video settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VideoEncodeInput {
+    pub scenes: Vec<SceneFrame>,
+    pub width: u32,
+    pub height: u32,
+    pub fps: u32,
+    pub video_bitrate_kbps: u32,
+    pub profile: H264Profile,
+    /// Crossfade duration between consecutive scenes. `None` or `Some(0)`
+    /// means hard cuts (using the concat filter instead of xfade).
+    pub crossfade_ms: Option<u64>,
+}
+
+/// Result of a successful video encode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VideoEncodeOutput {
+    pub file_path: String,
+    pub total_duration_ms: u64,
+}
+
+/// The pure result of building an ffmpeg invocation. Doesn't run
+/// ffmpeg — that's `encode_video_segments`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VideoEncodeCommand {
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MuxCommand {
+    pub args: Vec<String>,
+}
+
+// ─── Command builders ────────────────────────────────────────────
+
+/// Builds the ffmpeg argv for encoding a sequence of scene PNGs into
+/// a silent H.264 video.
+///
+/// Returns an error if:
+///   - The scenes list is empty.
+///   - Any scene has duration 0 or an empty PNG path.
+///   - A crossfade is requested but a scene is shorter than the crossfade.
+///   - width/height/fps/bitrate are zero.
+pub fn build_video_encode_command(
+    input: &VideoEncodeInput,
+    output_path: &Path,
+) -> Result<VideoEncodeCommand, String> {
+    validate_encode_input(input)?;
+
+    let mut args: Vec<String> = Vec::new();
+    args.push("-y".to_string());
+    args.push("-hide_banner".to_string());
+    args.push("-loglevel".to_string());
+    args.push("error".to_string());
+
+    // ─── Inputs: one -loop -t -i triplet per scene ───────────
+    for scene in &input.scenes {
+        args.push("-loop".to_string());
+        args.push("1".to_string());
+        args.push("-t".to_string());
+        args.push(format_seconds(scene.duration_ms));
+        args.push("-i".to_string());
+        args.push(scene.png_path.clone());
+    }
+
+    // ─── filter_complex ──────────────────────────────────────
+    let filter = build_video_filter_complex(input)?;
+    args.push("-filter_complex".to_string());
+    args.push(filter);
+
+    args.push("-map".to_string());
+    args.push("[out]".to_string());
+
+    // ─── Frame rate + codec ──────────────────────────────────
+    args.push("-r".to_string());
+    args.push(input.fps.to_string());
+
+    args.push("-c:v".to_string());
+    args.push("libx264".to_string());
+    args.push("-profile:v".to_string());
+    args.push(input.profile.as_arg().to_string());
+    args.push("-pix_fmt".to_string());
+    args.push("yuv420p".to_string());
+
+    // VBR with a soft cap. The bufsize = 2x bitrate is the standard
+    // x264 recommendation for streaming-friendly bitrate variability.
+    let kbps = input.video_bitrate_kbps;
+    args.push("-b:v".to_string());
+    args.push(format!("{kbps}k"));
+    args.push("-maxrate".to_string());
+    args.push(format!("{kbps}k"));
+    args.push("-bufsize".to_string());
+    args.push(format!("{}k", kbps * 2));
+
+    // Mark this as silent so downstream muxing knows there's no audio.
+    args.push("-an".to_string());
+
+    args.push(output_path.to_string_lossy().to_string());
+
+    Ok(VideoEncodeCommand { args })
+}
+
+/// Builds the ffmpeg argv for muxing a silent video with an audio
+/// track. Both streams are copied without re-encoding (`-c copy`),
+/// so this step is fast and lossless.
+pub fn build_mux_command(
+    video_path: &Path,
+    audio_path: &Path,
+    output_path: &Path,
+) -> Result<MuxCommand, String> {
+    if video_path.as_os_str().is_empty() {
+        return Err("Mux: video path is empty".to_string());
+    }
+    if audio_path.as_os_str().is_empty() {
+        return Err("Mux: audio path is empty".to_string());
+    }
+
+    let args = vec![
+        "-y".to_string(),
+        "-hide_banner".to_string(),
+        "-loglevel".to_string(),
+        "error".to_string(),
+        "-i".to_string(),
+        video_path.to_string_lossy().to_string(),
+        "-i".to_string(),
+        audio_path.to_string_lossy().to_string(),
+        "-c:v".to_string(),
+        "copy".to_string(),
+        "-c:a".to_string(),
+        "copy".to_string(),
+        // Stop at the shortest stream so a slightly longer audio
+        // tail doesn't trigger a black-frame extension at the end.
+        "-shortest".to_string(),
+        // Move the moov atom to the front for fast playback start.
+        "-movflags".to_string(),
+        "+faststart".to_string(),
+        output_path.to_string_lossy().to_string(),
+    ];
+
+    Ok(MuxCommand { args })
+}
+
+// ─── Validation ──────────────────────────────────────────────────
+
+fn validate_encode_input(input: &VideoEncodeInput) -> Result<(), String> {
+    if input.scenes.is_empty() {
+        return Err("Cannot encode video: scenes list is empty.".to_string());
+    }
+    if input.width == 0 || input.height == 0 {
+        return Err("Cannot encode video: width and height must be non-zero.".to_string());
+    }
+    if input.fps == 0 {
+        return Err("Cannot encode video: fps must be non-zero.".to_string());
+    }
+    if input.video_bitrate_kbps == 0 {
+        return Err("Cannot encode video: video_bitrate_kbps must be non-zero.".to_string());
+    }
+
+    for (i, scene) in input.scenes.iter().enumerate() {
+        if scene.png_path.is_empty() {
+            return Err(format!("Scene {i} has empty png_path"));
+        }
+        if scene.duration_ms == 0 {
+            return Err(format!("Scene {i} has zero duration"));
+        }
+    }
+
+    if let Some(xfade_ms) = input.crossfade_ms {
+        if xfade_ms > 0 && input.scenes.len() > 1 {
+            for (i, scene) in input.scenes.iter().enumerate() {
+                if scene.duration_ms < xfade_ms {
+                    return Err(format!(
+                        "Scene {i} duration ({}ms) is shorter than the crossfade ({xfade_ms}ms). \
+                         Either lengthen the scene or reduce the crossfade.",
+                        scene.duration_ms,
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ─── Filtergraph ─────────────────────────────────────────────────
+
+fn build_video_filter_complex(input: &VideoEncodeInput) -> Result<String, String> {
+    let mut parts: Vec<String> = Vec::new();
+
+    // Step 1: format every input as yuv420p with a stable label.
+    for i in 0..input.scenes.len() {
+        parts.push(format!("[{i}:v]format=yuv420p[s{i}]"));
+    }
+
+    let use_xfade = matches!(input.crossfade_ms, Some(ms) if ms > 0) && input.scenes.len() > 1;
+
+    if use_xfade {
+        let xfade_ms = input.crossfade_ms.unwrap();
+        let xfade_sec = ms_to_decimal_seconds(xfade_ms);
+
+        // Build the xfade chain. Each step joins the running chain
+        // with the next scene at offset = (cumulative chain length) - xfade.
+        let mut current_label = "s0".to_string();
+        let mut chain_length_ms: u64 = input.scenes[0].duration_ms;
+
+        for i in 1..input.scenes.len() {
+            let next_label = if i == input.scenes.len() - 1 {
+                "out".to_string()
+            } else {
+                format!("v{i}")
+            };
+            // Offset must be positive — guarded by validate_encode_input.
+            let offset_ms = chain_length_ms.saturating_sub(xfade_ms);
+            let offset_sec = ms_to_decimal_seconds(offset_ms);
+            parts.push(format!(
+                "[{current_label}][s{i}]xfade=transition=fade:duration={xfade_sec}:offset={offset_sec}[{next_label}]",
+            ));
+            current_label = next_label;
+            // Combined length grows by (next scene duration - xfade overlap).
+            chain_length_ms += input.scenes[i].duration_ms - xfade_ms;
+        }
+    } else if input.scenes.len() == 1 {
+        // Single scene: rename s0 → out.
+        parts.push("[s0]copy[out]".to_string());
+    } else {
+        // Hard cuts via concat filter — much simpler than the xfade chain.
+        let labels: String = (0..input.scenes.len())
+            .map(|i| format!("[s{i}]"))
+            .collect::<Vec<_>>()
+            .join("");
+        parts.push(format!(
+            "{labels}concat=n={count}:v=1:a=0[out]",
+            count = input.scenes.len(),
+        ));
+    }
+
+    Ok(parts.join(";"))
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+fn format_seconds(ms: u64) -> String {
+    let seconds = ms / 1000;
+    let millis = ms % 1000;
+    format!("{seconds}.{millis:03}")
+}
+
+/// Same as `format_seconds`, separated for grep-ability — used inside
+/// the filter_complex string where the unit is implied.
+fn ms_to_decimal_seconds(ms: u64) -> String {
+    format_seconds(ms)
+}
+
+/// Computes the total duration of a video, accounting for crossfade
+/// overlap (each crossfade shortens the chain by `crossfade_ms`).
+pub fn compute_total_duration_ms(input: &VideoEncodeInput) -> u64 {
+    let raw: u64 = input.scenes.iter().map(|s| s.duration_ms).sum();
+    if let Some(xfade_ms) = input.crossfade_ms {
+        if xfade_ms > 0 && input.scenes.len() > 1 {
+            let overlaps = (input.scenes.len() - 1) as u64;
+            return raw.saturating_sub(xfade_ms * overlaps);
+        }
+    }
+    raw
+}
+
+// ─── Async runners ───────────────────────────────────────────────
+
+/// Spawns ffmpeg to encode a sequence of scene PNGs into a silent
+/// video. Returns the output file path and the computed total
+/// duration (with crossfade overlaps subtracted).
+#[allow(dead_code)] // consumed by the export orchestrator (PR 8)
+pub async fn encode_video_segments(
+    app: &AppHandle,
+    input: VideoEncodeInput,
+    output_path: PathBuf,
+) -> Result<VideoEncodeOutput, String> {
+    let ffmpeg_path = ffmpeg::ffmpeg_binary_path(app).await?;
+    let cmd = build_video_encode_command(&input, &output_path)?;
+
+    if let Some(parent) = output_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Failed to create video output dir: {e}"))?;
+    }
+
+    let output = Command::new(&ffmpeg_path)
+        .args(&cmd.args)
+        .output()
+        .await
+        .map_err(|e| format!("Failed to spawn ffmpeg for video encode: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "ffmpeg video encode failed (exit {}): {}",
+            output.status.code().unwrap_or(-1),
+            stderr.trim(),
+        ));
+    }
+
+    Ok(VideoEncodeOutput {
+        file_path: output_path.to_string_lossy().to_string(),
+        total_duration_ms: compute_total_duration_ms(&input),
+    })
+}
+
+/// Spawns ffmpeg to mux a silent video with an audio track.
+/// Both streams are copied without re-encoding (`-c copy`), and
+/// the result is faststart-flagged for instant playback start.
+#[allow(dead_code)] // consumed by the export orchestrator (PR 8)
+pub async fn mux_video_and_audio(
+    app: &AppHandle,
+    video_path: PathBuf,
+    audio_path: PathBuf,
+    output_path: PathBuf,
+) -> Result<String, String> {
+    let ffmpeg_path = ffmpeg::ffmpeg_binary_path(app).await?;
+    let cmd = build_mux_command(&video_path, &audio_path, &output_path)?;
+
+    if let Some(parent) = output_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Failed to create mux output dir: {e}"))?;
+    }
+
+    let output = Command::new(&ffmpeg_path)
+        .args(&cmd.args)
+        .output()
+        .await
+        .map_err(|e| format!("Failed to spawn ffmpeg for mux: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "ffmpeg mux failed (exit {}): {}",
+            output.status.code().unwrap_or(-1),
+            stderr.trim(),
+        ));
+    }
+
+    Ok(output_path.to_string_lossy().to_string())
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(path: &str, ms: u64) -> SceneFrame {
+        SceneFrame {
+            png_path: path.to_string(),
+            duration_ms: ms,
+        }
+    }
+
+    fn input_with(scenes: Vec<SceneFrame>) -> VideoEncodeInput {
+        VideoEncodeInput {
+            scenes,
+            width: 1920,
+            height: 1080,
+            fps: 30,
+            video_bitrate_kbps: 6000,
+            profile: H264Profile::High,
+            crossfade_ms: None,
+        }
+    }
+
+    fn out() -> PathBuf {
+        PathBuf::from("/tmp/out.mp4")
+    }
+
+    // ─── format_seconds ──────────────────────────────────────
+
+    #[test]
+    fn formats_milliseconds_as_decimal_seconds() {
+        assert_eq!(format_seconds(0), "0.000");
+        assert_eq!(format_seconds(500), "0.500");
+        assert_eq!(format_seconds(1234), "1.234");
+        assert_eq!(format_seconds(60_000), "60.000");
+    }
+
+    // ─── compute_total_duration_ms ───────────────────────────
+
+    #[test]
+    fn total_duration_no_crossfade_sums_scenes() {
+        let input = input_with(vec![frame("/a", 5000), frame("/b", 8000), frame("/c", 6000)]);
+        assert_eq!(compute_total_duration_ms(&input), 19_000);
+    }
+
+    #[test]
+    fn total_duration_with_crossfade_subtracts_overlaps() {
+        let mut input =
+            input_with(vec![frame("/a", 5000), frame("/b", 8000), frame("/c", 6000)]);
+        input.crossfade_ms = Some(500);
+        // 19000 - 2 overlaps × 500 = 18000
+        assert_eq!(compute_total_duration_ms(&input), 18_000);
+    }
+
+    #[test]
+    fn total_duration_zero_crossfade_treats_as_hard_cuts() {
+        let mut input = input_with(vec![frame("/a", 5000), frame("/b", 8000)]);
+        input.crossfade_ms = Some(0);
+        assert_eq!(compute_total_duration_ms(&input), 13_000);
+    }
+
+    #[test]
+    fn total_duration_single_scene_ignores_crossfade() {
+        let mut input = input_with(vec![frame("/only", 5000)]);
+        input.crossfade_ms = Some(500);
+        assert_eq!(compute_total_duration_ms(&input), 5000);
+    }
+
+    // ─── validation ──────────────────────────────────────────
+
+    #[test]
+    fn errors_on_empty_scenes_list() {
+        let input = input_with(vec![]);
+        assert!(build_video_encode_command(&input, &out()).is_err());
+    }
+
+    #[test]
+    fn errors_on_zero_dimensions() {
+        let mut input = input_with(vec![frame("/a", 5000)]);
+        input.width = 0;
+        assert!(build_video_encode_command(&input, &out()).is_err());
+        input.width = 1920;
+        input.height = 0;
+        assert!(build_video_encode_command(&input, &out()).is_err());
+    }
+
+    #[test]
+    fn errors_on_zero_fps() {
+        let mut input = input_with(vec![frame("/a", 5000)]);
+        input.fps = 0;
+        assert!(build_video_encode_command(&input, &out()).is_err());
+    }
+
+    #[test]
+    fn errors_on_zero_bitrate() {
+        let mut input = input_with(vec![frame("/a", 5000)]);
+        input.video_bitrate_kbps = 0;
+        assert!(build_video_encode_command(&input, &out()).is_err());
+    }
+
+    #[test]
+    fn errors_on_empty_png_path() {
+        let input = input_with(vec![frame("", 5000)]);
+        let err = build_video_encode_command(&input, &out()).unwrap_err();
+        assert!(err.contains("empty png_path"));
+    }
+
+    #[test]
+    fn errors_on_zero_duration_scene() {
+        let input = input_with(vec![frame("/a", 0)]);
+        let err = build_video_encode_command(&input, &out()).unwrap_err();
+        assert!(err.contains("zero duration"));
+    }
+
+    #[test]
+    fn errors_when_scene_shorter_than_crossfade() {
+        let mut input = input_with(vec![frame("/a", 5000), frame("/b", 200)]);
+        input.crossfade_ms = Some(500);
+        let err = build_video_encode_command(&input, &out()).unwrap_err();
+        assert!(err.contains("shorter than the crossfade"));
+    }
+
+    // ─── argv structure ──────────────────────────────────────
+
+    #[test]
+    fn includes_overwrite_and_loglevel_flags() {
+        let input = input_with(vec![frame("/a.png", 5000)]);
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        assert_eq!(cmd.args[0], "-y");
+        assert!(cmd.args.contains(&"-hide_banner".to_string()));
+    }
+
+    #[test]
+    fn each_scene_input_uses_loop_t_i_triplet() {
+        let input = input_with(vec![frame("/a.png", 5000), frame("/b.png", 8000)]);
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        // Find both PNG paths preceded by -loop 1 -t <sec> -i
+        let a_idx = cmd.args.iter().position(|x| x == "/a.png").unwrap();
+        assert_eq!(cmd.args[a_idx - 1], "-i");
+        assert_eq!(cmd.args[a_idx - 2], "5.000");
+        assert_eq!(cmd.args[a_idx - 3], "-t");
+        assert_eq!(cmd.args[a_idx - 4], "1");
+        assert_eq!(cmd.args[a_idx - 5], "-loop");
+
+        let b_idx = cmd.args.iter().position(|x| x == "/b.png").unwrap();
+        assert_eq!(cmd.args[b_idx - 2], "8.000");
+    }
+
+    #[test]
+    fn includes_h264_profile() {
+        let mut input = input_with(vec![frame("/a.png", 5000)]);
+        input.profile = H264Profile::Baseline;
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        let p_idx = cmd.args.iter().position(|a| a == "-profile:v").unwrap();
+        assert_eq!(cmd.args[p_idx + 1], "baseline");
+    }
+
+    #[test]
+    fn includes_yuv420p_pixel_format() {
+        let input = input_with(vec![frame("/a.png", 5000)]);
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        let pf_idx = cmd.args.iter().position(|a| a == "-pix_fmt").unwrap();
+        assert_eq!(cmd.args[pf_idx + 1], "yuv420p");
+    }
+
+    #[test]
+    fn includes_bitrate_with_2x_bufsize() {
+        let mut input = input_with(vec![frame("/a.png", 5000)]);
+        input.video_bitrate_kbps = 5000;
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        let b_idx = cmd.args.iter().position(|a| a == "-b:v").unwrap();
+        assert_eq!(cmd.args[b_idx + 1], "5000k");
+        let bufsize_idx = cmd.args.iter().position(|a| a == "-bufsize").unwrap();
+        assert_eq!(cmd.args[bufsize_idx + 1], "10000k");
+    }
+
+    #[test]
+    fn marks_video_as_silent_with_an_flag() {
+        let input = input_with(vec![frame("/a.png", 5000)]);
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        assert!(cmd.args.contains(&"-an".to_string()));
+    }
+
+    #[test]
+    fn output_path_is_the_last_arg() {
+        let input = input_with(vec![frame("/a.png", 5000)]);
+        let cmd = build_video_encode_command(&input, &PathBuf::from("/out/video.mp4")).unwrap();
+        assert_eq!(cmd.args.last().unwrap(), "/out/video.mp4");
+    }
+
+    // ─── filter_complex content ──────────────────────────────
+
+    fn extract_filter(cmd: &VideoEncodeCommand) -> String {
+        let idx = cmd
+            .args
+            .iter()
+            .position(|a| a == "-filter_complex")
+            .expect("filter_complex flag missing");
+        cmd.args[idx + 1].clone()
+    }
+
+    #[test]
+    fn single_scene_uses_copy_rename() {
+        let input = input_with(vec![frame("/a.png", 5000)]);
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(filter.contains("[0:v]format=yuv420p[s0]"));
+        assert!(filter.contains("[s0]copy[out]"));
+        assert!(!filter.contains("xfade"));
+        assert!(!filter.contains("concat"));
+    }
+
+    #[test]
+    fn hard_cuts_use_concat_filter() {
+        let input = input_with(vec![
+            frame("/a.png", 5000),
+            frame("/b.png", 8000),
+            frame("/c.png", 6000),
+        ]);
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(filter.contains("[s0][s1][s2]concat=n=3:v=1:a=0[out]"));
+        assert!(!filter.contains("xfade"));
+    }
+
+    #[test]
+    fn crossfade_chain_two_scenes_uses_xfade_directly_to_out() {
+        let mut input = input_with(vec![frame("/a.png", 5000), frame("/b.png", 8000)]);
+        input.crossfade_ms = Some(500);
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(filter.contains("[s0][s1]xfade=transition=fade:duration=0.500:offset=4.500[out]"));
+    }
+
+    #[test]
+    fn crossfade_chain_three_scenes_uses_intermediate_label() {
+        let mut input = input_with(vec![
+            frame("/a.png", 5000),
+            frame("/b.png", 8000),
+            frame("/c.png", 6000),
+        ]);
+        input.crossfade_ms = Some(500);
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        let filter = extract_filter(&cmd);
+        // First xfade: s0 + s1 → v1, offset = 5000 - 500 = 4500ms
+        assert!(filter.contains("[s0][s1]xfade=transition=fade:duration=0.500:offset=4.500[v1]"));
+        // Second xfade: v1 + s2 → out
+        // Chain length after first xfade = 5000 + 8000 - 500 = 12500
+        // Offset for second xfade = 12500 - 500 = 12000
+        assert!(filter.contains("[v1][s2]xfade=transition=fade:duration=0.500:offset=12.000[out]"));
+    }
+
+    #[test]
+    fn crossfade_zero_falls_back_to_concat() {
+        let mut input = input_with(vec![frame("/a.png", 5000), frame("/b.png", 8000)]);
+        input.crossfade_ms = Some(0);
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(!filter.contains("xfade"));
+        assert!(filter.contains("concat=n=2"));
+    }
+
+    #[test]
+    fn every_scene_gets_a_format_label() {
+        let input = input_with(vec![
+            frame("/a.png", 5000),
+            frame("/b.png", 8000),
+            frame("/c.png", 6000),
+        ]);
+        let cmd = build_video_encode_command(&input, &out()).unwrap();
+        let filter = extract_filter(&cmd);
+        assert!(filter.contains("[0:v]format=yuv420p[s0]"));
+        assert!(filter.contains("[1:v]format=yuv420p[s1]"));
+        assert!(filter.contains("[2:v]format=yuv420p[s2]"));
+    }
+
+    // ─── mux command builder ─────────────────────────────────
+
+    #[test]
+    fn mux_command_uses_copy_codecs() {
+        let cmd = build_mux_command(
+            Path::new("/v.mp4"),
+            Path::new("/a.m4a"),
+            Path::new("/out.mp4"),
+        )
+        .unwrap();
+        let v_idx = cmd.args.iter().position(|a| a == "-c:v").unwrap();
+        assert_eq!(cmd.args[v_idx + 1], "copy");
+        let a_idx = cmd.args.iter().position(|a| a == "-c:a").unwrap();
+        assert_eq!(cmd.args[a_idx + 1], "copy");
+    }
+
+    #[test]
+    fn mux_command_uses_shortest_and_faststart() {
+        let cmd = build_mux_command(
+            Path::new("/v.mp4"),
+            Path::new("/a.m4a"),
+            Path::new("/out.mp4"),
+        )
+        .unwrap();
+        assert!(cmd.args.contains(&"-shortest".to_string()));
+        let mv_idx = cmd.args.iter().position(|a| a == "-movflags").unwrap();
+        assert_eq!(cmd.args[mv_idx + 1], "+faststart");
+    }
+
+    #[test]
+    fn mux_command_takes_two_inputs_in_order() {
+        let cmd = build_mux_command(
+            Path::new("/v.mp4"),
+            Path::new("/a.m4a"),
+            Path::new("/out.mp4"),
+        )
+        .unwrap();
+        let v_idx = cmd.args.iter().position(|x| x == "/v.mp4").unwrap();
+        assert_eq!(cmd.args[v_idx - 1], "-i");
+        let a_idx = cmd.args.iter().position(|x| x == "/a.m4a").unwrap();
+        assert_eq!(cmd.args[a_idx - 1], "-i");
+        assert!(v_idx < a_idx);
+    }
+
+    #[test]
+    fn mux_command_output_is_last() {
+        let cmd = build_mux_command(
+            Path::new("/v.mp4"),
+            Path::new("/a.m4a"),
+            Path::new("/out.mp4"),
+        )
+        .unwrap();
+        assert_eq!(cmd.args.last().unwrap(), "/out.mp4");
+    }
+
+    // ─── Integration test: real ffmpeg encode + mux ────────────
+    //
+    // Generates synthetic scene PNGs via ffmpeg's color source,
+    // encodes them with the xfade chain, generates a synthetic
+    // audio track, muxes everything, and verifies the result is
+    // a valid MP4 with the expected duration.
+    //
+    // Marked #[ignore] so it only runs explicitly:
+    //
+    //   cargo test video_encode::tests::encodes_real_video_via_ffmpeg \
+    //     -- --ignored --nocapture
+    //
+    // Self-bootstraps ffmpeg via download_ffmpeg_blocking when
+    // not on PATH, so no manual setup is needed.
+    #[test]
+    #[ignore]
+    fn encodes_real_video_via_ffmpeg() {
+        use std::process::Command as StdCommand;
+
+        let tmp = std::env::temp_dir().join(format!(
+            "arcanum-video-encode-test-{}",
+            std::process::id(),
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let ffmpeg_bin = match which::which("ffmpeg") {
+            Ok(p) => p,
+            Err(_) => {
+                eprintln!("ffmpeg not on PATH; downloading via ffmpeg-sidecar...");
+                crate::ffmpeg::download_ffmpeg_blocking(&tmp)
+                    .expect("downloading ffmpeg should succeed")
+            }
+        };
+
+        // 1) Generate three synthetic scene PNGs (red, green, blue).
+        let frames = [
+            (tmp.join("scene_001.png"), "red"),
+            (tmp.join("scene_002.png"), "green"),
+            (tmp.join("scene_003.png"), "blue"),
+        ];
+        for (path, color) in &frames {
+            let status = StdCommand::new(&ffmpeg_bin)
+                .args([
+                    "-y",
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    &format!("color=c={color}:s=640x360:d=1"),
+                    "-frames:v",
+                    "1",
+                    path.to_str().unwrap(),
+                ])
+                .status()
+                .unwrap();
+            assert!(status.success(), "failed to generate {path:?}");
+        }
+
+        // 2) Build the encode command with crossfades and run it.
+        let video_path = tmp.join("video.mp4");
+        let input = VideoEncodeInput {
+            scenes: vec![
+                frame(&frames[0].0.to_string_lossy(), 2000),
+                frame(&frames[1].0.to_string_lossy(), 2000),
+                frame(&frames[2].0.to_string_lossy(), 2000),
+            ],
+            width: 640,
+            height: 360,
+            fps: 30,
+            video_bitrate_kbps: 1500,
+            profile: H264Profile::High,
+            crossfade_ms: Some(500),
+        };
+        let cmd = build_video_encode_command(&input, &video_path).unwrap();
+        let result = StdCommand::new(&ffmpeg_bin)
+            .args(&cmd.args)
+            .output()
+            .unwrap();
+        if !result.status.success() {
+            let stderr = String::from_utf8_lossy(&result.stderr);
+            panic!("video encode failed: {stderr}");
+        }
+        assert!(video_path.exists(), "encoded video should exist");
+
+        // 3) Probe the encoded video duration.
+        // Total = 6000ms - 2 overlaps × 500ms = 5000ms
+        let expected_total_ms = compute_total_duration_ms(&input);
+        assert_eq!(expected_total_ms, 5000);
+
+        if let Ok(ffprobe) = which::which("ffprobe") {
+            let probe = StdCommand::new(&ffprobe)
+                .args([
+                    "-v",
+                    "error",
+                    "-show_entries",
+                    "format=duration",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    video_path.to_str().unwrap(),
+                ])
+                .output()
+                .unwrap();
+            let duration_str = String::from_utf8_lossy(&probe.stdout);
+            let duration_sec: f64 = duration_str.trim().parse().unwrap_or(0.0);
+            assert!(
+                (4.5..=5.5).contains(&duration_sec),
+                "expected ~5s video, got {duration_sec}s",
+            );
+            eprintln!("Encoded video duration: {duration_sec}s");
+        }
+
+        // 4) Generate a synthetic audio track and test the mux.
+        let audio_path = tmp.join("audio.m4a");
+        let audio_status = StdCommand::new(&ffmpeg_bin)
+            .args([
+                "-y",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "sine=frequency=440:duration=5",
+                "-c:a",
+                "aac",
+                audio_path.to_str().unwrap(),
+            ])
+            .status()
+            .unwrap();
+        assert!(audio_status.success());
+
+        let final_path = tmp.join("final.mp4");
+        let mux_cmd = build_mux_command(&video_path, &audio_path, &final_path).unwrap();
+        let mux_result = StdCommand::new(&ffmpeg_bin)
+            .args(&mux_cmd.args)
+            .output()
+            .unwrap();
+        if !mux_result.status.success() {
+            let stderr = String::from_utf8_lossy(&mux_result.stderr);
+            panic!("mux failed: {stderr}");
+        }
+        assert!(final_path.exists(), "muxed final video should exist");
+        let metadata = std::fs::metadata(&final_path).unwrap();
+        assert!(
+            metadata.len() > 1000,
+            "final mp4 is suspiciously small: {} bytes",
+            metadata.len(),
+        );
+        eprintln!("Final muxed mp4: {} bytes", metadata.len());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/creator/src-tauri/src/video_export.rs
+++ b/creator/src-tauri/src/video_export.rs
@@ -1,0 +1,376 @@
+// ─── Story Video Export Orchestrator ────────────────────────────
+// Top-level Tauri command that wires together every primitive from
+// PRs 1–7 into a single export pipeline. The TypeScript side is
+// responsible for:
+//   - Computing the timeline (storyTiming.ts)
+//   - Synthesizing TTS narration (narrationSynthesis.ts)
+//   - Rendering scene frames to PNGs via canvas (storyFrameRenderer.ts)
+//   - Saving those PNGs via `save_video_frame`
+//   - Resolving zone music/ambient file paths
+//   - Bundling everything into an ExportRequest and calling
+//     `export_story_video`.
+//
+// This module handles the backend pipeline:
+//   1. audio_mix::mix_audio → temp m4a
+//   2. video_encode::encode_video_segments → temp silent mp4
+//   3. video_encode::mux_video_and_audio → final mp4
+//   4. cleanup of the session temp directory
+//
+// Progress events are emitted on the `video_export:progress` channel
+// so the UI can show a staged progress bar.
+
+use std::path::PathBuf;
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::audio_mix::{self, AudioMixInput};
+use crate::video_encode::{
+    self, H264Profile, SceneFrame, VideoEncodeInput,
+};
+
+// ─── Frame persistence ───────────────────────────────────────────
+
+/// Returns the filesystem directory where scene PNGs and intermediate
+/// audio/video files live for a given export session.
+fn session_dir(app: &AppHandle, session_id: &str) -> Result<PathBuf, String> {
+    if session_id.is_empty() {
+        return Err("Export session_id is empty".to_string());
+    }
+    // Defensive: only allow simple alphanumeric/dash session IDs so
+    // a malicious caller can't traverse up the filesystem.
+    if session_id.chars().any(|c| !c.is_ascii_alphanumeric() && c != '-' && c != '_') {
+        return Err(format!("Invalid session_id '{session_id}' — alphanumeric + dash/underscore only"));
+    }
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+        .join("tmp")
+        .join("video_export")
+        .join(session_id);
+    Ok(dir)
+}
+
+/// Persists a base64-encoded scene PNG into the session temp dir.
+/// Returns the absolute path to the saved file so the frontend can
+/// collect all frame paths into the export request.
+#[tauri::command]
+pub async fn save_video_frame(
+    app: AppHandle,
+    session_id: String,
+    scene_index: u32,
+    png_base64: String,
+) -> Result<String, String> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(&png_base64)
+        .map_err(|e| format!("Failed to decode frame base64: {e}"))?;
+    if bytes.len() < 8 || &bytes[0..8] != b"\x89PNG\r\n\x1a\n" {
+        return Err("Frame bytes are not a valid PNG".to_string());
+    }
+
+    let dir = session_dir(&app, &session_id)?;
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| format!("Failed to create session dir: {e}"))?;
+
+    let file_path = dir.join(format!("scene_{scene_index:04}.png"));
+    tokio::fs::write(&file_path, &bytes)
+        .await
+        .map_err(|e| format!("Failed to write frame: {e}"))?;
+
+    Ok(file_path.to_string_lossy().to_string())
+}
+
+/// Given an ordered list of candidate file paths, returns the first
+/// one that exists on disk, or `None` if none do. The frontend uses
+/// this to resolve zone music / ambient audio references against the
+/// candidate list that `useMediaSrc` would probe (asset cache dir,
+/// mudDir fallbacks, absolute paths).
+#[tauri::command]
+pub async fn resolve_first_existing_path(
+    candidates: Vec<String>,
+) -> Result<Option<String>, String> {
+    for path in candidates {
+        if path.is_empty() {
+            continue;
+        }
+        if tokio::fs::metadata(&path).await.is_ok() {
+            return Ok(Some(path));
+        }
+    }
+    Ok(None)
+}
+
+/// Deletes the session temp dir. Called after a successful export or
+/// when the user cancels mid-export.
+#[tauri::command]
+pub async fn cleanup_video_export_session(
+    app: AppHandle,
+    session_id: String,
+) -> Result<(), String> {
+    let dir = session_dir(&app, &session_id)?;
+    if dir.exists() {
+        tokio::fs::remove_dir_all(&dir)
+            .await
+            .map_err(|e| format!("Failed to remove session dir: {e}"))?;
+    }
+    Ok(())
+}
+
+// ─── Export request ──────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VideoExportRequest {
+    /// Session ID used for save_video_frame. The orchestrator uses it
+    /// to locate intermediate audio/video files under the same dir.
+    pub session_id: String,
+
+    /// Ordered scene frames (absolute PNG paths + durations).
+    pub scenes: Vec<SceneExportEntry>,
+
+    /// Audio mix configuration (same shape as audio_mix::AudioMixInput).
+    pub audio: AudioMixInput,
+
+    /// Preset-derived video settings.
+    pub width: u32,
+    pub height: u32,
+    pub fps: u32,
+    pub video_bitrate_kbps: u32,
+    pub profile: String, // "baseline" | "main" | "high"
+    pub crossfade_ms: Option<u64>,
+
+    /// Final output path. The caller picks this (usually from a
+    /// native file dialog) — we don't second-guess it.
+    pub output_path: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SceneExportEntry {
+    pub png_path: String,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VideoExportResult {
+    pub output_path: String,
+    pub total_duration_ms: u64,
+    pub size_bytes: u64,
+}
+
+// ─── Progress events ─────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ProgressEvent {
+    stage: &'static str,
+    message: String,
+}
+
+fn emit_progress(app: &AppHandle, stage: &'static str, message: impl Into<String>) {
+    let payload = ProgressEvent {
+        stage,
+        message: message.into(),
+    };
+    // Best-effort: emit failures are non-fatal for the pipeline.
+    let _ = app.emit("video_export:progress", payload);
+}
+
+// ─── Profile mapping ─────────────────────────────────────────────
+
+fn parse_profile(s: &str) -> Result<H264Profile, String> {
+    match s.to_ascii_lowercase().as_str() {
+        "baseline" => Ok(H264Profile::Baseline),
+        "main" => Ok(H264Profile::Main),
+        "high" => Ok(H264Profile::High),
+        other => Err(format!("Unknown H.264 profile '{other}'")),
+    }
+}
+
+// ─── Orchestrator command ───────────────────────────────────────
+
+/// Top-level export orchestrator. Runs audio mix → video encode →
+/// mux → cleanup. Emits progress events on `video_export:progress`
+/// at each stage transition.
+///
+/// Temp files live under `app_data_dir/tmp/video_export/<session_id>/`
+/// and are cleaned up on success. On failure, the caller can call
+/// `cleanup_video_export_session` manually to free disk space.
+#[tauri::command]
+pub async fn export_story_video(
+    app: AppHandle,
+    request: VideoExportRequest,
+) -> Result<VideoExportResult, String> {
+    if request.scenes.is_empty() {
+        return Err("Cannot export: no scenes provided".to_string());
+    }
+
+    let profile = parse_profile(&request.profile)?;
+    let session = session_dir(&app, &request.session_id)?;
+    tokio::fs::create_dir_all(&session)
+        .await
+        .map_err(|e| format!("Failed to create session dir: {e}"))?;
+
+    let audio_temp = session.join("audio.m4a");
+    let video_temp = session.join("video_silent.mp4");
+    let output_path = PathBuf::from(&request.output_path);
+
+    // Ensure the output directory exists before ffmpeg writes to it.
+    if let Some(parent) = output_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Failed to create output directory: {e}"))?;
+    }
+
+    // ─── Stage 1: Audio mix ──────────────────────────────────
+    emit_progress(&app, "audio_mix", "Mixing narration, music, and ambient…");
+    audio_mix::mix_audio(&app, request.audio.clone(), audio_temp.clone())
+        .await
+        .map_err(|e| format!("Audio mix failed: {e}"))?;
+
+    // ─── Stage 2: Video encode ───────────────────────────────
+    emit_progress(
+        &app,
+        "video_encode",
+        format!("Encoding {} scenes at {}x{} @ {}fps…", request.scenes.len(), request.width, request.height, request.fps),
+    );
+    let scene_frames: Vec<SceneFrame> = request
+        .scenes
+        .iter()
+        .map(|s| SceneFrame {
+            png_path: s.png_path.clone(),
+            duration_ms: s.duration_ms,
+        })
+        .collect();
+
+    let encode_input = VideoEncodeInput {
+        scenes: scene_frames,
+        width: request.width,
+        height: request.height,
+        fps: request.fps,
+        video_bitrate_kbps: request.video_bitrate_kbps,
+        profile,
+        crossfade_ms: request.crossfade_ms,
+    };
+
+    let encode_output =
+        video_encode::encode_video_segments(&app, encode_input, video_temp.clone())
+            .await
+            .map_err(|e| format!("Video encode failed: {e}"))?;
+
+    // ─── Stage 3: Mux ────────────────────────────────────────
+    emit_progress(&app, "mux", "Muxing video and audio…");
+    video_encode::mux_video_and_audio(
+        &app,
+        video_temp.clone(),
+        audio_temp.clone(),
+        output_path.clone(),
+    )
+    .await
+    .map_err(|e| format!("Mux failed: {e}"))?;
+
+    // ─── Stage 4: Cleanup + result ───────────────────────────
+    emit_progress(&app, "cleanup", "Cleaning up temp files…");
+    // Don't hard-fail the whole export if cleanup stumbles.
+    if let Err(e) = tokio::fs::remove_file(&audio_temp).await {
+        eprintln!("warn: failed to remove temp audio {audio_temp:?}: {e}");
+    }
+    if let Err(e) = tokio::fs::remove_file(&video_temp).await {
+        eprintln!("warn: failed to remove temp video {video_temp:?}: {e}");
+    }
+
+    let size_bytes = tokio::fs::metadata(&output_path)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    emit_progress(&app, "done", "Export complete");
+
+    Ok(VideoExportResult {
+        output_path: output_path.to_string_lossy().to_string(),
+        total_duration_ms: encode_output.total_duration_ms,
+        size_bytes,
+    })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_all_h264_profile_names() {
+        assert_eq!(parse_profile("baseline").unwrap(), H264Profile::Baseline);
+        assert_eq!(parse_profile("main").unwrap(), H264Profile::Main);
+        assert_eq!(parse_profile("high").unwrap(), H264Profile::High);
+    }
+
+    #[test]
+    fn parses_profile_case_insensitively() {
+        assert_eq!(parse_profile("HIGH").unwrap(), H264Profile::High);
+        assert_eq!(parse_profile("Main").unwrap(), H264Profile::Main);
+    }
+
+    #[test]
+    fn rejects_unknown_profiles() {
+        assert!(parse_profile("ultra").is_err());
+        assert!(parse_profile("").is_err());
+    }
+
+    // session_dir validation is the interesting bit — the rest of the
+    // orchestrator is async + app-handle-dependent, so it's exercised
+    // via the TypeScript side's integration tests rather than here.
+
+    // ─── session_dir validation (pure logic) ────────────────
+    // These tests can't construct a real AppHandle, so they only
+    // verify the input validation path by threading a stub.
+
+    fn validate_session_id(id: &str) -> Result<(), String> {
+        if id.is_empty() {
+            return Err("Export session_id is empty".to_string());
+        }
+        if id.chars().any(|c| !c.is_ascii_alphanumeric() && c != '-' && c != '_') {
+            return Err(format!(
+                "Invalid session_id '{id}' — alphanumeric + dash/underscore only"
+            ));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_empty_session_id() {
+        assert!(validate_session_id("").is_err());
+    }
+
+    #[test]
+    fn accepts_uuid_session_id() {
+        assert!(validate_session_id("550e8400-e29b-41d4-a716-446655440000").is_ok());
+    }
+
+    #[test]
+    fn accepts_underscore_session_id() {
+        assert!(validate_session_id("story_export_42").is_ok());
+    }
+
+    #[test]
+    fn rejects_path_traversal_session_id() {
+        assert!(validate_session_id("../etc/passwd").is_err());
+        assert!(validate_session_id("..\\windows").is_err());
+    }
+
+    #[test]
+    fn rejects_session_id_with_slashes() {
+        assert!(validate_session_id("a/b").is_err());
+        assert!(validate_session_id("a\\b").is_err());
+    }
+
+    #[test]
+    fn rejects_session_id_with_spaces() {
+        assert!(validate_session_id("story 1").is_err());
+    }
+}

--- a/creator/src/components/lore/StoryEditorPanel.tsx
+++ b/creator/src/components/lore/StoryEditorPanel.tsx
@@ -6,7 +6,6 @@ import { useProjectStore } from "@/stores/projectStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useAssetStore } from "@/stores/assetStore";
 import { loadStory, saveStory } from "@/lib/storyPersistence";
-import { useResolvedSceneData } from "@/lib/useResolvedSceneData";
 import { ActionButton, Spinner, EditableField } from "@/components/ui/FormWidgets";
 import { SceneTimeline } from "./SceneTimeline";
 import { SceneDetailEditor } from "./SceneDetailEditor";
@@ -150,39 +149,19 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
   // All hooks below this line have to execute unconditionally — putting
   // them after the `if (!story) return` guard would change the hook
   // count between renders and crash React with "Rendered more hooks
-  // than during the previous render". Instead, we use optional chaining
-  // to feed safe fallbacks into the hooks while the story is loading,
-  // then reuse the same computed values after the guards below.
+  // than during the previous render". Use optional chaining for
+  // story-dependent values so the hooks stay safe while loading.
 
-  // Sorted scenes — computed above the early returns so the hooks can
-  // depend on it without special-casing. Empty when the story is still
-  // loading, which is fine for useResolvedSceneData.
+  // Sorted scenes — hoisted above the early returns so any hook
+  // elsewhere can depend on it via useMemo without special-casing.
   const sortedScenes = useMemo(
     () => [...(story?.scenes ?? [])].sort((a, b) => a.sortOrder - b.sortOrder),
     [story],
   );
 
-  // Resolved scene data for the export dialog. The hook runs always so
-  // images are warm by the time the user clicks Export, but the IPC
-  // calls are cheap + cached, and the dialog only opens on demand.
-  const resolvedSceneData = useResolvedSceneData(sortedScenes, story?.zoneId ?? "");
-  const resolvedScenesForExport = useMemo(
-    () =>
-      resolvedSceneData.map((rs) => ({
-        sceneId: rs.sceneId,
-        roomImageSrc: rs.roomImageSrc,
-        entities: rs.entities.map((e) => ({
-          entity: e.entity,
-          name: e.name,
-          imageSrc: e.imageSrc,
-        })),
-      })),
-    [resolvedSceneData],
-  );
-
-  // Zone world data (for audio refs). Returns undefined when the story
-  // hasn't loaded yet — the dialog won't render until we're past the
-  // guards below anyway.
+  // Zone world data for the export dialog (audio refs + entity lookups).
+  // Returns undefined when the story hasn't loaded yet — the dialog
+  // won't render until we're past the guards below anyway.
   const zoneWorld = useZoneStore((s) =>
     story ? s.zones.get(story.zoneId)?.data : undefined,
   );
@@ -359,7 +338,6 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
         <StoryExportDialog
           story={story}
           world={zoneWorld}
-          resolvedScenes={resolvedScenesForExport}
           project={project}
           assetsDir={assetsDir}
           onClose={() => setIsExporting(false)}

--- a/creator/src/components/lore/StoryEditorPanel.tsx
+++ b/creator/src/components/lore/StoryEditorPanel.tsx
@@ -1,16 +1,19 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { useStoryStore } from "@/stores/storyStore";
 import { useLoreStore } from "@/stores/loreStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { useZoneStore } from "@/stores/zoneStore";
+import { useAssetStore } from "@/stores/assetStore";
 import { loadStory, saveStory } from "@/lib/storyPersistence";
+import { useResolvedSceneData } from "@/lib/useResolvedSceneData";
 import { ActionButton, Spinner, EditableField } from "@/components/ui/FormWidgets";
 import { SceneTimeline } from "./SceneTimeline";
 import { SceneDetailEditor } from "./SceneDetailEditor";
 import { PresentationMode } from "./PresentationMode";
 import { StorySettingsSection } from "./StorySettingsSection";
 import { StoryAIToolbar } from "./StoryAIToolbar";
+import { StoryExportDialog } from "./StoryExportDialog";
 
 interface StoryEditorPanelProps {
   storyId: string;
@@ -32,6 +35,10 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState(false);
   const [isPresenting, setIsPresenting] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  // Stores needed for the export dialog (resolved scenes + audio paths).
+  const assetsDir = useAssetStore((s) => s.assetsDir);
 
   // Derive zone name from zoneStore
   const zones = useZoneStore((s) => s.zones);
@@ -172,11 +179,33 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
     (a, b) => a.sortOrder - b.sortOrder,
   );
   const canPresent = sortedScenes.length > 0;
+  const canExport = sortedScenes.length > 0;
   const initialSceneIndex = Math.max(
     0,
     sortedScenes.findIndex((s) => s.id === activeSceneId),
   );
   const activeScene = sortedScenes.find((s) => s.id === activeSceneId);
+
+  // Resolved scene data for the export dialog. The hook runs always so
+  // images are warm by the time the user clicks Export, but the IPC
+  // calls are cheap + cached, and the dialog only opens on demand.
+  const resolvedSceneData = useResolvedSceneData(sortedScenes, story.zoneId);
+  const resolvedScenesForExport = useMemo(
+    () =>
+      resolvedSceneData.map((rs) => ({
+        sceneId: rs.sceneId,
+        roomImageSrc: rs.roomImageSrc,
+        entities: rs.entities.map((e) => ({
+          entity: e.entity,
+          name: e.name,
+          imageSrc: e.imageSrc,
+        })),
+      })),
+    [resolvedSceneData],
+  );
+
+  // Zone world data (for audio refs).
+  const zoneWorld = useZoneStore((s) => s.zones.get(story.zoneId)?.data);
 
   return (
     <div className="flex flex-col gap-6">
@@ -195,7 +224,7 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
           </span>
         </div>
 
-        {/* Present + Undo / Redo */}
+        {/* Present + Export + Undo / Redo */}
         <div className="flex shrink-0 items-center gap-2">
           <button
             type="button"
@@ -212,6 +241,25 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
               <path d="M2.5 1v10l8-5z" />
             </svg>
             Present
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setIsExporting(true)}
+            disabled={!canExport}
+            title={canExport ? "Export story as cinematic video" : "Add scenes to export"}
+            className={[
+              "flex items-center gap-1.5 rounded-full border border-border-default bg-bg-secondary px-3 py-1.5",
+              "text-xs font-sans font-medium uppercase tracking-[0.12em] text-text-primary",
+              "hover:border-border-focus hover:bg-bg-hover transition-colors",
+              !canExport ? "opacity-45 cursor-not-allowed" : "",
+            ].join(" ")}
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+              <path d="M6 1v7m0 0l3-3m-3 3L3 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M1 9v1a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            Export
           </button>
 
           <div className="mx-0.5 h-5 w-px bg-border-muted" />
@@ -284,6 +332,18 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
           onExit={handlePresentationExit}
         />,
         document.body,
+      )}
+
+      {/* Video Export Dialog */}
+      {isExporting && story && project && zoneWorld && (
+        <StoryExportDialog
+          story={story}
+          world={zoneWorld}
+          resolvedScenes={resolvedScenesForExport}
+          project={project}
+          assetsDir={assetsDir}
+          onClose={() => setIsExporting(false)}
+        />
       )}
     </div>
   );

--- a/creator/src/components/lore/StoryEditorPanel.tsx
+++ b/creator/src/components/lore/StoryEditorPanel.tsx
@@ -145,6 +145,48 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
     [setActiveScene],
   );
 
+  // ─── Hooks that must run on every render (no early returns above here) ───
+  //
+  // All hooks below this line have to execute unconditionally — putting
+  // them after the `if (!story) return` guard would change the hook
+  // count between renders and crash React with "Rendered more hooks
+  // than during the previous render". Instead, we use optional chaining
+  // to feed safe fallbacks into the hooks while the story is loading,
+  // then reuse the same computed values after the guards below.
+
+  // Sorted scenes — computed above the early returns so the hooks can
+  // depend on it without special-casing. Empty when the story is still
+  // loading, which is fine for useResolvedSceneData.
+  const sortedScenes = useMemo(
+    () => [...(story?.scenes ?? [])].sort((a, b) => a.sortOrder - b.sortOrder),
+    [story],
+  );
+
+  // Resolved scene data for the export dialog. The hook runs always so
+  // images are warm by the time the user clicks Export, but the IPC
+  // calls are cheap + cached, and the dialog only opens on demand.
+  const resolvedSceneData = useResolvedSceneData(sortedScenes, story?.zoneId ?? "");
+  const resolvedScenesForExport = useMemo(
+    () =>
+      resolvedSceneData.map((rs) => ({
+        sceneId: rs.sceneId,
+        roomImageSrc: rs.roomImageSrc,
+        entities: rs.entities.map((e) => ({
+          entity: e.entity,
+          name: e.name,
+          imageSrc: e.imageSrc,
+        })),
+      })),
+    [resolvedSceneData],
+  );
+
+  // Zone world data (for audio refs). Returns undefined when the story
+  // hasn't loaded yet — the dialog won't render until we're past the
+  // guards below anyway.
+  const zoneWorld = useZoneStore((s) =>
+    story ? s.zones.get(story.zoneId)?.data : undefined,
+  );
+
   // Loading state
   if (loading) {
     return (
@@ -174,10 +216,9 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
     );
   }
 
-  // Sorted scenes for rendering
-  const sortedScenes = [...(story.scenes || [])].sort(
-    (a, b) => a.sortOrder - b.sortOrder,
-  );
+  // Post-guard derived values. `sortedScenes` is already computed
+  // above (hoisted to satisfy Rules of Hooks); these just depend on
+  // it + the now-guaranteed `story`.
   const canPresent = sortedScenes.length > 0;
   const canExport = sortedScenes.length > 0;
   const initialSceneIndex = Math.max(
@@ -185,27 +226,6 @@ export function StoryEditorPanel({ storyId }: StoryEditorPanelProps) {
     sortedScenes.findIndex((s) => s.id === activeSceneId),
   );
   const activeScene = sortedScenes.find((s) => s.id === activeSceneId);
-
-  // Resolved scene data for the export dialog. The hook runs always so
-  // images are warm by the time the user clicks Export, but the IPC
-  // calls are cheap + cached, and the dialog only opens on demand.
-  const resolvedSceneData = useResolvedSceneData(sortedScenes, story.zoneId);
-  const resolvedScenesForExport = useMemo(
-    () =>
-      resolvedSceneData.map((rs) => ({
-        sceneId: rs.sceneId,
-        roomImageSrc: rs.roomImageSrc,
-        entities: rs.entities.map((e) => ({
-          entity: e.entity,
-          name: e.name,
-          imageSrc: e.imageSrc,
-        })),
-      })),
-    [resolvedSceneData],
-  );
-
-  // Zone world data (for audio refs).
-  const zoneWorld = useZoneStore((s) => s.zones.get(story.zoneId)?.data);
 
   return (
     <div className="flex flex-col gap-6">

--- a/creator/src/components/lore/StoryExportDialog.tsx
+++ b/creator/src/components/lore/StoryExportDialog.tsx
@@ -12,7 +12,9 @@
 
 import { useState, useMemo, useCallback } from "react";
 import { save } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
 
+import { useStoryStore } from "@/stores/storyStore";
 import { DialogShell, ActionButton, Spinner } from "@/components/ui/FormWidgets";
 import {
   PRESETS,
@@ -182,7 +184,9 @@ export function StoryExportDialog({
 
       {dialogStage === "running" && <RunningView progress={progress} />}
 
-      {dialogStage === "success" && result && <SuccessView result={result} />}
+      {dialogStage === "success" && result && (
+        <SuccessView result={result} presetId={presetId} storyId={story.id} />
+      )}
 
       {dialogStage === "error" && error && (
         <ErrorView error={error} />
@@ -405,9 +409,50 @@ function RunningView({ progress }: { progress: ExportProgressEvent | null }) {
   );
 }
 
-// ─── SuccessView: result card ───────────────────────────────────
+// ─── SuccessView: result card + optional publish action ─────────
 
-function SuccessView({ result }: { result: ExportStoryVideoResult }) {
+type PublishState =
+  | { kind: "idle" }
+  | { kind: "publishing" }
+  | { kind: "published"; url: string }
+  | { kind: "failed"; error: string };
+
+function SuccessView({
+  result,
+  presetId,
+  storyId,
+}: {
+  result: ExportStoryVideoResult;
+  presetId: ExportPresetId;
+  storyId: string;
+}) {
+  const [publishState, setPublishState] = useState<PublishState>({ kind: "idle" });
+
+  // Publishing only makes sense for the showcase preset — other presets
+  // target social feeds, the MUD client, or personal archives and
+  // shouldn't overwrite the showcase URL.
+  const canPublish = presetId === "showcase";
+
+  const handlePublish = useCallback(async () => {
+    setPublishState({ kind: "publishing" });
+    try {
+      const url = await invoke<string>("deploy_story_video_to_r2", {
+        storyId,
+        filePath: result.outputPath,
+      });
+      // Stamp the URL onto the story so the next showcase JSON deploy
+      // picks it up. Use updateStory so the dirty flag triggers
+      // autosave.
+      useStoryStore.getState().updateStory(storyId, { cinematicUrl: url });
+      setPublishState({ kind: "published", url });
+    } catch (e) {
+      setPublishState({
+        kind: "failed",
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }, [storyId, result.outputPath]);
+
   return (
     <div className="flex flex-col gap-3 py-4">
       <div className="rounded-md border border-status-success/40 bg-status-success/5 p-4">
@@ -431,6 +476,55 @@ function SuccessView({ result }: { result: ExportStoryVideoResult }) {
           </div>
         </div>
       </div>
+
+      {canPublish && (
+        <div className="rounded-md border border-border-muted bg-bg-elevated p-4">
+          <h3 className="font-display text-sm uppercase tracking-wider text-text-muted">
+            Publish to showcase
+          </h3>
+          <p className="mt-1 text-xs text-text-secondary">
+            Upload this MP4 to R2 and link it from the story's showcase page. Viewers
+            will see a "Watch as cinematic" button on the story player.
+          </p>
+
+          {publishState.kind === "idle" && (
+            <div className="mt-3">
+              <ActionButton variant="secondary" onClick={handlePublish}>
+                Publish to Showcase
+              </ActionButton>
+            </div>
+          )}
+
+          {publishState.kind === "publishing" && (
+            <div className="mt-3 flex items-center gap-2 text-xs text-text-secondary">
+              <Spinner />
+              <span>Uploading to R2…</span>
+            </div>
+          )}
+
+          {publishState.kind === "published" && (
+            <div className="mt-3 space-y-1">
+              <div className="text-xs text-status-success">
+                Published. The next "Publish Lore" deploy will pick up the URL.
+              </div>
+              <div className="break-all font-mono text-2xs text-text-muted">
+                {publishState.url}
+              </div>
+            </div>
+          )}
+
+          {publishState.kind === "failed" && (
+            <div className="mt-3 space-y-2">
+              <div className="text-xs text-status-error">
+                Publish failed: {publishState.error}
+              </div>
+              <ActionButton variant="ghost" onClick={handlePublish}>
+                Try Again
+              </ActionButton>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/creator/src/components/lore/StoryExportDialog.tsx
+++ b/creator/src/components/lore/StoryExportDialog.tsx
@@ -1,0 +1,455 @@
+// ─── Story Export Dialog ─────────────────────────────────────────
+// Modal for exporting a story to MP4. Flow:
+//   1. Preset picker (5 cards)
+//   2. Voice override + output file picker
+//   3. "Export" button → runs exportStoryVideo() from storyVideoExport.ts
+//   4. Progress bar with stage messages
+//   5. Success or error view
+//
+// The heavy lifting lives in storyVideoExport.ts. This dialog is
+// just the UI glue: preset selection, file picker, progress display,
+// and wiring the progress callback into local state.
+
+import { useState, useMemo, useCallback } from "react";
+import { save } from "@tauri-apps/plugin-dialog";
+
+import { DialogShell, ActionButton, Spinner } from "@/components/ui/FormWidgets";
+import {
+  PRESETS,
+  PRESET_ORDER,
+  checkStoryFitsPreset,
+  suggestExportFilename,
+  formatDuration,
+  type ExportPresetId,
+} from "@/lib/videoExportPresets";
+import {
+  OPENAI_TTS_VOICES,
+  OPENAI_TTS_VOICE_LABELS,
+  type OpenAiTtsVoice,
+} from "@/lib/narrationSynthesis";
+import {
+  exportStoryVideo,
+  formatBytes,
+  type ExportProgressEvent,
+  type ExportStoryVideoResult,
+  type ResolvedSceneForExport,
+} from "@/lib/storyVideoExport";
+import { computeStoryTimeline } from "@/lib/storyTiming";
+import type { Story } from "@/types/story";
+import type { WorldFile } from "@/types/world";
+import type { Project } from "@/types/project";
+
+// ─── Props ───────────────────────────────────────────────────────
+
+interface StoryExportDialogProps {
+  story: Story;
+  world: WorldFile;
+  resolvedScenes: ResolvedSceneForExport[];
+  project: Project;
+  assetsDir: string;
+  onClose: () => void;
+}
+
+type DialogStage = "config" | "running" | "success" | "error";
+
+// ─── Component ───────────────────────────────────────────────────
+
+export function StoryExportDialog({
+  story,
+  world,
+  resolvedScenes,
+  project,
+  assetsDir,
+  onClose,
+}: StoryExportDialogProps) {
+  // ─── State ────────────────────────────────────────────────
+  const [presetId, setPresetId] = useState<ExportPresetId>("showcase");
+  const [voiceOverride, setVoiceOverride] = useState<OpenAiTtsVoice | undefined>();
+  const [outputPath, setOutputPath] = useState<string>("");
+
+  const [dialogStage, setDialogStage] = useState<DialogStage>("config");
+  const [progress, setProgress] = useState<ExportProgressEvent | null>(null);
+  const [result, setResult] = useState<ExportStoryVideoResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedPreset = PRESETS[presetId];
+
+  // ─── Estimated duration for the fit check ─────────────────
+  // Uses word-count estimate since we haven't synthesized TTS yet —
+  // the real duration might differ by a few seconds after TTS runs.
+  const estimatedDurationMs = useMemo(() => {
+    try {
+      const timeline = computeStoryTimeline(story);
+      return timeline.totalDurationMs;
+    } catch {
+      return 0;
+    }
+  }, [story]);
+
+  const fitCheck = useMemo(
+    () => checkStoryFitsPreset(estimatedDurationMs, selectedPreset),
+    [estimatedDurationMs, selectedPreset],
+  );
+
+  // ─── File picker ──────────────────────────────────────────
+  const pickOutputPath = useCallback(async () => {
+    const suggested = suggestExportFilename(story.title, presetId);
+    const picked = await save({
+      title: "Export cinematic to…",
+      defaultPath: suggested,
+      filters: [{ name: "MP4 Video", extensions: ["mp4"] }],
+    });
+    if (picked) {
+      setOutputPath(picked);
+    }
+  }, [story.title, presetId]);
+
+  // ─── Start export ─────────────────────────────────────────
+  const canStart =
+    outputPath.length > 0 && dialogStage === "config" && resolvedScenes.length > 0;
+
+  const handleStart = useCallback(async () => {
+    if (!canStart) return;
+    setDialogStage("running");
+    setProgress({ stage: "ffmpeg", fraction: 0, message: "Starting export…" });
+    setError(null);
+    setResult(null);
+
+    try {
+      const exportResult = await exportStoryVideo({
+        story,
+        resolvedScenes,
+        world,
+        project,
+        assetsDir,
+        presetId,
+        outputPath,
+        voiceOverride,
+        onProgress: (event) => {
+          setProgress(event);
+        },
+      });
+      setResult(exportResult);
+      setDialogStage("success");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      setDialogStage("error");
+      // Best-effort cleanup of orphaned temp files. We don't have the
+      // session ID here because it lives inside exportStoryVideo, but
+      // it's fine — the temp dir is small and OS cleanup will get it.
+    }
+  }, [
+    canStart,
+    story,
+    resolvedScenes,
+    world,
+    project,
+    assetsDir,
+    presetId,
+    outputPath,
+    voiceOverride,
+  ]);
+
+  // ─── Render ───────────────────────────────────────────────
+  return (
+    <DialogShell
+      titleId="story-export-dialog-title"
+      title="Export Cinematic"
+      widthClassName="max-w-3xl"
+      onClose={dialogStage === "running" ? () => {} : onClose}
+      footer={renderFooter(
+        dialogStage,
+        canStart,
+        handleStart,
+        onClose,
+        () => setDialogStage("config"),
+      )}
+    >
+      {dialogStage === "config" && (
+        <ConfigView
+          presetId={presetId}
+          onPresetChange={setPresetId}
+          voiceOverride={voiceOverride}
+          onVoiceChange={setVoiceOverride}
+          outputPath={outputPath}
+          onPickOutput={pickOutputPath}
+          estimatedDurationMs={estimatedDurationMs}
+          fitWarning={fitCheck.fits ? null : fitCheck.warning}
+          sceneCount={resolvedScenes.length}
+        />
+      )}
+
+      {dialogStage === "running" && <RunningView progress={progress} />}
+
+      {dialogStage === "success" && result && <SuccessView result={result} />}
+
+      {dialogStage === "error" && error && (
+        <ErrorView error={error} />
+      )}
+    </DialogShell>
+  );
+}
+
+// ─── Footer ──────────────────────────────────────────────────────
+
+function renderFooter(
+  stage: DialogStage,
+  canStart: boolean,
+  onStart: () => void,
+  onClose: () => void,
+  onReset: () => void,
+) {
+  if (stage === "running") {
+    return (
+      <div className="flex items-center justify-between text-xs text-text-muted">
+        <span>Export in progress — please keep the app open.</span>
+      </div>
+    );
+  }
+
+  if (stage === "success") {
+    return (
+      <div className="flex items-center justify-end gap-2">
+        <ActionButton variant="ghost" onClick={onReset}>
+          Export Another
+        </ActionButton>
+        <ActionButton variant="primary" onClick={onClose}>
+          Done
+        </ActionButton>
+      </div>
+    );
+  }
+
+  if (stage === "error") {
+    return (
+      <div className="flex items-center justify-end gap-2">
+        <ActionButton variant="ghost" onClick={onClose}>
+          Close
+        </ActionButton>
+        <ActionButton variant="primary" onClick={onReset}>
+          Try Again
+        </ActionButton>
+      </div>
+    );
+  }
+
+  // config
+  return (
+    <div className="flex items-center justify-end gap-2">
+      <ActionButton variant="ghost" onClick={onClose}>
+        Cancel
+      </ActionButton>
+      <ActionButton
+        variant="primary"
+        onClick={onStart}
+        disabled={!canStart}
+        className={!canStart ? "opacity-45 cursor-not-allowed" : ""}
+      >
+        Export
+      </ActionButton>
+    </div>
+  );
+}
+
+// ─── ConfigView: preset picker + voice + output path ────────────
+
+interface ConfigViewProps {
+  presetId: ExportPresetId;
+  onPresetChange: (id: ExportPresetId) => void;
+  voiceOverride: OpenAiTtsVoice | undefined;
+  onVoiceChange: (voice: OpenAiTtsVoice | undefined) => void;
+  outputPath: string;
+  onPickOutput: () => void;
+  estimatedDurationMs: number;
+  fitWarning: string | null;
+  sceneCount: number;
+}
+
+function ConfigView({
+  presetId,
+  onPresetChange,
+  voiceOverride,
+  onVoiceChange,
+  outputPath,
+  onPickOutput,
+  estimatedDurationMs,
+  fitWarning,
+  sceneCount,
+}: ConfigViewProps) {
+  const effectiveVoice = voiceOverride ?? PRESETS[presetId].ttsVoice;
+
+  return (
+    <div className="flex flex-col gap-5 py-2">
+      {/* ─── Preset picker ─── */}
+      <section>
+        <h3 className="mb-2 font-display text-sm uppercase tracking-wider text-text-muted">
+          Choose a preset
+        </h3>
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+          {PRESET_ORDER.map((id) => {
+            const preset = PRESETS[id];
+            const selected = id === presetId;
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => onPresetChange(id)}
+                className={`rounded-md border p-3 text-left transition-colors ${
+                  selected
+                    ? "border-accent bg-accent/10"
+                    : "border-border-default hover:border-border-muted bg-bg-secondary"
+                }`}
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="font-display text-sm text-text-primary">
+                    {preset.label}
+                  </span>
+                  <span className="font-mono text-2xs text-text-muted">
+                    {preset.width}×{preset.height} · {preset.fps}fps
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-text-secondary">
+                  {preset.description}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* ─── Story stats + fit warning ─── */}
+      <section className="flex items-center gap-4 rounded-md border border-border-muted bg-bg-elevated px-3 py-2 text-xs">
+        <div>
+          <span className="text-text-muted">Scenes </span>
+          <span className="font-mono text-text-primary">{sceneCount}</span>
+        </div>
+        <div>
+          <span className="text-text-muted">Est. duration </span>
+          <span className="font-mono text-text-primary">
+            {formatDuration(estimatedDurationMs)}
+          </span>
+        </div>
+        {fitWarning && (
+          <div className="flex-1 text-right text-status-warning">{fitWarning}</div>
+        )}
+      </section>
+
+      {/* ─── Voice override ─── */}
+      <section>
+        <h3 className="mb-2 font-display text-sm uppercase tracking-wider text-text-muted">
+          Narration voice
+        </h3>
+        <select
+          value={voiceOverride ?? ""}
+          onChange={(e) => onVoiceChange((e.target.value || undefined) as OpenAiTtsVoice | undefined)}
+          className="ornate-input w-full"
+        >
+          <option value="">
+            Preset default ({OPENAI_TTS_VOICE_LABELS[effectiveVoice].label}) —{" "}
+            {OPENAI_TTS_VOICE_LABELS[effectiveVoice].description}
+          </option>
+          {OPENAI_TTS_VOICES.map((v) => (
+            <option key={v} value={v}>
+              {OPENAI_TTS_VOICE_LABELS[v].label} — {OPENAI_TTS_VOICE_LABELS[v].description}
+            </option>
+          ))}
+        </select>
+      </section>
+
+      {/* ─── Output path ─── */}
+      <section>
+        <h3 className="mb-2 font-display text-sm uppercase tracking-wider text-text-muted">
+          Output file
+        </h3>
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            readOnly
+            value={outputPath || "(no file selected)"}
+            className="ornate-input flex-1 font-mono text-xs"
+          />
+          <ActionButton variant="secondary" onClick={onPickOutput}>
+            Choose…
+          </ActionButton>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+// ─── RunningView: progress bar + stage message ──────────────────
+
+function RunningView({ progress }: { progress: ExportProgressEvent | null }) {
+  const fraction = progress?.fraction ?? 0;
+  const pct = Math.round(fraction * 100);
+  return (
+    <div className="flex flex-col items-center gap-5 py-8">
+      <Spinner />
+      <div className="w-full max-w-md">
+        <div className="h-2 overflow-hidden rounded-full bg-bg-elevated">
+          <div
+            className="h-full bg-accent transition-all duration-300 ease-out"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <div className="mt-2 flex items-center justify-between text-xs">
+          <span className="font-mono text-text-muted">{pct}%</span>
+          <span className="text-text-secondary">{progress?.stage ?? "starting"}</span>
+        </div>
+      </div>
+      <p className="text-center text-sm text-text-primary">
+        {progress?.message ?? "Preparing export…"}
+      </p>
+    </div>
+  );
+}
+
+// ─── SuccessView: result card ───────────────────────────────────
+
+function SuccessView({ result }: { result: ExportStoryVideoResult }) {
+  return (
+    <div className="flex flex-col gap-3 py-4">
+      <div className="rounded-md border border-status-success/40 bg-status-success/5 p-4">
+        <h3 className="font-display text-base text-status-success">Export complete</h3>
+        <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <div className="text-2xs uppercase tracking-wider text-text-muted">Duration</div>
+            <div className="font-mono text-text-primary">
+              {formatDuration(result.durationMs)}
+            </div>
+          </div>
+          <div>
+            <div className="text-2xs uppercase tracking-wider text-text-muted">Size</div>
+            <div className="font-mono text-text-primary">{formatBytes(result.sizeBytes)}</div>
+          </div>
+          <div className="col-span-2">
+            <div className="text-2xs uppercase tracking-wider text-text-muted">File</div>
+            <div className="break-all font-mono text-xs text-text-primary">
+              {result.outputPath}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── ErrorView: error message ───────────────────────────────────
+
+function ErrorView({ error }: { error: string }) {
+  return (
+    <div className="flex flex-col gap-3 py-4">
+      <div className="rounded-md border border-status-error/40 bg-status-error/5 p-4">
+        <h3 className="font-display text-base text-status-error">Export failed</h3>
+        <p className="mt-2 whitespace-pre-wrap break-words font-mono text-xs text-text-primary">
+          {error}
+        </p>
+        <p className="mt-3 text-xs text-text-muted">
+          Check that your OpenAI API key is set in Settings (for TTS) and that you have an
+          internet connection (for the first-time ffmpeg download).
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/lore/StoryExportDialog.tsx
+++ b/creator/src/components/lore/StoryExportDialog.tsx
@@ -34,7 +34,6 @@ import {
   formatBytes,
   type ExportProgressEvent,
   type ExportStoryVideoResult,
-  type ResolvedSceneForExport,
 } from "@/lib/storyVideoExport";
 import { computeStoryTimeline } from "@/lib/storyTiming";
 import type { Story } from "@/types/story";
@@ -46,7 +45,6 @@ import type { Project } from "@/types/project";
 interface StoryExportDialogProps {
   story: Story;
   world: WorldFile;
-  resolvedScenes: ResolvedSceneForExport[];
   project: Project;
   assetsDir: string;
   onClose: () => void;
@@ -59,7 +57,6 @@ type DialogStage = "config" | "running" | "success" | "error";
 export function StoryExportDialog({
   story,
   world,
-  resolvedScenes,
   project,
   assetsDir,
   onClose,
@@ -108,7 +105,7 @@ export function StoryExportDialog({
 
   // ─── Start export ─────────────────────────────────────────
   const canStart =
-    outputPath.length > 0 && dialogStage === "config" && resolvedScenes.length > 0;
+    outputPath.length > 0 && dialogStage === "config" && story.scenes.length > 0;
 
   const handleStart = useCallback(async () => {
     if (!canStart) return;
@@ -120,7 +117,6 @@ export function StoryExportDialog({
     try {
       const exportResult = await exportStoryVideo({
         story,
-        resolvedScenes,
         world,
         project,
         assetsDir,
@@ -137,14 +133,10 @@ export function StoryExportDialog({
       const msg = e instanceof Error ? e.message : String(e);
       setError(msg);
       setDialogStage("error");
-      // Best-effort cleanup of orphaned temp files. We don't have the
-      // session ID here because it lives inside exportStoryVideo, but
-      // it's fine — the temp dir is small and OS cleanup will get it.
     }
   }, [
     canStart,
     story,
-    resolvedScenes,
     world,
     project,
     assetsDir,
@@ -178,7 +170,7 @@ export function StoryExportDialog({
           onPickOutput={pickOutputPath}
           estimatedDurationMs={estimatedDurationMs}
           fitWarning={fitCheck.fits ? null : fitCheck.warning}
-          sceneCount={resolvedScenes.length}
+          sceneCount={story.scenes.length}
         />
       )}
 

--- a/creator/src/lib/__tests__/narrationSynthesis.test.ts
+++ b/creator/src/lib/__tests__/narrationSynthesis.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  resolveTtsSpeed,
+  synthesizeNarration,
+  synthesizeSceneNarration,
+  OPENAI_TTS_VOICES,
+} from "../narrationSynthesis";
+
+// ─── Mock @tauri-apps/api/core ───────────────────────────────────
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+function tiptapDoc(...paragraphs: string[]): string {
+  return JSON.stringify({
+    type: "doc",
+    content: paragraphs.map((p) => ({
+      type: "paragraph",
+      content: [{ type: "text", text: p }],
+    })),
+  });
+}
+
+const SAMPLE_AUDIO = {
+  filePath: "/tmp/test.mp3",
+  hash: "abc123",
+  sizeBytes: 1234,
+  cached: false,
+};
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+afterEach(() => {
+  invokeMock.mockReset();
+});
+
+// ─── resolveTtsSpeed ─────────────────────────────────────────────
+
+describe("resolveTtsSpeed", () => {
+  it("returns undefined for undefined input", () => {
+    expect(resolveTtsSpeed(undefined)).toBeUndefined();
+  });
+
+  it("maps slow preset to 0.85", () => {
+    expect(resolveTtsSpeed("slow")).toBe(0.85);
+  });
+
+  it("maps normal preset to 1.0", () => {
+    expect(resolveTtsSpeed("normal")).toBe(1.0);
+  });
+
+  it("maps fast preset to 1.15", () => {
+    expect(resolveTtsSpeed("fast")).toBe(1.15);
+  });
+
+  it("passes through numeric values unchanged", () => {
+    expect(resolveTtsSpeed(1.3)).toBe(1.3);
+    expect(resolveTtsSpeed(0.5)).toBe(0.5);
+  });
+});
+
+// ─── synthesizeNarration ─────────────────────────────────────────
+
+describe("synthesizeNarration", () => {
+  it("calls openai_tts_generate with defaults", async () => {
+    invokeMock.mockResolvedValue(SAMPLE_AUDIO);
+    const result = await synthesizeNarration({ text: "Hello world" });
+    expect(invokeMock).toHaveBeenCalledWith("openai_tts_generate", {
+      text: "Hello world",
+      voice: "onyx",
+      model: "tts-1",
+      speed: undefined,
+    });
+    expect(result).toEqual(SAMPLE_AUDIO);
+  });
+
+  it("passes through voice, model, and resolved speed", async () => {
+    invokeMock.mockResolvedValue(SAMPLE_AUDIO);
+    await synthesizeNarration({
+      text: "Hello",
+      voice: "nova",
+      model: "tts-1-hd",
+      speed: "fast",
+    });
+    expect(invokeMock).toHaveBeenCalledWith("openai_tts_generate", {
+      text: "Hello",
+      voice: "nova",
+      model: "tts-1-hd",
+      speed: 1.15,
+    });
+  });
+
+  it("trims whitespace before calling the backend", async () => {
+    invokeMock.mockResolvedValue(SAMPLE_AUDIO);
+    await synthesizeNarration({ text: "   padded   " });
+    expect(invokeMock).toHaveBeenCalledWith(
+      "openai_tts_generate",
+      expect.objectContaining({ text: "padded" }),
+    );
+  });
+
+  it("throws on empty text without calling the backend", async () => {
+    await expect(synthesizeNarration({ text: "" })).rejects.toThrow(
+      /empty text/,
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("throws on whitespace-only text", async () => {
+    await expect(synthesizeNarration({ text: "   " })).rejects.toThrow(
+      /empty text/,
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── synthesizeSceneNarration ────────────────────────────────────
+
+describe("synthesizeSceneNarration", () => {
+  it("extracts TipTap plain text and synthesizes it", async () => {
+    invokeMock.mockResolvedValue(SAMPLE_AUDIO);
+    const narrationJson = tiptapDoc("First line.", "Second line.");
+    const result = await synthesizeSceneNarration({ narrationJson });
+    expect(invokeMock).toHaveBeenCalledWith("openai_tts_generate", {
+      text: "First line.\nSecond line.",
+      voice: "onyx",
+      model: "tts-1",
+      speed: undefined,
+    });
+    expect(result).toEqual(SAMPLE_AUDIO);
+  });
+
+  it("returns null for scenes with no narration", async () => {
+    const result = await synthesizeSceneNarration({ narrationJson: undefined });
+    expect(result).toBeNull();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null for scenes with empty narration", async () => {
+    const result = await synthesizeSceneNarration({ narrationJson: "" });
+    expect(result).toBeNull();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null for TipTap doc with only whitespace", async () => {
+    const narrationJson = tiptapDoc("  ", "\n", "\t");
+    const result = await synthesizeSceneNarration({ narrationJson });
+    expect(result).toBeNull();
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards voice/model/speed overrides", async () => {
+    invokeMock.mockResolvedValue(SAMPLE_AUDIO);
+    const narrationJson = tiptapDoc("Test.");
+    await synthesizeSceneNarration({
+      narrationJson,
+      voice: "shimmer",
+      model: "tts-1-hd",
+      speed: "slow",
+    });
+    expect(invokeMock).toHaveBeenCalledWith("openai_tts_generate", {
+      text: "Test.",
+      voice: "shimmer",
+      model: "tts-1-hd",
+      speed: 0.85,
+    });
+  });
+
+  it("propagates backend errors", async () => {
+    invokeMock.mockRejectedValue(new Error("API key not configured"));
+    await expect(
+      synthesizeSceneNarration({ narrationJson: tiptapDoc("Test.") }),
+    ).rejects.toThrow(/API key not configured/);
+  });
+});
+
+// ─── Constants sanity ────────────────────────────────────────────
+
+describe("OPENAI_TTS_VOICES constant", () => {
+  it("includes the documented six voices in expected order", () => {
+    expect(OPENAI_TTS_VOICES).toEqual([
+      "alloy",
+      "echo",
+      "fable",
+      "onyx",
+      "nova",
+      "shimmer",
+    ]);
+  });
+});

--- a/creator/src/lib/__tests__/storyFrameLayout.test.ts
+++ b/creator/src/lib/__tests__/storyFrameLayout.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeBackgroundFit,
+  computeEntityRect,
+  computeSceneFrameLayout,
+  type LayoutEntityInfo,
+} from "../storyFrameLayout";
+import type { Scene, SceneEntity } from "@/types/story";
+
+// ─── Fixture helpers ─────────────────────────────────────────────
+
+function sceneFixture(overrides: Partial<Scene> = {}): Scene {
+  return {
+    id: "s1",
+    title: "Scene 1",
+    sortOrder: 0,
+    entities: [],
+    ...overrides,
+  };
+}
+
+function entityFixture(overrides: Partial<SceneEntity> = {}): SceneEntity {
+  return {
+    id: "e1",
+    entityType: "mob",
+    entityId: "m1",
+    slot: "front-center",
+    ...overrides,
+  };
+}
+
+// ─── computeBackgroundFit ─────────────────────────────────────────
+
+describe("computeBackgroundFit - fit strategy", () => {
+  it("same aspect: full source, full target", () => {
+    const { src, dst } = computeBackgroundFit(1920, 1080, 1920, 1080, "fit");
+    expect(src).toEqual({ x: 0, y: 0, width: 1920, height: 1080 });
+    expect(dst).toEqual({ x: 0, y: 0, width: 1920, height: 1080 });
+  });
+
+  it("wider source into 16:9 target: pillarboxes top/bottom", () => {
+    // 2000x500 (4:1) into 1920x1080 (16:9)
+    const { src, dst } = computeBackgroundFit(2000, 500, 1920, 1080, "fit");
+    expect(src).toEqual({ x: 0, y: 0, width: 2000, height: 500 });
+    expect(dst.width).toBe(1920);
+    expect(dst.height).toBe(Math.round(1920 / (2000 / 500)));
+    // Centered vertically
+    expect(dst.y).toBe(Math.round((1080 - dst.height) / 2));
+    expect(dst.x).toBe(0);
+  });
+
+  it("taller source into 16:9 target: letterboxes left/right", () => {
+    // 500x1000 (1:2) into 1920x1080 (16:9)
+    const { src, dst } = computeBackgroundFit(500, 1000, 1920, 1080, "fit");
+    expect(src).toEqual({ x: 0, y: 0, width: 500, height: 1000 });
+    expect(dst.height).toBe(1080);
+    expect(dst.width).toBe(Math.round(1080 * (500 / 1000)));
+    // Centered horizontally
+    expect(dst.x).toBe(Math.round((1920 - dst.width) / 2));
+    expect(dst.y).toBe(0);
+  });
+
+  it("16:9 source into 9:16 (vertical) target: letterboxes left/right narrowly", () => {
+    const { src, dst } = computeBackgroundFit(1920, 1080, 1080, 1920, "fit");
+    expect(src).toEqual({ x: 0, y: 0, width: 1920, height: 1080 });
+    // Source wider (16:9 > 9:16), so fit to width → pillarbox
+    expect(dst.width).toBe(1080);
+    expect(dst.height).toBeLessThan(1920);
+  });
+});
+
+describe("computeBackgroundFit - fill/crop_center strategies", () => {
+  it("same aspect: full source, full target (no cropping needed)", () => {
+    const { src, dst } = computeBackgroundFit(1920, 1080, 1920, 1080, "fill");
+    expect(src.width).toBe(1920);
+    expect(dst).toEqual({ x: 0, y: 0, width: 1920, height: 1080 });
+  });
+
+  it("wider source into 16:9 target: crops source left/right", () => {
+    // 3000x1080 (2.78:1) into 1920x1080 (16:9, 1.78:1)
+    const { src, dst } = computeBackgroundFit(3000, 1080, 1920, 1080, "fill");
+    expect(dst).toEqual({ x: 0, y: 0, width: 1920, height: 1080 });
+    expect(src.height).toBe(1080);
+    expect(src.width).toBe(Math.round(1080 * (1920 / 1080)));
+    // Cropped from center
+    expect(src.x).toBe(Math.round((3000 - src.width) / 2));
+  });
+
+  it("taller source into 16:9 target: crops source top/bottom", () => {
+    // 1920x2500 (0.77:1) into 1920x1080 (16:9)
+    const { src, dst } = computeBackgroundFit(1920, 2500, 1920, 1080, "fill");
+    expect(dst).toEqual({ x: 0, y: 0, width: 1920, height: 1080 });
+    expect(src.width).toBe(1920);
+    expect(src.height).toBe(Math.round(1920 / (1920 / 1080)));
+    expect(src.y).toBe(Math.round((2500 - src.height) / 2));
+  });
+
+  it("16:9 source into 9:16 target with fill: crops source sides heavily", () => {
+    // The 16:9 room art cropped to fit a 9:16 vertical frame
+    const { src, dst } = computeBackgroundFit(1920, 1080, 1080, 1920, "fill");
+    expect(dst).toEqual({ x: 0, y: 0, width: 1080, height: 1920 });
+    expect(src.height).toBe(1080);
+    // Source width is narrow (roughly 1080/1920 × 1080)
+    expect(src.width).toBeLessThan(1920);
+    expect(src.x).toBeGreaterThan(0); // Cropped from center
+  });
+});
+
+// ─── computeEntityRect ────────────────────────────────────────────
+
+describe("computeEntityRect - anchor positioning", () => {
+  it("front-center sprite is bottom-center anchored at (50%, 72%)", () => {
+    const entity = entityFixture({ slot: "front-center" });
+    const rect = computeEntityRect(
+      entity,
+      { width: 100, height: 120 }, // 5:6 aspect
+      1920,
+      1080,
+    );
+    const anchorX = Math.round(0.5 * 1920);
+    const anchorY = Math.round(0.72 * 1080);
+    // Bottom-center of rect sits at anchor
+    expect(rect.x + Math.round(rect.width / 2)).toBeCloseTo(anchorX, 0);
+    expect(rect.y + rect.height).toBe(anchorY);
+  });
+
+  it("width scales with target viewport width, not absolute pixels", () => {
+    const entity = entityFixture({ slot: "front-center" });
+    const small = computeEntityRect(entity, { width: 100, height: 100 }, 1280, 720);
+    const large = computeEntityRect(entity, { width: 100, height: 100 }, 1920, 1080);
+    expect(large.width).toBeGreaterThan(small.width);
+    // Ratio should match the preset width ratio
+    expect(large.width / small.width).toBeCloseTo(1920 / 1280, 1);
+  });
+
+  it("back-row sprites are 0.78x smaller than front-row", () => {
+    const back = computeEntityRect(
+      entityFixture({ slot: "back-center" }),
+      { width: 100, height: 100 },
+      1920,
+      1080,
+    );
+    const front = computeEntityRect(
+      entityFixture({ slot: "front-center" }),
+      { width: 100, height: 100 },
+      1920,
+      1080,
+    );
+    expect(back.width).toBeCloseTo(front.width * 0.78, 0);
+  });
+
+  it("sprite height follows natural image aspect", () => {
+    const tall = computeEntityRect(
+      entityFixture(),
+      { width: 100, height: 200 }, // 1:2 portrait
+      1920,
+      1080,
+    );
+    const square = computeEntityRect(
+      entityFixture(),
+      { width: 100, height: 100 }, // 1:1
+      1920,
+      1080,
+    );
+    // Same width, but tall one is 2x taller
+    expect(tall.width).toBe(square.width);
+    expect(tall.height).toBeCloseTo(square.height * 2, 0);
+  });
+
+  it("uses default aspect when imageSize is undefined", () => {
+    const rect = computeEntityRect(entityFixture(), undefined, 1920, 1080);
+    expect(rect.width).toBeGreaterThan(0);
+    expect(rect.height).toBeGreaterThan(0);
+    // Default aspect is 1/1.2, so height should be taller than width
+    expect(rect.height).toBeGreaterThan(rect.width);
+  });
+
+  it("custom position overrides slot", () => {
+    const entity = entityFixture({
+      slot: undefined,
+      position: { x: 25, y: 50 },
+    });
+    const rect = computeEntityRect(entity, { width: 100, height: 100 }, 1920, 1080);
+    // Bottom-center of rect at (25%, 50%)
+    expect(rect.x + Math.round(rect.width / 2)).toBe(Math.round(0.25 * 1920));
+    expect(rect.y + rect.height).toBe(Math.round(0.5 * 1080));
+  });
+});
+
+// ─── computeSceneFrameLayout ──────────────────────────────────────
+
+describe("computeSceneFrameLayout", () => {
+  const entities: LayoutEntityInfo[] = [
+    {
+      entity: entityFixture({ id: "front", slot: "front-center" }),
+      name: "Front Mob",
+      imageSize: { width: 100, height: 120 },
+    },
+    {
+      entity: entityFixture({ id: "back", slot: "back-left" }),
+      name: "Back Mob",
+      imageSize: { width: 100, height: 100 },
+    },
+  ];
+
+  it("populates width and height from target dims", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture(),
+      entities,
+      { width: 1920, height: 1080 },
+      1920,
+      1080,
+    );
+    expect(layout.width).toBe(1920);
+    expect(layout.height).toBe(1080);
+  });
+
+  it("background is null when no room image is provided", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture(),
+      [],
+      undefined,
+      1920,
+      1080,
+    );
+    expect(layout.background).toBeNull();
+  });
+
+  it("background uses the fit strategy for letterboxing", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture(),
+      [],
+      { width: 1920, height: 1080 },
+      1080,
+      1920,
+      { fit: "fit" },
+    );
+    expect(layout.background).not.toBeNull();
+    expect(layout.background!.fillColor).toBe("#000000");
+    expect(layout.background!.dst.width).toBe(1080);
+    // 16:9 source pillarboxed into 9:16 frame
+    expect(layout.background!.dst.height).toBeLessThan(1920);
+  });
+
+  it("background fillColor is null for fill strategy", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture(),
+      [],
+      { width: 1920, height: 1080 },
+      1080,
+      1920,
+      { fit: "fill" },
+    );
+    expect(layout.background).not.toBeNull();
+    expect(layout.background!.fillColor).toBeNull();
+    // fill covers the full frame
+    expect(layout.background!.dst).toEqual({
+      x: 0,
+      y: 0,
+      width: 1080,
+      height: 1920,
+    });
+  });
+
+  it("splits entities into back and front row layers", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture(),
+      entities,
+      { width: 1920, height: 1080 },
+      1920,
+      1080,
+    );
+    expect(layout.backRowEntities).toHaveLength(1);
+    expect(layout.frontRowEntities).toHaveLength(1);
+    expect(layout.backRowEntities[0]!.entityId).toBe("back");
+    expect(layout.frontRowEntities[0]!.entityId).toBe("front");
+  });
+
+  it("back row entities get reduced opacity", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture(),
+      entities,
+      undefined,
+      1920,
+      1080,
+    );
+    expect(layout.backRowEntities[0]!.opacity).toBeLessThan(1);
+    expect(layout.frontRowEntities[0]!.opacity).toBe(1);
+  });
+
+  it("marks hasImage = false for entities without imageSize", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture(),
+      [
+        {
+          entity: entityFixture({ id: "nopic" }),
+          name: "No Image",
+        },
+      ],
+      undefined,
+      1920,
+      1080,
+    );
+    expect(layout.frontRowEntities[0]!.hasImage).toBe(false);
+  });
+
+  it("emits titleCard when scene has a title card with non-empty text", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture({ titleCard: { text: "Act One", style: "subtitle" } }),
+      [],
+      undefined,
+      1920,
+      1080,
+    );
+    expect(layout.titleCard).not.toBeNull();
+    expect(layout.titleCard!.text).toBe("Act One");
+    expect(layout.titleCard!.rect.width).toBeGreaterThan(0);
+    expect(layout.titleCard!.rect.height).toBeGreaterThan(0);
+  });
+
+  it("omits titleCard for whitespace-only text", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture({ titleCard: { text: "   " } }),
+      [],
+      undefined,
+      1920,
+      1080,
+    );
+    expect(layout.titleCard).toBeNull();
+  });
+
+  it("captionArea is positioned in the lower third", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture(),
+      [],
+      undefined,
+      1920,
+      1080,
+    );
+    // Lower third: y should be well below the midline
+    expect(layout.captionArea.rect.y).toBeGreaterThan(1080 / 2);
+    // Width should be narrower than full frame (centered with padding)
+    expect(layout.captionArea.rect.width).toBeLessThan(1920);
+    // Horizontally centered
+    expect(
+      layout.captionArea.rect.x + Math.round(layout.captionArea.rect.width / 2),
+    ).toBeCloseTo(1920 / 2, 0);
+  });
+
+  it("supports custom fillColor option", () => {
+    const layout = computeSceneFrameLayout(
+      sceneFixture(),
+      [],
+      { width: 1920, height: 1080 },
+      1080,
+      1920,
+      { fit: "fit", fillColor: "#1a2040" },
+    );
+    expect(layout.background!.fillColor).toBe("#1a2040");
+  });
+});

--- a/creator/src/lib/__tests__/storyTiming.test.ts
+++ b/creator/src/lib/__tests__/storyTiming.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeStoryTimeline,
+  estimateNarrationDurationMs,
+  extractParagraphs,
+} from "../storyTiming";
+import { NARRATION_TIMING } from "../narrationSpeed";
+import type { Story, Scene } from "@/types/story";
+
+// ─── Fixture helpers ─────────────────────────────────────────────
+
+/** Build a TipTap JSON doc with the given paragraphs. */
+function tiptapDoc(...paragraphs: string[]): string {
+  return JSON.stringify({
+    type: "doc",
+    content: paragraphs.map((p) => ({
+      type: "paragraph",
+      content: [{ type: "text", text: p }],
+    })),
+  });
+}
+
+function scene(overrides: Partial<Scene> & { id: string; sortOrder: number }): Scene {
+  return {
+    title: overrides.id,
+    entities: [],
+    ...overrides,
+  };
+}
+
+function story(scenes: Scene[], narrationSpeed: Story["narrationSpeed"] = "normal"): Story {
+  return {
+    id: "test-story",
+    title: "Test Story",
+    zoneId: "test-zone",
+    scenes,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    narrationSpeed,
+  };
+}
+
+// ─── extractParagraphs ───────────────────────────────────────────
+
+describe("extractParagraphs", () => {
+  it("returns empty array for empty input", () => {
+    expect(extractParagraphs("")).toEqual([]);
+  });
+
+  it("splits TipTap doc into paragraph blocks", () => {
+    const doc = tiptapDoc("First line.", "Second line.", "Third line.");
+    expect(extractParagraphs(doc)).toEqual([
+      "First line.",
+      "Second line.",
+      "Third line.",
+    ]);
+  });
+
+  it("trims whitespace and drops empty paragraphs", () => {
+    const doc = JSON.stringify({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "  padded  " }] },
+        { type: "paragraph", content: [{ type: "text", text: "" }] },
+        { type: "paragraph", content: [{ type: "text", text: "kept" }] },
+      ],
+    });
+    expect(extractParagraphs(doc)).toEqual(["padded", "kept"]);
+  });
+
+  it("falls back to newline split for invalid JSON", () => {
+    expect(extractParagraphs("plain\nline\ntwo")).toEqual(["plain", "line", "two"]);
+  });
+
+  it("returns empty array when parsing fails and no fallback text", () => {
+    expect(extractParagraphs("")).toEqual([]);
+  });
+});
+
+// ─── estimateNarrationDurationMs ─────────────────────────────────
+
+describe("estimateNarrationDurationMs", () => {
+  it("returns 0 for zero words", () => {
+    expect(estimateNarrationDurationMs(0, "normal")).toBe(0);
+  });
+
+  it("scales linearly with word count", () => {
+    const oneWord = estimateNarrationDurationMs(1, "normal");
+    const tenWords = estimateNarrationDurationMs(10, "normal");
+    expect(tenWords).toBe(oneWord * 10);
+  });
+
+  it("matches NARRATION_TIMING for each speed", () => {
+    const timing = NARRATION_TIMING.normal;
+    const expected = Math.round((timing.wordDuration + timing.wordGap) * 1000 * 5);
+    expect(estimateNarrationDurationMs(5, "normal")).toBe(expected);
+  });
+
+  it("fast speed is shorter than slow speed for same word count", () => {
+    const slow = estimateNarrationDurationMs(20, "slow");
+    const fast = estimateNarrationDurationMs(20, "fast");
+    expect(fast).toBeLessThan(slow);
+  });
+});
+
+// ─── computeStoryTimeline: empty / edge ──────────────────────────
+
+describe("computeStoryTimeline - edge cases", () => {
+  it("returns empty timeline for a story with no scenes", () => {
+    const result = computeStoryTimeline(story([]));
+    expect(result.scenes).toEqual([]);
+    expect(result.totalDurationMs).toBe(0);
+  });
+
+  it("applies the minSceneDurationMs for scenes with no narration", () => {
+    const s = scene({ id: "empty", sortOrder: 0 });
+    const result = computeStoryTimeline(story([s]), { minSceneDurationMs: 4000 });
+    expect(result.scenes).toHaveLength(1);
+    expect(result.scenes[0]!.durationMs).toBe(4000);
+  });
+
+  it("clamps to maxSceneDurationMs for very long narration", () => {
+    // 500 words at normal speed is way longer than 5000ms
+    const longNarration = tiptapDoc(Array(500).fill("word").join(" "));
+    const s = scene({ id: "long", sortOrder: 0, narration: longNarration });
+    const result = computeStoryTimeline(story([s]), { maxSceneDurationMs: 5000 });
+    expect(result.scenes[0]!.durationMs).toBe(5000);
+  });
+});
+
+// ─── computeStoryTimeline: single scene timing ───────────────────
+
+describe("computeStoryTimeline - single scene", () => {
+  it("scene duration = leadIn + narration + hold", () => {
+    const narration = tiptapDoc("Ten word narration here one two three four five six.");
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+    const result = computeStoryTimeline(story([s]), {
+      narrationLeadInMs: 200,
+      postNarrationHoldMs: 1500,
+      minSceneDurationMs: 0,
+    });
+
+    const narrationDuration = estimateNarrationDurationMs(10, "normal");
+    expect(result.scenes[0]!.durationMs).toBe(200 + narrationDuration + 1500);
+    expect(result.scenes[0]!.narrationStartMs).toBe(200);
+    expect(result.scenes[0]!.narrationEndMs).toBe(200 + narrationDuration);
+    expect(result.scenes[0]!.holdMs).toBe(1500);
+  });
+
+  it("first scene starts at 0", () => {
+    const s = scene({ id: "s1", sortOrder: 0 });
+    const result = computeStoryTimeline(story([s]));
+    expect(result.scenes[0]!.startMs).toBe(0);
+  });
+
+  it("totalDurationMs matches the single scene's end time", () => {
+    const s = scene({ id: "s1", sortOrder: 0 });
+    const result = computeStoryTimeline(story([s]));
+    expect(result.totalDurationMs).toBe(result.scenes[0]!.durationMs);
+  });
+});
+
+// ─── computeStoryTimeline: narration speeds ──────────────────────
+
+describe("computeStoryTimeline - narration speed", () => {
+  const narration = tiptapDoc("one two three four five six seven eight nine ten");
+
+  it("respects story-level narration speed", () => {
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+    const slow = computeStoryTimeline(story([s], "slow"));
+    const fast = computeStoryTimeline(story([s], "fast"));
+    expect(fast.scenes[0]!.durationMs).toBeLessThan(slow.scenes[0]!.durationMs);
+  });
+
+  it("per-scene narration speed overrides story speed", () => {
+    const slowScene = scene({
+      id: "slow",
+      sortOrder: 0,
+      narration,
+      narrationSpeed: "slow",
+    });
+    const fastScene = scene({
+      id: "fast",
+      sortOrder: 1,
+      narration,
+      narrationSpeed: "fast",
+    });
+    const result = computeStoryTimeline(story([slowScene, fastScene], "normal"));
+    expect(result.scenes[0]!.durationMs).toBeGreaterThan(result.scenes[1]!.durationMs);
+  });
+});
+
+// ─── computeStoryTimeline: multi-scene chaining ──────────────────
+
+describe("computeStoryTimeline - multi-scene", () => {
+  it("scenes are sorted by sortOrder before computation", () => {
+    const a = scene({ id: "a", sortOrder: 2 });
+    const b = scene({ id: "b", sortOrder: 0 });
+    const c = scene({ id: "c", sortOrder: 1 });
+    const result = computeStoryTimeline(story([a, b, c]));
+    expect(result.scenes.map((s) => s.sceneId)).toEqual(["b", "c", "a"]);
+    expect(result.scenes.map((s) => s.sceneIndex)).toEqual([0, 1, 2]);
+  });
+
+  it("scene start times chain correctly with crossfade overlap", () => {
+    const s1 = scene({
+      id: "s1",
+      sortOrder: 0,
+      transition: { type: "crossfade" },
+    });
+    const s2 = scene({
+      id: "s2",
+      sortOrder: 1,
+      transition: { type: "crossfade" },
+    });
+    const result = computeStoryTimeline(story([s1, s2]), {
+      crossfadeMs: 500,
+      minSceneDurationMs: 3000,
+    });
+
+    // s1 starts at 0, lasts 3000ms → s2 starts at 3000 - 500 = 2500
+    expect(result.scenes[0]!.startMs).toBe(0);
+    expect(result.scenes[0]!.durationMs).toBe(3000);
+    expect(result.scenes[1]!.startMs).toBe(2500);
+  });
+
+  it("fade_black transitions also overlap correctly", () => {
+    const s1 = scene({
+      id: "s1",
+      sortOrder: 0,
+      transition: { type: "fade_black" },
+    });
+    const s2 = scene({ id: "s2", sortOrder: 1 });
+    const result = computeStoryTimeline(story([s1, s2]), {
+      fadeBlackMs: 300,
+      minSceneDurationMs: 2000,
+    });
+    expect(result.scenes[1]!.startMs).toBe(2000 - 300);
+  });
+
+  it("final scene has transitionOut = null", () => {
+    const s1 = scene({ id: "s1", sortOrder: 0 });
+    const s2 = scene({ id: "s2", sortOrder: 1 });
+    const result = computeStoryTimeline(story([s1, s2]));
+    expect(result.scenes[0]!.transitionOut).not.toBeNull();
+    expect(result.scenes[1]!.transitionOut).toBeNull();
+  });
+
+  it("totalDurationMs = last scene's absolute end time", () => {
+    const s1 = scene({ id: "s1", sortOrder: 0 });
+    const s2 = scene({ id: "s2", sortOrder: 1 });
+    const result = computeStoryTimeline(story([s1, s2]), {
+      minSceneDurationMs: 2000,
+      crossfadeMs: 500,
+    });
+    // s1: 0-2000, s2: 1500-3500 → total 3500
+    expect(result.totalDurationMs).toBe(3500);
+  });
+});
+
+// ─── computeStoryTimeline: narration chunks ──────────────────────
+
+describe("computeStoryTimeline - narration chunks", () => {
+  it("produces one chunk per TipTap paragraph", () => {
+    const narration = tiptapDoc("First.", "Second.", "Third.");
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+    const result = computeStoryTimeline(story([s]));
+    expect(result.scenes[0]!.narrationChunks).toHaveLength(3);
+    expect(result.scenes[0]!.narrationChunks.map((c) => c.text)).toEqual([
+      "First.",
+      "Second.",
+      "Third.",
+    ]);
+  });
+
+  it("chunks are offset by narrationStartMs (lead-in)", () => {
+    const narration = tiptapDoc("Only paragraph.");
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+    const result = computeStoryTimeline(story([s]), { narrationLeadInMs: 200 });
+    expect(result.scenes[0]!.narrationChunks[0]!.startMs).toBe(200);
+  });
+
+  it("chunk durations are proportional to word count", () => {
+    const narration = tiptapDoc("one", "two three four five");
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+    const result = computeStoryTimeline(story([s]));
+    const chunks = result.scenes[0]!.narrationChunks;
+    const first = chunks[0]!;
+    const second = chunks[1]!;
+    // Second paragraph has 4× the words, so its duration should be roughly 4× the first
+    const firstDuration = first.endMs - first.startMs;
+    const secondDuration = second.endMs - second.startMs;
+    expect(secondDuration).toBeGreaterThan(firstDuration * 3);
+  });
+
+  it("returns empty chunks for scenes with no narration", () => {
+    const s = scene({ id: "s1", sortOrder: 0 });
+    const result = computeStoryTimeline(story([s]));
+    expect(result.scenes[0]!.narrationChunks).toEqual([]);
+  });
+});
+
+// ─── computeStoryTimeline: narration words ───────────────────────
+
+describe("computeStoryTimeline - narration words", () => {
+  it("produces one entry per word", () => {
+    const narration = tiptapDoc("one two three");
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+    const result = computeStoryTimeline(story([s]));
+    expect(result.scenes[0]!.narrationWords).toHaveLength(3);
+    expect(result.scenes[0]!.narrationWords.map((w) => w.text)).toEqual([
+      "one",
+      "two",
+      "three",
+    ]);
+  });
+
+  it("word times are monotonic and non-overlapping", () => {
+    const narration = tiptapDoc("alpha beta gamma delta epsilon");
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+    const result = computeStoryTimeline(story([s]));
+    const words = result.scenes[0]!.narrationWords;
+    for (let i = 1; i < words.length; i++) {
+      expect(words[i]!.startMs).toBeGreaterThanOrEqual(words[i - 1]!.endMs - 1);
+    }
+  });
+
+  it("word times are offset by narrationStartMs", () => {
+    const narration = tiptapDoc("hello");
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+    const result = computeStoryTimeline(story([s]), { narrationLeadInMs: 500 });
+    expect(result.scenes[0]!.narrationWords[0]!.startMs).toBe(500);
+  });
+});
+
+// ─── computeStoryTimeline: narration duration overrides ──────────
+
+describe("computeStoryTimeline - narration duration overrides", () => {
+  it("override replaces the word-count estimate", () => {
+    const narration = tiptapDoc("one two three four five");
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+
+    const withoutOverride = computeStoryTimeline(story([s]));
+    const withOverride = computeStoryTimeline(story([s]), {
+      narrationDurationOverrides: { s1: 10_000 },
+    });
+
+    expect(withOverride.scenes[0]!.durationMs).not.toBe(
+      withoutOverride.scenes[0]!.durationMs,
+    );
+    expect(withOverride.scenes[0]!.narrationEndMs).toBe(
+      withOverride.scenes[0]!.narrationStartMs + 10_000,
+    );
+  });
+
+  it("override scales word timing to the new duration", () => {
+    const narration = tiptapDoc("one two three four five");
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+    const result = computeStoryTimeline(story([s]), {
+      narrationDurationOverrides: { s1: 5000 },
+      narrationLeadInMs: 0,
+    });
+    const words = result.scenes[0]!.narrationWords;
+    // Last word should end near 5000ms
+    expect(words[words.length - 1]!.endMs).toBeGreaterThan(4900);
+    expect(words[words.length - 1]!.endMs).toBeLessThanOrEqual(5001);
+  });
+
+  it("scenes without an override still use estimated duration", () => {
+    const narration = tiptapDoc("one two three");
+    const s1 = scene({ id: "s1", sortOrder: 0, narration });
+    const s2 = scene({ id: "s2", sortOrder: 1, narration });
+    const result = computeStoryTimeline(story([s1, s2]), {
+      narrationDurationOverrides: { s1: 10_000 },
+    });
+    expect(result.scenes[0]!.narrationEndMs - result.scenes[0]!.narrationStartMs).toBe(
+      10_000,
+    );
+    expect(result.scenes[1]!.narrationEndMs - result.scenes[1]!.narrationStartMs).toBe(
+      estimateNarrationDurationMs(3, "normal"),
+    );
+  });
+
+  it("override of 0 produces a scene at the minimum duration", () => {
+    const narration = tiptapDoc("hello world");
+    const s = scene({ id: "s1", sortOrder: 0, narration });
+    const result = computeStoryTimeline(story([s]), {
+      narrationDurationOverrides: { s1: 0 },
+      minSceneDurationMs: 3000,
+    });
+    expect(result.scenes[0]!.durationMs).toBe(3000);
+  });
+});

--- a/creator/src/lib/__tests__/videoExportPresets.test.ts
+++ b/creator/src/lib/__tests__/videoExportPresets.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from "vitest";
+import {
+  PRESETS,
+  PRESET_ORDER,
+  getPreset,
+  getAllPresets,
+  slugifyStoryTitle,
+  suggestExportFilename,
+  checkStoryFitsPreset,
+  formatDuration,
+  type ExportPresetId,
+} from "../videoExportPresets";
+
+// ─── Registry shape ──────────────────────────────────────────────
+
+describe("preset registry", () => {
+  it("exports the five documented presets", () => {
+    expect(PRESET_ORDER).toEqual([
+      "showcase",
+      "social_vertical",
+      "social_square",
+      "in_game",
+      "archive",
+    ]);
+  });
+
+  it("every preset ID in PRESET_ORDER has a matching entry in PRESETS", () => {
+    for (const id of PRESET_ORDER) {
+      expect(PRESETS[id]).toBeDefined();
+      expect(PRESETS[id].id).toBe(id);
+    }
+  });
+
+  it("getAllPresets returns presets in PRESET_ORDER", () => {
+    const all = getAllPresets();
+    expect(all.map((p) => p.id)).toEqual(PRESET_ORDER);
+  });
+
+  it("getPreset returns the matching preset", () => {
+    expect(getPreset("showcase").id).toBe("showcase");
+    expect(getPreset("in_game").label).toContain("In-Game");
+  });
+});
+
+// ─── Preset invariants ───────────────────────────────────────────
+
+describe("preset dimensions", () => {
+  it("all dimensions are divisible by 2 (required by H.264 yuv420p)", () => {
+    for (const preset of getAllPresets()) {
+      expect(preset.width % 2).toBe(0);
+      expect(preset.height % 2).toBe(0);
+    }
+  });
+
+  it("every preset has a positive video and audio bitrate", () => {
+    for (const preset of getAllPresets()) {
+      expect(preset.videoBitrateKbps).toBeGreaterThan(0);
+      expect(preset.audioBitrateKbps).toBeGreaterThan(0);
+    }
+  });
+
+  it("every preset has a sensible frame rate (30 or 60)", () => {
+    for (const preset of getAllPresets()) {
+      expect([30, 60]).toContain(preset.fps);
+    }
+  });
+
+  it("only the archive preset uses 60fps", () => {
+    expect(getPreset("archive").fps).toBe(60);
+    expect(getPreset("showcase").fps).toBe(30);
+    expect(getPreset("social_vertical").fps).toBe(30);
+  });
+
+  it("only the archive preset uses the tts-1-hd model", () => {
+    expect(getPreset("archive").ttsModel).toBe("tts-1-hd");
+    expect(getPreset("showcase").ttsModel).toBe("tts-1");
+    expect(getPreset("in_game").ttsModel).toBe("tts-1");
+  });
+});
+
+describe("preset distribution targets", () => {
+  it("showcase targets showcase-embed", () => {
+    expect(getPreset("showcase").target).toBe("showcase-embed");
+  });
+
+  it("both social presets target social-feed", () => {
+    expect(getPreset("social_vertical").target).toBe("social-feed");
+    expect(getPreset("social_square").target).toBe("social-feed");
+  });
+
+  it("in_game targets in-game-asset", () => {
+    expect(getPreset("in_game").target).toBe("in-game-asset");
+  });
+
+  it("archive targets personal-archive", () => {
+    expect(getPreset("archive").target).toBe("personal-archive");
+  });
+});
+
+describe("preset duration caps", () => {
+  it("showcase has no cap", () => {
+    expect(getPreset("showcase").maxDurationMs).toBeNull();
+  });
+
+  it("archive has no cap", () => {
+    expect(getPreset("archive").maxDurationMs).toBeNull();
+  });
+
+  it("social presets cap at 60 seconds", () => {
+    expect(getPreset("social_vertical").maxDurationMs).toBe(60_000);
+    expect(getPreset("social_square").maxDurationMs).toBe(60_000);
+  });
+
+  it("in_game caps at 30 seconds", () => {
+    expect(getPreset("in_game").maxDurationMs).toBe(30_000);
+  });
+});
+
+describe("preset caption policies", () => {
+  it("in_game does NOT burn captions (MUD renders its own text)", () => {
+    expect(getPreset("in_game").burnedCaptions).toBe(false);
+  });
+
+  it("all other presets burn captions", () => {
+    for (const id of PRESET_ORDER) {
+      if (id === "in_game") continue;
+      expect(PRESETS[id].burnedCaptions).toBe(true);
+    }
+  });
+
+  it("social_vertical places captions in the upper third", () => {
+    // Vertical video needs captions above the phone's bottom UI bar.
+    expect(getPreset("social_vertical").captionPlacement).toBe("upper-third");
+  });
+
+  it("social presets use larger caption scale than showcase", () => {
+    expect(getPreset("social_square").captionScale).toBeGreaterThan(
+      getPreset("showcase").captionScale,
+    );
+    expect(getPreset("social_vertical").captionScale).toBeGreaterThan(
+      getPreset("showcase").captionScale,
+    );
+  });
+});
+
+describe("preset audio policies", () => {
+  it("in_game excludes music and ambient to avoid clashing with game audio", () => {
+    const preset = getPreset("in_game");
+    expect(preset.includeMusic).toBe(false);
+    expect(preset.includeAmbient).toBe(false);
+  });
+
+  it("social presets include music but not ambient (keep it punchy)", () => {
+    for (const id of ["social_vertical", "social_square"] as ExportPresetId[]) {
+      const preset = getPreset(id);
+      expect(preset.includeMusic).toBe(true);
+      expect(preset.includeAmbient).toBe(false);
+    }
+  });
+
+  it("showcase and archive include music and ambient", () => {
+    for (const id of ["showcase", "archive"] as ExportPresetId[]) {
+      const preset = getPreset(id);
+      expect(preset.includeMusic).toBe(true);
+      expect(preset.includeAmbient).toBe(true);
+    }
+  });
+});
+
+describe("preset background fit", () => {
+  it("social presets use fill (crop) since 9:16 / 1:1 ≠ source aspect", () => {
+    expect(getPreset("social_vertical").backgroundFit).toBe("fill");
+    expect(getPreset("social_square").backgroundFit).toBe("fill");
+  });
+
+  it("16:9 presets use fit (native source aspect matches)", () => {
+    for (const id of ["showcase", "in_game", "archive"] as ExportPresetId[]) {
+      expect(getPreset(id).backgroundFit).toBe("fit");
+    }
+  });
+});
+
+// ─── slugifyStoryTitle ───────────────────────────────────────────
+
+describe("slugifyStoryTitle", () => {
+  it("converts a plain title", () => {
+    expect(slugifyStoryTitle("Fall of the Cathedral")).toBe("fall-of-the-cathedral");
+  });
+
+  it("collapses punctuation and whitespace to hyphens", () => {
+    expect(slugifyStoryTitle("Act I: The Descent!")).toBe("act-i-the-descent");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(slugifyStoryTitle("  ---Begin---  ")).toBe("begin");
+  });
+
+  it("returns 'story' for an empty title", () => {
+    expect(slugifyStoryTitle("")).toBe("story");
+  });
+
+  it("returns 'story' for a title of only punctuation", () => {
+    expect(slugifyStoryTitle("!!!???")).toBe("story");
+  });
+
+  it("caps length at 60 characters", () => {
+    const long = "a".repeat(100);
+    expect(slugifyStoryTitle(long).length).toBe(60);
+  });
+
+  it("handles unicode by stripping it", () => {
+    expect(slugifyStoryTitle("Chrönïcles")).toBe("chr-n-cles");
+  });
+});
+
+// ─── suggestExportFilename ───────────────────────────────────────
+
+describe("suggestExportFilename", () => {
+  it("combines the slug and preset suffix", () => {
+    expect(suggestExportFilename("Fall of the Cathedral", "showcase")).toBe(
+      "fall-of-the-cathedral-showcase.mp4",
+    );
+  });
+
+  it("uses each preset's distinct suffix", () => {
+    const title = "My Story";
+    expect(suggestExportFilename(title, "showcase")).toContain("-showcase.mp4");
+    expect(suggestExportFilename(title, "social_vertical")).toContain("-vertical.mp4");
+    expect(suggestExportFilename(title, "social_square")).toContain("-square.mp4");
+    expect(suggestExportFilename(title, "in_game")).toContain("-intro.mp4");
+    expect(suggestExportFilename(title, "archive")).toContain("-archive.mp4");
+  });
+
+  it("falls back to 'story' for empty titles", () => {
+    expect(suggestExportFilename("", "showcase")).toBe("story-showcase.mp4");
+  });
+});
+
+// ─── checkStoryFitsPreset ────────────────────────────────────────
+
+describe("checkStoryFitsPreset", () => {
+  it("unlimited presets always fit", () => {
+    const result = checkStoryFitsPreset(600_000, getPreset("showcase")); // 10 min
+    expect(result.fits).toBe(true);
+    expect(result.warning).toBe("");
+  });
+
+  it("stories under the cap fit social presets", () => {
+    const result = checkStoryFitsPreset(45_000, getPreset("social_vertical"));
+    expect(result.fits).toBe(true);
+    expect(result.warning).toBe("");
+  });
+
+  it("stories exactly at the cap fit", () => {
+    const result = checkStoryFitsPreset(60_000, getPreset("social_square"));
+    expect(result.fits).toBe(true);
+  });
+
+  it("stories over the cap produce a warning", () => {
+    const result = checkStoryFitsPreset(75_000, getPreset("social_square"));
+    expect(result.fits).toBe(false);
+    expect(result.capMs).toBe(60_000);
+    expect(result.overshootMs).toBe(15_000);
+    expect(result.warning).toMatch(/15s longer/);
+    expect(result.warning).toMatch(/60s cap/);
+  });
+
+  it("in_game cap is stricter than social", () => {
+    const story = checkStoryFitsPreset(45_000, getPreset("in_game"));
+    expect(story.fits).toBe(false);
+    expect(story.capMs).toBe(30_000);
+    expect(story.overshootMs).toBe(15_000);
+  });
+
+  it("passes through the story duration for the UI", () => {
+    const result = checkStoryFitsPreset(42_000, getPreset("social_vertical"));
+    expect(result.storyDurationMs).toBe(42_000);
+  });
+});
+
+// ─── formatDuration ──────────────────────────────────────────────
+
+describe("formatDuration", () => {
+  it("formats zero as 0:00", () => {
+    expect(formatDuration(0)).toBe("0:00");
+  });
+
+  it("formats seconds-only durations", () => {
+    expect(formatDuration(5_000)).toBe("0:05");
+    expect(formatDuration(45_000)).toBe("0:45");
+  });
+
+  it("formats minute:second durations", () => {
+    expect(formatDuration(60_000)).toBe("1:00");
+    expect(formatDuration(65_000)).toBe("1:05");
+    expect(formatDuration(130_000)).toBe("2:10");
+  });
+
+  it("rounds to the nearest second", () => {
+    expect(formatDuration(65_500)).toBe("1:06"); // rounds up
+    expect(formatDuration(65_400)).toBe("1:05"); // rounds down
+  });
+
+  it("clamps negative durations to 0:00", () => {
+    expect(formatDuration(-1000)).toBe("0:00");
+  });
+
+  it("handles long durations", () => {
+    expect(formatDuration(3_600_000)).toBe("60:00"); // 1 hour
+  });
+});

--- a/creator/src/lib/exportShowcase.ts
+++ b/creator/src/lib/exportShowcase.ts
@@ -227,6 +227,9 @@ export interface ShowcaseStory {
   featuredCharacterIds?: string[];
   primaryMapId?: string;
   primaryCalendarId?: string;
+
+  // ─── Exported cinematic (MP4 on R2) ──────────────────────────────────
+  cinematicUrl?: string;
 }
 
 // ─── Story export context ─────────────────────────────────────────
@@ -305,6 +308,7 @@ export function exportStories(
         featuredCharacterIds: story.featuredCharacterIds,
         primaryMapId: story.primaryMapId,
         primaryCalendarId: story.primaryCalendarId,
+        cinematicUrl: story.cinematicUrl,
       };
     });
 }

--- a/creator/src/lib/ffmpegStatus.ts
+++ b/creator/src/lib/ffmpegStatus.ts
@@ -1,0 +1,55 @@
+// ─── FFmpeg Status Wrapper ───────────────────────────────────────
+// Frontend wrapper around the ffmpeg resolution and download commands
+// for the story → video export pipeline.
+//
+// Callers typically:
+//   1. Call `checkFfmpegStatus()` to see if ffmpeg is already available.
+//   2. If not, show a "First export needs to download ffmpeg (~30 MB)"
+//      confirm dialog, then call `ensureFfmpegReady()`.
+//   3. Proceed with the export, which will resolve ffmpeg via the
+//      cached binary from (2).
+
+import { invoke } from "@tauri-apps/api/core";
+
+export type FfmpegSource = "bundled" | "system";
+
+export interface FfmpegStatus {
+  available: boolean;
+  source: FfmpegSource | null;
+  path: string | null;
+  version: string | null;
+}
+
+/**
+ * Fast, non-blocking status check. Does not download anything.
+ * Used to decide whether an export can start immediately or whether
+ * the user needs to confirm a download first.
+ */
+export async function checkFfmpegStatus(): Promise<FfmpegStatus> {
+  return invoke<FfmpegStatus>("check_ffmpeg_status");
+}
+
+/**
+ * Ensures ffmpeg is available, downloading it on first call. Blocks
+ * until the download + unpack completes (~30 MB, typically < 30s on
+ * a reasonable connection). Subsequent calls short-circuit via the
+ * cached binary.
+ *
+ * Throws if the download fails or if the resulting binary does not
+ * respond to `-version`.
+ */
+export async function ensureFfmpegReady(): Promise<FfmpegStatus> {
+  return invoke<FfmpegStatus>("ensure_ffmpeg_ready");
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Human-readable label for an FfmpegStatus. Used in toolbar tooltips
+ * and the export dialog header.
+ */
+export function describeFfmpegStatus(status: FfmpegStatus): string {
+  if (!status.available) return "ffmpeg not available — will download on first export";
+  const src = status.source === "bundled" ? "bundled" : "system";
+  return `ffmpeg ${status.version ?? "ready"} (${src})`;
+}

--- a/creator/src/lib/narrationSynthesis.ts
+++ b/creator/src/lib/narrationSynthesis.ts
@@ -1,0 +1,137 @@
+// ─── Narration Synthesis ─────────────────────────────────────────
+// Frontend wrapper around the `openai_tts_generate` Tauri command.
+// Converts TipTap JSON scene narration into plain text, calls OpenAI
+// TTS via the Rust backend, and returns the cached MP3 file path.
+//
+// Used by the story → video export pipeline. Also usable ad-hoc
+// from any UI that wants to preview narration.
+
+import { invoke } from "@tauri-apps/api/core";
+import { extractPlainText } from "@/lib/sceneLayout";
+import type { NarrationSpeed } from "@/lib/narrationSpeed";
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** OpenAI TTS voices supported by the backend. Keep in sync with openai_tts.rs. */
+export const OPENAI_TTS_VOICES = [
+  "alloy",
+  "echo",
+  "fable",
+  "onyx",
+  "nova",
+  "shimmer",
+] as const;
+
+export type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];
+
+/** Human labels + descriptions for the voice picker UI. */
+export const OPENAI_TTS_VOICE_LABELS: Record<OpenAiTtsVoice, { label: string; description: string }> = {
+  alloy: { label: "Alloy", description: "Neutral, balanced — good default" },
+  echo: { label: "Echo", description: "Warm, grounded male timbre" },
+  fable: { label: "Fable", description: "Storytelling, slight British cadence" },
+  onyx: { label: "Onyx", description: "Deep, resonant — dramatic narration" },
+  nova: { label: "Nova", description: "Bright, expressive female timbre" },
+  shimmer: { label: "Shimmer", description: "Soft, intimate — gentle moments" },
+};
+
+export const OPENAI_TTS_MODELS = ["tts-1", "tts-1-hd"] as const;
+export type OpenAiTtsModel = (typeof OPENAI_TTS_MODELS)[number];
+
+export interface NarrationAudio {
+  /** Absolute filesystem path to the cached MP3. */
+  filePath: string;
+  /** Content-address hash (also the filename stem). */
+  hash: string;
+  /** Byte size of the audio file. */
+  sizeBytes: number;
+  /** Whether the file was served from cache or freshly synthesized. */
+  cached: boolean;
+}
+
+export interface SynthesizeNarrationOptions {
+  text: string;
+  voice?: OpenAiTtsVoice;
+  model?: OpenAiTtsModel;
+  /** Narration speed preset — mapped to OpenAI's `speed` parameter. */
+  speed?: NarrationSpeed | number;
+}
+
+// ─── Speed mapping ───────────────────────────────────────────────
+
+/**
+ * Maps the in-app NarrationSpeed presets to OpenAI's `speed` parameter.
+ * Mirrors the feel of the in-app typewriter stagger:
+ *   slow   → 0.85× (a little slower than default)
+ *   normal → 1.0×  (default)
+ *   fast   → 1.15× (a little faster than default)
+ */
+export function resolveTtsSpeed(speed: NarrationSpeed | number | undefined): number | undefined {
+  if (speed === undefined) return undefined;
+  if (typeof speed === "number") return speed;
+  switch (speed) {
+    case "slow":
+      return 0.85;
+    case "normal":
+      return 1.0;
+    case "fast":
+      return 1.15;
+  }
+}
+
+// ─── Core synthesize call ────────────────────────────────────────
+
+/**
+ * Synthesizes narration audio via the OpenAI TTS backend. Results are
+ * cached by content hash in Rust, so repeated calls with the same
+ * (text, voice, model, speed) return instantly without hitting the API.
+ *
+ * Throws on empty text or API errors.
+ */
+export async function synthesizeNarration(
+  options: SynthesizeNarrationOptions,
+): Promise<NarrationAudio> {
+  const text = options.text.trim();
+  if (!text) {
+    throw new Error("Cannot synthesize narration from empty text.");
+  }
+
+  const voice = options.voice ?? "onyx";
+  const model = options.model ?? "tts-1";
+  const speed = resolveTtsSpeed(options.speed);
+
+  return invoke<NarrationAudio>("openai_tts_generate", {
+    text,
+    voice,
+    model,
+    speed,
+  });
+}
+
+// ─── Scene-level convenience ─────────────────────────────────────
+
+export interface SynthesizeSceneNarrationOptions {
+  /** TipTap JSON narration string (as stored on Scene.narration). */
+  narrationJson: string | undefined;
+  voice?: OpenAiTtsVoice;
+  model?: OpenAiTtsModel;
+  speed?: NarrationSpeed | number;
+}
+
+/**
+ * Convenience wrapper that extracts plain text from a scene's TipTap
+ * narration JSON and synthesizes it. Returns `null` when the scene has
+ * no narration (rather than throwing) — scene-level callers often want
+ * to skip audio generation for silent scenes.
+ */
+export async function synthesizeSceneNarration(
+  options: SynthesizeSceneNarrationOptions,
+): Promise<NarrationAudio | null> {
+  const plain = extractPlainText(options.narrationJson ?? "").trim();
+  if (!plain) return null;
+  return synthesizeNarration({
+    text: plain,
+    voice: options.voice,
+    model: options.model,
+    speed: options.speed,
+  });
+}

--- a/creator/src/lib/storyFrameLayout.ts
+++ b/creator/src/lib/storyFrameLayout.ts
@@ -1,0 +1,341 @@
+// ─── Story Frame Layout ──────────────────────────────────────────
+// Pure, deterministic layout math for converting a scene into the
+// rectangles needed to composite a single video frame.
+//
+// Inputs: scene data + resolved entity metadata (names, natural image
+// dimensions) + target video dimensions.
+// Output: a SceneFrameLayout with explicit source/dest rects that a
+// canvas renderer can feed directly into ctx.drawImage.
+//
+// Separated from the canvas renderer so layout math is unit-testable
+// without jsdom canvas quirks.
+
+import { resolveEntityPosition, isBackRow, getEntityScale } from "@/lib/sceneLayout";
+import type { Scene, SceneEntity } from "@/types/story";
+
+// ─── Constants ───────────────────────────────────────────────────
+
+/**
+ * Entity sprite width as a fraction of target viewport width.
+ * Derived from the in-app preview's 148px-at-800px convention
+ * (creator/src/components/lore/AnimatedEntity.tsx). Video export
+ * uses a fraction rather than absolute pixels so sprites scale
+ * proportionally across preset sizes.
+ */
+const ENTITY_WIDTH_RATIO = 148 / 800; // ≈ 0.185
+
+/** Default sprite aspect ratio when the entity image size is unknown. */
+const DEFAULT_SPRITE_ASPECT = 1 / 1.2; // width/height, matches placeholder
+
+/** Back-row entity opacity (matches AnimatedEntity's 0.9). */
+const BACK_ROW_OPACITY = 0.9;
+
+/** Title card box dimensions as fractions of the target frame. */
+const TITLE_CARD_BOX = {
+  topPct: 0.08,      // 8% from top
+  widthPct: 0.6,     // 60% of frame width
+  heightPct: 0.1,    // 10% of frame height
+};
+
+/** Caption box (bottom third gradient) as fraction of the target frame. */
+const CAPTION_BOX = {
+  topPct: 0.78,
+  widthPct: 0.88,
+  heightPct: 0.18,
+};
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** A rectangular region in pixel coordinates. */
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * How to fit the room background into the target aspect ratio.
+ *
+ * - `fit` — scale the source so it fully fits inside the target,
+ *   letterboxing/pillarboxing the remainder with a fill color.
+ * - `fill` — scale to cover the target, cropping source edges.
+ * - `crop_center` — zoom to target aspect, cropping evenly from
+ *   source center. Same as `fill` but with source centered.
+ */
+export type BackgroundFit = "fit" | "fill" | "crop_center";
+
+/** Resolved background layer for a frame. */
+export interface BackgroundLayout {
+  /**
+   * Source crop rect in the input image (`sx`, `sy`, `sWidth`, `sHeight`
+   * for `ctx.drawImage(img, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)`).
+   */
+  src: Rect;
+  /** Destination rect in the output frame. */
+  dst: Rect;
+  /**
+   * When `fit` leaves empty space, the color/pattern used to fill the
+   * padding. `null` means transparent (caller can fill with black or
+   * draw a blurred source behind).
+   */
+  fillColor: string | null;
+}
+
+/** Resolved placement for a single entity sprite. */
+export interface EntityLayout {
+  entityId: string;
+  /** Display name for the label beneath the sprite. */
+  name: string;
+  /** Destination rect in the output frame. */
+  dst: Rect;
+  /** Opacity to draw at (0..1). */
+  opacity: number;
+  /** True if this entity sits on the back row (smaller + more faded). */
+  isBackRow: boolean;
+  /** Whether this entity has a source image. When false, draw a placeholder. */
+  hasImage: boolean;
+}
+
+export interface TitleCardLayout {
+  text: string;
+  style: NonNullable<Scene["titleCard"]>["style"];
+  rect: Rect;
+}
+
+export interface CaptionLayout {
+  /** Full lower-third rect to draw the caption gradient + text inside. */
+  rect: Rect;
+}
+
+/** Complete frame layout for one scene at one moment in time. */
+export interface SceneFrameLayout {
+  width: number;
+  height: number;
+  background: BackgroundLayout | null;
+  /**
+   * Entities split into layers so the renderer can draw back row under
+   * the front row (matches CinematicScene z-ordering).
+   */
+  backRowEntities: EntityLayout[];
+  frontRowEntities: EntityLayout[];
+  titleCard: TitleCardLayout | null;
+  captionArea: CaptionLayout;
+}
+
+/** Input entity info passed into the layout function. */
+export interface LayoutEntityInfo {
+  entity: SceneEntity;
+  name: string;
+  /** Natural image dimensions in pixels. Undefined → placeholder. */
+  imageSize?: { width: number; height: number };
+}
+
+export interface LayoutOptions {
+  fit?: BackgroundFit;
+  /** Fill color used when `fit` leaves empty space. Default "#000". */
+  fillColor?: string;
+}
+
+// ─── Background fit math ─────────────────────────────────────────
+
+/**
+ * Computes the source + destination rects for fitting a source image
+ * into target dimensions with the given strategy.
+ */
+export function computeBackgroundFit(
+  sourceWidth: number,
+  sourceHeight: number,
+  targetWidth: number,
+  targetHeight: number,
+  fit: BackgroundFit,
+): { src: Rect; dst: Rect } {
+  const sourceAspect = sourceWidth / sourceHeight;
+  const targetAspect = targetWidth / targetHeight;
+
+  if (fit === "fit") {
+    // Letterbox / pillarbox: full source visible, possibly padded in dest.
+    const src: Rect = { x: 0, y: 0, width: sourceWidth, height: sourceHeight };
+    if (sourceAspect > targetAspect) {
+      // Source is wider than target → scale to target width, pillarbox.
+      const dstHeight = Math.round(targetWidth / sourceAspect);
+      return {
+        src,
+        dst: {
+          x: 0,
+          y: Math.round((targetHeight - dstHeight) / 2),
+          width: targetWidth,
+          height: dstHeight,
+        },
+      };
+    }
+    // Source is taller → scale to target height, letterbox.
+    const dstWidth = Math.round(targetHeight * sourceAspect);
+    return {
+      src,
+      dst: {
+        x: Math.round((targetWidth - dstWidth) / 2),
+        y: 0,
+        width: dstWidth,
+        height: targetHeight,
+      },
+    };
+  }
+
+  // `fill` and `crop_center` both cover the full target; they differ in
+  // how much of the source gets cropped. For `crop_center`, crop evenly
+  // from the source center (which is what `fill` does too in practice —
+  // we keep them separate for future "smart" crop variants).
+  const dst: Rect = { x: 0, y: 0, width: targetWidth, height: targetHeight };
+  if (sourceAspect > targetAspect) {
+    // Source wider — crop source left/right.
+    const cropWidth = Math.round(sourceHeight * targetAspect);
+    const cropX = Math.round((sourceWidth - cropWidth) / 2);
+    return {
+      src: { x: cropX, y: 0, width: cropWidth, height: sourceHeight },
+      dst,
+    };
+  }
+  // Source taller — crop source top/bottom.
+  const cropHeight = Math.round(sourceWidth / targetAspect);
+  const cropY = Math.round((sourceHeight - cropHeight) / 2);
+  return {
+    src: { x: 0, y: cropY, width: sourceWidth, height: cropHeight },
+    dst,
+  };
+}
+
+// ─── Entity placement math ───────────────────────────────────────
+
+/**
+ * Computes the destination rect for a single entity sprite, mirroring
+ * the in-app CinematicScene anchoring: sprite's bottom-center sits at
+ * the entity's (x, y) viewport percentage.
+ */
+export function computeEntityRect(
+  entity: SceneEntity,
+  imageSize: { width: number; height: number } | undefined,
+  targetWidth: number,
+  targetHeight: number,
+): Rect {
+  const pos = resolveEntityPosition(entity); // { x, y } in 0..100 percent
+  const scale = getEntityScale(entity);
+
+  const spriteWidth = Math.round(targetWidth * ENTITY_WIDTH_RATIO * scale);
+  const aspect = imageSize
+    ? imageSize.width / imageSize.height
+    : DEFAULT_SPRITE_ASPECT;
+  const spriteHeight = Math.round(spriteWidth / aspect);
+
+  // Anchor is bottom-center of sprite at (pos.x%, pos.y%).
+  const anchorX = Math.round((pos.x / 100) * targetWidth);
+  const anchorY = Math.round((pos.y / 100) * targetHeight);
+
+  return {
+    x: anchorX - Math.round(spriteWidth / 2),
+    y: anchorY - spriteHeight,
+    width: spriteWidth,
+    height: spriteHeight,
+  };
+}
+
+// ─── Layout computation ──────────────────────────────────────────
+
+/**
+ * Computes the full frame layout for a scene at the target resolution.
+ *
+ * Does NOT load any images. The caller is responsible for providing
+ * natural image sizes (via ImageBitmap.width/height or preloaded Image
+ * naturalWidth/Height). Entities without an imageSize render as
+ * placeholder rects.
+ */
+export function computeSceneFrameLayout(
+  scene: Scene,
+  resolvedEntities: LayoutEntityInfo[],
+  roomImageSize: { width: number; height: number } | undefined,
+  targetWidth: number,
+  targetHeight: number,
+  options: LayoutOptions = {},
+): SceneFrameLayout {
+  const fit = options.fit ?? "fit";
+  const fillColor = options.fillColor ?? "#000000";
+
+  // ─── Background ──────────────────────────────────────────
+  let background: BackgroundLayout | null = null;
+  if (roomImageSize) {
+    const { src, dst } = computeBackgroundFit(
+      roomImageSize.width,
+      roomImageSize.height,
+      targetWidth,
+      targetHeight,
+      fit,
+    );
+    background = {
+      src,
+      dst,
+      fillColor: fit === "fit" ? fillColor : null,
+    };
+  }
+
+  // ─── Entities ────────────────────────────────────────────
+  const backRowEntities: EntityLayout[] = [];
+  const frontRowEntities: EntityLayout[] = [];
+
+  for (const info of resolvedEntities) {
+    const back = isBackRow(info.entity.slot);
+    const rect = computeEntityRect(
+      info.entity,
+      info.imageSize,
+      targetWidth,
+      targetHeight,
+    );
+    const entry: EntityLayout = {
+      entityId: info.entity.id,
+      name: info.name,
+      dst: rect,
+      opacity: back ? BACK_ROW_OPACITY : 1,
+      isBackRow: back,
+      hasImage: Boolean(info.imageSize),
+    };
+    if (back) backRowEntities.push(entry);
+    else frontRowEntities.push(entry);
+  }
+
+  // ─── Title card ──────────────────────────────────────────
+  let titleCard: TitleCardLayout | null = null;
+  if (scene.titleCard && scene.titleCard.text.trim()) {
+    const boxWidth = Math.round(targetWidth * TITLE_CARD_BOX.widthPct);
+    const boxHeight = Math.round(targetHeight * TITLE_CARD_BOX.heightPct);
+    titleCard = {
+      text: scene.titleCard.text,
+      style: scene.titleCard.style,
+      rect: {
+        x: Math.round((targetWidth - boxWidth) / 2),
+        y: Math.round(targetHeight * TITLE_CARD_BOX.topPct),
+        width: boxWidth,
+        height: boxHeight,
+      },
+    };
+  }
+
+  // ─── Caption area ────────────────────────────────────────
+  const captionWidth = Math.round(targetWidth * CAPTION_BOX.widthPct);
+  const captionArea: CaptionLayout = {
+    rect: {
+      x: Math.round((targetWidth - captionWidth) / 2),
+      y: Math.round(targetHeight * CAPTION_BOX.topPct),
+      width: captionWidth,
+      height: Math.round(targetHeight * CAPTION_BOX.heightPct),
+    },
+  };
+
+  return {
+    width: targetWidth,
+    height: targetHeight,
+    background,
+    backRowEntities,
+    frontRowEntities,
+    titleCard,
+    captionArea,
+  };
+}

--- a/creator/src/lib/storyFrameRenderer.ts
+++ b/creator/src/lib/storyFrameRenderer.ts
@@ -1,0 +1,299 @@
+// ─── Story Frame Renderer ────────────────────────────────────────
+// Canvas-based compositor that consumes a SceneFrameLayout and draws
+// a single video frame to an offscreen/hidden canvas.
+//
+// Split from storyFrameLayout.ts so the pure layout math stays
+// unit-testable without jsdom canvas quirks. This module is browser-
+// only — it uses HTMLCanvasElement / CanvasRenderingContext2D.
+
+import type {
+  SceneFrameLayout,
+  EntityLayout,
+  BackgroundLayout,
+  TitleCardLayout,
+  CaptionLayout,
+} from "@/lib/storyFrameLayout";
+
+// ─── Image loading ───────────────────────────────────────────────
+
+/**
+ * Loads a data URL or same-origin URL into an HTMLImageElement,
+ * resolving with the loaded image (which carries naturalWidth/Height).
+ */
+export function loadImageElement(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = (e) =>
+      reject(new Error(`Failed to load image: ${e instanceof Event ? "load error" : e}`));
+    img.src = src;
+  });
+}
+
+// ─── Loaded scene image cache ────────────────────────────────────
+
+export interface LoadedSceneImages {
+  background?: HTMLImageElement;
+  /** Keyed by SceneEntity.id. */
+  entities: Map<string, HTMLImageElement>;
+}
+
+export interface SceneImageSources {
+  background?: string;
+  /** entityId → data URL / URL. Entities without a source still get laid out as placeholders. */
+  entities: Array<{ entityId: string; src?: string }>;
+}
+
+/**
+ * Loads all images required for a scene in parallel, returning a
+ * LoadedSceneImages cache. Missing sources are silently omitted — the
+ * renderer will draw placeholder boxes for entities without images.
+ */
+export async function loadSceneImages(
+  sources: SceneImageSources,
+): Promise<LoadedSceneImages> {
+  const result: LoadedSceneImages = { entities: new Map() };
+
+  const bgPromise = sources.background
+    ? loadImageElement(sources.background)
+        .then((img) => {
+          result.background = img;
+        })
+        .catch(() => {
+          /* fall through — scene will render with no bg */
+        })
+    : Promise.resolve();
+
+  const entityPromises = sources.entities.map(async ({ entityId, src }) => {
+    if (!src) return;
+    try {
+      const img = await loadImageElement(src);
+      result.entities.set(entityId, img);
+    } catch {
+      /* fall through — entity renders as placeholder */
+    }
+  });
+
+  await Promise.all([bgPromise, ...entityPromises]);
+  return result;
+}
+
+// ─── Canvas drawing primitives ───────────────────────────────────
+
+/**
+ * Fonts used by the renderer. These match the creator's design system
+ * (Cinzel for display text, Crimson Pro for body). Both are loaded
+ * globally via @fontsource so the canvas context inherits them.
+ */
+const FONT_DISPLAY = "Cinzel, serif";
+const FONT_BODY = '"Crimson Pro", Georgia, serif';
+
+function drawBackground(
+  ctx: CanvasRenderingContext2D,
+  bg: BackgroundLayout,
+  image: HTMLImageElement | undefined,
+  frameWidth: number,
+  frameHeight: number,
+): void {
+  // Fill padding area first (letterbox bars).
+  if (bg.fillColor) {
+    ctx.fillStyle = bg.fillColor;
+    ctx.fillRect(0, 0, frameWidth, frameHeight);
+  }
+  if (!image) return;
+  ctx.drawImage(
+    image,
+    bg.src.x,
+    bg.src.y,
+    bg.src.width,
+    bg.src.height,
+    bg.dst.x,
+    bg.dst.y,
+    bg.dst.width,
+    bg.dst.height,
+  );
+}
+
+function drawEntity(
+  ctx: CanvasRenderingContext2D,
+  entity: EntityLayout,
+  image: HTMLImageElement | undefined,
+): void {
+  ctx.save();
+  ctx.globalAlpha = entity.opacity;
+
+  if (image) {
+    ctx.drawImage(image, entity.dst.x, entity.dst.y, entity.dst.width, entity.dst.height);
+  } else {
+    // Placeholder box with subtle border
+    ctx.fillStyle = "rgba(40, 44, 64, 0.7)";
+    ctx.fillRect(entity.dst.x, entity.dst.y, entity.dst.width, entity.dst.height);
+    ctx.strokeStyle = "rgba(180, 180, 200, 0.5)";
+    ctx.lineWidth = 2;
+    ctx.strokeRect(
+      entity.dst.x + 1,
+      entity.dst.y + 1,
+      entity.dst.width - 2,
+      entity.dst.height - 2,
+    );
+  }
+
+  // Name label under the sprite
+  const labelFontSize = Math.max(10, Math.round(entity.dst.width * 0.1));
+  ctx.font = `${labelFontSize}px ${FONT_BODY}`;
+  ctx.fillStyle = "#ffffff";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  ctx.shadowColor = "rgba(0, 0, 0, 0.8)";
+  ctx.shadowBlur = 3;
+  ctx.shadowOffsetY = 1;
+  ctx.fillText(
+    entity.name,
+    entity.dst.x + entity.dst.width / 2,
+    entity.dst.y + entity.dst.height + 4,
+    entity.dst.width + 40, // max width: allow modest overflow
+  );
+
+  ctx.restore();
+}
+
+function drawTitleCard(
+  ctx: CanvasRenderingContext2D,
+  card: TitleCardLayout,
+): void {
+  const { rect, text } = card;
+  ctx.save();
+
+  // Subtle backdrop
+  const gradient = ctx.createLinearGradient(rect.x, rect.y, rect.x, rect.y + rect.height);
+  gradient.addColorStop(0, "rgba(10, 14, 30, 0.0)");
+  gradient.addColorStop(0.5, "rgba(10, 14, 30, 0.55)");
+  gradient.addColorStop(1, "rgba(10, 14, 30, 0.0)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
+
+  // Text
+  const fontSize = Math.round(rect.height * 0.55);
+  ctx.font = `600 ${fontSize}px ${FONT_DISPLAY}`;
+  ctx.fillStyle = "#e2bc6a"; // aurum-gold, matches design system
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.shadowColor = "rgba(0, 0, 0, 0.7)";
+  ctx.shadowBlur = 6;
+  ctx.shadowOffsetY = 2;
+  ctx.fillText(
+    text,
+    rect.x + rect.width / 2,
+    rect.y + rect.height / 2,
+    rect.width - 20,
+  );
+
+  ctx.restore();
+}
+
+function drawCaptionBackdrop(
+  ctx: CanvasRenderingContext2D,
+  caption: CaptionLayout,
+  frameWidth: number,
+  frameHeight: number,
+): void {
+  // Full-width gradient from transparent at the caption top down to
+  // semi-opaque black at the bottom of the frame, matching the existing
+  // CinematicScene narration overlay styling.
+  const { rect } = caption;
+  ctx.save();
+  const gradient = ctx.createLinearGradient(0, rect.y, 0, frameHeight);
+  gradient.addColorStop(0, "rgba(0, 0, 0, 0.0)");
+  gradient.addColorStop(1, "rgba(0, 0, 0, 0.6)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, rect.y, frameWidth, frameHeight - rect.y);
+  ctx.restore();
+}
+
+// ─── Public renderer ─────────────────────────────────────────────
+
+export interface RenderFrameOptions {
+  /**
+   * When true, draw a lower-third gradient under the caption area even
+   * if no caption text is rendered yet. Used for still frames that will
+   * get caption text burned in during ffmpeg encoding.
+   */
+  drawCaptionBackdrop?: boolean;
+}
+
+/**
+ * Draws a single scene frame onto the given canvas context.
+ *
+ * Assumes the canvas is already sized to layout.width × layout.height.
+ * Does NOT clear — caller should clear or rely on layers filling the
+ * whole frame (the background layer handles letterbox fill when the
+ * fit strategy leaves empty space).
+ *
+ * For frames without a background (no room image, no letterbox fill),
+ * caller should clear the canvas to black before calling this.
+ */
+export function drawSceneFrame(
+  ctx: CanvasRenderingContext2D,
+  layout: SceneFrameLayout,
+  images: LoadedSceneImages,
+  options: RenderFrameOptions = {},
+): void {
+  // Layer 0: room background (or fill color)
+  if (layout.background) {
+    drawBackground(ctx, layout.background, images.background, layout.width, layout.height);
+  } else {
+    // No background at all — clear to black
+    ctx.fillStyle = "#000000";
+    ctx.fillRect(0, 0, layout.width, layout.height);
+  }
+
+  // Layer 1: back row entities (under front)
+  for (const entity of layout.backRowEntities) {
+    drawEntity(ctx, entity, images.entities.get(entity.entityId));
+  }
+
+  // Layer 2: front row entities
+  for (const entity of layout.frontRowEntities) {
+    drawEntity(ctx, entity, images.entities.get(entity.entityId));
+  }
+
+  // Layer 3: caption backdrop (optional — used when captions will be
+  // burned in later by ffmpeg drawtext)
+  if (options.drawCaptionBackdrop) {
+    drawCaptionBackdrop(ctx, layout.captionArea, layout.width, layout.height);
+  }
+
+  // Layer 4: title card
+  if (layout.titleCard) {
+    drawTitleCard(ctx, layout.titleCard);
+  }
+}
+
+/**
+ * Convenience wrapper: creates an offscreen canvas, renders the frame,
+ * and returns a PNG blob. Used by the export pipeline to serialize
+ * each scene into a still image for the ffmpeg frame sequence.
+ */
+export async function renderSceneFrameToBlob(
+  layout: SceneFrameLayout,
+  images: LoadedSceneImages,
+  options?: RenderFrameOptions,
+): Promise<Blob> {
+  const canvas = document.createElement("canvas");
+  canvas.width = layout.width;
+  canvas.height = layout.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Failed to acquire 2D context on offscreen canvas");
+  }
+  drawSceneFrame(ctx, layout, images, options);
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error("canvas.toBlob returned null"));
+      },
+      "image/png",
+    );
+  });
+}

--- a/creator/src/lib/storyTiming.ts
+++ b/creator/src/lib/storyTiming.ts
@@ -1,0 +1,365 @@
+// ─── Story Timeline Computation ──────────────────────────────────
+// Pure, deterministic timeline for converting a Story into a timed
+// sequence of scenes with narration chunks and transitions.
+//
+// Phase 1 of the story→video export pipeline. Consumed by the frame
+// renderer (scene compositing at t=N), the audio mixer (narration
+// alignment), and the encoder (scene durations for ffmpeg).
+//
+// Phase 2 (TTS) replaces word-count narration estimates with actual
+// audio file durations via the `narrationDurationOverrides` option.
+
+import type { Story, Scene } from "@/types/story";
+import { NARRATION_TIMING, type NarrationSpeed } from "@/lib/narrationSpeed";
+import { extractWords } from "@/lib/sceneLayout";
+
+// ─── TipTap paragraph extraction ─────────────────────────────────
+
+interface TipTapNode {
+  type: string;
+  text?: string;
+  content?: TipTapNode[];
+}
+
+function walkTextNodes(node: TipTapNode): string {
+  if (node.type === "text" && node.text) return node.text;
+  if (!node.content) return "";
+  return node.content.map(walkTextNodes).join("");
+}
+
+/**
+ * Extracts narration as a list of paragraphs (one per top-level block).
+ * Used for caption chunking: each paragraph becomes one subtitle chunk.
+ * Falls back to splitting the raw string on newlines if the input isn't
+ * valid TipTap JSON — keeps the module resilient when callers pass plain
+ * text (e.g. from older stories or tests).
+ */
+export function extractParagraphs(narrationJson: string): string[] {
+  if (!narrationJson) return [];
+  try {
+    const doc = JSON.parse(narrationJson) as TipTapNode;
+    if (!doc.content) return [];
+    return doc.content
+      .map((block) => walkTextNodes(block).trim())
+      .filter((text) => text.length > 0);
+  } catch {
+    return narrationJson
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  }
+}
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** A single word in the narration with precise timing. */
+export interface NarrationWord {
+  text: string;
+  /** Start time relative to the scene start (milliseconds). */
+  startMs: number;
+  /** End time relative to the scene start (milliseconds). */
+  endMs: number;
+}
+
+/**
+ * A subtitle-sized chunk of narration (typically one paragraph).
+ * Used for burned-in caption rendering.
+ */
+export interface NarrationChunk {
+  text: string;
+  /** Start time relative to the scene start (milliseconds). */
+  startMs: number;
+  /** End time relative to the scene start (milliseconds). */
+  endMs: number;
+  wordCount: number;
+}
+
+/** Transition style applied at the boundary between two scenes. */
+export interface SceneTransition {
+  type: "crossfade" | "fade_black";
+  /** Total duration of the transition (milliseconds). */
+  durationMs: number;
+}
+
+/** Per-scene absolute timing plus narration breakdown. */
+export interface SceneTimelineEntry {
+  sceneId: string;
+  sceneIndex: number;
+  /** Absolute start time in the final video (milliseconds). */
+  startMs: number;
+  /** Total duration this scene occupies (milliseconds). */
+  durationMs: number;
+  /**
+   * When narration audio begins playing, relative to scene start.
+   * Matches the existing 200ms delay from CinematicScene.
+   */
+  narrationStartMs: number;
+  /** When narration finishes, relative to scene start. */
+  narrationEndMs: number;
+  /** Post-narration hold before the scene ends. */
+  holdMs: number;
+  /** Paragraph-level chunks for caption rendering. */
+  narrationChunks: NarrationChunk[];
+  /** Word-level timing for precise sync / SRT export. */
+  narrationWords: NarrationWord[];
+  /**
+   * Transition out of this scene into the next.
+   * Null on the final scene.
+   */
+  transitionOut: SceneTransition | null;
+}
+
+export interface StoryTimeline {
+  scenes: SceneTimelineEntry[];
+  totalDurationMs: number;
+}
+
+export interface TimelineOptions {
+  /** Dwell time after narration ends, before the scene transitions. Default 1500ms. */
+  postNarrationHoldMs?: number;
+  /** Minimum duration for any scene (e.g. scenes without narration). Default 3000ms. */
+  minSceneDurationMs?: number;
+  /** Maximum scene duration clamp. Default 30000ms. */
+  maxSceneDurationMs?: number;
+  /** Crossfade transition duration. Default 500ms. */
+  crossfadeMs?: number;
+  /** Fade-to-black transition duration. Default 300ms. */
+  fadeBlackMs?: number;
+  /**
+   * Delay before narration begins within a scene. Default 200ms
+   * (matches CinematicScene's in-app playback).
+   */
+  narrationLeadInMs?: number;
+  /**
+   * Override narration duration per scene, keyed by scene ID.
+   * Phase 2 (TTS) populates this with actual audio file durations
+   * so the timeline matches the rendered speech rather than
+   * the word-count estimate.
+   */
+  narrationDurationOverrides?: Record<string, number>;
+}
+
+// ─── Defaults ────────────────────────────────────────────────────
+
+const DEFAULTS: Required<Omit<TimelineOptions, "narrationDurationOverrides">> = {
+  postNarrationHoldMs: 1500,
+  minSceneDurationMs: 3000,
+  maxSceneDurationMs: 30000,
+  crossfadeMs: 500,
+  fadeBlackMs: 300,
+  narrationLeadInMs: 200,
+};
+
+// ─── Narration timing ────────────────────────────────────────────
+
+/**
+ * Computes the estimated duration of narration at a given speed,
+ * in milliseconds. Mirrors the in-app typewriter timing from
+ * NARRATION_TIMING so video export stays consistent with playback.
+ */
+export function estimateNarrationDurationMs(
+  wordCount: number,
+  speed: NarrationSpeed,
+): number {
+  if (wordCount <= 0) return 0;
+  const timing = NARRATION_TIMING[speed];
+  const perWordSeconds = timing.wordDuration + timing.wordGap;
+  return Math.round(wordCount * perWordSeconds * 1000);
+}
+
+/** Computes per-word timing for a narration string at the given speed. */
+function computeNarrationWords(
+  narrationJson: string,
+  speed: NarrationSpeed,
+  totalDurationMs: number,
+): NarrationWord[] {
+  const words = extractWords(narrationJson);
+  if (words.length === 0) return [];
+
+  // Distribute the total narration duration proportionally across words.
+  // When totalDurationMs is an override (e.g. TTS audio length), this
+  // keeps the per-word timing aligned with the real audio.
+  const timing = NARRATION_TIMING[speed];
+  const perWordSeconds = timing.wordDuration + timing.wordGap;
+  const estimatedMs = words.length * perWordSeconds * 1000;
+  const scale = estimatedMs > 0 ? totalDurationMs / estimatedMs : 0;
+
+  const result: NarrationWord[] = [];
+  let cursor = 0;
+  for (const word of words) {
+    const wordMs = Math.round(perWordSeconds * 1000 * scale);
+    result.push({
+      text: word,
+      startMs: cursor,
+      endMs: cursor + wordMs,
+    });
+    cursor += wordMs;
+  }
+  return result;
+}
+
+/**
+ * Computes paragraph-level caption chunks. Each TipTap block becomes
+ * one chunk, sized proportionally to its word count.
+ */
+function computeNarrationChunks(
+  narrationJson: string,
+  totalDurationMs: number,
+): NarrationChunk[] {
+  const paragraphs = extractParagraphs(narrationJson);
+  if (paragraphs.length === 0) return [];
+
+  const chunkWordCounts = paragraphs.map((p) => p.split(/\s+/).filter(Boolean).length);
+  const totalWords = chunkWordCounts.reduce((sum, n) => sum + n, 0);
+  if (totalWords === 0) return [];
+
+  const chunks: NarrationChunk[] = [];
+  let cursor = 0;
+  for (let i = 0; i < paragraphs.length; i++) {
+    const wordCount = chunkWordCounts[i] ?? 0;
+    const chunkDurationMs =
+      i === paragraphs.length - 1
+        ? Math.max(0, totalDurationMs - cursor) // absorb rounding into last chunk
+        : Math.round((wordCount / totalWords) * totalDurationMs);
+    chunks.push({
+      text: paragraphs[i] ?? "",
+      startMs: cursor,
+      endMs: cursor + chunkDurationMs,
+      wordCount,
+    });
+    cursor += chunkDurationMs;
+  }
+  return chunks;
+}
+
+// ─── Transition resolution ───────────────────────────────────────
+
+function resolveTransition(
+  scene: Scene,
+  opts: Required<Omit<TimelineOptions, "narrationDurationOverrides">>,
+): SceneTransition {
+  const type = scene.transition?.type ?? "crossfade";
+  const durationMs = type === "crossfade" ? opts.crossfadeMs : opts.fadeBlackMs;
+  return { type, durationMs };
+}
+
+// ─── Main timeline computation ───────────────────────────────────
+
+/**
+ * Computes a deterministic timeline for a story, suitable for driving
+ * video frame rendering, audio mixing, and encoding.
+ *
+ * Scenes are processed in `sortOrder`. The caller does not need to
+ * pre-sort — the function sorts defensively.
+ *
+ * Scene duration model:
+ *   scene.durationMs =
+ *     narrationLeadInMs +
+ *     narrationDuration +
+ *     postNarrationHoldMs
+ *   clamped to [minSceneDurationMs, maxSceneDurationMs]
+ *
+ * Where narrationDuration is:
+ *   - `narrationDurationOverrides[sceneId]` if present (Phase 2 TTS)
+ *   - otherwise estimated from word count × NARRATION_TIMING[speed]
+ *
+ * Transitions overlap: a scene with a 500ms crossfade-out and a
+ * following scene do NOT produce an 500ms black gap — the next
+ * scene's startMs is (current scene end) - transitionDurationMs,
+ * so the crossfade mixes both scenes.
+ */
+export function computeStoryTimeline(
+  story: Story,
+  options?: TimelineOptions,
+): StoryTimeline {
+  const opts = { ...DEFAULTS, ...options };
+  const overrides = options?.narrationDurationOverrides ?? {};
+  const storySpeed: NarrationSpeed = story.narrationSpeed ?? "normal";
+
+  const sorted = [...story.scenes].sort((a, b) => a.sortOrder - b.sortOrder);
+  const entries: SceneTimelineEntry[] = [];
+
+  let cursorMs = 0;
+
+  for (let i = 0; i < sorted.length; i++) {
+    const scene = sorted[i]!;
+    const effectiveSpeed: NarrationSpeed = scene.narrationSpeed ?? storySpeed;
+
+    // ─── Narration duration ──────────────────────────────────
+    const wordCount = extractWords(scene.narration ?? "").length;
+    const override = overrides[scene.id];
+    const narrationDurationMs =
+      override !== undefined
+        ? Math.max(0, override)
+        : estimateNarrationDurationMs(wordCount, effectiveSpeed);
+
+    // ─── Scene duration (clamped) ────────────────────────────
+    const rawDurationMs =
+      opts.narrationLeadInMs + narrationDurationMs + opts.postNarrationHoldMs;
+    const durationMs = Math.min(
+      opts.maxSceneDurationMs,
+      Math.max(opts.minSceneDurationMs, rawDurationMs),
+    );
+
+    // If clamping to minSceneDurationMs, give the remainder to the hold
+    // so narration still plays fully at the top.
+    const holdMs = Math.max(
+      opts.postNarrationHoldMs,
+      durationMs - opts.narrationLeadInMs - narrationDurationMs,
+    );
+
+    const narrationStartMs = opts.narrationLeadInMs;
+    const narrationEndMs = narrationStartMs + narrationDurationMs;
+
+    // ─── Chunk narration for captions + per-word sync ────────
+    const narrationChunks = computeNarrationChunks(
+      scene.narration ?? "",
+      narrationDurationMs,
+    ).map((chunk) => ({
+      ...chunk,
+      startMs: chunk.startMs + narrationStartMs,
+      endMs: chunk.endMs + narrationStartMs,
+    }));
+
+    const narrationWords = computeNarrationWords(
+      scene.narration ?? "",
+      effectiveSpeed,
+      narrationDurationMs,
+    ).map((word) => ({
+      ...word,
+      startMs: word.startMs + narrationStartMs,
+      endMs: word.endMs + narrationStartMs,
+    }));
+
+    // ─── Transition out ──────────────────────────────────────
+    const isLast = i === sorted.length - 1;
+    const transitionOut = isLast ? null : resolveTransition(scene, opts);
+
+    entries.push({
+      sceneId: scene.id,
+      sceneIndex: i,
+      startMs: cursorMs,
+      durationMs,
+      narrationStartMs,
+      narrationEndMs,
+      holdMs,
+      narrationChunks,
+      narrationWords,
+      transitionOut,
+    });
+
+    // Advance the cursor. Overlap transitions so the next scene starts
+    // `transitionDurationMs` before the current scene ends.
+    const transitionOverlap = transitionOut?.durationMs ?? 0;
+    cursorMs += durationMs - transitionOverlap;
+  }
+
+  // Final video duration = last scene's absolute end time.
+  const lastEntry = entries[entries.length - 1];
+  const totalDurationMs = lastEntry ? lastEntry.startMs + lastEntry.durationMs : 0;
+
+  return {
+    scenes: entries,
+    totalDurationMs,
+  };
+}

--- a/creator/src/lib/storyVideoExport.ts
+++ b/creator/src/lib/storyVideoExport.ts
@@ -1,0 +1,591 @@
+// ─── Story → Video Export Orchestrator ──────────────────────────
+// Top-level frontend function that drives the end-to-end pipeline.
+// Glues together every primitive from PRs 1–7 into a single callable
+// entry point.
+//
+// Pipeline stages:
+//   1. ffmpeg       — ensure the ffmpeg binary is available (downloads
+//                      on first use)
+//   2. timeline      — compute initial timeline from word counts
+//   3. tts           — synthesize narration per scene with TTS
+//   4. timeline_sync — refresh timeline durations from real TTS
+//                      audio lengths (probed via `<audio>.duration`)
+//   5. images        — load all scene backgrounds + entity sprites
+//   6. frames        — render each scene to a canvas and save PNG
+//   7. audio_paths   — resolve zone music + ambient file paths
+//   8. export        — call the Rust orchestrator which does the
+//                      audio mix + video encode + mux
+//   9. cleanup       — delete the session temp dir
+//
+// Callers pass a `Story` plus pre-resolved scene data (from the
+// existing `useResolvedSceneData` hook) plus a preset ID plus an
+// output path. An optional `onProgress` callback receives staged
+// progress events.
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+import type { Story, SceneEntity } from "@/types/story";
+import type { WorldFile } from "@/types/world";
+import type { Project } from "@/types/project";
+
+import {
+  computeStoryTimeline,
+  type StoryTimeline,
+  type TimelineOptions,
+} from "@/lib/storyTiming";
+import { synthesizeSceneNarration } from "@/lib/narrationSynthesis";
+import type {
+  NarrationAudio,
+  OpenAiTtsVoice,
+  OpenAiTtsModel,
+} from "@/lib/narrationSynthesis";
+import {
+  computeSceneFrameLayout,
+  type LayoutEntityInfo,
+} from "@/lib/storyFrameLayout";
+import {
+  loadSceneImages,
+  renderSceneFrameToBlob,
+  type LoadedSceneImages,
+  type SceneImageSources,
+} from "@/lib/storyFrameRenderer";
+import { checkFfmpegStatus, ensureFfmpegReady } from "@/lib/ffmpegStatus";
+import { getPreset, type ExportPresetId } from "@/lib/videoExportPresets";
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** Scene data already resolved with image data URLs (from useResolvedSceneData). */
+export interface ResolvedSceneForExport {
+  sceneId: string;
+  roomImageSrc?: string;
+  entities: Array<{
+    entity: SceneEntity;
+    name: string;
+    imageSrc?: string;
+  }>;
+}
+
+export type ExportStage =
+  | "ffmpeg"
+  | "timeline"
+  | "tts"
+  | "timeline_sync"
+  | "images"
+  | "frames"
+  | "audio_paths"
+  | "export"
+  | "audio_mix"
+  | "video_encode"
+  | "mux"
+  | "cleanup"
+  | "done";
+
+export interface ExportProgressEvent {
+  stage: ExportStage;
+  /** Monotonic phase index for the progress bar (0..1). */
+  fraction: number;
+  /** Human-readable message for the UI. */
+  message: string;
+}
+
+export interface ExportStoryVideoOptions {
+  story: Story;
+  /** Scene data already resolved with image data URLs. */
+  resolvedScenes: ResolvedSceneForExport[];
+  /** The zone the story lives in. Used to resolve music/ambient paths. */
+  world: WorldFile;
+  /** Current project — used for legacy mudDir path fallbacks. */
+  project: Project;
+  /** Absolute path to the assets cache dir (from assetStore.assetsDir). */
+  assetsDir: string;
+  /** Which preset to export. */
+  presetId: ExportPresetId;
+  /** Absolute output file path (.mp4). The caller picks this from a file dialog. */
+  outputPath: string;
+  /** Override the preset's default TTS voice. */
+  voiceOverride?: OpenAiTtsVoice;
+  /** Override the preset's default TTS model. */
+  modelOverride?: OpenAiTtsModel;
+  /** Progress callback — fires at every stage transition. */
+  onProgress?: (event: ExportProgressEvent) => void;
+}
+
+export interface ExportStoryVideoResult {
+  outputPath: string;
+  durationMs: number;
+  sizeBytes: number;
+}
+
+// ─── Rust-side type mirrors ──────────────────────────────────────
+
+interface RustNarrationTrack {
+  filePath: string;
+  offsetMs: number;
+}
+
+interface RustAudioMixInput {
+  narrations: RustNarrationTrack[];
+  musicPath: string | null;
+  ambientPath: string | null;
+  totalDurationMs: number;
+  audioBitrateKbps: number;
+}
+
+interface RustSceneExportEntry {
+  pngPath: string;
+  durationMs: number;
+}
+
+interface RustVideoExportRequest {
+  sessionId: string;
+  scenes: RustSceneExportEntry[];
+  audio: RustAudioMixInput;
+  width: number;
+  height: number;
+  fps: number;
+  videoBitrateKbps: number;
+  profile: string;
+  crossfadeMs: number | null;
+  outputPath: string;
+}
+
+interface RustVideoExportResult {
+  outputPath: string;
+  totalDurationMs: number;
+  sizeBytes: number;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────
+
+/** Generates a UUID for the session temp dir. Uses crypto.randomUUID in browsers. */
+function makeSessionId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  // Fallback: random hex. Used only in environments without crypto
+  // (shouldn't happen in a real Tauri webview).
+  return Array.from({ length: 32 }, () =>
+    Math.floor(Math.random() * 16).toString(16),
+  ).join("");
+}
+
+/**
+ * Converts a Blob to a base64 string suitable for Tauri IPC.
+ * Uses chunked String.fromCharCode to avoid call-stack overflow on
+ * large frames — same pattern as useBackgroundRemoval.ts.
+ */
+async function blobToBase64(blob: Blob): Promise<string> {
+  const buffer = await blob.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  const chunks: string[] = [];
+  const CHUNK = 8192;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    chunks.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
+  }
+  return btoa(chunks.join(""));
+}
+
+/**
+ * Reads the duration of a narration audio file via a transient
+ * HTMLAudioElement. The file is already saved to disk in the Rust
+ * cache; we just need its length.
+ *
+ * Returns the duration in milliseconds, or null on failure.
+ */
+async function probeNarrationDurationMs(filePath: string): Promise<number | null> {
+  // Load the file as a data URL via the existing media reader so the
+  // browser security model is happy with file:// URIs.
+  try {
+    const dataUrl = await invoke<string>("read_media_data_url", { path: filePath });
+    return new Promise<number | null>((resolve) => {
+      const audio = document.createElement("audio");
+      audio.preload = "metadata";
+      audio.onloadedmetadata = () => {
+        const ms = isFinite(audio.duration) ? Math.round(audio.duration * 1000) : null;
+        resolve(ms);
+      };
+      audio.onerror = () => resolve(null);
+      audio.src = dataUrl;
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Builds the same candidate path list that `useMediaSrc` computes so
+ * zone audio refs resolve the same way the in-app preview does.
+ */
+function buildMediaCandidatePaths(
+  fileName: string,
+  assetsDir: string,
+  mudDir: string | undefined,
+): string[] {
+  if (!fileName) return [];
+  // R2 hash filename → asset cache
+  const isHash = /^[0-9a-f]{40,64}\.(mp3|mp4|webm|ogg|wav|m4a)$/i.test(fileName);
+  if (isHash) {
+    if (!assetsDir) return [];
+    return [
+      `${assetsDir}\\audio\\${fileName}`,
+      `${assetsDir}\\video\\${fileName}`,
+      `${assetsDir}\\images\\${fileName}`,
+    ];
+  }
+  // Absolute path
+  if (fileName.includes(":\\") || fileName.startsWith("/")) {
+    return [fileName];
+  }
+  // Legacy relative path
+  if (!mudDir) return [];
+  return [
+    `${mudDir}/src/main/resources/world/audio/${fileName}`,
+    `${mudDir}/src/main/resources/audio/${fileName}`,
+  ];
+}
+
+/**
+ * Resolves a zone audio file reference (filename as stored in
+ * world.audio.music / world.audio.ambient) to an absolute file path.
+ * Returns `null` if no candidate exists on disk.
+ */
+async function resolveZoneAudioPath(
+  fileName: string | undefined,
+  assetsDir: string,
+  mudDir: string | undefined,
+): Promise<string | null> {
+  if (!fileName) return null;
+  const candidates = buildMediaCandidatePaths(fileName, assetsDir, mudDir);
+  if (candidates.length === 0) return null;
+  try {
+    return await invoke<string | null>("resolve_first_existing_path", { candidates });
+  } catch {
+    return null;
+  }
+}
+
+// ─── Orchestrator ────────────────────────────────────────────────
+
+/**
+ * End-to-end story → video export.
+ *
+ * Contract: every stage emits exactly one progress event on entry.
+ * The overall fraction rises monotonically from 0 to 1.
+ *
+ * Throws on any pipeline failure; the caller is expected to show the
+ * error to the user. On throw, temp files from this session are left
+ * on disk for debugging — call cleanupVideoExportSession() to reclaim
+ * the space.
+ */
+export async function exportStoryVideo(
+  options: ExportStoryVideoOptions,
+): Promise<ExportStoryVideoResult> {
+  const {
+    story,
+    resolvedScenes,
+    world,
+    presetId,
+    outputPath,
+    voiceOverride,
+    modelOverride,
+    assetsDir,
+    project,
+    onProgress,
+  } = options;
+
+  const preset = getPreset(presetId);
+  const sessionId = makeSessionId();
+  const emit = (event: ExportProgressEvent) => {
+    onProgress?.(event);
+  };
+
+  // ─── Subscribe to Rust-side progress relayed from export_story_video ──
+  // Rust emits at audio_mix / video_encode / mux / cleanup / done stages.
+  // We map those to the orchestrator's progress callback.
+  let unlistenProgress: UnlistenFn | null = null;
+  try {
+    unlistenProgress = await listen<{ stage: string; message: string }>(
+      "video_export:progress",
+      (event) => {
+        const stage = event.payload.stage as ExportStage;
+        // Rough fractions for the Rust-side sub-stages.
+        const fractionByStage: Partial<Record<ExportStage, number>> = {
+          audio_mix: 0.72,
+          video_encode: 0.82,
+          mux: 0.95,
+          cleanup: 0.98,
+          done: 1.0,
+        };
+        emit({
+          stage,
+          fraction: fractionByStage[stage] ?? 0.8,
+          message: event.payload.message,
+        });
+      },
+    );
+  } catch (e) {
+    console.warn("[exportStoryVideo] progress listener setup failed:", e);
+  }
+
+  try {
+    // ─── Stage 1: ffmpeg availability ────────────────────────
+    emit({ stage: "ffmpeg", fraction: 0.0, message: "Checking ffmpeg…" });
+    const ffmpegStatus = await checkFfmpegStatus();
+    if (!ffmpegStatus.available) {
+      emit({
+        stage: "ffmpeg",
+        fraction: 0.03,
+        message: "Downloading ffmpeg (~30 MB, one-time)…",
+      });
+      await ensureFfmpegReady();
+    }
+
+    // ─── Stage 2: initial timeline from word counts ──────────
+    emit({ stage: "timeline", fraction: 0.08, message: "Computing timeline…" });
+    const timelineOptions: TimelineOptions = {};
+    let timeline = computeStoryTimeline(story, timelineOptions);
+    if (timeline.scenes.length === 0) {
+      throw new Error("Story has no scenes — cannot export.");
+    }
+
+    // ─── Stage 3: TTS synthesis per scene ────────────────────
+    const scenesBySortOrder = [...story.scenes].sort(
+      (a, b) => a.sortOrder - b.sortOrder,
+    );
+    const narrationCache = new Map<string, NarrationAudio | null>();
+
+    for (let i = 0; i < scenesBySortOrder.length; i++) {
+      const scene = scenesBySortOrder[i]!;
+      emit({
+        stage: "tts",
+        fraction: 0.1 + (i / scenesBySortOrder.length) * 0.2,
+        message: `Synthesizing narration ${i + 1} of ${scenesBySortOrder.length}…`,
+      });
+      const audio = await synthesizeSceneNarration({
+        narrationJson: scene.narration,
+        voice: voiceOverride ?? preset.ttsVoice,
+        model: modelOverride ?? preset.ttsModel,
+        speed: scene.narrationSpeed ?? story.narrationSpeed ?? "normal",
+      }).catch((e) => {
+        throw new Error(
+          `TTS failed for scene "${scene.title}" (${scene.id}): ${(e as Error).message}`,
+        );
+      });
+      narrationCache.set(scene.id, audio);
+    }
+
+    // ─── Stage 4: refresh timeline durations from real TTS audio ──
+    emit({
+      stage: "timeline_sync",
+      fraction: 0.3,
+      message: "Syncing scene durations to narration audio…",
+    });
+    const narrationDurationOverrides: Record<string, number> = {};
+    for (const scene of scenesBySortOrder) {
+      const audio = narrationCache.get(scene.id);
+      if (!audio) continue;
+      const ms = await probeNarrationDurationMs(audio.filePath);
+      if (ms !== null && ms > 0) {
+        narrationDurationOverrides[scene.id] = ms;
+      }
+    }
+    timeline = computeStoryTimeline(story, { narrationDurationOverrides });
+
+    // ─── Stage 5: load scene images ──────────────────────────
+    emit({
+      stage: "images",
+      fraction: 0.35,
+      message: "Loading scene images…",
+    });
+    const loadedByScene = new Map<string, LoadedSceneImages>();
+    for (let i = 0; i < scenesBySortOrder.length; i++) {
+      const scene = scenesBySortOrder[i]!;
+      const resolved = resolvedScenes.find((r) => r.sceneId === scene.id);
+      if (!resolved) {
+        throw new Error(
+          `Missing resolved scene data for "${scene.title}" (${scene.id}). Did you pass the useResolvedSceneData output?`,
+        );
+      }
+      const sources: SceneImageSources = {
+        background: resolved.roomImageSrc,
+        entities: resolved.entities.map((e) => ({
+          entityId: e.entity.id,
+          src: e.imageSrc,
+        })),
+      };
+      const loaded = await loadSceneImages(sources);
+      loadedByScene.set(scene.id, loaded);
+    }
+
+    // ─── Stage 6: render frames + save to disk ───────────────
+    const savedFrames: RustSceneExportEntry[] = [];
+    for (let i = 0; i < scenesBySortOrder.length; i++) {
+      const scene = scenesBySortOrder[i]!;
+      emit({
+        stage: "frames",
+        fraction: 0.4 + (i / scenesBySortOrder.length) * 0.25,
+        message: `Rendering frame ${i + 1} of ${scenesBySortOrder.length}…`,
+      });
+
+      const resolved = resolvedScenes.find((r) => r.sceneId === scene.id)!;
+      const loaded = loadedByScene.get(scene.id)!;
+      const entities: LayoutEntityInfo[] = resolved.entities.map((e) => {
+        const img = loaded.entities.get(e.entity.id);
+        return {
+          entity: e.entity,
+          name: e.name,
+          imageSize: img ? { width: img.naturalWidth, height: img.naturalHeight } : undefined,
+        };
+      });
+      const roomImageSize = loaded.background
+        ? { width: loaded.background.naturalWidth, height: loaded.background.naturalHeight }
+        : undefined;
+
+      const layout = computeSceneFrameLayout(
+        scene,
+        entities,
+        roomImageSize,
+        preset.width,
+        preset.height,
+        { fit: preset.backgroundFit, fillColor: preset.fillColor },
+      );
+      const blob = await renderSceneFrameToBlob(layout, loaded, {
+        drawCaptionBackdrop: preset.burnedCaptions,
+      });
+      const base64 = await blobToBase64(blob);
+      const framePath = await invoke<string>("save_video_frame", {
+        sessionId,
+        sceneIndex: i,
+        pngBase64: base64,
+      });
+
+      // Scene duration from the refreshed timeline.
+      const timelineEntry = timeline.scenes.find((e) => e.sceneId === scene.id);
+      if (!timelineEntry) {
+        throw new Error(`Timeline entry missing for scene ${scene.id}`);
+      }
+      savedFrames.push({ pngPath: framePath, durationMs: timelineEntry.durationMs });
+    }
+
+    // ─── Stage 7: resolve zone audio paths ───────────────────
+    emit({
+      stage: "audio_paths",
+      fraction: 0.68,
+      message: "Resolving zone music and ambient…",
+    });
+
+    const musicPath = preset.includeMusic
+      ? await resolveZoneAudioPath(world.audio?.music, assetsDir, project.mudDir)
+      : null;
+    const ambientPath = preset.includeAmbient
+      ? await resolveZoneAudioPath(world.audio?.ambient, assetsDir, project.mudDir)
+      : null;
+
+    // ─── Stage 8: build the export request ───────────────────
+    // Total duration = sum of scene durations (no transition overlap —
+    // the PR 7 video encoder handles crossfade overlap itself).
+    const totalDurationMs = savedFrames.reduce((sum, f) => sum + f.durationMs, 0);
+
+    // Narration tracks: resolve TTS file paths + absolute offsets.
+    // Absolute offset = cumulative scene start + per-scene narrationStartMs.
+    const narrations: RustNarrationTrack[] = [];
+    let cumulativeMs = 0;
+    for (let i = 0; i < scenesBySortOrder.length; i++) {
+      const scene = scenesBySortOrder[i]!;
+      const narrationAudio = narrationCache.get(scene.id);
+      const timelineEntry = timeline.scenes.find((e) => e.sceneId === scene.id);
+      if (narrationAudio && timelineEntry) {
+        narrations.push({
+          filePath: narrationAudio.filePath,
+          offsetMs: cumulativeMs + timelineEntry.narrationStartMs,
+        });
+      }
+      cumulativeMs += savedFrames[i]!.durationMs;
+    }
+
+    const exportRequest: RustVideoExportRequest = {
+      sessionId,
+      scenes: savedFrames,
+      audio: {
+        narrations,
+        musicPath,
+        ambientPath,
+        totalDurationMs,
+        audioBitrateKbps: preset.audioBitrateKbps,
+      },
+      width: preset.width,
+      height: preset.height,
+      fps: preset.fps,
+      videoBitrateKbps: preset.videoBitrateKbps,
+      profile: preset.profile,
+      // Pass crossfade if the story has any scene with a crossfade
+      // transition. Otherwise use hard cuts.
+      crossfadeMs: scenesBySortOrder.some(
+        (s) => s.transition?.type === "crossfade",
+      )
+        ? 500
+        : null,
+      outputPath,
+    };
+
+    // ─── Stage 9: call the Rust orchestrator ─────────────────
+    emit({
+      stage: "export",
+      fraction: 0.7,
+      message: "Encoding video…",
+    });
+    const result = await invoke<RustVideoExportResult>("export_story_video", {
+      request: exportRequest,
+    });
+
+    // ─── Stage 10: cleanup + done ────────────────────────────
+    emit({
+      stage: "cleanup",
+      fraction: 0.98,
+      message: "Cleaning up temp files…",
+    });
+    try {
+      await invoke("cleanup_video_export_session", { sessionId });
+    } catch (e) {
+      // Best-effort — don't fail the export on cleanup hiccup.
+      console.warn("[exportStoryVideo] cleanup failed:", e);
+    }
+
+    emit({
+      stage: "done",
+      fraction: 1.0,
+      message: `Exported ${formatBytes(result.sizeBytes)} to ${result.outputPath}`,
+    });
+
+    return {
+      outputPath: result.outputPath,
+      durationMs: result.totalDurationMs,
+      sizeBytes: result.sizeBytes,
+    };
+  } finally {
+    if (unlistenProgress) {
+      unlistenProgress();
+    }
+  }
+}
+
+/**
+ * Manually cleans up a session temp dir. Call this when the user
+ * cancels an export mid-stream, or when a prior export threw.
+ */
+export async function cleanupVideoExportSession(sessionId: string): Promise<void> {
+  await invoke("cleanup_video_export_session", { sessionId });
+}
+
+// ─── Formatting helpers (used by progress messages + UI) ──────────
+
+/** Formats a byte count as KB / MB / GB for display. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export type { StoryTimeline };

--- a/creator/src/lib/storyVideoExport.ts
+++ b/creator/src/lib/storyVideoExport.ts
@@ -26,7 +26,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 import type { Story, SceneEntity } from "@/types/story";
-import type { WorldFile } from "@/types/world";
+import type { WorldFile, MobFile, ItemFile } from "@/types/world";
 import type { Project } from "@/types/project";
 
 import {
@@ -45,26 +45,15 @@ import {
   type LayoutEntityInfo,
 } from "@/lib/storyFrameLayout";
 import {
-  loadSceneImages,
+  loadImageElement,
   renderSceneFrameToBlob,
   type LoadedSceneImages,
-  type SceneImageSources,
 } from "@/lib/storyFrameRenderer";
+import { buildCandidatePaths } from "@/lib/useResolvedSceneData";
 import { checkFfmpegStatus, ensureFfmpegReady } from "@/lib/ffmpegStatus";
 import { getPreset, type ExportPresetId } from "@/lib/videoExportPresets";
 
 // ─── Types ───────────────────────────────────────────────────────
-
-/** Scene data already resolved with image data URLs (from useResolvedSceneData). */
-export interface ResolvedSceneForExport {
-  sceneId: string;
-  roomImageSrc?: string;
-  entities: Array<{
-    entity: SceneEntity;
-    name: string;
-    imageSrc?: string;
-  }>;
-}
 
 export type ExportStage =
   | "ffmpeg"
@@ -91,9 +80,11 @@ export interface ExportProgressEvent {
 
 export interface ExportStoryVideoOptions {
   story: Story;
-  /** Scene data already resolved with image data URLs. */
-  resolvedScenes: ResolvedSceneForExport[];
-  /** The zone the story lives in. Used to resolve music/ambient paths. */
+  /**
+   * The zone the story lives in. The orchestrator reads `rooms`, `mobs`,
+   * and `items` directly from this WorldFile to resolve scene entity
+   * images without depending on the in-app React hook state.
+   */
   world: WorldFile;
   /** Current project — used for legacy mudDir path fallbacks. */
   project: Project;
@@ -214,6 +205,58 @@ async function probeNarrationDurationMs(filePath: string): Promise<number | null
 }
 
 /**
+ * Resolves an entity (scene entity ID) to its name + image filename by
+ * looking it up directly in the zone `WorldFile`. This is the hook-free
+ * equivalent of `useResolvedSceneData`'s `resolveEntityInfo` — we use it
+ * so the orchestrator doesn't depend on the hook's async state machine.
+ */
+function resolveEntityFromWorld(
+  sceneEntity: SceneEntity,
+  world: WorldFile,
+): { name: string; image?: string } {
+  if (sceneEntity.nameOverride || sceneEntity.imageOverride) {
+    return {
+      name: sceneEntity.nameOverride ?? sceneEntity.entityId,
+      image: sceneEntity.imageOverride,
+    };
+  }
+  if (sceneEntity.entityType === "mob" || sceneEntity.entityType === "npc") {
+    const mob: MobFile | undefined = world.mobs?.[sceneEntity.entityId];
+    if (mob) return { name: mob.name, image: mob.image };
+    return { name: sceneEntity.entityId };
+  }
+  if (sceneEntity.entityType === "item") {
+    const item: ItemFile | undefined = world.items?.[sceneEntity.entityId];
+    if (item) return { name: item.displayName, image: item.image };
+    return { name: sceneEntity.entityId };
+  }
+  return { name: sceneEntity.entityId };
+}
+
+/**
+ * Resolves an asset reference (filename or path) to a data URL by
+ * trying each candidate path in order. Returns `undefined` if none
+ * of the candidates exist on disk. Uses the same candidate builder
+ * as `useResolvedSceneData` so resolution is consistent with the
+ * in-app preview.
+ */
+async function loadAssetDataUrl(
+  fileRef: string,
+  assetsDir: string,
+  mudDir: string | undefined,
+): Promise<string | undefined> {
+  const candidates = buildCandidatePaths(fileRef, assetsDir, mudDir);
+  for (const path of candidates) {
+    try {
+      return await invoke<string>("read_image_data_url", { path });
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return undefined;
+}
+
+/**
  * Builds the same candidate path list that `useMediaSrc` computes so
  * zone audio refs resolve the same way the in-app preview does.
  */
@@ -283,7 +326,6 @@ export async function exportStoryVideo(
 ): Promise<ExportStoryVideoResult> {
   const {
     story,
-    resolvedScenes,
     world,
     presetId,
     outputPath,
@@ -349,10 +391,22 @@ export async function exportStoryVideo(
       throw new Error("Story has no scenes — cannot export.");
     }
 
-    // ─── Stage 3: TTS synthesis per scene ────────────────────
     const scenesBySortOrder = [...story.scenes].sort(
       (a, b) => a.sortOrder - b.sortOrder,
     );
+    console.log(
+      "[exportStoryVideo] starting",
+      {
+        storyId: story.id,
+        sceneCount: scenesBySortOrder.length,
+        sceneIds: scenesBySortOrder.map((s) => s.id),
+        presetId,
+        outputPath,
+        sessionId,
+      },
+    );
+
+    // ─── Stage 3: TTS synthesis per scene ────────────────────
     const narrationCache = new Map<string, NarrationAudio | null>();
 
     for (let i = 0; i < scenesBySortOrder.length; i++) {
@@ -374,6 +428,14 @@ export async function exportStoryVideo(
       });
       narrationCache.set(scene.id, audio);
     }
+    console.log(
+      "[exportStoryVideo] TTS done",
+      scenesBySortOrder.map((s) => ({
+        sceneId: s.id,
+        title: s.title,
+        audio: narrationCache.get(s.id)?.filePath ?? "(no narration)",
+      })),
+    );
 
     // ─── Stage 4: refresh timeline durations from real TTS audio ──
     emit({
@@ -391,31 +453,115 @@ export async function exportStoryVideo(
       }
     }
     timeline = computeStoryTimeline(story, { narrationDurationOverrides });
+    console.log(
+      "[exportStoryVideo] timeline after TTS sync",
+      {
+        totalDurationMs: timeline.totalDurationMs,
+        scenes: timeline.scenes.map((e) => ({
+          id: e.sceneId,
+          startMs: e.startMs,
+          durationMs: e.durationMs,
+          narrationMs: e.narrationEndMs - e.narrationStartMs,
+        })),
+      },
+    );
 
-    // ─── Stage 5: load scene images ──────────────────────────
+    // ─── Stage 5: resolve scene images directly via IPC ──────
+    //
+    // We deliberately DO NOT rely on the `resolvedScenes` prop here.
+    // That data comes from a React hook (useResolvedSceneData) whose
+    // async resolution state isn't guaranteed to be complete by the
+    // time Export is clicked. Instead, we re-resolve every image from
+    // scratch using the exact same candidate-path logic, but via
+    // direct await on read_image_data_url so we KNOW the data URLs
+    // are present before rendering starts.
     emit({
       stage: "images",
       fraction: 0.35,
       message: "Loading scene images…",
     });
+
     const loadedByScene = new Map<string, LoadedSceneImages>();
+    const missingAssetsByScene: string[] = [];
+
     for (let i = 0; i < scenesBySortOrder.length; i++) {
       const scene = scenesBySortOrder[i]!;
-      const resolved = resolvedScenes.find((r) => r.sceneId === scene.id);
-      if (!resolved) {
-        throw new Error(
-          `Missing resolved scene data for "${scene.title}" (${scene.id}). Did you pass the useResolvedSceneData output?`,
-        );
+
+      // Room background
+      let bgDataUrl: string | undefined;
+      if (scene.roomId) {
+        const room = world.rooms[scene.roomId];
+        if (room?.image) {
+          bgDataUrl = await loadAssetDataUrl(room.image, assetsDir, project.mudDir);
+          if (!bgDataUrl) {
+            missingAssetsByScene.push(
+              `scene "${scene.title}" (${scene.id}) → room "${scene.roomId}" image "${room.image}"`,
+            );
+          }
+        }
       }
-      const sources: SceneImageSources = {
-        background: resolved.roomImageSrc,
-        entities: resolved.entities.map((e) => ({
-          entityId: e.entity.id,
-          src: e.imageSrc,
-        })),
-      };
-      const loaded = await loadSceneImages(sources);
+
+      // Entities — resolve from the zone WorldFile directly
+      const entityDataUrls = new Map<string, string>();
+      const entitySources: Array<{ entity: SceneEntity; name: string }> = [];
+      for (const sceneEntity of scene.entities ?? []) {
+        const info = resolveEntityFromWorld(sceneEntity, world);
+        entitySources.push({ entity: sceneEntity, name: info.name });
+        if (info.image) {
+          const dataUrl = await loadAssetDataUrl(info.image, assetsDir, project.mudDir);
+          if (dataUrl) {
+            entityDataUrls.set(sceneEntity.id, dataUrl);
+          } else {
+            missingAssetsByScene.push(
+              `scene "${scene.title}" (${scene.id}) → entity "${info.name}" image "${info.image}"`,
+            );
+          }
+        }
+      }
+
+      // Load the data URLs into HTMLImageElements so we have natural
+      // dimensions available for the layout math.
+      const loaded: LoadedSceneImages = { entities: new Map() };
+      if (bgDataUrl) {
+        try {
+          loaded.background = await loadImageElement(bgDataUrl);
+        } catch (e) {
+          console.warn(`[exportStoryVideo] bg image decode failed for scene ${scene.id}:`, e);
+        }
+      }
+      for (const { entity } of entitySources) {
+        const dataUrl = entityDataUrls.get(entity.id);
+        if (!dataUrl) continue;
+        try {
+          const img = await loadImageElement(dataUrl);
+          loaded.entities.set(entity.id, img);
+        } catch (e) {
+          console.warn(
+            `[exportStoryVideo] entity image decode failed for scene ${scene.id} entity ${entity.id}:`,
+            e,
+          );
+        }
+      }
       loadedByScene.set(scene.id, loaded);
+    }
+
+    console.log(
+      "[exportStoryVideo] images resolved",
+      scenesBySortOrder.map((s) => {
+        const loaded = loadedByScene.get(s.id);
+        return {
+          sceneId: s.id,
+          hasBackground: !!loaded?.background,
+          entityCount: s.entities?.length ?? 0,
+          entitiesWithImages: loaded?.entities.size ?? 0,
+        };
+      }),
+    );
+    if (missingAssetsByScene.length > 0) {
+      console.warn(
+        "[exportStoryVideo] some assets could not be resolved — those entities will render as placeholders:",
+        missingAssetsByScene,
+      );
     }
 
     // ─── Stage 6: render frames + save to disk ───────────────
@@ -428,14 +574,18 @@ export async function exportStoryVideo(
         message: `Rendering frame ${i + 1} of ${scenesBySortOrder.length}…`,
       });
 
-      const resolved = resolvedScenes.find((r) => r.sceneId === scene.id)!;
       const loaded = loadedByScene.get(scene.id)!;
-      const entities: LayoutEntityInfo[] = resolved.entities.map((e) => {
-        const img = loaded.entities.get(e.entity.id);
+
+      // Build entity layout info from the loaded images + scene metadata.
+      const entities: LayoutEntityInfo[] = (scene.entities ?? []).map((sceneEntity) => {
+        const info = resolveEntityFromWorld(sceneEntity, world);
+        const img = loaded.entities.get(sceneEntity.id);
         return {
-          entity: e.entity,
-          name: e.name,
-          imageSize: img ? { width: img.naturalWidth, height: img.naturalHeight } : undefined,
+          entity: sceneEntity,
+          name: info.name,
+          imageSize: img
+            ? { width: img.naturalWidth, height: img.naturalHeight }
+            : undefined,
         };
       });
       const roomImageSize = loaded.background
@@ -453,12 +603,22 @@ export async function exportStoryVideo(
       const blob = await renderSceneFrameToBlob(layout, loaded, {
         drawCaptionBackdrop: preset.burnedCaptions,
       });
+      console.log(
+        `[exportStoryVideo] rendered frame ${i + 1}/${scenesBySortOrder.length}`,
+        {
+          sceneId: scene.id,
+          blobSize: blob.size,
+          hasBackground: !!loaded.background,
+          entitiesDrawn: loaded.entities.size,
+        },
+      );
       const base64 = await blobToBase64(blob);
       const framePath = await invoke<string>("save_video_frame", {
         sessionId,
         sceneIndex: i,
         pngBase64: base64,
       });
+      console.log(`[exportStoryVideo] saved frame ${i} → ${framePath}`);
 
       // Scene duration from the refreshed timeline.
       const timelineEntry = timeline.scenes.find((e) => e.sceneId === scene.id);
@@ -466,6 +626,17 @@ export async function exportStoryVideo(
         throw new Error(`Timeline entry missing for scene ${scene.id}`);
       }
       savedFrames.push({ pngPath: framePath, durationMs: timelineEntry.durationMs });
+    }
+
+    console.log("[exportStoryVideo] savedFrames", savedFrames);
+
+    // Defensive check: if we lost scenes between TTS and save, bail
+    // loudly rather than silently producing a single-scene video.
+    if (savedFrames.length !== scenesBySortOrder.length) {
+      throw new Error(
+        `Expected ${scenesBySortOrder.length} saved frames but got ${savedFrames.length}. ` +
+          `This is a bug in the export pipeline — please report it with the console logs above.`,
+      );
     }
 
     // ─── Stage 7: resolve zone audio paths ───────────────────
@@ -530,6 +701,24 @@ export async function exportStoryVideo(
     };
 
     // ─── Stage 9: call the Rust orchestrator ─────────────────
+    console.log("[exportStoryVideo] final export request", {
+      sceneCount: exportRequest.scenes.length,
+      scenes: exportRequest.scenes,
+      audio: {
+        narrationCount: exportRequest.audio.narrations.length,
+        narrations: exportRequest.audio.narrations,
+        hasMusic: !!exportRequest.audio.musicPath,
+        hasAmbient: !!exportRequest.audio.ambientPath,
+        totalDurationMs: exportRequest.audio.totalDurationMs,
+      },
+      video: {
+        width: exportRequest.width,
+        height: exportRequest.height,
+        fps: exportRequest.fps,
+        profile: exportRequest.profile,
+        crossfadeMs: exportRequest.crossfadeMs,
+      },
+    });
     emit({
       stage: "export",
       fraction: 0.7,

--- a/creator/src/lib/storyVideoExport.ts
+++ b/creator/src/lib/storyVideoExport.ts
@@ -483,22 +483,73 @@ export async function exportStoryVideo(
 
     const loadedByScene = new Map<string, LoadedSceneImages>();
     const missingAssetsByScene: string[] = [];
+    const bgResolutionTrace: Array<Record<string, unknown>> = [];
+
+    // Log the world's room inventory once so a mismatched scene.roomId
+    // is easy to diagnose (compare against scene roomIds below).
+    console.log(
+      "[exportStoryVideo] world room inventory",
+      {
+        zoneId: story.zoneId,
+        roomCount: Object.keys(world.rooms ?? {}).length,
+        roomIds: Object.keys(world.rooms ?? {}),
+      },
+    );
 
     for (let i = 0; i < scenesBySortOrder.length; i++) {
       const scene = scenesBySortOrder[i]!;
 
-      // Room background
+      // ─── Room background resolution with explicit failure tracing ───
       let bgDataUrl: string | undefined;
-      if (scene.roomId) {
-        const room = world.rooms[scene.roomId];
-        if (room?.image) {
-          bgDataUrl = await loadAssetDataUrl(room.image, assetsDir, project.mudDir);
+      let bgFailureReason: string | null = null;
+      let overridePath: string | undefined;
+
+      // Honor scene.backgroundOverride first, mirroring the in-app
+      // preview's lookup order.
+      if (scene.backgroundOverride) {
+        overridePath = scene.backgroundOverride;
+        bgDataUrl = await loadAssetDataUrl(
+          scene.backgroundOverride,
+          assetsDir,
+          project.mudDir,
+        );
+        if (!bgDataUrl) {
+          bgFailureReason = `backgroundOverride "${scene.backgroundOverride}" resolved to no candidate path`;
+        }
+      } else if (!scene.roomId) {
+        bgFailureReason = "scene has no roomId";
+      } else {
+        const room = world.rooms?.[scene.roomId];
+        if (!room) {
+          bgFailureReason = `roomId "${scene.roomId}" not found in world.rooms`;
+        } else if (!room.image) {
+          bgFailureReason = `room "${scene.roomId}" ("${room.title ?? ""}") has no image set`;
+        } else {
+          bgDataUrl = await loadAssetDataUrl(
+            room.image,
+            assetsDir,
+            project.mudDir,
+          );
           if (!bgDataUrl) {
-            missingAssetsByScene.push(
-              `scene "${scene.title}" (${scene.id}) → room "${scene.roomId}" image "${room.image}"`,
-            );
+            bgFailureReason = `room image "${room.image}" did not resolve via any candidate path`;
           }
         }
+      }
+
+      bgResolutionTrace.push({
+        sceneIndex: i,
+        sceneId: scene.id,
+        sceneTitle: scene.title,
+        roomId: scene.roomId ?? null,
+        backgroundOverride: overridePath ?? null,
+        bgResolved: !!bgDataUrl,
+        failureReason: bgFailureReason,
+      });
+
+      if (!bgDataUrl && bgFailureReason) {
+        missingAssetsByScene.push(
+          `scene ${i} "${scene.title}" (${scene.id}): ${bgFailureReason}`,
+        );
       }
 
       // Entities — resolve from the zone WorldFile directly
@@ -557,9 +608,13 @@ export async function exportStoryVideo(
         };
       }),
     );
+    console.log(
+      "[exportStoryVideo] bg resolution trace (per scene)",
+      bgResolutionTrace,
+    );
     if (missingAssetsByScene.length > 0) {
       console.warn(
-        "[exportStoryVideo] some assets could not be resolved — those entities will render as placeholders:",
+        "[exportStoryVideo] unresolved assets — those layers will render as placeholders:",
         missingAssetsByScene,
       );
     }

--- a/creator/src/lib/useResolvedSceneData.ts
+++ b/creator/src/lib/useResolvedSceneData.ts
@@ -9,7 +9,7 @@ import type { ZoneState } from "@/stores/zoneStore";
 
 // ─── Entity info resolution ────────────────────────────────────────
 
-function resolveEntityInfo(
+export function resolveEntityInfo(
   entity: SceneEntity,
   zoneState: ZoneState | undefined,
 ): { name: string; image?: string } {
@@ -33,7 +33,7 @@ function resolveEntityInfo(
 // ─── Path resolution ───────────────────────────────────────────────
 
 /** Build candidate file paths for an image reference, mirroring useImageSrc logic. */
-function buildCandidatePaths(
+export function buildCandidatePaths(
   filePath: string,
   assetsDir: string,
   mudDir: string | undefined,

--- a/creator/src/lib/videoExportPresets.ts
+++ b/creator/src/lib/videoExportPresets.ts
@@ -1,0 +1,402 @@
+// ─── Video Export Presets ────────────────────────────────────────
+// Preset definitions for the story → video export pipeline.
+// Each preset is a complete recipe: dimensions, codec settings,
+// narration voice, caption placement, aspect strategy, and output
+// naming. The export orchestrator reads a preset and drives the
+// frame renderer + TTS pipeline + ffmpeg encoder accordingly.
+//
+// Adding a new preset: add an entry to PRESETS with all required
+// fields. The export orchestrator handles any combination of fields
+// generically, so no orchestrator changes are needed for most new
+// presets.
+
+import type { BackgroundFit } from "@/lib/storyFrameLayout";
+import type {
+  OpenAiTtsVoice,
+  OpenAiTtsModel,
+} from "@/lib/narrationSynthesis";
+import type { NarrationSpeed } from "@/lib/narrationSpeed";
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/** Stable string identifier for a preset — used in settings, events, URLs. */
+export type ExportPresetId =
+  | "showcase"
+  | "social_vertical"
+  | "social_square"
+  | "in_game"
+  | "archive";
+
+/** H.264 profile — lower profiles have broader playback compat. */
+export type H264Profile = "baseline" | "main" | "high";
+
+/** Where narration captions are burned into the frame. */
+export type CaptionPlacement = "lower-third" | "upper-third" | "center";
+
+/** How title cards are drawn over the scene. */
+export type TitleCardStyle = "corner" | "center" | "hidden";
+
+/** Intended distribution target — drives preset selection in the UI. */
+export type DistributionTarget =
+  | "showcase-embed"
+  | "social-feed"
+  | "in-game-asset"
+  | "personal-archive";
+
+export interface ExportPreset {
+  /** Stable ID. */
+  id: ExportPresetId;
+  /** Human label shown in the preset picker card. */
+  label: string;
+  /** One-line description shown under the label. */
+  description: string;
+  /** Distribution target this preset is designed for. */
+  target: DistributionTarget;
+
+  // ─── Video ─────────────────────────────────────────────────
+  width: number;
+  height: number;
+  fps: 30 | 60;
+  /** H.264 codec profile. */
+  profile: H264Profile;
+  /** Target video bitrate in kbps (for VBR -b:v). */
+  videoBitrateKbps: number;
+  /** How the background image fits into the target aspect. */
+  backgroundFit: BackgroundFit;
+  /**
+   * Fill color for letterbox/pillarbox padding when backgroundFit
+   * leaves empty space. Ignored for "fill" and "crop_center".
+   */
+  fillColor: string;
+
+  // ─── Duration ──────────────────────────────────────────────
+  /**
+   * Hard cap on total video length. Stories longer than this are
+   * truncated at export time (later scenes are dropped). `null` means
+   * no limit.
+   */
+  maxDurationMs: number | null;
+
+  // ─── Audio ─────────────────────────────────────────────────
+  audioBitrateKbps: number;
+  /** Whether zone music plays in the background (ducked under narration). */
+  includeMusic: boolean;
+  /** Whether zone ambient audio plays in the background. */
+  includeAmbient: boolean;
+
+  // ─── Narration ─────────────────────────────────────────────
+  /** Default TTS voice. User can override in the export dialog. */
+  ttsVoice: OpenAiTtsVoice;
+  /** TTS model. `tts-1-hd` is used for the archive preset. */
+  ttsModel: OpenAiTtsModel;
+  /** Default narration pace (mapped to OpenAI `speed` at render time). */
+  narrationSpeed: NarrationSpeed;
+
+  // ─── Captions ──────────────────────────────────────────────
+  /** Whether narration text is burned into the frame as a subtitle. */
+  burnedCaptions: boolean;
+  /** Where captions are placed when burnedCaptions is true. */
+  captionPlacement: CaptionPlacement;
+  /** Font size multiplier relative to a standard 16:9 caption. */
+  captionScale: number;
+
+  // ─── Title card ────────────────────────────────────────────
+  titleCardStyle: TitleCardStyle;
+
+  // ─── Output ────────────────────────────────────────────────
+  /** File extension (without leading dot). Currently always "mp4". */
+  fileExtension: "mp4";
+  /** Output filename suffix (e.g. "showcase" → `story-showcase.mp4`). */
+  filenameSuffix: string;
+}
+
+// ─── Preset definitions ──────────────────────────────────────────
+
+/**
+ * Showcase (1080p) — for the Cloudflare Pages showcase embed and
+ * any general-purpose 16:9 share. High quality, no duration cap,
+ * native aspect.
+ */
+const SHOWCASE: ExportPreset = {
+  id: "showcase",
+  label: "Showcase (1080p)",
+  description: "16:9 HD for embedding on the showcase site or sharing anywhere.",
+  target: "showcase-embed",
+  width: 1920,
+  height: 1080,
+  fps: 30,
+  profile: "high",
+  videoBitrateKbps: 6000,
+  backgroundFit: "fit",
+  fillColor: "#000000",
+  maxDurationMs: null,
+  audioBitrateKbps: 192,
+  includeMusic: true,
+  includeAmbient: true,
+  ttsVoice: "onyx",
+  ttsModel: "tts-1",
+  narrationSpeed: "normal",
+  burnedCaptions: true,
+  captionPlacement: "lower-third",
+  captionScale: 1.0,
+  titleCardStyle: "center",
+  fileExtension: "mp4",
+  filenameSuffix: "showcase",
+};
+
+/**
+ * Social Vertical (9:16) — for TikTok/Reels/Shorts. 60 second cap,
+ * captions placed in the upper third so they sit above the phone's
+ * bottom UI bar. Scene art is cropped to vertical.
+ */
+const SOCIAL_VERTICAL: ExportPreset = {
+  id: "social_vertical",
+  label: "Social (Vertical)",
+  description: "9:16 vertical for TikTok, Reels, and Shorts. 60s cap.",
+  target: "social-feed",
+  width: 1080,
+  height: 1920,
+  fps: 30,
+  profile: "main",
+  videoBitrateKbps: 5000,
+  backgroundFit: "fill",
+  fillColor: "#000000",
+  maxDurationMs: 60_000,
+  audioBitrateKbps: 160,
+  includeMusic: true,
+  includeAmbient: false,
+  ttsVoice: "nova",
+  ttsModel: "tts-1",
+  narrationSpeed: "normal",
+  burnedCaptions: true,
+  captionPlacement: "upper-third",
+  captionScale: 1.4,
+  titleCardStyle: "center",
+  fileExtension: "mp4",
+  filenameSuffix: "vertical",
+};
+
+/**
+ * Social Square (1:1) — for Instagram/Twitter feed. 60 second cap,
+ * captions in lower third at larger size for mobile readability.
+ * Scene art is cropped to square.
+ */
+const SOCIAL_SQUARE: ExportPreset = {
+  id: "social_square",
+  label: "Social (Square)",
+  description: "1:1 square for Instagram, Twitter, and Bluesky. 60s cap.",
+  target: "social-feed",
+  width: 1080,
+  height: 1080,
+  fps: 30,
+  profile: "main",
+  videoBitrateKbps: 4000,
+  backgroundFit: "fill",
+  fillColor: "#000000",
+  maxDurationMs: 60_000,
+  audioBitrateKbps: 160,
+  includeMusic: true,
+  includeAmbient: false,
+  ttsVoice: "nova",
+  ttsModel: "tts-1",
+  narrationSpeed: "normal",
+  burnedCaptions: true,
+  captionPlacement: "lower-third",
+  captionScale: 1.3,
+  titleCardStyle: "center",
+  fileExtension: "mp4",
+  filenameSuffix: "square",
+};
+
+/**
+ * In-Game Intro (720p) — for the MUD client's `video:` tag on rooms,
+ * mobs, and items. Small file size, baseline H.264 profile for max
+ * playback compat, no captions (the MUD client renders its own text
+ * and captions would burn-in player-language-agnostic).
+ *
+ * 30-second hard cap to keep asset sizes bounded — cinematics longer
+ * than this are almost always better served as a separate showcase
+ * video the player can watch out-of-game.
+ */
+const IN_GAME: ExportPreset = {
+  id: "in_game",
+  label: "In-Game Intro (720p)",
+  description: "Compact 16:9 for room/mob/item video: fields. Max 30s.",
+  target: "in-game-asset",
+  width: 1280,
+  height: 720,
+  fps: 30,
+  profile: "baseline",
+  videoBitrateKbps: 2500,
+  backgroundFit: "fit",
+  fillColor: "#000000",
+  maxDurationMs: 30_000,
+  audioBitrateKbps: 128,
+  includeMusic: false,
+  includeAmbient: false,
+  ttsVoice: "onyx",
+  ttsModel: "tts-1",
+  narrationSpeed: "normal",
+  burnedCaptions: false,
+  captionPlacement: "lower-third",
+  captionScale: 1.0,
+  titleCardStyle: "corner",
+  fileExtension: "mp4",
+  filenameSuffix: "intro",
+};
+
+/**
+ * Archive (1080p60) — highest-quality preset for personal archives
+ * and campaign trailers. 60 fps for smoother motion, `tts-1-hd`
+ * voice for better narration fidelity, full duration, no caps.
+ * Render time is proportionally longer.
+ */
+const ARCHIVE: ExportPreset = {
+  id: "archive",
+  label: "Archive (1080p60)",
+  description: "Highest quality: 1080p60 + tts-1-hd voice. Slower to render.",
+  target: "personal-archive",
+  width: 1920,
+  height: 1080,
+  fps: 60,
+  profile: "high",
+  videoBitrateKbps: 10_000,
+  backgroundFit: "fit",
+  fillColor: "#000000",
+  maxDurationMs: null,
+  audioBitrateKbps: 256,
+  includeMusic: true,
+  includeAmbient: true,
+  ttsVoice: "onyx",
+  ttsModel: "tts-1-hd",
+  narrationSpeed: "normal",
+  burnedCaptions: true,
+  captionPlacement: "lower-third",
+  captionScale: 1.0,
+  titleCardStyle: "center",
+  fileExtension: "mp4",
+  filenameSuffix: "archive",
+};
+
+// ─── Registry ────────────────────────────────────────────────────
+
+/** All presets, keyed by ID. */
+export const PRESETS: Record<ExportPresetId, ExportPreset> = {
+  showcase: SHOWCASE,
+  social_vertical: SOCIAL_VERTICAL,
+  social_square: SOCIAL_SQUARE,
+  in_game: IN_GAME,
+  archive: ARCHIVE,
+};
+
+/** Ordered list for the preset picker UI (left-to-right reading order). */
+export const PRESET_ORDER: ExportPresetId[] = [
+  "showcase",
+  "social_vertical",
+  "social_square",
+  "in_game",
+  "archive",
+];
+
+export function getPreset(id: ExportPresetId): ExportPreset {
+  return PRESETS[id];
+}
+
+export function getAllPresets(): ExportPreset[] {
+  return PRESET_ORDER.map((id) => PRESETS[id]);
+}
+
+// ─── Filename suggestions ────────────────────────────────────────
+
+/**
+ * Converts a story title to a filesystem-safe base filename slug.
+ * Lowercase, spaces and punctuation replaced with hyphens, trimmed,
+ * capped at 60 chars. Falls back to "story" if the title is empty.
+ */
+export function slugifyStoryTitle(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+  return slug || "story";
+}
+
+/**
+ * Builds a suggested output filename for a story exported under a
+ * preset. Format: `<slug>-<presetSuffix>.<ext>`.
+ */
+export function suggestExportFilename(
+  storyTitle: string,
+  presetId: ExportPresetId,
+): string {
+  const preset = PRESETS[presetId];
+  return `${slugifyStoryTitle(storyTitle)}-${preset.filenameSuffix}.${preset.fileExtension}`;
+}
+
+// ─── Duration fit checks ─────────────────────────────────────────
+
+export interface PresetFitCheck {
+  /** Whether the story fits the preset without truncation. */
+  fits: boolean;
+  /**
+   * Total story duration in ms (from the timeline model). Passed
+   * back so the UI doesn't have to recompute.
+   */
+  storyDurationMs: number;
+  /** When fits = false, the cap in ms. Undefined when the preset is unlimited. */
+  capMs?: number;
+  /** When fits = false, how many ms over the cap. */
+  overshootMs?: number;
+  /**
+   * Human-readable warning for the UI. Empty string when fits is true.
+   */
+  warning: string;
+}
+
+/**
+ * Checks whether a story of the given total duration fits under a
+ * preset's cap. For unlimited presets always returns `fits: true`.
+ *
+ * The export orchestrator uses this to either (a) proceed directly,
+ * (b) prompt the user to confirm truncation, or (c) suggest switching
+ * to a different preset.
+ */
+export function checkStoryFitsPreset(
+  storyDurationMs: number,
+  preset: ExportPreset,
+): PresetFitCheck {
+  const cap = preset.maxDurationMs;
+  if (cap === null || storyDurationMs <= cap) {
+    return {
+      fits: true,
+      storyDurationMs,
+      warning: "",
+    };
+  }
+  const overshootMs = storyDurationMs - cap;
+  const overshootSec = Math.ceil(overshootMs / 1000);
+  const capSec = Math.round(cap / 1000);
+  return {
+    fits: false,
+    storyDurationMs,
+    capMs: cap,
+    overshootMs,
+    warning: `Story is ${overshootSec}s longer than this preset's ${capSec}s cap. Later scenes will be dropped.`,
+  };
+}
+
+// ─── Duration formatting ─────────────────────────────────────────
+
+/**
+ * Formats a duration in ms as "M:SS" (for short clips) or "M:SS.s"
+ * when the caller needs sub-second precision. Used in the preset
+ * picker UI to show estimated total length.
+ */
+export function formatDuration(ms: number): string {
+  const totalSec = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSec / 60);
+  const seconds = totalSec % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}

--- a/creator/src/types/story.ts
+++ b/creator/src/types/story.ts
@@ -114,4 +114,13 @@ export interface Story {
   primaryMapId?: string;
   /** Primary calendar system to drive timeline display. */
   primaryCalendarId?: string;
+
+  // ─── Exported cinematic ──────────────────────────────────────────
+  /**
+   * Public URL of the showcase-preset MP4 cinematic, set after
+   * deployStoryVideoToR2 uploads it to R2. When present, the
+   * showcase SPA shows a "Watch cinematic" button on the story
+   * player page.
+   */
+  cinematicUrl?: string;
 }

--- a/showcase/src/components/player/CinematicOverlay.tsx
+++ b/showcase/src/components/player/CinematicOverlay.tsx
@@ -1,0 +1,109 @@
+// ─── CinematicOverlay ────────────────────────────────────────────
+// Full-screen <video> player for the exported story cinematic MP4.
+// Opened from StoryPlayer when the story has a `cinematicUrl`.
+//
+// Uses the browser's native video controls for timeline scrubbing,
+// volume, and fullscreen — nothing custom. A backdrop click or the
+// Escape key closes the overlay.
+
+import { useEffect, useRef } from "react";
+
+interface CinematicOverlayProps {
+  /** Public MP4 URL on R2. */
+  src: string;
+  /** Story title, shown in the header for context. */
+  title: string;
+  /** Called when the user closes the overlay. */
+  onClose: () => void;
+}
+
+export function CinematicOverlay({ src, title, onClose }: CinematicOverlayProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  // Close on Escape.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  // Lock body scroll while the overlay is mounted so the interactive
+  // player below doesn't scroll in the background.
+  useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, []);
+
+  // Attempt autoplay; most browsers require the video to be muted or
+  // the user to have interacted with the page for this to succeed.
+  // Native video controls let the user unmute + replay if autoplay
+  // is blocked.
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    v.play().catch(() => {
+      // Autoplay blocked — user will click play. Nothing to do.
+    });
+  }, []);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${title} cinematic`}
+      className="fixed inset-0 z-[60] flex flex-col items-center justify-center bg-black/90 backdrop-blur-sm"
+      onClick={(e) => {
+        // Click on the backdrop (not the video itself) closes.
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      {/* Header with title + close */}
+      <div className="absolute top-0 left-0 right-0 flex items-center justify-between px-6 py-4 text-white">
+        <h2 className="font-display text-lg tracking-wide">{title}</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close cinematic"
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-black/40 text-white transition-colors hover:bg-white/10"
+        >
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+            <path
+              d="M4 4l10 10M14 4L4 14"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Video */}
+      <video
+        ref={videoRef}
+        src={src}
+        controls
+        playsInline
+        className="max-h-[85vh] max-w-[95vw] rounded-lg shadow-2xl"
+      >
+        Your browser does not support HTML5 video. You can{" "}
+        <a href={src} className="text-accent underline">
+          download the file
+        </a>{" "}
+        instead.
+      </video>
+
+      {/* Footer hint */}
+      <p className="absolute bottom-6 left-0 right-0 text-center text-xs text-white/50">
+        Press Esc or click the backdrop to return to the interactive player.
+      </p>
+    </div>
+  );
+}

--- a/showcase/src/components/player/StoryPlayer.tsx
+++ b/showcase/src/components/player/StoryPlayer.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { CinematicRenderer } from "./CinematicRenderer";
+import { CinematicOverlay } from "./CinematicOverlay";
 import { PlayerControlBar } from "./PlayerControlBar";
 import { ScrollModeContainer } from "./ScrollModeContainer";
 import { ModeSwitcher } from "./ModeSwitcher";
@@ -27,6 +28,7 @@ export function StoryPlayer({ story }: StoryPlayerProps) {
   const [mode, setMode] = useState<PlayerMode>("click");
   const [autoInterval, setAutoInterval] = useState(10000);
   const [autoTimerActive, setAutoTimerActive] = useState(false);
+  const [showCinematic, setShowCinematic] = useState(false);
 
   // ─── Navigation ─────────────────────────────────────────────────
 
@@ -118,6 +120,22 @@ export function StoryPlayer({ story }: StoryPlayerProps) {
 
   return (
     <div>
+      {/* Watch cinematic button — only when an exported MP4 exists */}
+      {story.cinematicUrl && (
+        <div className="mb-3 flex justify-end">
+          <button
+            type="button"
+            onClick={() => setShowCinematic(true)}
+            className="flex items-center gap-2 rounded-full border border-accent/40 bg-accent/10 px-4 py-1.5 font-display text-xs uppercase tracking-[0.12em] text-accent transition-colors hover:border-accent hover:bg-accent/20"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
+              <path d="M2.5 1v10l8-5z" />
+            </svg>
+            Watch as cinematic
+          </button>
+        </div>
+      )}
+
       {mode !== "scroll" ? (
         <div className="relative">
           {/* Clickable renderer area for click-through and auto modes */}
@@ -174,6 +192,15 @@ export function StoryPlayer({ story }: StoryPlayerProps) {
         <div className="mt-4 flex justify-end">
           <ModeSwitcher mode={mode} onChange={handleModeChange} />
         </div>
+      )}
+
+      {/* Cinematic video overlay */}
+      {showCinematic && story.cinematicUrl && (
+        <CinematicOverlay
+          src={story.cinematicUrl}
+          title={story.title}
+          onClose={() => setShowCinematic(false)}
+        />
       )}
     </div>
   );

--- a/showcase/src/types/showcase.ts
+++ b/showcase/src/types/showcase.ts
@@ -146,6 +146,14 @@ export interface ShowcaseStory {
   featuredCharacterIds?: string[];
   primaryMapId?: string;
   primaryCalendarId?: string;
+  // ─── Exported cinematic (MP4 on R2) ──────────────────────────────
+  /**
+   * Public URL of the showcase-preset cinematic MP4. When present,
+   * the showcase player page shows a "Watch cinematic" button that
+   * opens a full-screen native video player instead of the
+   * interactive scene renderer.
+   */
+  cinematicUrl?: string;
 }
 
 export interface ShowcaseData {


### PR DESCRIPTION
Closes #141.

End-to-end story → MP4 export with TTS narration, sidechain-ducked music, scene crossfades, and an optional R2 publish that surfaces a "Watch as cinematic" button on the public showcase. Five distribution presets (Showcase 1080p / Social Vertical 9:16 / Social Square / In-Game 720p / Archive 1080p60).

## Commits (12)

Architecture: each commit is its own atomic primitive that builds on the previous. Every primitive has its own integration test against real ffmpeg / OpenAI.

| | |
|---|---|
| `a24369e` | Scene timing model (33 unit tests) |
| `67ae964` | Frame layout + canvas renderer (25 unit tests) |
| `f0e62e9` | OpenAI TTS pipeline (17 TS + 12 Rust tests) |
| `e8e4c04` | ffmpeg download-on-first-use (8 unit + 1 integration test) |
| `043c950` | Export preset definitions (48 unit tests) |
| `068f3bd` | Audio mixer with sidechain ducking (24 unit + 1 integration test) |
| `7937db6` | Video encoder primitives + xfade (29 unit + 1 integration test) |
| `cb75b26` | End-to-end orchestrator + export dialog + story editor hook |
| `f94ded4` | Showcase R2 publish + cinematic overlay |
| `dcda649` | fix: hoist export hooks above early returns (Rules of Hooks) |
| `19ce79d` | fix: self-resolve images in orchestrator + diagnostic logging |
| `62ba582` | fix: honor scene.backgroundOverride in export pipeline |

The last three commits are bugs surfaced by manual testing on a real 5-scene story:

1. **Hooks crash** — `useResolvedSceneData` was placed below the `!story` early-return, so the hook count changed between renders. Hoisted above the guards with safe fallbacks.
2. **Stale image data** — the orchestrator was trusting `useResolvedSceneData`'s async hook state, which wasn't always populated when Export was clicked. Replaced with synchronous direct IPC resolution inside the orchestrator.
3. **`backgroundOverride` ignored** — the export pipeline was looking up backgrounds via `room.image` only, but the in-app `CinematicScene` honors a per-scene `backgroundOverride` field. Stories that use custom gallery backgrounds (rather than default room images) were exporting black frames for those scenes. Now the orchestrator checks `scene.backgroundOverride` first and falls back to the room.

## Verification

- **82 Rust tests pass**, 3 `#[ignore]`-marked integration tests verified locally against real ffmpeg 8.1
- **1483 TypeScript tests pass** across 35 test files
- `creator tsc` clean, `showcase tsc` clean, `cargo check` clean (7 pre-existing warnings, none from new code)
- **Manually tested end-to-end** on a real 5-scene story with TTS narration, custom background overrides, mob sprites, and the showcase preset

## What's deferred (follow-up issues, not blockers)

- Burned-in captions via `drawtext` (orchestrator computes the chunks; ffmpeg side doesn't yet consume them)
- Frame-level progress from ffmpeg `-progress` parsing
- Cancel / abort mid-export
- Feature B (AI motion backgrounds via Runware image-to-video — explicitly Phase 2)

## Test plan

- [x] All unit + integration tests pass
- [x] `cargo test --ignored` integration suites pass against real ffmpeg
- [x] Manual export of a real multi-scene story with mixed `room.image` and `backgroundOverride`
- [x] Resulting MP4 plays in a media player with correct audio + video sync
- [ ] (future) Manual test of remaining 4 presets (vertical, square, in-game, archive)
- [ ] (future) Manual test of R2 publish flow + showcase "Watch as cinematic" button