### PR TITLE
feat(ui): add 4-color theme picker with live preview

### DIFF
--- a/creator/src/components/AppearancePanel.tsx
+++ b/creator/src/components/AppearancePanel.tsx
@@ -1,0 +1,378 @@
+import { useEffect, useMemo, useState } from "react";
+import { useThemeStore } from "@/stores/themeStore";
+import {
+  DEFAULT_THEME,
+  PRESET_THEMES,
+  isValidHex,
+  luminance,
+  normalizeHex,
+  parsePalettePaste,
+  type ThemePalette,
+} from "@/lib/theme";
+
+type Slot = "background" | "surface" | "text" | "accent";
+
+const SLOT_META: { key: Slot; label: string; help: string }[] = [
+  { key: "background", label: "Background", help: "Page and abyss — should be the darkest swatch." },
+  { key: "surface", label: "Surface", help: "Panels, sections, hover states, borders." },
+  { key: "text", label: "Text", help: "Primary text color — should be the lightest swatch." },
+  { key: "accent", label: "Accent", help: "Links, focus rings, glows, active highlights." },
+];
+
+function PresetCard({
+  preset,
+  active,
+  onSelect,
+}: {
+  preset: ThemePalette;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const swatches: Slot[] = ["background", "surface", "text", "accent"];
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`group flex flex-col gap-2 rounded-xl border p-3 text-left transition focus-ring ${
+        active
+          ? "border-accent/60 bg-accent/10"
+          : "border-border-muted bg-bg-secondary/50 hover:border-accent/40 hover:bg-bg-hover/40"
+      }`}
+    >
+      <div className="flex h-12 overflow-hidden rounded-md border border-border-muted">
+        {swatches.map((slot) => (
+          <div
+            key={slot}
+            className="flex-1"
+            style={{ background: preset[slot] }}
+            aria-hidden
+          />
+        ))}
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="font-display text-sm text-text-primary">{preset.name}</span>
+        {active && <span className="text-3xs uppercase tracking-ui text-accent">Active</span>}
+      </div>
+    </button>
+  );
+}
+
+function SlotEditor({
+  slot,
+  value,
+  onChange,
+}: {
+  slot: { key: Slot; label: string; help: string };
+  value: string;
+  onChange: (hex: string) => void;
+}) {
+  const [text, setText] = useState(value);
+  useEffect(() => setText(value), [value]);
+
+  const commit = (raw: string) => {
+    if (isValidHex(raw)) onChange(normalizeHex(raw));
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-border-muted bg-bg-secondary/40 p-3">
+      <div className="flex items-center justify-between">
+        <label className="font-display text-sm text-text-primary">{slot.label}</label>
+        <span className="text-3xs uppercase tracking-ui text-text-muted">
+          L {(luminance(value) * 100).toFixed(0)}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-10 w-12 cursor-pointer rounded-md border border-border-muted bg-bg-primary"
+          aria-label={`${slot.label} color picker`}
+        />
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={() => commit(text)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              commit(text);
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          placeholder="#22293c"
+          className="ornate-input flex-1 font-mono text-xs"
+          spellCheck={false}
+        />
+      </div>
+      <p className="text-2xs text-text-muted">{slot.help}</p>
+    </div>
+  );
+}
+
+function PreviewCard({ palette }: { palette: ThemePalette }) {
+  return (
+    <div
+      className="rounded-2xl border p-5"
+      style={{
+        background: `linear-gradient(160deg, ${palette.surface}, ${palette.background})`,
+        borderColor: palette.surface,
+        color: palette.text,
+      }}
+    >
+      <p
+        className="text-3xs uppercase"
+        style={{ letterSpacing: "0.32em", color: palette.accent, opacity: 0.85 }}
+      >
+        Preview
+      </p>
+      <h3 className="mt-2 font-display text-2xl" style={{ color: palette.text }}>
+        Aurum dusk over the abyss
+      </h3>
+      <p className="mt-2 text-sm leading-6" style={{ color: palette.text, opacity: 0.7 }}>
+        Body text uses the text color at reduced opacity. Accent appears in the link below.
+      </p>
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          className="rounded-full px-4 py-1.5 font-display text-xs"
+          style={{
+            background: palette.accent,
+            color: palette.background,
+            border: `1px solid ${palette.accent}`,
+          }}
+        >
+          Primary action
+        </button>
+        <button
+          type="button"
+          className="rounded-full px-4 py-1.5 text-xs"
+          style={{
+            background: "transparent",
+            color: palette.accent,
+            border: `1px solid ${palette.accent}80`,
+          }}
+        >
+          Secondary
+        </button>
+        <a className="text-xs underline" style={{ color: palette.accent }}>
+          Linked text
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export function AppearancePanel() {
+  const persisted = useThemeStore((s) => s.theme);
+  const setTheme = useThemeStore((s) => s.setTheme);
+  const previewTheme = useThemeStore((s) => s.previewTheme);
+  const cancelPreview = useThemeStore((s) => s.cancelPreview);
+
+  const initial: ThemePalette = persisted ?? DEFAULT_THEME;
+  const [draft, setDraft] = useState<ThemePalette>(initial);
+  const [pasteValue, setPasteValue] = useState("");
+  const [pasteError, setPasteError] = useState<string | null>(null);
+
+  // Live preview as the draft changes.
+  useEffect(() => {
+    previewTheme(draft);
+  }, [draft, previewTheme]);
+
+  // Cancel preview if the panel unmounts without saving.
+  useEffect(() => {
+    return () => {
+      cancelPreview();
+    };
+  }, [cancelPreview]);
+
+  const dirty = useMemo(() => {
+    const baseline = persisted ?? DEFAULT_THEME;
+    return (
+      draft.background !== baseline.background ||
+      draft.surface !== baseline.surface ||
+      draft.text !== baseline.text ||
+      draft.accent !== baseline.accent ||
+      draft.name !== baseline.name
+    );
+  }, [draft, persisted]);
+
+  const luminanceWarning = useMemo(() => {
+    if (luminance(draft.background) > 0.4) {
+      return "Background is quite light — Arcanum is designed for dark themes and panels may look washed out.";
+    }
+    if (luminance(draft.text) < 0.5) {
+      return "Text color is dark — it may be hard to read against the background.";
+    }
+    return null;
+  }, [draft]);
+
+  const updateSlot = (slot: Slot, hex: string) => {
+    setDraft((d) => ({ ...d, name: "Custom", [slot]: hex }));
+  };
+
+  const applyPreset = (preset: ThemePalette) => {
+    setDraft({ ...preset });
+  };
+
+  const handlePaste = () => {
+    setPasteError(null);
+    const parsed = parsePalettePaste(pasteValue);
+    if (!parsed || parsed.length < 4) {
+      setPasteError("Need 4 hex colors. Paste them in any order — sorted by luminance.");
+      return;
+    }
+    // Sort by luminance: darkest → background, lightest → text. Of the middle
+    // two, the more saturated one is the accent.
+    const sorted = [...parsed].sort((a, b) => luminance(a) - luminance(b));
+    const background = sorted[0]!;
+    const text = sorted[3]!;
+    const mid1 = sorted[1]!;
+    const mid2 = sorted[2]!;
+    // Pick the more chromatic of the two mids as accent.
+    const chroma = (hex: string) => {
+      const r = parseInt(hex.slice(1, 3), 16);
+      const g = parseInt(hex.slice(3, 5), 16);
+      const b = parseInt(hex.slice(5, 7), 16);
+      return Math.max(r, g, b) - Math.min(r, g, b);
+    };
+    const [accent, surface] = chroma(mid2) > chroma(mid1) ? [mid2, mid1] : [mid1, mid2];
+    setDraft({ name: "Custom (pasted)", background, surface, text, accent });
+    setPasteValue("");
+  };
+
+  const handleSave = () => {
+    setTheme(draft);
+  };
+
+  const handleReset = () => {
+    setTheme(null);
+    setDraft({ ...DEFAULT_THEME });
+  };
+
+  const handleRevert = () => {
+    setDraft({ ...(persisted ?? DEFAULT_THEME) });
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-6">
+      <header>
+        <p className="text-3xs uppercase tracking-wide-ui text-text-muted">Operations</p>
+        <h2 className="mt-2 font-display text-3xl text-text-primary">Appearance</h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
+          Pick a 4-color palette to retheme the entire app. Background, Surface, Text, and Accent
+          drive every UI surface — semantic colors (status, classes, lore templates) stay fixed.
+        </p>
+      </header>
+
+      <section className="panel-surface rounded-3xl p-5 shadow-section">
+        <h3 className="mb-3 font-display text-lg text-text-primary">Presets</h3>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-3">
+          {PRESET_THEMES.map((p) => (
+            <PresetCard
+              key={p.name}
+              preset={p}
+              active={
+                draft.background === p.background &&
+                draft.surface === p.surface &&
+                draft.text === p.text &&
+                draft.accent === p.accent
+              }
+              onSelect={() => applyPreset(p)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="panel-surface rounded-3xl p-5 shadow-section">
+        <div className="mb-3 flex items-baseline justify-between">
+          <h3 className="font-display text-lg text-text-primary">Custom palette</h3>
+          <span className="text-3xs uppercase tracking-ui text-text-muted">{draft.name}</span>
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {SLOT_META.map((slot) => (
+            <SlotEditor
+              key={slot.key}
+              slot={slot}
+              value={draft[slot.key]}
+              onChange={(hex) => updateSlot(slot.key, hex)}
+            />
+          ))}
+        </div>
+
+        <div className="mt-5 rounded-xl border border-border-muted bg-bg-secondary/40 p-3">
+          <label className="block text-3xs uppercase tracking-ui text-text-muted">
+            Paste a palette
+          </label>
+          <p className="mt-1 text-2xs text-text-muted">
+            Copy 4 hex codes from coolors.co, lospec, or anywhere — order doesn't matter.
+          </p>
+          <div className="mt-2 flex gap-2">
+            <input
+              type="text"
+              value={pasteValue}
+              onChange={(e) => setPasteValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handlePaste();
+              }}
+              placeholder="#22293c #313a56 #dbe3f8 #a897d2"
+              className="ornate-input flex-1 font-mono text-xs"
+              spellCheck={false}
+            />
+            <button
+              type="button"
+              onClick={handlePaste}
+              disabled={!pasteValue.trim()}
+              className="shell-pill rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
+            >
+              Apply
+            </button>
+          </div>
+          {pasteError && (
+            <p className="mt-2 text-2xs text-status-error">{pasteError}</p>
+          )}
+        </div>
+
+        {luminanceWarning && (
+          <p className="mt-4 rounded-md border border-status-warning/30 bg-status-warning/10 p-2 text-2xs text-status-warning">
+            {luminanceWarning}
+          </p>
+        )}
+      </section>
+
+      <section className="panel-surface rounded-3xl p-5 shadow-section">
+        <h3 className="mb-3 font-display text-lg text-text-primary">Live preview</h3>
+        <PreviewCard palette={draft} />
+        <p className="mt-3 text-2xs text-text-muted">
+          The whole app is also previewing your draft right now — save to keep it, or revert.
+        </p>
+      </section>
+
+      <div className="sticky bottom-4 flex items-center justify-end gap-2 rounded-2xl border border-border-muted bg-bg-secondary/80 p-3 backdrop-blur">
+        <button
+          type="button"
+          onClick={handleReset}
+          className="shell-pill rounded-full px-4 py-1.5 text-xs"
+        >
+          Reset to default
+        </button>
+        <button
+          type="button"
+          onClick={handleRevert}
+          disabled={!dirty}
+          className="shell-pill rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
+        >
+          Revert
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!dirty}
+          className="shell-pill-primary rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
+        >
+          Save theme
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/MainArea.tsx
+++ b/creator/src/components/MainArea.tsx
@@ -32,6 +32,7 @@ const PlayerSpriteManager = lazy(() => import("./PlayerSpriteManager").then(m =>
 const Console = lazy(() => import("./Console").then(m => ({ default: m.Console })));
 const AdminDashboard = lazy(() => import("./admin/AdminDashboard").then(m => ({ default: m.AdminDashboard })));
 const TuningWizard = lazy(() => import("./tuning/TuningWizard").then(m => ({ default: m.TuningWizard })));
+const AppearancePanel = lazy(() => import("./AppearancePanel").then(m => ({ default: m.AppearancePanel })));
 
 function LazyFallback() {
   return (
@@ -102,6 +103,7 @@ export function MainArea({ workspace }: { workspace: Workspace }) {
           case "console": content = <Console />; break;
           case "admin": content = <AdminDashboard />; break;
           case "tuningWizard": content = <TuningWizard />; break;
+          case "appearance": content = <AppearancePanel />; break;
           default: content = null;
         }
       } else {

--- a/creator/src/lib/panelRegistry.ts
+++ b/creator/src/lib/panelRegistry.ts
@@ -112,6 +112,7 @@ const LORE_PANELS: PanelDef[] = [
 // ─── Operations panels ──────────────────────────────────────────────
 
 const OPERATIONS_PANELS: PanelDef[] = [
+  { id: "appearance", label: "Appearance", group: "operations", host: "command", kicker: "Operations", title: "Appearance", description: "Theme color palette — pick or paste 4 colors to retheme the app.", maxWidth: "max-w-5xl" },
   { id: "services", label: "Services", group: "operations", host: "config", kicker: "Operations", title: "Services", description: "API keys, image providers, and LLM settings.", maxWidth: "max-w-5xl" },
   { id: "deployment", label: "Deployment", group: "operations", host: "config", kicker: "Operations", title: "Deployment", description: "Export, sync, and deploy your MUD.", maxWidth: "max-w-5xl" },
   { id: "sharedAssets", label: "Shared Assets", group: "operations", host: "config", kicker: "Operations", title: "Shared assets", description: "Global asset keys and image configuration.", maxWidth: "max-w-5xl" },

--- a/creator/src/lib/theme.ts
+++ b/creator/src/lib/theme.ts
@@ -1,0 +1,309 @@
+// ─── Theme system ───────────────────────────────────────────────────
+// 4-color theme palettes derive the full set of CSS custom properties used
+// throughout the app. The user picks (or pastes) Background, Surface, Text,
+// and Accent — everything else is derived from those four anchors.
+//
+// Status colors, class identity colors, lore template colors, diff colors,
+// and chart colors are intentionally NOT themed — they are semantic.
+
+export interface ThemePalette {
+  /** Name shown in the UI. */
+  name: string;
+  /** Darkest color — drives the abyss / page background. */
+  background: string;
+  /** Mid surface — drives panels, sections, hover states, borders. */
+  surface: string;
+  /** Light color — drives primary text. */
+  text: string;
+  /** Saturated pop — drives accent, links, glows, active states. */
+  accent: string;
+}
+
+export const DEFAULT_THEME: ThemePalette = {
+  name: "Arcanum (default)",
+  background: "#22293c",
+  surface: "#313a56",
+  text: "#dbe3f8",
+  accent: "#a897d2",
+};
+
+/** Built-in palettes the user can apply with one click. */
+export const PRESET_THEMES: ThemePalette[] = [
+  DEFAULT_THEME,
+  {
+    name: "Aurum Dusk",
+    background: "#1a1410",
+    surface: "#2e241c",
+    text: "#f0e4d0",
+    accent: "#c8a46a",
+  },
+  {
+    name: "Verdant Hollow",
+    background: "#0f1a14",
+    surface: "#1d2e23",
+    text: "#dbe8d6",
+    accent: "#8da97b",
+  },
+  {
+    name: "Cinder Rose",
+    background: "#1a0f14",
+    surface: "#2c1a23",
+    text: "#f3dde2",
+    accent: "#d68aa0",
+  },
+  {
+    name: "Tidepool",
+    background: "#0c1820",
+    surface: "#162a36",
+    text: "#d6e8f0",
+    accent: "#6fb5c7",
+  },
+  {
+    name: "Lichen",
+    background: "#13181a",
+    surface: "#222b2c",
+    text: "#dde6e2",
+    accent: "#a3c48e",
+  },
+];
+
+// ─── Color math ─────────────────────────────────────────────────────
+
+export interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export function hexToRgb(hex: string): RGB {
+  const m = hex.replace("#", "").trim();
+  const v = m.length === 3 ? m.split("").map((c) => c + c).join("") : m;
+  const n = parseInt(v, 16);
+  return { r: (n >> 16) & 0xff, g: (n >> 8) & 0xff, b: n & 0xff };
+}
+
+export function rgbToHex({ r, g, b }: RGB): string {
+  const c = (x: number) => Math.max(0, Math.min(255, Math.round(x)));
+  return "#" + [c(r), c(g), c(b)].map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+export function rgba(hex: string, alpha: number): string {
+  const { r, g, b } = hexToRgb(hex);
+  return `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${alpha})`;
+}
+
+/** Linearly mix two hex colors. t=0 → a, t=1 → b. */
+export function mix(a: string, b: string, t: number): string {
+  const ra = hexToRgb(a);
+  const rb = hexToRgb(b);
+  return rgbToHex({
+    r: ra.r + (rb.r - ra.r) * t,
+    g: ra.g + (rb.g - ra.g) * t,
+    b: ra.b + (rb.b - ra.b) * t,
+  });
+}
+
+/** Relative luminance (0..1) for a hex color, per WCAG. */
+export function luminance(hex: string): number {
+  const { r, g, b } = hexToRgb(hex);
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+// ─── Derivation ─────────────────────────────────────────────────────
+
+/** Build the full CSS-variable map from a 4-color palette. */
+export function themeToVars(theme: ThemePalette): Record<string, string> {
+  const bg = theme.background;
+  const surface = theme.surface;
+  const text = theme.text;
+  const accent = theme.accent;
+
+  // Background ramp: darker than bg for the abyss, then surface, with lighter
+  // variants mixed toward the surface color.
+  const abyss = mix(bg, "#000000", 0.18);
+  const bgPrimary = bg;
+  const bgSecondary = mix(bg, surface, 0.4);
+  const bgTertiary = surface;
+  const bgElevated = surface;
+  const bgHover = mix(surface, text, 0.08);
+
+  // Borders: from muted (closer to surface) to default (mid) to accent-tinted focus.
+  const borderMuted = mix(surface, text, 0.05);
+  const borderDefault = mix(surface, text, 0.18);
+  const borderFocus = accent;
+
+  // Text ramp: primary is the literal text color, lower tiers mix toward bg.
+  const textPrimary = text;
+  const textSecondary = mix(text, bg, 0.22);
+  const textMuted = mix(text, bg, 0.42);
+
+  // Accent variants.
+  const accentMuted = mix(accent, bg, 0.22);
+  const accentEmphasis = text;
+
+  // Warm: a tonally shifted version of the accent — slightly toward the
+  // complementary warm side. We just use accent-mixed-with-text for a softer
+  // glow band when the accent itself is cool.
+  const warm = accent;
+  const warmPale = mix(accent, text, 0.38);
+  const warmDeep = mix(accent, bg, 0.42);
+
+  // Surface scrims (panel backdrops).
+  const scrim = rgba(bg, 0.72);
+  const scrimLight = rgba(bg, 0.46);
+
+  // Graph backgrounds — keep them tied to bg ramp.
+  const graphBg = mix(bg, "#000000", 0.32);
+  const graphGrid = mix(bg, surface, 0.5);
+  const graphNode = surface;
+  const graphEdge = mix(surface, text, 0.32);
+  const graphEdgeUp = accent;
+
+  return {
+    // ─── Backgrounds ─────────────────────────────────────
+    "--color-bg-abyss": abyss,
+    "--color-bg-primary": bgPrimary,
+    "--color-bg-secondary": bgSecondary,
+    "--color-bg-tertiary": bgTertiary,
+    "--color-bg-elevated": bgElevated,
+    "--color-bg-hover": bgHover,
+
+    // ─── Borders ─────────────────────────────────────────
+    "--color-border-default": borderDefault,
+    "--color-border-muted": borderMuted,
+    "--color-border-focus": borderFocus,
+    "--color-border-active": rgba(accent, 0.35),
+
+    // ─── Text ────────────────────────────────────────────
+    "--color-text-primary": textPrimary,
+    "--color-text-secondary": textSecondary,
+    "--color-text-muted": textMuted,
+    "--color-text-link": accent,
+    "--color-text-dirty": mix(accent, text, 0.3),
+
+    // ─── Accent ──────────────────────────────────────────
+    "--color-accent": accent,
+    "--color-accent-muted": accentMuted,
+    "--color-accent-emphasis": accentEmphasis,
+
+    // ─── Warm (decorative, tracks accent) ────────────────
+    "--color-warm": warm,
+    "--color-warm-pale": warmPale,
+    "--color-warm-deep": warmDeep,
+
+    // ─── Surfaces ────────────────────────────────────────
+    "--color-surface-scrim": scrim,
+    "--color-surface-scrim-light": scrimLight,
+
+    // ─── Graph (zone map) ────────────────────────────────
+    "--color-graph-bg": graphBg,
+    "--color-graph-grid": graphGrid,
+    "--color-graph-node": graphNode,
+    "--color-graph-edge": graphEdge,
+    "--color-graph-edge-up": graphEdgeUp,
+
+    // ─── Derived rgba tokens (the :root block) ───────────
+    "--glow-accent": `0 0 32px ${rgba(accent, 0.28)}`,
+    "--glow-accent-strong": `0 0 48px ${rgba(text, 0.32)}`,
+    "--glow-warm": `0 0 32px ${rgba(warm, 0.32)}`,
+    "--glow-warm-strong": `0 0 48px ${rgba(warmPale, 0.42)}`,
+    "--glow-violet": `0 0 28px ${rgba(accent, 0.24)}`,
+    "--glow-blue": `0 0 24px ${rgba(mix(accent, text, 0.4), 0.22)}`,
+
+    "--border-accent-ring": rgba(accent, 0.45),
+    "--border-accent-subtle": rgba(accent, 0.35),
+    "--border-glow": rgba(text, 0.25),
+    "--border-glow-strong": rgba(text, 0.48),
+
+    "--bg-accent-subtle": rgba(accent, 0.14),
+    "--bg-accent-hover": rgba(accent, 0.2),
+
+    "--bg-active": `linear-gradient(135deg, ${rgba(accent, 0.16)}, ${rgba(mix(accent, text, 0.4), 0.12)})`,
+    "--bg-active-strong": `linear-gradient(135deg, ${rgba(accent, 0.18)}, ${rgba(mix(accent, text, 0.4), 0.14)})`,
+    "--bg-panel": `linear-gradient(160deg, ${rgba(mix(surface, text, 0.05), 0.95)}, ${rgba(bgPrimary, 0.92)})`,
+    "--bg-panel-light": `linear-gradient(160deg, ${rgba(mix(surface, text, 0.08), 0.9)}, ${rgba(mix(bgPrimary, surface, 0.4), 0.92)})`,
+    "--bg-glow-top": `linear-gradient(180deg, ${rgba(accent, 0.18)}, transparent)`,
+    "--graph-minimap-mask": rgba(graphBg, 0.8),
+  };
+}
+
+/** Apply a theme by writing every derived variable onto :root. */
+export function applyTheme(theme: ThemePalette): void {
+  const vars = themeToVars(theme);
+  const root = document.documentElement;
+  for (const [k, v] of Object.entries(vars)) {
+    root.style.setProperty(k, v);
+  }
+}
+
+/** Reset all theme variables (falls back to the @theme block in index.css). */
+export function clearTheme(): void {
+  const root = document.documentElement;
+  for (const k of Object.keys(themeToVars(DEFAULT_THEME))) {
+    root.style.removeProperty(k);
+  }
+}
+
+// ─── Persistence ────────────────────────────────────────────────────
+
+const STORAGE_KEY = "arcanum.theme.v1";
+
+export function loadStoredTheme(): ThemePalette | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ThemePalette>;
+    if (
+      typeof parsed.background === "string" &&
+      typeof parsed.surface === "string" &&
+      typeof parsed.text === "string" &&
+      typeof parsed.accent === "string"
+    ) {
+      return {
+        name: typeof parsed.name === "string" ? parsed.name : "Custom",
+        background: parsed.background,
+        surface: parsed.surface,
+        text: parsed.text,
+        accent: parsed.accent,
+      };
+    }
+  } catch (err) {
+    console.error("Failed to read stored theme:", err);
+  }
+  return null;
+}
+
+export function saveStoredTheme(theme: ThemePalette | null): void {
+  try {
+    if (theme === null) {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(theme));
+    }
+  } catch (err) {
+    console.error("Failed to write stored theme:", err);
+  }
+}
+
+/** Validate a hex color string. */
+export function isValidHex(s: string): boolean {
+  return /^#?[0-9a-fA-F]{6}$/.test(s.trim()) || /^#?[0-9a-fA-F]{3}$/.test(s.trim());
+}
+
+/** Normalize to a #rrggbb 7-char string. */
+export function normalizeHex(s: string): string {
+  const t = s.trim().replace(/^#/, "");
+  const full = t.length === 3 ? t.split("").map((c) => c + c).join("") : t;
+  return "#" + full.toLowerCase();
+}
+
+/** Parse a free-form palette paste (whitespace, commas, newlines) into 4 hexes. */
+export function parsePalettePaste(input: string): string[] | null {
+  const tokens = input.match(/#?[0-9a-fA-F]{6}/g);
+  if (!tokens || tokens.length < 4) return null;
+  return tokens.slice(0, 4).map(normalizeHex);
+}

--- a/creator/src/main.tsx
+++ b/creator/src/main.tsx
@@ -14,6 +14,10 @@ import "@fontsource/jetbrains-mono/500.css";
 
 import { App } from "./App";
 import "./index.css";
+import { bootstrapTheme } from "./stores/themeStore";
+
+// Apply persisted theme before first render to avoid a flash of defaults.
+bootstrapTheme();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/creator/src/stores/themeStore.ts
+++ b/creator/src/stores/themeStore.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+import {
+  DEFAULT_THEME,
+  applyTheme,
+  clearTheme,
+  loadStoredTheme,
+  saveStoredTheme,
+  type ThemePalette,
+} from "@/lib/theme";
+
+interface ThemeStore {
+  /** The currently applied theme. Null means "use index.css defaults". */
+  theme: ThemePalette | null;
+  /** Set and persist a custom theme. Pass null to revert to defaults. */
+  setTheme: (theme: ThemePalette | null) => void;
+  /** Live-preview a theme without persisting it. */
+  previewTheme: (theme: ThemePalette) => void;
+  /** Cancel an in-progress preview and re-apply the persisted theme. */
+  cancelPreview: () => void;
+}
+
+export const useThemeStore = create<ThemeStore>((set, get) => ({
+  theme: null,
+
+  setTheme: (theme) => {
+    if (theme === null) {
+      clearTheme();
+    } else {
+      applyTheme(theme);
+    }
+    saveStoredTheme(theme);
+    set({ theme });
+  },
+
+  previewTheme: (theme) => {
+    applyTheme(theme);
+  },
+
+  cancelPreview: () => {
+    const persisted = get().theme;
+    if (persisted === null) {
+      clearTheme();
+    } else {
+      applyTheme(persisted);
+    }
+  },
+}));
+
+/**
+ * Read the persisted theme from localStorage and apply it. Call once at app
+ * startup before first paint to avoid a flash of the default theme.
+ */
+export function bootstrapTheme(): void {
+  const stored = loadStoredTheme();
+  if (stored) {
+    applyTheme(stored);
+    useThemeStore.setState({ theme: stored });
+  }
+}
+
+export { DEFAULT_THEME };


### PR DESCRIPTION
## Summary
- Adds an **Appearance** panel under Operations with a 4-color theme picker (background, surface, text, accent), 6 built-in presets, and a paste field that accepts any 4 hex codes from palette sites
- Theme derives into ~40 CSS custom properties (bg ramp, text ramp, borders, accent variants, glows, gradients) applied via inline styles on `:root`
- Persisted to `localStorage`, applied pre-paint on app boot, with live preview as you edit and auto-revert if you navigate away unsaved
- Semantic colors (status, class identity, lore templates, charts) intentionally stay fixed

## Test plan
- [ ] Open Worldmaker → Operations → Appearance
- [ ] Click each preset and confirm the whole app rethemes instantly
- [ ] Edit a slot via color picker — chrome updates live
- [ ] Paste `#22293c #313a56 #dbe3f8 #a897d2` and confirm slots assign by luminance
- [ ] Save a theme, reload the app, confirm it persists with no flash
- [ ] Click "Reset to default" and confirm the index.css defaults return
- [ ] Confirm class colors, status colors, and lore template tags do NOT change with the theme