### PR TITLE
Frame-level progress from ffmpeg -progress stream

### DIFF
--- a/creator/src-tauri/src/audio_mix.rs
+++ b/creator/src-tauri/src/audio_mix.rs
@@ -32,11 +32,15 @@
 // Returns an error if there is nothing to mix at all.
 
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 use crate::ffmpeg;
+use crate::ffmpeg_progress::FfmpegProgressParser;
+use crate::video_export::emit_stage_progress;
 use tauri::AppHandle;
 
 // ─── Types ───────────────────────────────────────────────────────
@@ -128,6 +132,12 @@ pub fn build_mix_command(
     args.push("-hide_banner".to_string());
     args.push("-loglevel".to_string());
     args.push("error".to_string());
+    // Emit progress key=value pairs to stdout so the async runner
+    // can parse them and forward intra-stage progress events to the
+    // UI. Stderr is reserved for actual error messages.
+    args.push("-progress".to_string());
+    args.push("pipe:1".to_string());
+    args.push("-nostats".to_string());
 
     // ─── Inputs (in declared order, indexed for the filter) ──
     let mut next_index: usize = 0;
@@ -312,6 +322,11 @@ fn build_filter_complex(
 /// `build_mix_command`. Resolves ffmpeg from the bundled cache or
 /// system PATH (must already be available — call `ensure_ffmpeg_ready`
 /// from the frontend before invoking this).
+///
+/// Streams ffmpeg's `-progress pipe:1` output to parse per-frame
+/// progress and forward it to the UI via `video_export:progress`
+/// events. Stderr is buffered in the background and surfaced only
+/// if ffmpeg exits with a non-zero status.
 #[allow(dead_code)] // consumed by the export orchestrator (PR 7)
 pub async fn mix_audio(
     app: &AppHandle,
@@ -327,24 +342,77 @@ pub async fn mix_audio(
             .map_err(|e| format!("Failed to create output directory: {e}"))?;
     }
 
-    let output = Command::new(&ffmpeg_path)
+    let total_duration_ms = input.total_duration_ms;
+
+    let mut child = Command::new(&ffmpeg_path)
         .args(&cmd.args)
-        .output()
-        .await
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| format!("Failed to spawn ffmpeg: {e}"))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "ffmpeg stdout pipe was not captured".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "ffmpeg stderr pipe was not captured".to_string())?;
+
+    // Drain stderr in the background so the child can't block on a
+    // full stderr pipe while we're reading stdout. The collected
+    // lines are surfaced only if ffmpeg exits non-zero.
+    let stderr_handle = tokio::spawn(async move {
+        let mut reader = BufReader::new(stderr).lines();
+        let mut buf: Vec<String> = Vec::new();
+        while let Ok(Some(line)) = reader.next_line().await {
+            buf.push(line);
+        }
+        buf
+    });
+
+    // Read progress from stdout as ffmpeg emits it (~every 500ms).
+    // Each complete key=value block terminates with `progress=continue`
+    // or `progress=end` and flushes one FfmpegProgressEvent.
+    let mut parser = FfmpegProgressParser::new();
+    let mut stdout_reader = BufReader::new(stdout).lines();
+    while let Ok(Some(line)) = stdout_reader.next_line().await {
+        if let Some(event) = parser.feed_line(&line) {
+            let fraction = event.fraction(total_duration_ms);
+            emit_stage_progress(
+                app,
+                "audio_mix",
+                "Mixing narration, music, and ambient…",
+                fraction,
+                event.speed,
+                event.frame,
+            );
+            if event.ended {
+                break;
+            }
+        }
+    }
+
+    let exit_status = child
+        .wait()
+        .await
+        .map_err(|e| format!("Failed to wait on ffmpeg: {e}"))?;
+    let stderr_lines = stderr_handle
+        .await
+        .map_err(|e| format!("stderr drain task panicked: {e}"))?;
+
+    if !exit_status.success() {
         return Err(format!(
             "ffmpeg audio mix failed (exit {}): {}",
-            output.status.code().unwrap_or(-1),
-            stderr.trim(),
+            exit_status.code().unwrap_or(-1),
+            stderr_lines.join("\n").trim(),
         ));
     }
 
     Ok(AudioMixOutput {
         file_path: output_path.to_string_lossy().to_string(),
-        duration_ms: input.total_duration_ms,
+        duration_ms: total_duration_ms,
     })
 }
 

--- a/creator/src-tauri/src/ffmpeg_progress.rs
+++ b/creator/src-tauri/src/ffmpeg_progress.rs
@@ -1,0 +1,329 @@
+// ─── ffmpeg Progress Parser ──────────────────────────────────────
+// Parses the stream of key=value pairs ffmpeg emits when invoked
+// with `-progress pipe:1`. Each block of progress data ends with a
+// `progress=continue` or `progress=end` marker; the parser
+// accumulates mid-block lines and flushes a complete
+// `FfmpegProgressEvent` on every marker.
+//
+// Used by audio_mix and video_encode to translate ffmpeg's native
+// progress stream into Tauri events the UI can render as a smooth
+// progress bar (instead of the previous "jumps between stages"
+// behavior).
+//
+// Sample input from ffmpeg -progress pipe:1:
+//
+//   frame=127
+//   fps=30.12
+//   stream_0_0_q=28.0
+//   bitrate=1500.0kbits/s
+//   total_size=50000
+//   out_time_us=4233000
+//   out_time_ms=4233000
+//   out_time=00:00:04.233000
+//   dup_frames=0
+//   drop_frames=0
+//   speed=1.01x
+//   progress=continue
+//
+// Flush cadence is typically ~500ms (ffmpeg's default) but can be
+// configured via `-stats_period`. We don't rely on a specific
+// interval — the parser is purely line-driven.
+
+use std::collections::HashMap;
+
+/// One complete batch of progress data emitted by ffmpeg between
+/// `progress=` markers. All numeric fields are optional because
+/// older ffmpeg versions may omit some keys or emit them with
+/// unexpected formatting.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct FfmpegProgressEvent {
+    /// Current output timestamp in microseconds. Used with the
+    /// total expected duration to compute a progress fraction.
+    pub out_time_us: Option<u64>,
+    /// Current encoder frame count.
+    pub frame: Option<u64>,
+    /// Instantaneous encoding frame rate (output frames per
+    /// wall-clock second).
+    pub fps: Option<f64>,
+    /// Speed multiplier (1.0 = realtime; 2.0 = 2x faster than
+    /// realtime). Parsed from strings like "1.23x".
+    pub speed: Option<f64>,
+    /// True when the block was terminated by `progress=end` (the
+    /// last event ffmpeg emits before exiting). Subsequent
+    /// `feed_line` calls after this will start a fresh block, but
+    /// in practice ffmpeg doesn't emit more data after end.
+    pub ended: bool,
+}
+
+impl FfmpegProgressEvent {
+    /// Computes the progress fraction (0..1) given the total
+    /// expected duration in milliseconds. Returns `None` when
+    /// the event lacks `out_time_us` or `total_duration_ms` is zero.
+    /// Clamps to [0, 1] so late frames at the tail don't
+    /// overshoot.
+    pub fn fraction(&self, total_duration_ms: u64) -> Option<f32> {
+        if total_duration_ms == 0 {
+            return None;
+        }
+        let us = self.out_time_us?;
+        let current_ms = us / 1000;
+        let f = current_ms as f64 / total_duration_ms as f64;
+        Some(f.clamp(0.0, 1.0) as f32)
+    }
+}
+
+/// Incremental parser for a single ffmpeg progress stream.
+/// Feed each line from the spawned process's stdout via
+/// `feed_line`; it returns `Some(event)` when a `progress=`
+/// marker completes a block, `None` when still accumulating
+/// mid-block fields.
+///
+/// The parser is stateful but cheap — one instance per ffmpeg
+/// invocation.
+pub struct FfmpegProgressParser {
+    pending: HashMap<String, String>,
+}
+
+impl FfmpegProgressParser {
+    pub fn new() -> Self {
+        Self {
+            pending: HashMap::new(),
+        }
+    }
+
+    /// Feeds one line from ffmpeg's -progress stream. Returns
+    /// `Some(event)` on block completion (any `progress=` line),
+    /// `None` otherwise. Malformed lines (no `=`) are silently
+    /// ignored — ffmpeg occasionally emits blank lines or
+    /// diagnostic text on the same stream and we shouldn't crash
+    /// on them.
+    pub fn feed_line(&mut self, line: &str) -> Option<FfmpegProgressEvent> {
+        let line = line.trim();
+        if line.is_empty() {
+            return None;
+        }
+        let (key, value) = match line.split_once('=') {
+            Some(pair) => pair,
+            None => return None,
+        };
+        let key = key.trim();
+        let value = value.trim();
+
+        if key == "progress" {
+            let ended = value == "end";
+            let event = self.build_event(ended);
+            self.pending.clear();
+            return Some(event);
+        }
+
+        self.pending.insert(key.to_string(), value.to_string());
+        None
+    }
+
+    fn build_event(&self, ended: bool) -> FfmpegProgressEvent {
+        FfmpegProgressEvent {
+            out_time_us: self
+                .pending
+                .get("out_time_us")
+                .and_then(|s| s.parse().ok()),
+            frame: self.pending.get("frame").and_then(|s| s.parse().ok()),
+            fps: self.pending.get("fps").and_then(|s| s.parse().ok()),
+            speed: self
+                .pending
+                .get("speed")
+                .and_then(|s| s.trim_end_matches('x').parse().ok()),
+            ended,
+        }
+    }
+}
+
+impl Default for FfmpegProgressParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feed_all(parser: &mut FfmpegProgressParser, text: &str) -> Vec<FfmpegProgressEvent> {
+        let mut events = Vec::new();
+        for line in text.lines() {
+            if let Some(event) = parser.feed_line(line) {
+                events.push(event);
+            }
+        }
+        events
+    }
+
+    // ─── feed_line: mid-block accumulation ──────────────────
+
+    #[test]
+    fn empty_line_yields_nothing() {
+        let mut p = FfmpegProgressParser::new();
+        assert_eq!(p.feed_line(""), None);
+        assert_eq!(p.feed_line("   "), None);
+    }
+
+    #[test]
+    fn line_without_equals_is_ignored() {
+        let mut p = FfmpegProgressParser::new();
+        assert_eq!(p.feed_line("garbage"), None);
+        assert_eq!(p.feed_line("something-else"), None);
+    }
+
+    #[test]
+    fn key_value_pair_without_progress_marker_returns_none() {
+        let mut p = FfmpegProgressParser::new();
+        assert_eq!(p.feed_line("frame=100"), None);
+        assert_eq!(p.feed_line("fps=30.0"), None);
+    }
+
+    // ─── feed_line: block completion ────────────────────────
+
+    #[test]
+    fn progress_continue_flushes_accumulated_fields() {
+        let mut p = FfmpegProgressParser::new();
+        p.feed_line("frame=100");
+        p.feed_line("fps=30.0");
+        p.feed_line("out_time_us=3500000");
+        p.feed_line("speed=1.5x");
+        let event = p.feed_line("progress=continue").expect("should flush");
+        assert_eq!(event.frame, Some(100));
+        assert_eq!(event.fps, Some(30.0));
+        assert_eq!(event.out_time_us, Some(3500000));
+        assert_eq!(event.speed, Some(1.5));
+        assert!(!event.ended);
+    }
+
+    #[test]
+    fn progress_end_sets_ended_flag() {
+        let mut p = FfmpegProgressParser::new();
+        p.feed_line("frame=600");
+        p.feed_line("out_time_us=20000000");
+        let event = p.feed_line("progress=end").expect("should flush");
+        assert!(event.ended);
+        assert_eq!(event.out_time_us, Some(20000000));
+    }
+
+    #[test]
+    fn block_state_resets_between_progress_markers() {
+        let mut p = FfmpegProgressParser::new();
+        p.feed_line("frame=100");
+        p.feed_line("progress=continue");
+        // Second block should not carry over frame=100
+        p.feed_line("out_time_us=5000000");
+        let second = p.feed_line("progress=continue").unwrap();
+        assert_eq!(second.frame, None);
+        assert_eq!(second.out_time_us, Some(5000000));
+    }
+
+    #[test]
+    fn malformed_numeric_fields_are_none() {
+        let mut p = FfmpegProgressParser::new();
+        p.feed_line("frame=not-a-number");
+        p.feed_line("fps=also-bad");
+        p.feed_line("out_time_us=garbage");
+        let event = p.feed_line("progress=continue").unwrap();
+        assert_eq!(event.frame, None);
+        assert_eq!(event.fps, None);
+        assert_eq!(event.out_time_us, None);
+    }
+
+    #[test]
+    fn real_world_block_parses_correctly() {
+        let mut p = FfmpegProgressParser::new();
+        let block = "\
+frame=127
+fps=30.12
+stream_0_0_q=28.0
+bitrate=1500.0kbits/s
+total_size=50000
+out_time_us=4233000
+out_time_ms=4233000
+out_time=00:00:04.233000
+dup_frames=0
+drop_frames=0
+speed=1.01x
+progress=continue";
+        let events = feed_all(&mut p, block);
+        assert_eq!(events.len(), 1);
+        let e = &events[0];
+        assert_eq!(e.frame, Some(127));
+        assert_eq!(e.fps, Some(30.12));
+        assert_eq!(e.out_time_us, Some(4233000));
+        assert_eq!(e.speed, Some(1.01));
+        assert!(!e.ended);
+    }
+
+    #[test]
+    fn multi_block_stream_emits_one_event_per_progress_marker() {
+        let mut p = FfmpegProgressParser::new();
+        let stream = "\
+frame=30
+out_time_us=1000000
+progress=continue
+frame=60
+out_time_us=2000000
+progress=continue
+frame=90
+out_time_us=3000000
+progress=end";
+        let events = feed_all(&mut p, stream);
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].frame, Some(30));
+        assert_eq!(events[1].frame, Some(60));
+        assert_eq!(events[2].frame, Some(90));
+        assert!(events[2].ended);
+        assert!(!events[0].ended);
+    }
+
+    // ─── fraction ────────────────────────────────────────────
+
+    #[test]
+    fn fraction_computes_from_out_time_and_total() {
+        let event = FfmpegProgressEvent {
+            out_time_us: Some(5_000_000),
+            ..Default::default()
+        };
+        assert_eq!(event.fraction(10_000), Some(0.5));
+    }
+
+    #[test]
+    fn fraction_clamps_to_one_when_past_end() {
+        let event = FfmpegProgressEvent {
+            out_time_us: Some(12_000_000),
+            ..Default::default()
+        };
+        assert_eq!(event.fraction(10_000), Some(1.0));
+    }
+
+    #[test]
+    fn fraction_clamps_to_zero_for_negative_would_be() {
+        // out_time_us can't actually go negative (u64), but we
+        // still guard against edge cases.
+        let event = FfmpegProgressEvent {
+            out_time_us: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(event.fraction(10_000), Some(0.0));
+    }
+
+    #[test]
+    fn fraction_is_none_when_out_time_us_missing() {
+        let event = FfmpegProgressEvent::default();
+        assert_eq!(event.fraction(10_000), None);
+    }
+
+    #[test]
+    fn fraction_is_none_when_total_is_zero() {
+        let event = FfmpegProgressEvent {
+            out_time_us: Some(5_000_000),
+            ..Default::default()
+        };
+        assert_eq!(event.fraction(0), None);
+    }
+}

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod audio_mix;
 mod captions;
 mod deepinfra;
 mod ffmpeg;
+mod ffmpeg_progress;
 mod git;
 mod generation;
 mod llm;

--- a/creator/src-tauri/src/video_encode.rs
+++ b/creator/src-tauri/src/video_encode.rs
@@ -28,11 +28,15 @@
 // to a `concat` filter which is simpler and faster.
 
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
 use crate::ffmpeg;
+use crate::ffmpeg_progress::FfmpegProgressParser;
+use crate::video_export::emit_stage_progress;
 use tauri::AppHandle;
 
 // ─── Types ───────────────────────────────────────────────────────
@@ -139,6 +143,12 @@ pub fn build_video_encode_command(
     args.push("-hide_banner".to_string());
     args.push("-loglevel".to_string());
     args.push("error".to_string());
+    // Stream progress key=value pairs to stdout so the async runner
+    // can forward intra-stage progress to the UI. `-nostats` keeps
+    // the normal stats line off stderr (the progress stream replaces it).
+    args.push("-progress".to_string());
+    args.push("pipe:1".to_string());
+    args.push("-nostats".to_string());
 
     // ─── Inputs: one -loop -t -i triplet per scene ───────────
     for scene in &input.scenes {
@@ -412,6 +422,13 @@ pub fn compute_total_duration_ms(input: &VideoEncodeInput) -> u64 {
 /// Spawns ffmpeg to encode a sequence of scene PNGs into a silent
 /// video. Returns the output file path and the computed total
 /// duration (with crossfade overlaps subtracted).
+///
+/// Streams ffmpeg's `-progress pipe:1` output to parse per-frame
+/// progress and forward it to the UI via `video_export:progress`
+/// events. The progress fraction is relative to the total computed
+/// output duration (same value returned in `VideoEncodeOutput`).
+/// Stderr is buffered in the background and surfaced only if
+/// ffmpeg exits with a non-zero status.
 #[allow(dead_code)] // consumed by the export orchestrator (PR 8)
 pub async fn encode_video_segments(
     app: &AppHandle,
@@ -419,6 +436,7 @@ pub async fn encode_video_segments(
     output_path: PathBuf,
 ) -> Result<VideoEncodeOutput, String> {
     let ffmpeg_path = ffmpeg::ffmpeg_binary_path(app).await?;
+    let total_duration_ms = compute_total_duration_ms(&input);
     let cmd = build_video_encode_command(&input, &output_path)?;
 
     if let Some(parent) = output_path.parent() {
@@ -427,24 +445,81 @@ pub async fn encode_video_segments(
             .map_err(|e| format!("Failed to create video output dir: {e}"))?;
     }
 
-    let output = Command::new(&ffmpeg_path)
+    let mut child = Command::new(&ffmpeg_path)
         .args(&cmd.args)
-        .output()
-        .await
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| format!("Failed to spawn ffmpeg for video encode: {e}"))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "ffmpeg stdout pipe was not captured".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "ffmpeg stderr pipe was not captured".to_string())?;
+
+    // Background stderr drain — prevents the child from blocking on
+    // a full stderr buffer while we're reading stdout for progress.
+    let stderr_handle = tokio::spawn(async move {
+        let mut reader = BufReader::new(stderr).lines();
+        let mut buf: Vec<String> = Vec::new();
+        while let Ok(Some(line)) = reader.next_line().await {
+            buf.push(line);
+        }
+        buf
+    });
+
+    // Parse progress blocks as ffmpeg emits them. For long encodes
+    // (4K archive preset, 2+ minute stories) this is what turns the
+    // UI progress bar from "stuck at 72%" into a smooth scrub.
+    let mut parser = FfmpegProgressParser::new();
+    let mut stdout_reader = BufReader::new(stdout).lines();
+    while let Ok(Some(line)) = stdout_reader.next_line().await {
+        if let Some(event) = parser.feed_line(&line) {
+            let fraction = event.fraction(total_duration_ms);
+            let message = match (event.frame, event.fps) {
+                (Some(frame), Some(fps)) => {
+                    format!("Encoding video — frame {frame} @ {fps:.0} fps")
+                }
+                (Some(frame), None) => format!("Encoding video — frame {frame}"),
+                _ => "Encoding video…".to_string(),
+            };
+            emit_stage_progress(
+                app,
+                "video_encode",
+                message,
+                fraction,
+                event.speed,
+                event.frame,
+            );
+            if event.ended {
+                break;
+            }
+        }
+    }
+
+    let exit_status = child
+        .wait()
+        .await
+        .map_err(|e| format!("Failed to wait on ffmpeg: {e}"))?;
+    let stderr_lines = stderr_handle
+        .await
+        .map_err(|e| format!("stderr drain task panicked: {e}"))?;
+
+    if !exit_status.success() {
         return Err(format!(
             "ffmpeg video encode failed (exit {}): {}",
-            output.status.code().unwrap_or(-1),
-            stderr.trim(),
+            exit_status.code().unwrap_or(-1),
+            stderr_lines.join("\n").trim(),
         ));
     }
 
     Ok(VideoEncodeOutput {
         file_path: output_path.to_string_lossy().to_string(),
-        total_duration_ms: compute_total_duration_ms(&input),
+        total_duration_ms,
     })
 }
 

--- a/creator/src-tauri/src/video_export.rs
+++ b/creator/src-tauri/src/video_export.rs
@@ -172,17 +172,50 @@ pub struct VideoExportResult {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ProgressEvent {
-    stage: &'static str,
-    message: String,
+pub struct ProgressEvent {
+    pub stage: &'static str,
+    pub message: String,
+    /// Fraction within the stage, 0..1. `None` on stage-transition
+    /// announcements (e.g. "audio_mix starting"); `Some` when
+    /// forwarded from the inline ffmpeg parser.
+    pub stage_fraction: Option<f32>,
+    /// Encoding speed multiplier, if available (e.g. 1.23 = 1.23×
+    /// realtime). Shown in the UI as "1.23x realtime".
+    pub speed: Option<f64>,
+    /// Current frame number (video encode only).
+    pub frame: Option<u64>,
 }
 
 fn emit_progress(app: &AppHandle, stage: &'static str, message: impl Into<String>) {
     let payload = ProgressEvent {
         stage,
         message: message.into(),
+        stage_fraction: None,
+        speed: None,
+        frame: None,
     };
     // Best-effort: emit failures are non-fatal for the pipeline.
+    let _ = app.emit("video_export:progress", payload);
+}
+
+/// Emits a progress event with an inline fraction from the ffmpeg
+/// parser. Called by audio_mix and video_encode during the spawn
+/// loop.
+pub fn emit_stage_progress(
+    app: &AppHandle,
+    stage: &'static str,
+    message: impl Into<String>,
+    fraction: Option<f32>,
+    speed: Option<f64>,
+    frame: Option<u64>,
+) {
+    let payload = ProgressEvent {
+        stage,
+        message: message.into(),
+        stage_fraction: fraction,
+        speed,
+        frame,
+    };
     let _ = app.emit("video_export:progress", payload);
 }
 

--- a/creator/src/lib/storyVideoExport.ts
+++ b/creator/src/lib/storyVideoExport.ts
@@ -418,27 +418,49 @@ export async function exportStoryVideo(
   };
 
   // ─── Subscribe to Rust-side progress relayed from export_story_video ──
-  // Rust emits at audio_mix / video_encode / mux / cleanup / done stages.
-  // We map those to the orchestrator's progress callback.
+  // Rust emits stage-transition events (stage_fraction: null) and
+  // intra-stage progress events parsed from ffmpeg's -progress stream
+  // (stage_fraction: 0..1). We map each event onto the overall progress
+  // bar by assigning each stage a [start, end] band and interpolating
+  // within it using the stage_fraction when present.
+  //
+  // Stage bands total the 0.70..1.00 window — everything before 0.70 is
+  // client-side work (TTS, frame render, asset resolution) whose progress
+  // is already emitted directly from the main pipeline below.
+  const stageBands: Partial<Record<ExportStage, [number, number]>> = {
+    audio_mix: [0.70, 0.78],
+    video_encode: [0.78, 0.93],
+    mux: [0.93, 0.97],
+    cleanup: [0.97, 0.99],
+    done: [1.0, 1.0],
+  };
+
   let unlistenProgress: UnlistenFn | null = null;
   try {
-    unlistenProgress = await listen<{ stage: string; message: string }>(
+    unlistenProgress = await listen<{
+      stage: string;
+      message: string;
+      stageFraction?: number | null;
+      speed?: number | null;
+      frame?: number | null;
+    }>(
       "video_export:progress",
       (event) => {
         const stage = event.payload.stage as ExportStage;
-        // Rough fractions for the Rust-side sub-stages.
-        const fractionByStage: Partial<Record<ExportStage, number>> = {
-          audio_mix: 0.72,
-          video_encode: 0.82,
-          mux: 0.95,
-          cleanup: 0.98,
-          done: 1.0,
-        };
-        emit({
-          stage,
-          fraction: fractionByStage[stage] ?? 0.8,
-          message: event.payload.message,
-        });
+        const band = stageBands[stage];
+        if (!band) return;
+        const [start, end] = band;
+        const stageFraction =
+          event.payload.stageFraction ?? (stage === "done" ? 1 : 0);
+        const overall = start + (end - start) * Math.max(0, Math.min(1, stageFraction));
+        // Decorate the message with speed/frame info when the ffmpeg
+        // parser produced them. Keeps the UI informative during long
+        // encodes without needing a new payload field.
+        let message = event.payload.message;
+        if (event.payload.speed != null) {
+          message = `${message} (${event.payload.speed.toFixed(2)}x)`;
+        }
+        emit({ stage, fraction: overall, message });
       },
     );
   } catch (e) {


### PR DESCRIPTION
Second of the three remaining follow-ups from #141.

## What this fixes

The progress bar used to jump between stages: 30% (TTS), 65% (frames rendered), then a single jump to 72% where it sat for 10–30 seconds during the Rust orchestrator's audio mix + video encode, then another jump to 95%. For long exports (4K archive or multi-minute stories) this felt broken — the UI looked stuck at 72-82% for most of the actual encode time.

Now the progress bar scrubs smoothly across the 0.70–0.93 band driven by ffmpeg's real encode position, with a message like:

> Encoding video — frame 127 @ 30 fps (1.01x)

## Architecture

- **New `ffmpeg_progress.rs` module** — a pure `FfmpegProgressParser` state machine. Feeds lines from ffmpeg's `-progress pipe:1` stream and flushes one `FfmpegProgressEvent` per `progress=continue` or `progress=end` marker. Extracts `out_time_us`, `frame`, `fps`, `speed` — all optional so older ffmpeg versions or malformed blocks don't crash. A `fraction(total_duration_ms)` helper computes a clamped 0..1 progress value. 14 unit tests.

- **Spawn-and-read refactor** in `audio_mix` and `video_encode`: switched from `Command::output().await` (buffers everything until exit) to `Command::spawn()` with piped stdout + stderr. Stdout is read line-by-line on the main task and fed to the parser; stderr is drained into a background `tokio::spawn` buffer that's only surfaced if ffmpeg exits non-zero. This avoids the child blocking on a full pipe while we read the other one.

- **`-progress pipe:1 -nostats` args** on both command builders — sends key=value pairs to stdout every ~500ms and suppresses the normal stats line on stderr.

- **`video_export::ProgressEvent`** gains three new fields: `stage_fraction` (0..1), `speed`, and `frame`. New public helper `emit_stage_progress()` wraps the event with these set; the existing `emit_progress()` still sends stage-transition events with `stage_fraction: None`.

- **`storyVideoExport.ts`** assigns each Rust-side stage a `[start, end]` band in the overall progress bar:
  - `audio_mix` → 0.70–0.78
  - `video_encode` → 0.78–0.93
  - `mux` → 0.93–0.97
  - `cleanup` → 0.97–0.99
  
  Interpolates within the band using the received `stage_fraction`. The speed multiplier is appended to the progress message when present.

## Verification

- **141 Rust tests pass** (up from 127: +14 parser tests)
- **4 ignored integration tests pass against real ffmpeg** — the audio mix, video encode, captions, and ffmpeg download paths all still work with the new `-progress -nostats` args
- **1490 TypeScript tests pass**
- `tsc` clean, `cargo check` clean (7 pre-existing warnings)

## Test plan

- [x] Unit tests pass
- [x] Integration tests against real ffmpeg pass
- [ ] Manual export of a multi-scene story with the **archive** preset → progress bar should scrub smoothly across 0.78-0.93 during the encode
- [ ] Speed multiplier and frame count appear in the progress message
- [ ] No change to the 0.00-0.70 client-side progress (TTS, frame render, asset resolution)

Closes the "frame-level progress from ffmpeg" item from #141.