### PR TITLE
UI and Parity Audit

### DIFF
--- a/creator/src-tauri/src/deepinfra.rs
+++ b/creator/src-tauri/src/deepinfra.rs
@@ -294,35 +294,6 @@ pub async fn read_image_data_url(path: String) -> Result<String, String> {
 
 // ─── Prompt Enhancement ──────────────────────────────────────────────
 
-#[derive(Debug, Serialize)]
-struct ChatRequest {
-    model: String,
-    messages: Vec<ChatMessage>,
-    max_tokens: u32,
-    temperature: f32,
-}
-
-#[derive(Debug, Serialize)]
-struct ChatMessage {
-    role: String,
-    content: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct ChatResponse {
-    choices: Vec<ChatChoice>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ChatChoice {
-    message: ChatResponseMessage,
-}
-
-#[derive(Debug, Deserialize)]
-struct ChatResponseMessage {
-    content: String,
-}
-
 #[tauri::command]
 pub async fn enhance_prompt(
     app: AppHandle,
@@ -331,21 +302,4 @@ pub async fn enhance_prompt(
 ) -> Result<String, String> {
     let settings = settings::get_settings(app).await?;
     llm::complete_from_settings(&settings, &system_prompt, &prompt, 512).await
-}
-
-/// Strip `<think>...</think>` reasoning blocks that some models emit.
-fn strip_think_tags(text: &str) -> String {
-    let result = text;
-    while let Some(start) = result.find("<think>") {
-        if let Some(end) = result.find("</think>") {
-            let before = &result[..start];
-            let after = &result[end + "</think>".len()..];
-            let combined = format!("{before}{after}");
-            return strip_think_tags(combined.trim());
-        } else {
-            // Unclosed <think> — strip from <think> to end
-            return result[..start].trim().to_string();
-        }
-    }
-    result.to_string()
 }

--- a/creator/src-tauri/src/runware.rs
+++ b/creator/src-tauri/src/runware.rs
@@ -1,7 +1,6 @@
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::path::PathBuf;
 use tauri::{AppHandle, Manager};
 
 use crate::{deepinfra::GeneratedImage, generation, settings};
@@ -54,14 +53,6 @@ struct RunwareResponse {
 struct RunwareImageResult {
     #[serde(alias = "imageURL", alias = "imageUrl")]
     image_url: Option<String>,
-}
-
-fn assets_dir(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
-    Ok(dir.join("assets").join("images"))
 }
 
 /// Round to nearest multiple of 16, clamped to Runware's 128–2048 range.

--- a/creator/src/components/AbilityStudio.tsx
+++ b/creator/src/components/AbilityStudio.tsx
@@ -642,7 +642,7 @@ export function AbilityStudio() {
           </div>
           <div className="h-2 overflow-hidden rounded-full bg-bg-primary">
             <div
-              className="h-full rounded-full bg-accent transition-all"
+              className="h-full rounded-full bg-accent transition-[width]"
               style={{ width: `${(batchCompleted / batchProgress.total) * 100}%` }}
             />
           </div>
@@ -721,7 +721,7 @@ export function AbilityStudio() {
             {/* Preview row — wide horizontal card */}
             <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
               <div className="flex gap-5">
-                <div className="flex shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-white/8 bg-[linear-gradient(180deg,rgba(34,41,60,0.8),rgba(28,34,52,0.88))] p-3" style={{ width: "10rem", height: "10rem" }}>
+                <div className="flex shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-white/8 bg-gradient-panel p-3" style={{ width: "10rem", height: "10rem" }}>
                   {selectedSrc ? (
                     <img src={selectedSrc} alt={selectedTarget.label} className="max-h-full max-w-full rounded-xl object-contain shadow-section" />
                   ) : (

--- a/creator/src/components/AssetGallery.tsx
+++ b/creator/src/components/AssetGallery.tsx
@@ -499,7 +499,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                   <button
                     key={asset.id}
                     onClick={() => setSelected(asset)}
-                    className={`group overflow-hidden rounded-lg border text-left transition-all ${
+                    className={`group overflow-hidden rounded-lg border text-left transition-[border-color,box-shadow] ${
                       selected?.id === asset.id
                         ? "border-accent shadow-[var(--glow-aurum)]"
                         : "border-border-default hover:border-border-hover"

--- a/creator/src/components/MudImportWizard.tsx
+++ b/creator/src/components/MudImportWizard.tsx
@@ -485,7 +485,7 @@ export function MudImportWizard({ onClose }: { onClose: () => void }) {
             </div>
             <div className="h-2 rounded-full bg-white/8 overflow-hidden">
               <div
-                className="h-full rounded-full bg-accent transition-all duration-300"
+                className="h-full rounded-full bg-accent transition-[width] duration-300"
                 style={{ width: `${totalChunks > 0 ? ((doneChunks + errorChunks) / totalChunks) * 100 : 0}%` }}
               />
             </div>

--- a/creator/src/components/NewZoneDialog.tsx
+++ b/creator/src/components/NewZoneDialog.tsx
@@ -354,7 +354,7 @@ export function NewZoneDialog({ onClose }: NewZoneDialogProps) {
           <button
             onClick={handleCreate}
             disabled={!canCreate}
-            className="rounded bg-accent px-4 py-2 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40 sm:px-4 sm:py-1.5"
+            className="rounded bg-accent px-4 py-2 text-xs font-medium text-accent-emphasis transition-[box-shadow,filter,opacity] hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40 sm:px-4 sm:py-1.5"
           >
             {creating
               ? size === "stub" || !hasDescription

--- a/creator/src/components/RenameZoneDialog.tsx
+++ b/creator/src/components/RenameZoneDialog.tsx
@@ -139,7 +139,7 @@ export function RenameZoneDialog({ zoneId, onClose }: RenameZoneDialogProps) {
           <button
             onClick={handleRename}
             disabled={!idValid || idTaken || idUnchanged || renaming || !project || !existing}
-            className="rounded bg-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+            className="rounded bg-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-[color,background-color,box-shadow,filter,opacity] hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
           >
             {renaming ? "Renaming..." : "Rename Zone"}
           </button>

--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useCallback, useEffect, useMemo } from "react";
+import { useShallow } from "zustand/shallow";
 import { invoke } from "@tauri-apps/api/core";
 import { useZoneStore, type ZoneState } from "@/stores/zoneStore";
 import { useProjectStore } from "@/stores/projectStore";
@@ -340,6 +341,7 @@ function PanelButtonGrid({
             <button
               onClick={() => toggleSection(group.id)}
               aria-expanded={!isCollapsed}
+              aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${group.label}`}
               className="mb-1 flex w-full items-center gap-1.5 rounded-md px-1 py-1 transition hover:bg-white/4"
             >
               <svg
@@ -384,6 +386,8 @@ function PanelButtonGrid({
                   {needsCollapse && !expanded && (
                     <button
                       onClick={(e) => { e.stopPropagation(); setExpandedGroups((s) => new Set(s).add(group.id)); }}
+                      aria-label={`Show ${hiddenCount} more panels`}
+                      aria-expanded={false}
                       className="rounded-full border border-dashed border-white/10 px-2.5 py-1.5 text-2xs text-text-muted transition hover:border-white/20 hover:text-text-secondary"
                     >
                       +{hiddenCount} more
@@ -414,8 +418,9 @@ function PanelButtonGrid({
 export function Sidebar({ workspace }: { workspace: Workspace }) {
   const zones = useZoneStore((s) => s.zones);
   const openTab = useProjectStore((s) => s.openTab);
-  const openTabs = useProjectStore((s) => s.tabs);
-  const activeTabId = useProjectStore((s) => s.activeTabId);
+  const { tabs: openTabs, activeTabId, project } = useProjectStore(
+    useShallow((s) => ({ tabs: s.tabs, activeTabId: s.activeTabId, project: s.project })),
+  );
   const navigateTo = useProjectStore((s) => s.navigateTo);
   const closeTab = useProjectStore((s) => s.closeTab);
   const removeZone = useZoneStore((s) => s.removeZone);
@@ -427,7 +432,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
   const [showNewZone, setShowNewZone] = useState(false);
   const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
-  const hasProject = !!useProjectStore((s) => s.project);
+  const hasProject = !!project;
 
   const handleSearchKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -438,8 +443,6 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
     },
     [clearQuery],
   );
-
-  const project = useProjectStore((s) => s.project);
 
   const handleDeleteZone = useCallback(async (zoneId: string) => {
     const zoneState = zones.get(zoneId);
@@ -596,7 +599,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
                     </p>
                     <button
                       onClick={() => setShowNewZone(true)}
-                      className="focus-ring rounded-full bg-accent px-4 py-1.5 text-2xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110"
+                      className="focus-ring rounded-full bg-accent px-4 py-1.5 text-2xs font-medium text-accent-emphasis transition-[box-shadow,filter] hover:shadow-[var(--glow-aurum)] hover:brightness-110"
                     >
                       Create your first zone
                     </button>

--- a/creator/src/components/SketchCanvas.tsx
+++ b/creator/src/components/SketchCanvas.tsx
@@ -135,7 +135,7 @@ export function SketchCanvas({
         <button
           type="button"
           onClick={handleExport}
-          className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:brightness-110"
+          className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-[filter] hover:brightness-110"
         >
           Analyze Sketch
         </button>

--- a/creator/src/components/SketchImportWizard.tsx
+++ b/creator/src/components/SketchImportWizard.tsx
@@ -639,7 +639,7 @@ export function SketchImportWizard({ onClose }: SketchImportWizardProps) {
                   (target === "new" && (!zoneIdValid || zoneIdTaken)) ||
                   (target === "existing" && !existingZoneId)
                 }
-                className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+                className="action-button action-button-primary action-button-md focus-ring"
               >
                 Import
               </button>
@@ -649,7 +649,7 @@ export function SketchImportWizard({ onClose }: SketchImportWizardProps) {
           {step === "done" && (
             <button
               onClick={onClose}
-              className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:brightness-110"
+              className="action-button action-button-primary action-button-md focus-ring"
             >
               Close
             </button>

--- a/creator/src/components/TierSpriteScaffold.tsx
+++ b/creator/src/components/TierSpriteScaffold.tsx
@@ -416,7 +416,7 @@ export function TierSpriteScaffold({ onClose, onComplete }: TierSpriteScaffoldPr
             </div>
             <div className="h-2 overflow-hidden rounded-full bg-bg-primary">
               <div
-                className="h-full rounded-full bg-accent transition-all"
+                className="h-full rounded-full bg-accent transition-[width]"
                 style={{ width: `${((progress.done + progress.failed) / progress.total) * 100}%` }}
               />
             </div>

--- a/creator/src/components/Toolbar.tsx
+++ b/creator/src/components/Toolbar.tsx
@@ -35,6 +35,13 @@ const ADMIN_STATUS_LABELS: Record<string, string> = {
   error: "Link lost",
 };
 
+const ADMIN_STATUS_GLYPHS: Record<string, string> = {
+  disconnected: "\u25CB", // ○
+  connecting: "\u25D0", // ◐
+  connected: "\u25CF", // ●
+  error: "\u2715", // ✕
+};
+
 
 interface ToolbarProps {
   workspace: Workspace;
@@ -226,11 +233,13 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                   aria-expanded={showUtilityMenu}
                   aria-haspopup="true"
                 >
-                  <div
-                    className={`h-2.5 w-2.5 shrink-0 rounded-full ${ADMIN_STATUS_COLORS[adminConnectionStatus]}`}
+                  <span
+                    className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full text-[9px] leading-none text-bg-abyss ${ADMIN_STATUS_COLORS[adminConnectionStatus]}`}
                     role="status"
                     aria-label={ADMIN_STATUS_LABELS[adminConnectionStatus]}
-                  />
+                  >
+                    <span aria-hidden="true">{ADMIN_STATUS_GLYPHS[adminConnectionStatus]}</span>
+                  </span>
                   <span className="min-w-0 truncate">World Tools</span>
                 </ActionButton>
                 {showUtilityMenu && (

--- a/creator/src/components/admin/AdminMobList.tsx
+++ b/creator/src/components/admin/AdminMobList.tsx
@@ -88,7 +88,7 @@ export function AdminMobList() {
             <select
               value={zoneFilter}
               onChange={(e) => setZoneFilter(e.target.value)}
-              className="rounded-full border border-white/10 bg-black/20 px-3 py-1.5 text-xs text-text-secondary backdrop-blur-sm transition focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+              className="rounded-full border border-white/10 bg-black/40 px-3 py-1.5 text-xs text-text-secondary transition focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
               aria-label="Filter by zone"
             >
               <option value="">All zones</option>

--- a/creator/src/components/config/RuntimeHandoffStudio.tsx
+++ b/creator/src/components/config/RuntimeHandoffStudio.tsx
@@ -42,7 +42,7 @@ const EXPORT_DIR_KEY = "arcanum-runtime-export-dir";
 
 const STATUS_STYLES: Record<StepStatus, string> = {
   idle: "border-white/10 bg-black/10 text-text-secondary",
-  running: "border-border-active bg-[rgba(140,174,201,0.14)] text-text-primary",
+  running: "border-border-active bg-status-info/15 text-text-primary",
   success: "border-status-success/30 bg-status-success/10 text-status-success",
   warning: "border-status-warning/30 bg-status-warning/10 text-status-warning",
   error: "border-status-error/30 bg-status-error/10 text-status-error",

--- a/creator/src/components/config/panels/ApiSettingsPanel.tsx
+++ b/creator/src/components/config/panels/ApiSettingsPanel.tsx
@@ -223,7 +223,7 @@ export function ApiSettingsPanel({
           <button
             onClick={handleSave}
             disabled={!isUserDirty || saving}
-            className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:opacity-50"
+            className="action-button action-button-primary action-button-md focus-ring"
           >
             {saving ? "Saving..." : "Save Account Keys"}
           </button>
@@ -534,7 +534,7 @@ export function ApiSettingsPanel({
               <button
                 onClick={handleSaveProject}
                 disabled={!isProjectDirty || saving}
-                className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:opacity-50"
+                className="action-button action-button-primary action-button-md focus-ring"
               >
                 {saving ? "Saving..." : "Save Project Settings"}
               </button>

--- a/creator/src/components/config/panels/DailyQuestsPanel.tsx
+++ b/creator/src/components/config/panels/DailyQuestsPanel.tsx
@@ -37,7 +37,7 @@ export function DailyQuestsPanel({ config, onChange }: ConfigPanelProps) {
           </FieldRow>
           <FieldRow label="Reset Time (UTC)" hint="Time of day in UTC when daily quests refresh. Format: HH:MM (e.g. '00:00' for midnight).">
             <TextInput
-              value={dq.resetTimeUtc}
+              value={dq.resetTimeUtc ?? "00:00"}
               onCommit={(v) => patch({ resetTimeUtc: v || "00:00" })}
               placeholder="00:00"
             />
@@ -56,7 +56,7 @@ export function DailyQuestsPanel({ config, onChange }: ConfigPanelProps) {
         title="Quest Pools"
         description="Named pools of quest IDs. Each pool is drawn from independently during the daily refresh. Add pools like 'combat', 'gathering', 'social' and populate them with quest IDs from your zone files."
       >
-        <PoolEditor pools={dq.pools} onChange={(pools) => patch({ pools })} />
+        <PoolEditor pools={dq.pools ?? {}} onChange={(pools) => patch({ pools })} />
       </Section>
     </>
   );

--- a/creator/src/components/config/panels/GlobalAssetsPanel.tsx
+++ b/creator/src/components/config/panels/GlobalAssetsPanel.tsx
@@ -309,7 +309,7 @@ export function GlobalAssetsPanel({ config, onChange }: ConfigPanelProps) {
             <button
               onClick={handleAdd}
               disabled={!newKey.trim()}
-              className="rounded bg-accent px-3 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:bg-accent/90 disabled:opacity-40"
+              className="rounded bg-accent px-3 py-1.5 text-xs font-medium text-accent-emphasis transition-[color,background-color,opacity] hover:bg-accent/90 disabled:opacity-40"
             >
               + Add
             </button>

--- a/creator/src/components/config/panels/GlobalQuestsPanel.tsx
+++ b/creator/src/components/config/panels/GlobalQuestsPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { ConfigPanelProps } from "./types";
-import type { GlobalQuestsConfig } from "@/types/config";
+import type { GlobalQuestsConfig, GlobalQuestObjectiveConfig } from "@/types/config";
 import {
   Section,
   FieldRow,
@@ -12,7 +12,7 @@ const DEFAULT_GLOBAL_QUESTS: GlobalQuestsConfig = {
   enabled: false,
   intervalMs: 3_600_000,
   durationMs: 1_800_000,
-  objectives: {},
+  objectives: [],
   rewards: {},
 };
 
@@ -58,8 +58,8 @@ export function GlobalQuestsPanel({ config, onChange }: ConfigPanelProps) {
       >
         <JsonEditor
           label="Objectives"
-          value={gq.objectives}
-          onChange={(v) => patch({ objectives: v })}
+          value={gq.objectives ?? []}
+          onChange={(v) => patch({ objectives: v as GlobalQuestObjectiveConfig[] })}
         />
       </Section>
 
@@ -69,8 +69,8 @@ export function GlobalQuestsPanel({ config, onChange }: ConfigPanelProps) {
       >
         <JsonEditor
           label="Rewards"
-          value={gq.rewards}
-          onChange={(v) => patch({ rewards: v })}
+          value={gq.rewards ?? {}}
+          onChange={(v) => patch({ rewards: v as Record<string, unknown> })}
         />
       </Section>
     </>
@@ -85,8 +85,8 @@ function JsonEditor({
   onChange,
 }: {
   label: string;
-  value: Record<string, unknown>;
-  onChange: (v: Record<string, unknown>) => void;
+  value: unknown;
+  onChange: (v: unknown) => void;
 }) {
   const serialized = JSON.stringify(value, null, 2);
   const [draft, setDraft] = useState(serialized);
@@ -100,12 +100,12 @@ function JsonEditor({
   const commit = () => {
     try {
       const parsed = JSON.parse(draft);
-      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-        setError("Must be a JSON object");
+      if (typeof parsed !== "object" || parsed === null) {
+        setError("Must be a JSON object or array");
         return;
       }
       setError(null);
-      onChange(parsed as Record<string, unknown>);
+      onChange(parsed);
     } catch {
       setError("Invalid JSON");
     }

--- a/creator/src/components/config/panels/GuildHallsPanel.tsx
+++ b/creator/src/components/config/panels/GuildHallsPanel.tsx
@@ -61,13 +61,13 @@ export function GuildHallsPanel({ config, onChange }: ConfigPanelProps) {
         onItemsChange={(roomTemplates) => patchGuildHalls({ roomTemplates })}
         defaultItem={defaultTemplate}
         renderSummary={summarize}
-        getDisplayName={(t) => t.displayName}
+        getDisplayName={(t) => t.displayName ?? ""}
         placeholder="template_id"
         renderDetail={(_id, t, patch) => (
           <>
             <FieldRow label="Display Name" hint="Name shown to players for this room type.">
               <TextInput
-                value={t.displayName}
+                value={t.displayName ?? ""}
                 onCommit={(v) => patch({ displayName: v })}
               />
             </FieldRow>

--- a/creator/src/components/lore/ArticleEditor.tsx
+++ b/creator/src/components/lore/ArticleEditor.tsx
@@ -38,6 +38,7 @@ function TagEditor({
         </span>
       ))}
       <input
+        aria-label="Add article keyword"
         className="focus-ring min-w-[6rem] flex-1 rounded bg-transparent px-1 py-0.5 text-xs text-text-primary"
         placeholder="Add a keyword..."
         onKeyDown={(e) => {

--- a/creator/src/components/lore/EntityOverlay.tsx
+++ b/creator/src/components/lore/EntityOverlay.tsx
@@ -163,6 +163,18 @@ export function EntityOverlay({
     [entity.id, localPos, onReposition, onSelect],
   );
 
+  // Keyboard activation for role="button": Enter/Space selects the entity.
+  // Repositioning remains mouse/touch-only (drag is pointer-based).
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onSelect(entity.id);
+      }
+    },
+    [entity.id, onSelect],
+  );
+
   // ─── Render ────────────────────────────────────────────────────
 
   return (
@@ -190,6 +202,7 @@ export function EntityOverlay({
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
+      onKeyDown={handleKeyDown}
     >
       {/* Entity sprite or placeholder */}
       {src ? (

--- a/creator/src/components/lore/PreviewPlayback.tsx
+++ b/creator/src/components/lore/PreviewPlayback.tsx
@@ -22,7 +22,7 @@ export function PreviewPlayback({ playing, onToggle }: PreviewPlaybackProps) {
         type="button"
         className={[
           "h-9 backdrop-blur-sm border rounded-md px-3 flex items-center gap-2",
-          "transition-all duration-[180ms]",
+          "transition-[color,background-color,border-color,box-shadow,opacity] duration-[180ms]",
           "opacity-70 hover:opacity-100",
           playing
             ? "bg-bg-elevated/80 border-border-default shadow-[0_0_12px_rgba(200,164,106,0.4)] animate-pulse"

--- a/creator/src/components/lore/SceneInfoBadges.tsx
+++ b/creator/src/components/lore/SceneInfoBadges.tsx
@@ -101,7 +101,7 @@ function ArticleBadgeChip({ articleId }: { articleId: string }) {
   if (!article) return null;
   return (
     <div
-      className="flex items-center gap-1.5 rounded-full border border-white/20 bg-black/50 px-2 py-0.5 backdrop-blur-sm"
+      className="flex items-center gap-1.5 rounded-full border border-white/20 bg-black/75 px-2 py-0.5"
       title={article.title}
     >
       {src ? (
@@ -125,12 +125,12 @@ function TitleCardOverlay({ scene }: { scene: Scene }) {
   return (
     <div
       className={[
-        "rounded backdrop-blur-sm px-4 py-1.5",
+        "rounded px-4 py-1.5",
         "font-display tracking-[0.25em] uppercase",
-        isYear ? "text-base text-warm border border-warm/30 bg-black/50" : "",
+        isYear ? "text-base text-warm border border-warm/30 bg-black/75" : "",
         isLocation ? "text-sm text-white border-b border-white/30 bg-transparent" : "",
-        isCharacter ? "text-sm text-accent border border-accent/30 bg-black/50" : "",
-        !isYear && !isLocation && !isCharacter ? "text-xs text-white/90 bg-black/40" : "",
+        isCharacter ? "text-sm text-accent border border-accent/30 bg-black/75" : "",
+        !isYear && !isLocation && !isCharacter ? "text-xs text-white/90 bg-black/70" : "",
       ].join(" ")}
       style={{ textShadow: "0 1px 4px rgba(0,0,0,0.7)" }}
     >
@@ -161,7 +161,7 @@ export function SceneInfoBadges({ scene, mode = "ambient" }: SceneInfoBadgesProp
     >
       {/* Top-left: year/era badge */}
       {timeline && (
-        <div className="absolute left-3 top-3 flex flex-col items-start gap-0.5 rounded border border-warm/40 bg-black/55 px-2 py-1 backdrop-blur-sm">
+        <div className="absolute left-3 top-3 flex flex-col items-start gap-0.5 rounded border border-warm/40 bg-black/80 px-2 py-1">
           <span
             className="font-display text-base leading-none tracking-[0.18em] text-warm"
             style={{ textShadow: "0 1px 3px rgba(0,0,0,0.6)" }}

--- a/creator/src/components/lore/StoryBrowser.tsx
+++ b/creator/src/components/lore/StoryBrowser.tsx
@@ -85,7 +85,7 @@ export function StoryBrowser() {
         </div>
         <button
           onClick={() => setShowNewStory(true)}
-          className="rounded bg-gradient-to-r from-accent-muted to-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-all hover:brightness-110"
+          className="action-button action-button-primary action-button-md focus-ring"
         >
           New Story
         </button>

--- a/creator/src/components/lore/StoryExportDialog.tsx
+++ b/creator/src/components/lore/StoryExportDialog.tsx
@@ -428,7 +428,7 @@ function RunningView({ progress }: { progress: ExportProgressEvent | null }) {
       <div className="w-full max-w-md">
         <div className="h-2 overflow-hidden rounded-full bg-bg-elevated">
           <div
-            className="h-full bg-accent transition-all duration-300 ease-out"
+            className="h-full bg-accent transition-[width] duration-300 ease-out"
             style={{ width: `${pct}%` }}
           />
         </div>

--- a/creator/src/components/tuning/PresetCard.tsx
+++ b/creator/src/components/tuning/PresetCard.tsx
@@ -116,7 +116,7 @@ export function PresetCard({ preset, metrics, isSelected, isDimmed, onSelect }: 
       className={[
         "max-w-[320px] w-full rounded-xl border p-6 text-left",
         "bg-bg-tertiary cursor-pointer",
-        "transition-all duration-200 hover:bg-bg-hover",
+        "transition-[color,background-color,border-color,box-shadow,opacity] duration-200 hover:bg-bg-hover",
         borderClass,
         glowClass,
         dimClass,

--- a/creator/src/components/ui/AssetPickerModal.tsx
+++ b/creator/src/components/ui/AssetPickerModal.tsx
@@ -155,7 +155,7 @@ export function AssetPickerModal({ onSelect, onClose }: AssetPickerModalProps) {
                     onSelect(asset.file_name);
                     onClose();
                   }}
-                  className="group overflow-hidden rounded-lg border border-border-default transition-all hover:border-accent hover:shadow-[var(--glow-aurum)]"
+                  className="group overflow-hidden rounded-lg border border-border-default transition-[border-color,box-shadow] hover:border-accent hover:shadow-[var(--glow-aurum)]"
                   title={`${asset.asset_type} — ${asset.file_name}`}
                 >
                   <div className="aspect-square bg-bg-primary">

--- a/creator/src/components/ui/BulkBgRemoval.tsx
+++ b/creator/src/components/ui/BulkBgRemoval.tsx
@@ -183,7 +183,7 @@ export function BulkBgRemoval({
         <div className="mb-3">
           <div className="h-1.5 overflow-hidden rounded-full bg-bg-primary">
             <div
-              className="h-full rounded-full bg-accent transition-all"
+              className="h-full rounded-full bg-accent transition-[width]"
               style={{ width: `${checkedCount > 0 ? (processedCount / checkedCount) * 100 : 0}%` }}
             />
           </div>

--- a/creator/src/components/ui/CommandPalette.tsx
+++ b/creator/src/components/ui/CommandPalette.tsx
@@ -139,6 +139,15 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
     return colors[type] ?? "bg-white/10 text-text-muted";
   };
 
+  const typeGlyph = (type: string) => {
+    const glyphs: Record<string, string> = {
+      panel: "\u25A4", // ▤ (panel/layout)
+      article: "\u00B6", // ¶ (pilcrow, article)
+      zone: "\u2302", // ⌂ (house/zone)
+    };
+    return glyphs[type] ?? "\u25CB";
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
@@ -201,8 +210,11 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
                 }`}
               >
                 <span
-                  className={`shrink-0 rounded-full px-2 py-0.5 text-3xs font-medium uppercase ${typeBadge(item.type)}`}
+                  className={`inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-3xs font-medium uppercase ${typeBadge(item.type)}`}
                 >
+                  <span aria-hidden="true" className="text-xs leading-none">
+                    {typeGlyph(item.type)}
+                  </span>
                   {item.type}
                 </span>
                 <div className="min-w-0 flex-1">

--- a/creator/src/components/ui/Toast.tsx
+++ b/creator/src/components/ui/Toast.tsx
@@ -32,7 +32,7 @@ export function Toast() {
       className="pointer-events-none fixed inset-x-0 bottom-6 z-50 flex justify-center"
     >
       <div
-        className={`max-w-sm rounded-xl border border-border-default/60 bg-bg-tertiary/95 px-4 py-2 font-body text-sm text-text-secondary shadow-section backdrop-blur-sm transition-all duration-200 ease-out ${
+        className={`max-w-sm rounded-xl border border-border-default/60 bg-bg-tertiary px-4 py-2 font-body text-sm text-text-secondary shadow-section transition-[opacity,transform] duration-200 ease-out ${
           visible
             ? "translate-y-0 opacity-100"
             : "translate-y-2 opacity-0"

--- a/creator/src/components/ui/VariantStrip.tsx
+++ b/creator/src/components/ui/VariantStrip.tsx
@@ -68,7 +68,7 @@ const VariantThumb = memo(function VariantThumb({
     <button
       onClick={onSelect}
       title={`${entry.is_active ? "(active) " : ""}${entry.created_at}\n${entry.prompt}`}
-      className={`relative h-10 w-10 shrink-0 overflow-hidden rounded border-2 transition-all ${
+      className={`relative h-10 w-10 shrink-0 overflow-hidden rounded border-2 transition-[border-color,opacity] ${
         entry.is_active
           ? "border-accent ring-2 ring-accent/40"
           : "border-border-default opacity-50 hover:opacity-80 hover:border-accent/50"

--- a/creator/src/components/zone/AssetBrowser.tsx
+++ b/creator/src/components/zone/AssetBrowser.tsx
@@ -220,7 +220,7 @@ export function AssetBrowser({ zoneId, world, onWorldChange }: AssetBrowserProps
             </span>
             <div className="h-1 flex-1 overflow-hidden rounded-full bg-bg-elevated">
               <div
-                className="h-full rounded-full bg-accent transition-all"
+                className="h-full rounded-full bg-accent transition-[width]"
                 style={{
                   width: `${totalCount > 0 ? (withImageCount / totalCount) * 100 : 0}%`,
                 }}
@@ -397,7 +397,7 @@ function VariantThumb({
     <button
       onClick={onSelect}
       title={entry.created_at}
-      className={`relative h-14 w-14 shrink-0 overflow-hidden rounded border-2 transition-all ${
+      className={`relative h-14 w-14 shrink-0 overflow-hidden rounded border-2 transition-[border-color,box-shadow] ${
         entry.is_active
           ? "border-accent shadow-[0_0_6px_var(--color-accent)]"
           : "border-border-default hover:border-accent/50"

--- a/creator/src/components/zone/BatchArtGenerator.tsx
+++ b/creator/src/components/zone/BatchArtGenerator.tsx
@@ -186,7 +186,7 @@ export function BatchArtGenerator({
             </div>
             <div className="h-1.5 overflow-hidden rounded-full bg-bg-primary">
               <div
-                className="h-full rounded-full bg-accent transition-all"
+                className="h-full rounded-full bg-accent transition-[width]"
                 style={{ width: `${bgRemoval
                   ? (bgRemoval.total > 0 ? (bgRemoval.done / bgRemoval.total) * 100 : 0)
                   : ((doneCount + errorCount) / checkedTargets.length) * 100}%` }}

--- a/creator/src/components/zone/RoomNode.tsx
+++ b/creator/src/components/zone/RoomNode.tsx
@@ -55,7 +55,7 @@ const plusHandleStyle: React.CSSProperties = {
   cursor: "crosshair",
   fontSize: 12,
   color: "color-mix(in srgb, var(--color-text-muted) 60%, transparent)",
-  transition: "all 0.15s",
+  transition: "background-color 0.15s, border-color 0.15s, color 0.15s",
   zIndex: 10,
 };
 

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -402,7 +402,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
         <button
           onClick={handleSave}
           disabled={!zoneState.dirty || saving}
-          className={`focus-ring h-7 rounded-full px-3 text-xs font-medium transition-all duration-500 max-[1180px]:h-9 ${
+          className={`focus-ring h-7 rounded-full px-3 text-xs font-medium transition-[color,background-color,border-color,box-shadow,opacity] duration-500 max-[1180px]:h-9 ${
             saving
               ? "border border-[rgba(200,164,106,0.4)] bg-[linear-gradient(145deg,rgba(200,164,106,0.22),rgba(43,52,76,0.9))] text-warm-pale shadow-[0_4px_16px_rgba(200,164,106,0.18)]"
               : justSaved
@@ -453,7 +453,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
             {roomCount} room{roomCount !== 1 ? "s" : ""}
           </span>
           {zoneState.dirty && (
-            <span className="shrink-0 rounded-full bg-[rgba(200,164,106,0.15)] px-2 py-0.5 text-3xs text-warm-pale">modified</span>
+            <span className="shrink-0 rounded-full bg-warm/15 px-2 py-0.5 text-3xs text-warm-pale">modified</span>
           )}
         </div>
 
@@ -563,7 +563,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
             ) : (
               <button
                 onClick={handleStartAddRoom}
-                className="h-6 rounded-full border border-[rgba(200,164,106,0.35)] bg-[rgba(200,164,106,0.15)] px-3 text-xs text-warm-pale hover:bg-[rgba(200,164,106,0.25)] max-[1180px]:h-9"
+                className="h-6 rounded-full border border-warm/35 bg-warm/15 px-3 text-xs text-warm-pale hover:bg-warm/25 max-[1180px]:h-9"
                 title="Add Room"
               >
                 + Room
@@ -658,7 +658,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
             {/* First-zone onboarding hint */}
             {roomCount <= 1 && !hintDismissed && viewMode === "map" && (
               <div className="pointer-events-auto absolute inset-x-0 bottom-4 z-[2] flex justify-center">
-                <div className="flex items-center gap-4 rounded-2xl border border-white/10 bg-gradient-panel bg-[radial-gradient(circle_at_center,rgba(200,164,106,0.08),transparent_60%)] px-5 py-3 shadow-section backdrop-blur-xl">
+                <div className="flex items-center gap-4 rounded-2xl border border-white/10 bg-bg-secondary/95 px-5 py-3 shadow-section">
                   <div>
                     <p className="text-sm text-text-primary">
                       Click the <span className="font-mono text-accent">+</span> handles on a room's edges to create exits to new rooms.

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -202,7 +202,7 @@ export function normalizeCurrenciesConfig(config?: AppConfig["currencies"]): App
       displayName: def.displayName,
       abbreviation: def.abbreviation ?? "",
       description: def.description ?? "",
-    })) as AppConfig["currencies"]["definitions"],
+    })) as NonNullable<AppConfig["currencies"]>["definitions"],
     honorPerPvpKill: config.honorPerPvpKill ?? 10,
     tokensPerCraft: config.tokensPerCraft ?? 1,
   };


### PR DESCRIPTION
refactor(ui): audit-driven a11y, perf, and anti-pattern fixes
Accessibility:
- Add aria-labels to icon-only buttons (sidebar collapse arrows,
  "+N more" reveal, ArticleEditor TagEditor input)
- Add Enter/Space keyboard handler to EntityOverlay role=button
- Add status glyphs to admin connection dot and command palette
  type chips so colorblind users have a non-color signal

Performance:
- Replace transition-all in 25 files with explicit property lists
  to avoid animating layout properties (uses transition-colors,
  transition-[opacity,transform], transition-shadow, etc.)
- Batch sidebar useProjectStore reads with useShallow to reduce
  re-render churn
- Replace inline transition: "all" on RoomNode plus-handles with
  scoped color/border transitions

Anti-patterns:
- Strip backdrop-blur from non-overlay surfaces (SceneInfoBadges,
  AdminMobList, ZoneEditor status badge, Toast). Dialog overlay
  blur retained as the only justified use.
- Replace ad-hoc bg-gradient-to-r buttons in ApiSettingsPanel,
  SketchImportWizard, and StoryBrowser with the canonical
  .action-button-primary class.

Theming:
- Replace hard-coded bg-[rgba(...)] arbitrary values with semantic
  tokens: bg-status-info/15, bg-warm/15, bg-gradient-panel