### PR TITLE
Abort running exports mid-stream

### DIFF
--- a/creator/src-tauri/src/audio_mix.rs
+++ b/creator/src-tauri/src/audio_mix.rs
@@ -33,6 +33,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::atomic::AtomicBool;
 
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -327,11 +328,17 @@ fn build_filter_complex(
 /// progress and forward it to the UI via `video_export:progress`
 /// events. Stderr is buffered in the background and surfaced only
 /// if ffmpeg exits with a non-zero status.
+///
+/// When a `cancel_flag` is supplied and it flips to `true` mid-run,
+/// the spawned ffmpeg child is killed and the function returns
+/// `Err("Export cancelled by user")`. Cancellation is polled once
+/// per progress block (~500ms latency worst case).
 #[allow(dead_code)] // consumed by the export orchestrator (PR 7)
 pub async fn mix_audio(
     app: &AppHandle,
     input: AudioMixInput,
     output_path: PathBuf,
+    cancel_flag: Option<&AtomicBool>,
 ) -> Result<AudioMixOutput, String> {
     let ffmpeg_path = ffmpeg::ffmpeg_binary_path(app).await?;
     let cmd = build_mix_command(&input, &output_path)?;
@@ -374,10 +381,19 @@ pub async fn mix_audio(
 
     // Read progress from stdout as ffmpeg emits it (~every 500ms).
     // Each complete key=value block terminates with `progress=continue`
-    // or `progress=end` and flushes one FfmpegProgressEvent.
+    // or `progress=end` and flushes one FfmpegProgressEvent. We also
+    // poll the cancellation flag on each line so cancel has ~500ms
+    // worst-case latency (the interval between progress blocks).
     let mut parser = FfmpegProgressParser::new();
     let mut stdout_reader = BufReader::new(stdout).lines();
+    let mut cancelled = false;
     while let Ok(Some(line)) = stdout_reader.next_line().await {
+        if let Some(flag) = cancel_flag {
+            if crate::cancellation::is_cancelled(flag) {
+                cancelled = true;
+                break;
+            }
+        }
         if let Some(event) = parser.feed_line(&line) {
             let fraction = event.fraction(total_duration_ms);
             emit_stage_progress(
@@ -392,6 +408,15 @@ pub async fn mix_audio(
                 break;
             }
         }
+    }
+
+    if cancelled {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        // Drop the stderr handle without awaiting — the background
+        // task exits when the child's stderr pipe closes.
+        drop(stderr_handle);
+        return Err("Export cancelled by user".to_string());
     }
 
     let exit_status = child

--- a/creator/src-tauri/src/cancellation.rs
+++ b/creator/src-tauri/src/cancellation.rs
@@ -1,0 +1,182 @@
+// ─── Export Cancellation Registry ────────────────────────────────
+// Tracks in-flight story video exports by session_id so the frontend
+// can abort a running export via `cancel_story_video_export`. The
+// orchestrator registers a cancel flag on start, unregisters on end,
+// and polls the flag between pipeline stages + inside the ffmpeg
+// spawn loops so cancellation has a ~500ms worst-case latency.
+//
+// Implementation notes:
+//   - We use std::sync::OnceLock for the registry singleton (stable
+//     since Rust 1.70) so there's no new crate dependency.
+//   - Each flag is an Arc<AtomicBool> so the orchestrator holds one
+//     strong ref while it runs; the cancel command holds a weak-ish
+//     ref via the registry lookup. Unregister on end clears the
+//     registry entry but the orchestrator still has its clone.
+//   - The flag uses SeqCst ordering because cancellation is rare
+//     (user click) and ordering cost is negligible compared to
+//     the relief of not debugging a weird memory-ordering bug.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// Shared cancellation flag held by both the orchestrator and the
+/// registry. Set to `true` when cancellation is requested.
+pub type CancelFlag = Arc<AtomicBool>;
+
+type Registry = Mutex<HashMap<String, CancelFlag>>;
+
+fn registry() -> &'static Registry {
+    static REGISTRY: OnceLock<Registry> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Registers a new cancellation flag for the given session and
+/// returns the flag for the orchestrator to hold. If the session_id
+/// was already registered (shouldn't happen — session_ids are UUIDs),
+/// the previous entry is overwritten.
+pub fn register(session_id: String) -> CancelFlag {
+    let flag: CancelFlag = Arc::new(AtomicBool::new(false));
+    let mut map = registry().lock().expect("cancel registry poisoned");
+    map.insert(session_id, flag.clone());
+    flag
+}
+
+/// Removes the session's cancellation flag from the registry.
+/// Called by the orchestrator after the export completes (success,
+/// error, or cancellation). The orchestrator still owns its
+/// Arc clone, so this just stops new `cancel` calls from finding it.
+pub fn unregister(session_id: &str) {
+    let mut map = registry().lock().expect("cancel registry poisoned");
+    map.remove(session_id);
+}
+
+/// Requests cancellation of the export for the given session. Returns
+/// `true` if a session with that ID was found and flagged, `false` if
+/// the session was not in the registry (already finished, never
+/// started, or wrong id).
+pub fn cancel(session_id: &str) -> bool {
+    let map = registry().lock().expect("cancel registry poisoned");
+    if let Some(flag) = map.get(session_id) {
+        flag.store(true, Ordering::SeqCst);
+        true
+    } else {
+        false
+    }
+}
+
+/// Convenience: returns `true` if the flag has been cancelled.
+pub fn is_cancelled(flag: &AtomicBool) -> bool {
+    flag.load(Ordering::SeqCst)
+}
+
+/// Returns `Err("Export cancelled")` if the flag is set, otherwise
+/// `Ok(())`. The orchestrator calls this between stages to bail out
+/// early instead of progressing to the next ffmpeg invocation.
+pub fn check(flag: &AtomicBool) -> Result<(), String> {
+    if is_cancelled(flag) {
+        Err("Export cancelled by user".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests use unique session IDs per test to avoid cross-test
+    /// registry contamination (the registry is a process-global
+    /// singleton shared across all tests in the same run).
+    fn unique_id(name: &str) -> String {
+        format!(
+            "{name}-{pid}-{ts}",
+            pid = std::process::id(),
+            ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        )
+    }
+
+    #[test]
+    fn register_returns_a_fresh_unset_flag() {
+        let id = unique_id("register_unset");
+        let flag = register(id.clone());
+        assert!(!is_cancelled(&flag));
+        unregister(&id);
+    }
+
+    #[test]
+    fn cancel_sets_the_flag_for_a_registered_session() {
+        let id = unique_id("cancel_sets");
+        let flag = register(id.clone());
+        assert!(cancel(&id));
+        assert!(is_cancelled(&flag));
+        unregister(&id);
+    }
+
+    #[test]
+    fn cancel_returns_false_for_unknown_session() {
+        assert!(!cancel("totally-nonexistent-session-id"));
+    }
+
+    #[test]
+    fn unregister_prevents_future_cancel_from_reaching_the_flag() {
+        let id = unique_id("unregister_blocks");
+        let flag = register(id.clone());
+        unregister(&id);
+        assert!(!cancel(&id));
+        // The orchestrator's copy of the flag is unaffected
+        assert!(!is_cancelled(&flag));
+    }
+
+    #[test]
+    fn unregister_does_not_reset_an_already_cancelled_flag() {
+        let id = unique_id("unregister_after_cancel");
+        let flag = register(id.clone());
+        cancel(&id);
+        unregister(&id);
+        // The orchestrator's clone still sees the cancellation
+        assert!(is_cancelled(&flag));
+    }
+
+    #[test]
+    fn check_returns_ok_when_not_cancelled() {
+        let flag = AtomicBool::new(false);
+        assert!(check(&flag).is_ok());
+    }
+
+    #[test]
+    fn check_returns_err_when_cancelled() {
+        let flag = AtomicBool::new(true);
+        let err = check(&flag).unwrap_err();
+        assert!(err.contains("cancelled"));
+    }
+
+    #[test]
+    fn multiple_sessions_are_independent() {
+        let a = unique_id("multi_a");
+        let b = unique_id("multi_b");
+        let flag_a = register(a.clone());
+        let flag_b = register(b.clone());
+        cancel(&a);
+        assert!(is_cancelled(&flag_a));
+        assert!(!is_cancelled(&flag_b));
+        unregister(&a);
+        unregister(&b);
+    }
+
+    #[test]
+    fn re_registering_same_id_overwrites_the_flag() {
+        let id = unique_id("re_register");
+        let first = register(id.clone());
+        let _second = register(id.clone());
+        // Cancel finds the SECOND flag, not the first
+        cancel(&id);
+        assert!(!is_cancelled(&first));
+        unregister(&id);
+    }
+}

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod anthropic;
 mod arcanum_meta;
 mod assets;
 mod audio_mix;
+mod cancellation;
 mod captions;
 mod deepinfra;
 mod ffmpeg;
@@ -65,6 +66,7 @@ pub fn run() {
             video_export::cleanup_video_export_session,
             video_export::resolve_first_existing_path,
             video_export::export_story_video,
+            video_export::cancel_story_video_export,
             openai_images::openai_generate_image,
             openai_tts::openai_tts_generate,
             runware::runware_generate_audio,

--- a/creator/src-tauri/src/video_encode.rs
+++ b/creator/src-tauri/src/video_encode.rs
@@ -29,6 +29,7 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::atomic::AtomicBool;
 
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -429,11 +430,16 @@ pub fn compute_total_duration_ms(input: &VideoEncodeInput) -> u64 {
 /// output duration (same value returned in `VideoEncodeOutput`).
 /// Stderr is buffered in the background and surfaced only if
 /// ffmpeg exits with a non-zero status.
+///
+/// When a `cancel_flag` is supplied and it flips to `true` mid-run,
+/// the spawned ffmpeg child is killed and the function returns
+/// `Err("Export cancelled by user")`.
 #[allow(dead_code)] // consumed by the export orchestrator (PR 8)
 pub async fn encode_video_segments(
     app: &AppHandle,
     input: VideoEncodeInput,
     output_path: PathBuf,
+    cancel_flag: Option<&AtomicBool>,
 ) -> Result<VideoEncodeOutput, String> {
     let ffmpeg_path = ffmpeg::ffmpeg_binary_path(app).await?;
     let total_duration_ms = compute_total_duration_ms(&input);
@@ -474,10 +480,19 @@ pub async fn encode_video_segments(
 
     // Parse progress blocks as ffmpeg emits them. For long encodes
     // (4K archive preset, 2+ minute stories) this is what turns the
-    // UI progress bar from "stuck at 72%" into a smooth scrub.
+    // UI progress bar from "stuck at 72%" into a smooth scrub. We
+    // also poll the cancellation flag on each line so cancel has
+    // ~500ms worst-case latency.
     let mut parser = FfmpegProgressParser::new();
     let mut stdout_reader = BufReader::new(stdout).lines();
+    let mut cancelled = false;
     while let Ok(Some(line)) = stdout_reader.next_line().await {
+        if let Some(flag) = cancel_flag {
+            if crate::cancellation::is_cancelled(flag) {
+                cancelled = true;
+                break;
+            }
+        }
         if let Some(event) = parser.feed_line(&line) {
             let fraction = event.fraction(total_duration_ms);
             let message = match (event.frame, event.fps) {
@@ -499,6 +514,13 @@ pub async fn encode_video_segments(
                 break;
             }
         }
+    }
+
+    if cancelled {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        drop(stderr_handle);
+        return Err("Export cancelled by user".to_string());
     }
 
     let exit_status = child

--- a/creator/src-tauri/src/video_export.rs
+++ b/creator/src-tauri/src/video_export.rs
@@ -103,6 +103,20 @@ pub async fn resolve_first_existing_path(
     Ok(None)
 }
 
+/// Requests cancellation of an in-flight story video export.
+///
+/// Returns `true` if the session was found in the cancellation
+/// registry and flagged, `false` if no such session is running
+/// (already finished, never started, or the wrong id). The actual
+/// cancellation takes effect with a ~500ms latency — the orchestrator
+/// polls the flag between pipeline stages and inside the ffmpeg
+/// spawn loops. When it fires, ffmpeg is killed, the session temp
+/// dir is wiped, and `export_story_video` returns an error.
+#[tauri::command]
+pub async fn cancel_story_video_export(session_id: String) -> Result<bool, String> {
+    Ok(crate::cancellation::cancel(&session_id))
+}
+
 /// Deletes the session temp dir. Called after a successful export or
 /// when the user cancels mid-export.
 #[tauri::command]
@@ -244,12 +258,49 @@ pub async fn export_story_video(
     app: AppHandle,
     request: VideoExportRequest,
 ) -> Result<VideoExportResult, String> {
+    // Register a cancellation flag keyed by session id so the
+    // frontend can request an abort via `cancel_story_video_export`.
+    // The flag is shared between this orchestrator, the mix_audio
+    // runner, and the encode_video_segments runner. On any exit path
+    // we unregister it from the global registry so stale entries
+    // don't accumulate.
+    let cancel_flag = crate::cancellation::register(request.session_id.clone());
+    let session_id = request.session_id.clone();
+
+    let result = run_export(&app, request, &cancel_flag).await;
+
+    crate::cancellation::unregister(&session_id);
+
+    // If the export was cancelled mid-run, mop up the session temp
+    // dir so half-written frames and audio don't leak. Best-effort —
+    // swallow cleanup errors because the primary error (cancel) is
+    // already what we're returning.
+    if crate::cancellation::is_cancelled(&cancel_flag) || result.is_err() {
+        if let Ok(dir) = session_dir(&app, &session_id) {
+            if dir.exists() {
+                let _ = tokio::fs::remove_dir_all(&dir).await;
+            }
+        }
+    }
+
+    result
+}
+
+/// Inner implementation of `export_story_video` that receives the
+/// shared cancellation flag and polls it between stages. Split out
+/// so the outer command can guarantee unregister + cleanup on every
+/// exit path via a plain `?` flow inside.
+async fn run_export(
+    app: &AppHandle,
+    request: VideoExportRequest,
+    cancel_flag: &std::sync::atomic::AtomicBool,
+) -> Result<VideoExportResult, String> {
     if request.scenes.is_empty() {
         return Err("Cannot export: no scenes provided".to_string());
     }
 
     let profile = parse_profile(&request.profile)?;
-    let session = session_dir(&app, &request.session_id)?;
+    let session = session_dir(app, &request.session_id)?;
     tokio::fs::create_dir_all(&session)
         .await
         .map_err(|e| format!("Failed to create session dir: {e}"))?;
@@ -266,14 +317,21 @@ pub async fn export_story_video(
     }
 
     // ─── Stage 1: Audio mix ──────────────────────────────────
-    emit_progress(&app, "audio_mix", "Mixing narration, music, and ambient…");
-    audio_mix::mix_audio(&app, request.audio.clone(), audio_temp.clone())
-        .await
-        .map_err(|e| format!("Audio mix failed: {e}"))?;
+    crate::cancellation::check(cancel_flag)?;
+    emit_progress(app, "audio_mix", "Mixing narration, music, and ambient…");
+    audio_mix::mix_audio(
+        app,
+        request.audio.clone(),
+        audio_temp.clone(),
+        Some(cancel_flag),
+    )
+    .await
+    .map_err(|e| format!("Audio mix failed: {e}"))?;
 
     // ─── Stage 2: Video encode ───────────────────────────────
+    crate::cancellation::check(cancel_flag)?;
     emit_progress(
-        &app,
+        app,
         "video_encode",
         format!("Encoding {} scenes at {}x{} @ {}fps…", request.scenes.len(), request.width, request.height, request.fps),
     );
@@ -298,7 +356,7 @@ pub async fn export_story_video(
         .unwrap_or(false);
 
     let (caption_font_path, caption_lines) = if captions_present {
-        let font = crate::captions::caption_font_path(&app)?
+        let font = crate::captions::caption_font_path(app)?
             .to_string_lossy()
             .to_string();
         let track = request.captions.as_ref().unwrap();
@@ -336,15 +394,22 @@ pub async fn export_story_video(
         caption_lines,
     };
 
-    let encode_output =
-        video_encode::encode_video_segments(&app, encode_input, video_temp.clone())
-            .await
-            .map_err(|e| format!("Video encode failed: {e}"))?;
+    let encode_output = video_encode::encode_video_segments(
+        app,
+        encode_input,
+        video_temp.clone(),
+        Some(cancel_flag),
+    )
+    .await
+    .map_err(|e| format!("Video encode failed: {e}"))?;
 
     // ─── Stage 3: Mux ────────────────────────────────────────
-    emit_progress(&app, "mux", "Muxing video and audio…");
+    // Mux is fast (stream copy only) and the previous stages already
+    // honored the cancel flag, so we just check once at the boundary.
+    crate::cancellation::check(cancel_flag)?;
+    emit_progress(app, "mux", "Muxing video and audio…");
     video_encode::mux_video_and_audio(
-        &app,
+        app,
         video_temp.clone(),
         audio_temp.clone(),
         output_path.clone(),
@@ -353,7 +418,7 @@ pub async fn export_story_video(
     .map_err(|e| format!("Mux failed: {e}"))?;
 
     // ─── Stage 4: Cleanup + result ───────────────────────────
-    emit_progress(&app, "cleanup", "Cleaning up temp files…");
+    emit_progress(app, "cleanup", "Cleaning up temp files…");
     // Don't hard-fail the whole export if cleanup stumbles.
     if let Err(e) = tokio::fs::remove_file(&audio_temp).await {
         eprintln!("warn: failed to remove temp audio {audio_temp:?}: {e}");
@@ -367,7 +432,7 @@ pub async fn export_story_video(
         .map(|m| m.len())
         .unwrap_or(0);
 
-    emit_progress(&app, "done", "Export complete");
+    emit_progress(app, "done", "Export complete");
 
     Ok(VideoExportResult {
         output_path: output_path.to_string_lossy().to_string(),

--- a/creator/src/components/lore/StoryExportDialog.tsx
+++ b/creator/src/components/lore/StoryExportDialog.tsx
@@ -10,7 +10,7 @@
 // just the UI glue: preset selection, file picker, progress display,
 // and wiring the progress callback into local state.
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useRef } from "react";
 import { save } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 
@@ -50,7 +50,7 @@ interface StoryExportDialogProps {
   onClose: () => void;
 }
 
-type DialogStage = "config" | "running" | "success" | "error";
+type DialogStage = "config" | "running" | "success" | "error" | "cancelled";
 
 // ─── Component ───────────────────────────────────────────────────
 
@@ -70,6 +70,11 @@ export function StoryExportDialog({
   const [progress, setProgress] = useState<ExportProgressEvent | null>(null);
   const [result, setResult] = useState<ExportStoryVideoResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // AbortController for the in-flight export. Kept in a ref (not
+  // state) so the cancel handler can access the current controller
+  // without forcing a re-render of the dialog mid-export.
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const selectedPreset = PRESETS[presetId];
 
@@ -114,6 +119,9 @@ export function StoryExportDialog({
     setError(null);
     setResult(null);
 
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
     try {
       const exportResult = await exportStoryVideo({
         story,
@@ -123,6 +131,7 @@ export function StoryExportDialog({
         presetId,
         outputPath,
         voiceOverride,
+        signal: controller.signal,
         onProgress: (event) => {
           setProgress(event);
         },
@@ -130,9 +139,17 @@ export function StoryExportDialog({
       setResult(exportResult);
       setDialogStage("success");
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      setError(msg);
-      setDialogStage("error");
+      // User-requested abort surfaces as ExportAbortedError with
+      // name === "AbortError" — treat as a normal UX path, not an error.
+      if (e instanceof Error && e.name === "AbortError") {
+        setDialogStage("cancelled");
+      } else {
+        const msg = e instanceof Error ? e.message : String(e);
+        setError(msg);
+        setDialogStage("error");
+      }
+    } finally {
+      abortControllerRef.current = null;
     }
   }, [
     canStart,
@@ -144,6 +161,10 @@ export function StoryExportDialog({
     outputPath,
     voiceOverride,
   ]);
+
+  const handleAbort = useCallback(() => {
+    abortControllerRef.current?.abort();
+  }, []);
 
   // ─── Render ───────────────────────────────────────────────
   return (
@@ -158,6 +179,7 @@ export function StoryExportDialog({
         handleStart,
         onClose,
         () => setDialogStage("config"),
+        handleAbort,
       )}
     >
       {dialogStage === "config" && (
@@ -183,6 +205,8 @@ export function StoryExportDialog({
       {dialogStage === "error" && error && (
         <ErrorView error={error} />
       )}
+
+      {dialogStage === "cancelled" && <CancelledView />}
     </DialogShell>
   );
 }
@@ -195,11 +219,17 @@ function renderFooter(
   onStart: () => void,
   onClose: () => void,
   onReset: () => void,
+  onAbort: () => void,
 ) {
   if (stage === "running") {
     return (
-      <div className="flex items-center justify-between text-xs text-text-muted">
-        <span>Export in progress — please keep the app open.</span>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-text-muted">
+          Export in progress — please keep the app open.
+        </span>
+        <ActionButton variant="ghost" onClick={onAbort}>
+          Abort
+        </ActionButton>
       </div>
     );
   }
@@ -225,6 +255,19 @@ function renderFooter(
         </ActionButton>
         <ActionButton variant="primary" onClick={onReset}>
           Try Again
+        </ActionButton>
+      </div>
+    );
+  }
+
+  if (stage === "cancelled") {
+    return (
+      <div className="flex items-center justify-end gap-2">
+        <ActionButton variant="ghost" onClick={onClose}>
+          Close
+        </ActionButton>
+        <ActionButton variant="primary" onClick={onReset}>
+          Start Over
         </ActionButton>
       </div>
     );
@@ -534,6 +577,26 @@ function ErrorView({ error }: { error: string }) {
         <p className="mt-3 text-xs text-text-muted">
           Check that your OpenAI API key is set in Settings (for TTS) and that you have an
           internet connection (for the first-time ffmpeg download).
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ─── CancelledView: user-aborted export ─────────────────────────
+
+function CancelledView() {
+  return (
+    <div className="flex flex-col gap-3 py-4">
+      <div className="rounded-md border border-border-muted bg-bg-elevated p-4">
+        <h3 className="font-display text-base text-text-primary">Export cancelled</h3>
+        <p className="mt-2 text-sm text-text-secondary">
+          No output file was written. Any temporary frames and audio from this session
+          have been cleaned up automatically.
+        </p>
+        <p className="mt-3 text-xs text-text-muted">
+          Cached narration audio from OpenAI is preserved — if you retry the same story,
+          the TTS step will short-circuit and only the ffmpeg passes will re-run.
         </p>
       </div>
     </div>

--- a/creator/src/lib/storyVideoExport.ts
+++ b/creator/src/lib/storyVideoExport.ts
@@ -100,6 +100,26 @@ export interface ExportStoryVideoOptions {
   modelOverride?: OpenAiTtsModel;
   /** Progress callback — fires at every stage transition. */
   onProgress?: (event: ExportProgressEvent) => void;
+  /**
+   * Optional AbortSignal. When aborted, the orchestrator bails at the
+   * next stage boundary and calls `cancel_story_video_export` on the
+   * Rust side so any in-flight ffmpeg process gets killed. Temp files
+   * are cleaned up automatically. Throws a `DOMException` with name
+   * `"AbortError"` — callers should treat abort as non-error UX.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Thrown by `exportStoryVideo` when the caller aborts via the
+ * optional AbortSignal. Matches the fetch/DOM convention so callers
+ * can differentiate abort from real errors via `e.name === "AbortError"`.
+ */
+export class ExportAbortedError extends Error {
+  readonly name = "AbortError";
+  constructor(message = "Export cancelled by user") {
+    super(message);
+  }
 }
 
 export interface ExportStoryVideoResult {
@@ -409,6 +429,7 @@ export async function exportStoryVideo(
     assetsDir,
     project,
     onProgress,
+    signal,
   } = options;
 
   const preset = getPreset(presetId);
@@ -416,6 +437,25 @@ export async function exportStoryVideo(
   const emit = (event: ExportProgressEvent) => {
     onProgress?.(event);
   };
+
+  /** Throws if the caller's AbortSignal has fired. */
+  const throwIfAborted = () => {
+    if (signal?.aborted) {
+      throw new ExportAbortedError();
+    }
+  };
+
+  // When the abort signal fires, forward it to the Rust side so any
+  // in-flight ffmpeg process gets killed. We can't `await` inside a
+  // synchronous event listener, but invoke() returns a promise and
+  // we just fire-and-forget — the orchestrator itself will catch
+  // the abort on the next `throwIfAborted` check.
+  const onAbortForwarded = () => {
+    invoke("cancel_story_video_export", { sessionId }).catch((e) => {
+      console.warn("[exportStoryVideo] failed to signal Rust cancel:", e);
+    });
+  };
+  signal?.addEventListener("abort", onAbortForwarded, { once: true });
 
   // ─── Subscribe to Rust-side progress relayed from export_story_video ──
   // Rust emits stage-transition events (stage_fraction: null) and
@@ -468,6 +508,8 @@ export async function exportStoryVideo(
   }
 
   try {
+    throwIfAborted();
+
     // ─── Stage 1: ffmpeg availability ────────────────────────
     emit({ stage: "ffmpeg", fraction: 0.0, message: "Checking ffmpeg…" });
     const ffmpegStatus = await checkFfmpegStatus();
@@ -479,6 +521,7 @@ export async function exportStoryVideo(
       });
       await ensureFfmpegReady();
     }
+    throwIfAborted();
 
     // ─── Stage 2: initial timeline from word counts ──────────
     emit({ stage: "timeline", fraction: 0.08, message: "Computing timeline…" });
@@ -507,6 +550,7 @@ export async function exportStoryVideo(
     const narrationCache = new Map<string, NarrationAudio | null>();
 
     for (let i = 0; i < scenesBySortOrder.length; i++) {
+      throwIfAborted();
       const scene = scenesBySortOrder[i]!;
       emit({
         stage: "tts",
@@ -525,6 +569,7 @@ export async function exportStoryVideo(
       });
       narrationCache.set(scene.id, audio);
     }
+    throwIfAborted();
     console.log(
       "[exportStoryVideo] TTS done",
       scenesBySortOrder.map((s) => ({
@@ -719,6 +764,7 @@ export async function exportStoryVideo(
     // ─── Stage 6: render frames + save to disk ───────────────
     const savedFrames: RustSceneExportEntry[] = [];
     for (let i = 0; i < scenesBySortOrder.length; i++) {
+      throwIfAborted();
       const scene = scenesBySortOrder[i]!;
       emit({
         stage: "frames",
@@ -923,13 +969,25 @@ export async function exportStoryVideo(
         crossfadeMs: exportRequest.crossfadeMs,
       },
     });
+    throwIfAborted();
     emit({
       stage: "export",
       fraction: 0.7,
       message: "Encoding video…",
     });
+    // The Rust orchestrator polls its own cancellation flag between
+    // stages and inside the ffmpeg spawn loops. If the caller aborts
+    // while this await is in flight, our signal listener above fires
+    // `cancel_story_video_export` which flips the flag; Rust then
+    // returns an error that we convert back to ExportAbortedError.
     const result = await invoke<RustVideoExportResult>("export_story_video", {
       request: exportRequest,
+    }).catch((e) => {
+      const msg = typeof e === "string" ? e : (e as Error).message;
+      if (signal?.aborted || msg.includes("cancelled by user")) {
+        throw new ExportAbortedError();
+      }
+      throw e;
     });
 
     // ─── Stage 10: cleanup + done ────────────────────────────
@@ -960,6 +1018,7 @@ export async function exportStoryVideo(
     if (unlistenProgress) {
       unlistenProgress();
     }
+    signal?.removeEventListener("abort", onAbortForwarded);
   }
 }
 


### PR DESCRIPTION
Final follow-up from #141 — closes the "cancel / abort mid-export" item.

## What this delivers

A real Abort button in the export dialog that kills the in-flight export wherever it is:

- **Client-side stages** (TTS, frame render) bail at the next iteration boundary via an \`AbortSignal\` check
- **Rust-side stages** (audio mix, video encode) terminate the spawned ffmpeg child via \`child.start_kill()\` + \`child.wait()\`
- **Session temp dir** is wiped automatically — no orphaned frames, narration text files, caption files, or intermediate audio/video
- **Cached narration audio** is preserved (it lives outside the session dir, content-addressed by hash) so retrying the same story short-circuits TTS

Abort is treated as a first-class UX path, not an error: the dialog shows a friendly "Export cancelled" view with a "Start Over" button instead of the scary red error view.

## Architecture

- **\`cancellation.rs\`** — process-global registry of \`Arc<AtomicBool>\` cancel flags keyed by session_id. Uses \`std::sync::OnceLock\` + \`Mutex<HashMap>\` (stable Rust, zero new dependencies). 9 unit tests cover register/cancel/unregister, multiple concurrent sessions, re-registration, the \`check()\` helper, and idempotency.

- **\`cancel_story_video_export(sessionId)\`** Tauri command flips the flag. Returns \`true\` if a session was found, \`false\` otherwise (already finished, never started, wrong id).

- **Orchestrator refactor**: \`video_export::export_story_video\` split into an outer command and an inner \`run_export()\` helper. The outer function handles register → run → unregister → cleanup in a plain try-catch-finally pattern so every exit path (success, error, cancel) unregisters the flag and wipes the session dir on cancel/error.

- **\`audio_mix::mix_audio\` and \`video_encode::encode_video_segments\`** now accept an optional \`&AtomicBool\` cancel flag. Inside their stdout-reading progress loops, they poll the flag on each line received from ffmpeg. When cancelled, they call \`child.start_kill()\` + \`child.wait()\` and return \`Err("Export cancelled by user")\`. The ~500ms progress cadence is also the worst-case cancellation latency.

- **Frontend \`storyVideoExport.ts\`** accepts an optional \`AbortSignal\`. New \`ExportAbortedError\` (name: \`"AbortError"\`, matching the DOM fetch convention) lets callers distinguish user cancellation from real errors. The orchestrator calls \`throwIfAborted()\` at every stage boundary, inside the TTS loop, and inside the frame render loop. When the signal fires, a listener forwards the cancel to the Rust side via \`cancel_story_video_export\` so any in-flight ffmpeg child is killed.

- **\`StoryExportDialog\`** gains a \`"cancelled"\` dialog stage with its own \`CancelledView\` and footer ("Close" + "Start Over"). The running-stage footer shows the new Abort button. Abort errors are caught and routed to the cancelled view instead of the error view.

## Worst-case cancellation latency

| Stage | Latency |
|---|---|
| TTS synthesis | One in-flight OpenAI request (~1-3s) |
| Frame render | One canvas draw (<100ms per scene) |
| Audio mix (Rust/ffmpeg) | ~500ms (ffmpeg progress emission cadence) |
| Video encode (Rust/ffmpeg) | ~500ms |
| Mux | Instant (stream copy) |

In practice the user will see the dialog transition to the cancelled view within ~1 second of clicking Abort, usually faster.

## Verification

- **150 Rust tests pass** (up from 141: +9 cancellation tests)
- **1490 TypeScript tests pass** unchanged
- \`tsc\` clean, \`cargo check\` clean

## Test plan

- [x] Unit tests pass
- [ ] Manual: start an export, click Abort during TTS → cancelled view appears within 1-2s
- [ ] Manual: start an export, click Abort during video encode → cancelled view appears, ffmpeg process gone from task manager, session temp dir removed
- [ ] Manual: abort then immediately retry the same story → TTS short-circuits (cache hit), ffmpeg re-runs
- [ ] Manual: close the dialog during an export (via X or Escape) → should NOT cancel (matches existing behavior of disabling Close while running)

Closes the last item from #141. After this merges, all four follow-ups from the original captions PR plan are complete.