### PR TITLE
feat(ui): full token-system migration + light theme support

### DIFF
--- a/creator/src/components/AbilityStudio.tsx
+++ b/creator/src/components/AbilityStudio.tsx
@@ -98,13 +98,13 @@ const VariantCard = memo(function VariantCard({
       className={`relative h-16 w-16 shrink-0 overflow-hidden rounded-2xl border-2 transition ${
         entry.is_active
           ? "border-accent shadow-[0_0_0_1px_var(--border-accent-ring)]"
-          : "border-white/12 hover:border-[var(--border-glow)]"
+          : "border-[var(--chrome-stroke-strong)] hover:border-[var(--border-glow)]"
       }`}
     >
       {thumbSrc ? (
         <img src={thumbSrc} alt="" loading="lazy" className="h-full w-full object-cover" />
       ) : (
-        <div className="h-full w-full bg-white/6" />
+        <div className="h-full w-full bg-[var(--chrome-highlight)]" />
       )}
     </button>
   );
@@ -575,7 +575,7 @@ export function AbilityStudio() {
   const batchCompleted = batchProgress.done + batchProgress.failed;
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-gradient-panel p-5 shadow-section">
+    <section className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel p-5 shadow-section">
       <div className="mb-5 flex items-center justify-between gap-4">
         <div>
           <h2 className="font-display text-xl text-text-primary">Ability studio</h2>
@@ -593,7 +593,7 @@ export function AbilityStudio() {
           <button
             onClick={handleGenerateTemplate}
             disabled={!hasLlmKey || anyBusy}
-            className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+            className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
           >
             {generatingTemplate ? (
               <span className="flex items-center gap-1.5"><Spinner />Generating template</span>
@@ -611,7 +611,7 @@ export function AbilityStudio() {
           <button
             onClick={handleGenerateAll}
             disabled={!hasImageKey || anyBusy}
-            className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+            className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
           >
             {batchGenerating ? (
               <span className="flex items-center gap-1.5"><Spinner />Generating tab</span>
@@ -622,7 +622,7 @@ export function AbilityStudio() {
 
       {/* Batch progress bar */}
       {batchGenerating && batchProgress.total > 0 && (
-        <div className="mb-5 rounded-2xl border border-white/8 bg-black/12 px-4 py-3">
+        <div className="mb-5 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3">
           <div className="mb-2 flex items-center justify-between text-xs">
             <span className="text-text-secondary">
               {batchCompleted} of {batchProgress.total}
@@ -650,12 +650,12 @@ export function AbilityStudio() {
       )}
 
       {!selectedTarget ? (
-        <div className="rounded-2xl border border-dashed border-white/12 bg-black/12 px-4 py-8 text-sm text-text-muted">
+        <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-fill)] px-4 py-8 text-sm text-text-muted">
           Add abilities or status effects in config to start generating icons.
         </div>
       ) : (
         <div className="grid gap-5 xl:grid-cols-[0.62fr_1.38fr]">
-          <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+          <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
             <div className="mb-3 flex flex-wrap gap-2">
               {tabs.map((tab) => {
                 // Compute per-tab counts for badge
@@ -679,8 +679,8 @@ export function AbilityStudio() {
                       activeTab === tab
                         ? "border-border-active bg-[var(--bg-accent-subtle)] text-text-primary"
                         : tabMissing > 0
-                          ? "border-accent/30 bg-accent/5 text-text-muted hover:bg-white/8"
-                          : "border-white/8 bg-black/10 text-text-muted hover:bg-white/8"
+                          ? "border-accent/30 bg-accent/5 text-text-muted hover:bg-[var(--chrome-highlight-strong)]"
+                          : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-muted hover:bg-[var(--chrome-highlight-strong)]"
                     }`}
                   >
                     {tab === STATUS_TAB ? "Status Effects" : tab === GENERAL_TAB ? "General" : config.classes[tab]?.displayName || tab}
@@ -702,7 +702,7 @@ export function AbilityStudio() {
                       className={`flex items-center gap-3 rounded-2xl border px-3 py-3 text-left transition ${
                         selected
                           ? "border-border-active bg-gradient-active"
-                          : "border-white/8 bg-black/10 hover:bg-white/8"
+                          : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] hover:bg-[var(--chrome-highlight-strong)]"
                       }`}
                     >
                       <span className={`h-2.5 w-2.5 rounded-full ${target.image ? "bg-status-success" : "bg-text-muted/50"}`} />
@@ -719,9 +719,9 @@ export function AbilityStudio() {
 
           <div className="flex flex-col gap-5">
             {/* Preview row — wide horizontal card */}
-            <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+            <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
               <div className="flex gap-5">
-                <div className="flex shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-white/8 bg-gradient-panel p-3" style={{ width: "10rem", height: "10rem" }}>
+                <div className="flex shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-[var(--chrome-stroke)] bg-gradient-panel p-3" style={{ width: "10rem", height: "10rem" }}>
                   {selectedSrc ? (
                     <img src={selectedSrc} alt={selectedTarget.label} className="max-h-full max-w-full rounded-xl object-contain shadow-section" />
                   ) : (
@@ -738,7 +738,7 @@ export function AbilityStudio() {
                       <h3 className="mt-0.5 font-display text-xl text-text-primary">{selectedTarget.label}</h3>
                       <div className="mt-0.5 text-xs text-text-secondary">{selectedTarget.subtitle}</div>
                     </div>
-                    <span className="rounded-full bg-white/8 px-3 py-1 text-2xs uppercase tracking-label text-text-muted">
+                    <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-2xs uppercase tracking-label text-text-muted">
                       {variants.length} variants
                     </span>
                   </div>
@@ -758,7 +758,7 @@ export function AbilityStudio() {
             </div>
 
             {/* Prompt engineering — full width */}
-            <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+            <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
               <div className="mb-3 flex items-center justify-between">
                 <div className="text-2xs uppercase tracking-ui text-text-muted">Prompt engineering</div>
                 {template && (
@@ -776,11 +776,11 @@ export function AbilityStudio() {
                     setPromptGeneratedByLlm(false);
                   }}
                   rows={8}
-                  className="w-full resize-y rounded-2xl border border-white/10 bg-surface-scrim px-4 py-3 font-mono text-xs leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+                  className="w-full resize-y rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim px-4 py-3 font-mono text-xs leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
                   placeholder="Generate an icon prompt..."
                 />
 
-                <div className="rounded-2xl border border-white/8 bg-surface-scrim-light px-4 py-3">
+                <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim-light px-4 py-3">
                   <div className="text-2xs uppercase tracking-ui text-text-muted">Definition context</div>
                   <div className="mt-1.5 max-h-36 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-text-secondary">
                     {selectedTarget.kind === "ability" && selectedTarget.ability
@@ -796,14 +796,14 @@ export function AbilityStudio() {
                 <button
                   onClick={handleGeneratePrompt}
                   disabled={!hasLlmKey || anyBusy}
-                  className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
                 >
                   {generatingPrompt ? <span className="flex items-center gap-1.5"><Spinner />Generating</span> : "Generate prompt"}
                 </button>
                 <button
                   onClick={handleEnhancePrompt}
                   disabled={!hasLlmKey || !promptDraft.trim() || anyBusy}
-                  className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
                 >
                   Enhance prompt
                 </button>
@@ -811,7 +811,7 @@ export function AbilityStudio() {
                   <button
                     onClick={handleFillFromTemplate}
                     disabled={anyBusy}
-                    className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+                    className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
                   >
                     Fill from template
                   </button>
@@ -826,7 +826,7 @@ export function AbilityStudio() {
                 <button
                   onClick={handleImport}
                   disabled={anyBusy}
-                  className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
                 >
                   {importing ? <span className="flex items-center gap-1.5"><Spinner />Importing</span> : "Import image"}
                 </button>

--- a/creator/src/components/AppShell.tsx
+++ b/creator/src/components/AppShell.tsx
@@ -39,19 +39,19 @@ export function AppShell() {
   }, []);
 
   return (
-    <div className="relative flex min-h-screen min-h-dvh flex-col overflow-x-hidden bg-bg-abyss">
+    <div className="relative flex h-screen h-dvh flex-col overflow-hidden bg-bg-abyss">
       <div aria-hidden="true" className="pointer-events-none absolute inset-0">
-        <div className="absolute left-[-10rem] top-[-8rem] h-[34rem] w-[34rem] rounded-full bg-[radial-gradient(circle,rgba(168,151,210,0.14),transparent_68%)] blur-3xl" />
-        <div className="absolute bottom-[-14rem] right-[-12rem] h-[40rem] w-[40rem] rounded-full bg-[radial-gradient(circle,rgba(140,174,201,0.12),transparent_72%)] blur-3xl" />
+        <div className="absolute left-[-10rem] top-[-8rem] h-[34rem] w-[34rem] rounded-full bg-[radial-gradient(circle,rgb(var(--accent-rgb)/0.14),transparent_68%)] blur-3xl" />
+        <div className="absolute bottom-[-14rem] right-[-12rem] h-[40rem] w-[40rem] rounded-full bg-[radial-gradient(circle,rgb(var(--accent-rgb)/0.10),transparent_72%)] blur-3xl" />
       </div>
-      <header><Toolbar workspace={workspace} setWorkspace={setWorkspace} /></header>
-      <div className="relative z-10 flex flex-1 flex-col gap-3 px-4 pb-3 lg:min-h-0 lg:flex-row">
-        <aside className="min-w-0 lg:min-h-0"><Sidebar workspace={workspace} /></aside>
-        <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-3xl border border-white/10 bg-bg-primary shadow-panel">
+      <header className="shrink-0"><Toolbar workspace={workspace} setWorkspace={setWorkspace} /></header>
+      <div className="relative z-10 flex min-h-0 flex-1 flex-col gap-3 px-4 pb-3 lg:flex-row">
+        <Sidebar workspace={workspace} />
+        <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-3xl border border-[var(--chrome-stroke)] bg-bg-primary shadow-panel">
           <MainArea workspace={workspace} />
         </main>
       </div>
-      <footer><StatusBar /></footer>
+      <footer className="shrink-0"><StatusBar /></footer>
       {showPalette && <CommandPalette onClose={() => setShowPalette(false)} />}
       <Suspense>
         {showHelp && <ShortcutsHelp onClose={() => setShowHelp(false)} />}

--- a/creator/src/components/AppearancePanel.tsx
+++ b/creator/src/components/AppearancePanel.tsx
@@ -1,0 +1,378 @@
+import { useEffect, useMemo, useState } from "react";
+import { useThemeStore } from "@/stores/themeStore";
+import {
+  DEFAULT_THEME,
+  PRESET_THEMES,
+  isValidHex,
+  luminance,
+  normalizeHex,
+  parsePalettePaste,
+  type ThemePalette,
+} from "@/lib/theme";
+
+type Slot = "background" | "surface" | "text" | "accent";
+
+const SLOT_META: { key: Slot; label: string; help: string }[] = [
+  { key: "background", label: "Background", help: "Page and abyss — should be the darkest swatch." },
+  { key: "surface", label: "Surface", help: "Panels, sections, hover states, borders." },
+  { key: "text", label: "Text", help: "Primary text color — should be the lightest swatch." },
+  { key: "accent", label: "Accent", help: "Links, focus rings, glows, active highlights." },
+];
+
+function PresetCard({
+  preset,
+  active,
+  onSelect,
+}: {
+  preset: ThemePalette;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const swatches: Slot[] = ["background", "surface", "text", "accent"];
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`group flex flex-col gap-2 rounded-xl border p-3 text-left transition focus-ring ${
+        active
+          ? "border-accent/60 bg-accent/10"
+          : "border-border-muted bg-bg-secondary/50 hover:border-accent/40 hover:bg-bg-hover/40"
+      }`}
+    >
+      <div className="flex h-12 overflow-hidden rounded-md border border-border-muted">
+        {swatches.map((slot) => (
+          <div
+            key={slot}
+            className="flex-1"
+            style={{ background: preset[slot] }}
+            aria-hidden
+          />
+        ))}
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="font-display text-sm text-text-primary">{preset.name}</span>
+        {active && <span className="text-3xs uppercase tracking-ui text-accent">Active</span>}
+      </div>
+    </button>
+  );
+}
+
+function SlotEditor({
+  slot,
+  value,
+  onChange,
+}: {
+  slot: { key: Slot; label: string; help: string };
+  value: string;
+  onChange: (hex: string) => void;
+}) {
+  const [text, setText] = useState(value);
+  useEffect(() => setText(value), [value]);
+
+  const commit = (raw: string) => {
+    if (isValidHex(raw)) onChange(normalizeHex(raw));
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-border-muted bg-bg-secondary/40 p-3">
+      <div className="flex items-center justify-between">
+        <label className="font-display text-sm text-text-primary">{slot.label}</label>
+        <span className="text-3xs uppercase tracking-ui text-text-muted">
+          L {(luminance(value) * 100).toFixed(0)}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-10 w-12 cursor-pointer rounded-md border border-border-muted bg-bg-primary"
+          aria-label={`${slot.label} color picker`}
+        />
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={() => commit(text)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              commit(text);
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          placeholder="#22293c"
+          className="ornate-input flex-1 font-mono text-xs"
+          spellCheck={false}
+        />
+      </div>
+      <p className="text-2xs text-text-muted">{slot.help}</p>
+    </div>
+  );
+}
+
+function PreviewCard({ palette }: { palette: ThemePalette }) {
+  return (
+    <div
+      className="rounded-2xl border p-5"
+      style={{
+        background: `linear-gradient(160deg, ${palette.surface}, ${palette.background})`,
+        borderColor: palette.surface,
+        color: palette.text,
+      }}
+    >
+      <p
+        className="text-3xs uppercase"
+        style={{ letterSpacing: "0.32em", color: palette.accent, opacity: 0.85 }}
+      >
+        Preview
+      </p>
+      <h3 className="mt-2 font-display text-2xl" style={{ color: palette.text }}>
+        Aurum dusk over the abyss
+      </h3>
+      <p className="mt-2 text-sm leading-6" style={{ color: palette.text, opacity: 0.7 }}>
+        Body text uses the text color at reduced opacity. Accent appears in the link below.
+      </p>
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          className="rounded-full px-4 py-1.5 font-display text-xs"
+          style={{
+            background: palette.accent,
+            color: palette.background,
+            border: `1px solid ${palette.accent}`,
+          }}
+        >
+          Primary action
+        </button>
+        <button
+          type="button"
+          className="rounded-full px-4 py-1.5 text-xs"
+          style={{
+            background: "transparent",
+            color: palette.accent,
+            border: `1px solid ${palette.accent}80`,
+          }}
+        >
+          Secondary
+        </button>
+        <a className="text-xs underline" style={{ color: palette.accent }}>
+          Linked text
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export function AppearancePanel() {
+  const persisted = useThemeStore((s) => s.theme);
+  const setTheme = useThemeStore((s) => s.setTheme);
+  const previewTheme = useThemeStore((s) => s.previewTheme);
+  const cancelPreview = useThemeStore((s) => s.cancelPreview);
+
+  const initial: ThemePalette = persisted ?? DEFAULT_THEME;
+  const [draft, setDraft] = useState<ThemePalette>(initial);
+  const [pasteValue, setPasteValue] = useState("");
+  const [pasteError, setPasteError] = useState<string | null>(null);
+
+  // Live preview as the draft changes.
+  useEffect(() => {
+    previewTheme(draft);
+  }, [draft, previewTheme]);
+
+  // Cancel preview if the panel unmounts without saving.
+  useEffect(() => {
+    return () => {
+      cancelPreview();
+    };
+  }, [cancelPreview]);
+
+  const dirty = useMemo(() => {
+    const baseline = persisted ?? DEFAULT_THEME;
+    return (
+      draft.background !== baseline.background ||
+      draft.surface !== baseline.surface ||
+      draft.text !== baseline.text ||
+      draft.accent !== baseline.accent ||
+      draft.name !== baseline.name
+    );
+  }, [draft, persisted]);
+
+  const luminanceWarning = useMemo(() => {
+    if (luminance(draft.background) > 0.4) {
+      return "Background is quite light — Arcanum is designed for dark themes and panels may look washed out.";
+    }
+    if (luminance(draft.text) < 0.5) {
+      return "Text color is dark — it may be hard to read against the background.";
+    }
+    return null;
+  }, [draft]);
+
+  const updateSlot = (slot: Slot, hex: string) => {
+    setDraft((d) => ({ ...d, name: "Custom", [slot]: hex }));
+  };
+
+  const applyPreset = (preset: ThemePalette) => {
+    setDraft({ ...preset });
+  };
+
+  const handlePaste = () => {
+    setPasteError(null);
+    const parsed = parsePalettePaste(pasteValue);
+    if (!parsed || parsed.length < 4) {
+      setPasteError("Need 4 hex colors. Paste them in any order — sorted by luminance.");
+      return;
+    }
+    // Sort by luminance: darkest → background, lightest → text. Of the middle
+    // two, the more saturated one is the accent.
+    const sorted = [...parsed].sort((a, b) => luminance(a) - luminance(b));
+    const background = sorted[0]!;
+    const text = sorted[3]!;
+    const mid1 = sorted[1]!;
+    const mid2 = sorted[2]!;
+    // Pick the more chromatic of the two mids as accent.
+    const chroma = (hex: string) => {
+      const r = parseInt(hex.slice(1, 3), 16);
+      const g = parseInt(hex.slice(3, 5), 16);
+      const b = parseInt(hex.slice(5, 7), 16);
+      return Math.max(r, g, b) - Math.min(r, g, b);
+    };
+    const [accent, surface] = chroma(mid2) > chroma(mid1) ? [mid2, mid1] : [mid1, mid2];
+    setDraft({ name: "Custom (pasted)", background, surface, text, accent });
+    setPasteValue("");
+  };
+
+  const handleSave = () => {
+    setTheme(draft);
+  };
+
+  const handleReset = () => {
+    setTheme(null);
+    setDraft({ ...DEFAULT_THEME });
+  };
+
+  const handleRevert = () => {
+    setDraft({ ...(persisted ?? DEFAULT_THEME) });
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-6">
+      <header>
+        <p className="text-3xs uppercase tracking-wide-ui text-text-muted">Operations</p>
+        <h2 className="mt-2 font-display text-3xl text-text-primary">Appearance</h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
+          Pick a 4-color palette to retheme the entire app. Background, Surface, Text, and Accent
+          drive every UI surface — semantic colors (status, classes, lore templates) stay fixed.
+        </p>
+      </header>
+
+      <section className="panel-surface rounded-3xl p-5 shadow-section">
+        <h3 className="mb-3 font-display text-lg text-text-primary">Presets</h3>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-3">
+          {PRESET_THEMES.map((p) => (
+            <PresetCard
+              key={p.name}
+              preset={p}
+              active={
+                draft.background === p.background &&
+                draft.surface === p.surface &&
+                draft.text === p.text &&
+                draft.accent === p.accent
+              }
+              onSelect={() => applyPreset(p)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="panel-surface rounded-3xl p-5 shadow-section">
+        <div className="mb-3 flex items-baseline justify-between">
+          <h3 className="font-display text-lg text-text-primary">Custom palette</h3>
+          <span className="text-3xs uppercase tracking-ui text-text-muted">{draft.name}</span>
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {SLOT_META.map((slot) => (
+            <SlotEditor
+              key={slot.key}
+              slot={slot}
+              value={draft[slot.key]}
+              onChange={(hex) => updateSlot(slot.key, hex)}
+            />
+          ))}
+        </div>
+
+        <div className="mt-5 rounded-xl border border-border-muted bg-bg-secondary/40 p-3">
+          <label className="block text-3xs uppercase tracking-ui text-text-muted">
+            Paste a palette
+          </label>
+          <p className="mt-1 text-2xs text-text-muted">
+            Copy 4 hex codes from coolors.co, lospec, or anywhere — order doesn't matter.
+          </p>
+          <div className="mt-2 flex gap-2">
+            <input
+              type="text"
+              value={pasteValue}
+              onChange={(e) => setPasteValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handlePaste();
+              }}
+              placeholder="#22293c #313a56 #dbe3f8 #a897d2"
+              className="ornate-input flex-1 font-mono text-xs"
+              spellCheck={false}
+            />
+            <button
+              type="button"
+              onClick={handlePaste}
+              disabled={!pasteValue.trim()}
+              className="shell-pill rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
+            >
+              Apply
+            </button>
+          </div>
+          {pasteError && (
+            <p className="mt-2 text-2xs text-status-error">{pasteError}</p>
+          )}
+        </div>
+
+        {luminanceWarning && (
+          <p className="mt-4 rounded-md border border-status-warning/30 bg-status-warning/10 p-2 text-2xs text-status-warning">
+            {luminanceWarning}
+          </p>
+        )}
+      </section>
+
+      <section className="panel-surface rounded-3xl p-5 shadow-section">
+        <h3 className="mb-3 font-display text-lg text-text-primary">Live preview</h3>
+        <PreviewCard palette={draft} />
+        <p className="mt-3 text-2xs text-text-muted">
+          The whole app is also previewing your draft right now — save to keep it, or revert.
+        </p>
+      </section>
+
+      <div className="sticky bottom-4 flex items-center justify-end gap-2 rounded-2xl border border-border-muted bg-bg-secondary/80 p-3 backdrop-blur">
+        <button
+          type="button"
+          onClick={handleReset}
+          className="shell-pill rounded-full px-4 py-1.5 text-xs"
+        >
+          Reset to default
+        </button>
+        <button
+          type="button"
+          onClick={handleRevert}
+          disabled={!dirty}
+          className="shell-pill rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
+        >
+          Revert
+        </button>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!dirty}
+          className="shell-pill-primary rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
+        >
+          Save theme
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/AssetGallery.tsx
+++ b/creator/src/components/AssetGallery.tsx
@@ -282,7 +282,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0">
       <div ref={trapRef} role="dialog" aria-modal="true" aria-labelledby="gallery-title" className="mx-4 flex max-h-[90vh] w-full max-w-6xl flex-col rounded-3xl border border-border-default bg-bg-secondary shadow-xl">
         <div className="flex shrink-0 items-center justify-between border-b border-border-default px-5 py-3">
           <div className="flex flex-wrap items-center gap-3">
@@ -294,7 +294,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
             <button
               onClick={handleImport}
               disabled={importing}
-              className="rounded-full border border-white/10 bg-black/10 px-3 py-1.5 text-2xs font-medium text-accent transition-colors hover:bg-accent/15 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1.5 text-2xs font-medium text-accent transition-colors hover:bg-accent/15 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {importing ? <span className="flex items-center gap-1.5"><Spinner />Importing</span> : "Import"}
             </button>
@@ -314,7 +314,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                     setSyncResult(result);
                   }}
                   disabled={syncing || unsyncedCount === 0}
-                  className="rounded-full border border-white/10 px-3 py-1.5 text-2xs font-medium transition-colors enabled:bg-accent/15 enabled:text-accent enabled:hover:bg-accent/25 disabled:cursor-not-allowed disabled:text-text-muted disabled:opacity-50"
+                  className="rounded-full border border-[var(--chrome-stroke)] px-3 py-1.5 text-2xs font-medium transition-colors enabled:bg-accent/15 enabled:text-accent enabled:hover:bg-accent/25 disabled:cursor-not-allowed disabled:text-text-muted disabled:opacity-50"
                 >
                   {syncing ? <span className="flex items-center gap-1.5"><Spinner />Syncing</span> : unsyncedCount > 0 ? `Sync ${unsyncedCount} to R2` : "All synced"}
                 </button>
@@ -338,7 +338,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex flex-wrap items-center gap-2">
               <span className="text-2xs uppercase tracking-ui text-text-muted">View</span>
-              <div className="flex gap-1 rounded-full border border-white/10 bg-black/10 p-1">
+              <div className="flex gap-1 rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-1">
                 {(["curated", "all"] as ViewMode[]).map((mode) => (
                   <button
                     key={mode}
@@ -357,7 +357,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
 
             <div className="flex items-center gap-2">
               <span className="text-2xs uppercase tracking-ui text-text-muted">Sort</span>
-              <div className="flex gap-1 rounded-full border border-white/10 bg-black/10 p-1">
+              <div className="flex gap-1 rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-1">
                 {(["newest", "oldest", "type"] as SortKey[]).map((key) => (
                   <button
                     key={key}
@@ -385,7 +385,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                   className={`rounded-full border px-3 py-1 text-2xs transition-colors ${
                     mediaFilter === kind
                       ? "border-border-active bg-gradient-active-strong text-text-primary"
-                      : "border-white/10 bg-black/10 text-text-muted hover:text-text-secondary"
+                      : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-muted hover:text-text-secondary"
                   }`}
                 >
                   {kind}
@@ -404,7 +404,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                   className={`rounded-full border px-3 py-1 text-2xs capitalize transition-colors ${
                     workspaceFilter === ws
                       ? "border-border-active bg-gradient-active-strong text-text-primary"
-                      : "border-white/10 bg-black/10 text-text-muted hover:text-text-secondary"
+                      : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-muted hover:text-text-secondary"
                   }`}
                 >
                   {ws === "all" ? "All assets" : ws}
@@ -419,7 +419,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                   className={`rounded-full border px-3 py-1 text-2xs transition-colors ${
                     typeFilter === "all"
                       ? "border-border-active bg-gradient-active-strong text-text-primary"
-                      : "border-white/10 bg-black/10 text-text-muted hover:text-text-secondary"
+                      : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-muted hover:text-text-secondary"
                   }`}
                 >
                   All types
@@ -431,7 +431,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                     className={`rounded-full border px-3 py-1 text-2xs transition-colors ${
                       typeFilter === type
                         ? "border-border-active bg-gradient-active-strong text-text-primary"
-                        : "border-white/10 bg-black/10 text-text-muted hover:text-text-secondary"
+                        : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-muted hover:text-text-secondary"
                     }`}
                   >
                     {type.replace(/_/g, " ")}
@@ -449,7 +449,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                     className={`rounded-full border px-3 py-1 text-2xs transition-colors ${
                       zoneFilter === "all"
                         ? "border-border-active bg-gradient-active-strong text-text-primary"
-                        : "border-white/10 bg-black/10 text-text-muted hover:text-text-secondary"
+                        : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-muted hover:text-text-secondary"
                     }`}
                   >
                     All zones
@@ -460,7 +460,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                       className={`rounded-full border px-3 py-1 text-2xs transition-colors ${
                         zoneFilter === "__global__"
                           ? "border-border-active bg-gradient-active-strong text-text-primary"
-                          : "border-white/10 bg-black/10 text-text-muted hover:text-text-secondary"
+                          : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-muted hover:text-text-secondary"
                       }`}
                     >
                       Global
@@ -473,7 +473,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                       className={`rounded-full border px-3 py-1 text-2xs transition-colors ${
                         zoneFilter === zone
                           ? "border-border-active bg-gradient-active-strong text-text-primary"
-                          : "border-white/10 bg-black/10 text-text-muted hover:text-text-secondary"
+                          : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-muted hover:text-text-secondary"
                       }`}
                     >
                       {zone.replace(/_/g, " ")}

--- a/creator/src/components/AssetGenerator.tsx
+++ b/creator/src/components/AssetGenerator.tsx
@@ -196,7 +196,7 @@ export function AssetGenerator() {
       widthClassName="max-w-5xl"
       onClose={closeGenerator}
       status={
-        <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs text-text-secondary">
+        <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs text-text-secondary">
           {stage === "compose" ? "Prompt forge" : stage === "generating" ? "Rendering" : "Preview"}
         </span>
       }
@@ -230,7 +230,7 @@ export function AssetGenerator() {
         <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
           <section className="panel-surface-light rounded-3xl p-5">
             <div className="grid gap-5">
-              <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+              <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
                 <p className="text-2xs uppercase tracking-wide-ui text-text-muted">Style system</p>
                 <p className="mt-2 font-display text-base text-text-primary">{ART_STYLE_LABELS[artStyle]}</p>
               </div>
@@ -272,7 +272,7 @@ export function AssetGenerator() {
                         className={`focus-ring rounded-3xl border p-4 text-left transition ${
                           modelId === model.id
                             ? "border-[var(--border-glow-strong)] bg-[linear-gradient(145deg,rgba(168,151,210,0.18),rgba(42,50,71,0.9))] shadow-glow"
-                            : "border-white/8 bg-black/12 hover:border-white/14 hover:bg-white/6"
+                            : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] hover:border-[var(--chrome-stroke-strong)] hover:bg-[var(--chrome-highlight)]"
                         }`}
                       >
                         <input
@@ -362,7 +362,7 @@ export function AssetGenerator() {
               <p>
                 Use asset type to control composition, then add only the details that make this image belong to the world you are building.
               </p>
-              <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+              <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
                 <p className="font-display text-sm text-text-primary">Best results</p>
                 <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-text-secondary">
                   <li>Name atmosphere before decoration.</li>
@@ -376,7 +376,7 @@ export function AssetGenerator() {
       )}
 
       {stage === "generating" && (
-        <div className="relative overflow-hidden rounded-3xl border border-white/8">
+        <div className="relative overflow-hidden rounded-3xl border border-[var(--chrome-stroke)]">
           <img src={loadingVignette} alt="" className="absolute inset-0 h-full w-full object-cover opacity-20" />
           <div className="absolute inset-0 bg-gradient-to-t from-bg-secondary via-bg-secondary/78 to-bg-secondary/55" />
           <div className="relative flex min-h-[24rem] flex-col items-center justify-center gap-5 px-6 py-12 text-center">
@@ -392,14 +392,14 @@ export function AssetGenerator() {
       {stage === "preview" && result && (
         <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]">
           <section className="panel-surface-light rounded-3xl p-5">
-            <div className="overflow-hidden rounded-3xl border border-white/8 bg-black/14">
+            <div className="overflow-hidden rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)]">
               <img src={result.data_url} alt="Generated art" className="w-full" />
             </div>
             <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-text-muted">
-              <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1">
+              <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1">
                 {result.width}x{result.height}
               </span>
-              <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1">
+              <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1">
                 {result.model.split("/").pop()}
               </span>
             </div>

--- a/creator/src/components/BatchLegacyImport.tsx
+++ b/creator/src/components/BatchLegacyImport.tsx
@@ -211,7 +211,7 @@ export function BatchLegacyImport({ onClose }: { onClose: () => void }) {
               <p className="mt-3 text-sm leading-7 text-text-secondary">
                 The importer will inspect the local resources tree, collect images, video, and audio, then prepare them for migration.
               </p>
-              <p className="mt-4 rounded-2xl border border-white/8 bg-black/12 px-4 py-3 font-mono text-xs text-text-muted">
+              <p className="mt-4 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3 font-mono text-xs text-text-muted">
                 {mudDir ? `${mudDir}/src/main/resources/` : "No project directory is available."}
               </p>
               <div className="mt-5">
@@ -235,7 +235,7 @@ export function BatchLegacyImport({ onClose }: { onClose: () => void }) {
             <div className="panel-surface-light rounded-3xl p-5">
               <div className="flex flex-wrap items-center gap-2">
                 <p className="text-2xs uppercase tracking-wide-ui text-text-muted">Asset queue</p>
-                <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs text-text-secondary">
+                <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs text-text-secondary">
                   {targets!.length} candidate{targets!.length !== 1 ? "s" : ""}
                 </span>
               </div>
@@ -251,7 +251,7 @@ export function BatchLegacyImport({ onClose }: { onClose: () => void }) {
                     </span>
                   </div>
                   <div
-                    className="h-3 overflow-hidden rounded-full border border-white/8 bg-black/18"
+                    className="h-3 overflow-hidden rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)]"
                     role="progressbar"
                     aria-valuenow={completedCount}
                     aria-valuemax={targets!.length}
@@ -268,8 +268,8 @@ export function BatchLegacyImport({ onClose }: { onClose: () => void }) {
               {!running && !importFinished && (
                 <div className="mt-4 max-h-72 space-y-2 overflow-y-auto pr-1">
                   {targets!.map((target, index) => (
-                    <div key={index} className="flex items-center gap-3 rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-sm">
-                      <span className="flex h-10 w-10 items-center justify-center rounded-full border border-white/8 bg-white/4 text-2xs text-text-muted">
+                    <div key={index} className="flex items-center gap-3 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3 text-sm">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] text-2xs text-text-muted">
                         {index + 1}
                       </span>
                       <span className="min-w-0 flex-1 truncate font-mono text-text-secondary">
@@ -289,7 +289,7 @@ export function BatchLegacyImport({ onClose }: { onClose: () => void }) {
           )}
 
           {syncStatus && (
-            <div className="rounded-3xl border border-white/8 bg-black/12 px-4 py-3 text-sm text-text-secondary">
+            <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3 text-sm text-text-secondary">
               {syncStatus}
             </div>
           )}
@@ -333,7 +333,7 @@ export function BatchLegacyImport({ onClose }: { onClose: () => void }) {
                   </p>
                   <div className="mt-3 max-h-44 space-y-2 overflow-y-auto pr-1 text-xs text-text-secondary">
                     {migrationReport.errors.map((entry, index) => (
-                      <div key={index} className="rounded-2xl border border-status-error/18 bg-black/10 px-3 py-2">
+                      <div key={index} className="rounded-2xl border border-status-error/18 bg-[var(--chrome-fill)] px-3 py-2">
                         {entry}
                       </div>
                     ))}
@@ -361,7 +361,7 @@ function StepPill({ phase }: { phase: Phase }) {
             : "Complete";
 
   return (
-    <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs text-text-secondary">
+    <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs text-text-secondary">
       {label}
     </span>
   );
@@ -385,7 +385,7 @@ function StageCard({
           ? "border-[var(--border-accent-subtle)] bg-[rgba(168,151,210,0.12)]"
           : active
             ? "border-[var(--border-glow-strong)] bg-[rgba(140,174,201,0.12)]"
-            : "border-white/8 bg-black/12"
+            : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)]"
       }`}
     >
       <p className="font-display text-sm text-text-primary">{title}</p>

--- a/creator/src/components/CustomAssetStudio.tsx
+++ b/creator/src/components/CustomAssetStudio.tsx
@@ -79,13 +79,13 @@ function VariantCard({
       className={`relative h-16 w-16 shrink-0 overflow-hidden rounded-2xl border-2 transition ${
         entry.is_active
           ? "border-accent shadow-[0_0_0_1px_var(--border-accent-ring)]"
-          : "border-white/12 hover:border-[var(--border-glow)]"
+          : "border-[var(--chrome-stroke-strong)] hover:border-[var(--border-glow)]"
       }`}
     >
       {thumbSrc ? (
         <img src={thumbSrc} alt="" loading="lazy" className="h-full w-full object-cover" />
       ) : (
-        <div className="h-full w-full bg-white/6" />
+        <div className="h-full w-full bg-[var(--chrome-highlight)]" />
       )}
     </button>
   );
@@ -342,7 +342,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
   };
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-gradient-panel p-5 shadow-section">
+    <section className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel p-5 shadow-section">
       <div className="mb-4">
         <h2 className="font-display text-xl text-text-primary">Custom asset studio</h2>
         <p className="mt-1 text-sm text-text-secondary">
@@ -359,7 +359,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
                 value={title}
                 onChange={(event) => setTitle(event.target.value)}
                 placeholder="Moonwell loading vignette"
-                className="w-full rounded-2xl border border-white/10 bg-surface-scrim px-4 py-3 text-sm text-text-primary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+                className="w-full rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim px-4 py-3 text-sm text-text-primary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
               />
             </div>
             <div>
@@ -368,7 +368,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
                 value={globalAssetKey}
                 onChange={(event) => setGlobalAssetKey(event.target.value)}
                 placeholder="loading_moonwell"
-                className="w-full rounded-2xl border border-white/10 bg-surface-scrim px-4 py-3 text-sm text-text-primary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+                className="w-full rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim px-4 py-3 text-sm text-text-primary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
               />
             </div>
           </div>
@@ -379,7 +379,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
               <select
                 value={assetType}
                 onChange={(event) => setAssetType(event.target.value as AssetType)}
-                className="w-full rounded-2xl border border-white/10 bg-surface-scrim px-4 py-3 text-sm text-text-primary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+                className="w-full rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim px-4 py-3 text-sm text-text-primary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
               >
                 {CUSTOM_ASSET_TYPES.map((type) => (
                   <option key={type} value={type}>
@@ -393,7 +393,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
               <select
                 value={zoneId}
                 onChange={(event) => setZoneId(event.target.value)}
-                className="w-full rounded-2xl border border-white/10 bg-surface-scrim px-4 py-3 text-sm text-text-primary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+                className="w-full rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim px-4 py-3 text-sm text-text-primary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
               >
                 <option value="">No zone context</option>
                 {zoneOptions.map((zone) => (
@@ -415,12 +415,12 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
               }}
               rows={5}
               placeholder="Describe the asset you want. The generator will translate it into your world's visual style."
-              className="w-full resize-y rounded-2xl border border-white/10 bg-surface-scrim px-4 py-3 text-sm leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+              className="w-full resize-y rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim px-4 py-3 text-sm leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
             />
           </div>
 
           {zoneVibe && (
-            <div className="rounded-2xl border border-white/8 bg-surface-scrim-light px-4 py-3">
+            <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim-light px-4 py-3">
               <div className="text-2xs uppercase tracking-ui text-text-muted">Selected zone vibe</div>
               <div className="mt-2 whitespace-pre-wrap text-xs leading-6 text-text-secondary">{zoneVibe}</div>
             </div>
@@ -435,7 +435,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
                 setPromptGeneratedByLlm(false);
               }}
               rows={10}
-              className="w-full resize-y rounded-2xl border border-white/10 bg-surface-scrim px-4 py-3 font-mono text-xs leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+              className="w-full resize-y rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim px-4 py-3 font-mono text-xs leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
               placeholder="Generate a prompt from your brief..."
             />
           </div>
@@ -444,7 +444,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
             <button
               onClick={handleGeneratePrompt}
               disabled={!hasLlmKey || !description.trim() || generatingPrompt || generatingImage || batchGenerating}
-              className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+              className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
             >
               {generatingPrompt ? <span className="flex items-center gap-1.5"><Spinner />Generating prompt</span> : "Generate prompt"}
             </button>
@@ -458,14 +458,14 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
             <button
               onClick={handleGenerateFour}
               disabled={!hasImageKey || !promptDraft.trim() || generatingPrompt || generatingImage || batchGenerating}
-              className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+              className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
             >
               {batchGenerating ? <span className="flex items-center gap-1.5"><Spinner />Generating 4</span> : "Generate 4"}
             </button>
             <button
               onClick={handleImport}
               disabled={importing || generatingPrompt || generatingImage || batchGenerating}
-              className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+              className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
             >
               {importing ? <span className="flex items-center gap-1.5"><Spinner />Importing</span> : "Import image"}
             </button>
@@ -476,7 +476,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
           )}
         </div>
 
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
           <div className="mb-3 flex items-start justify-between gap-3">
             <div>
               <div className="text-2xs uppercase tracking-ui text-text-muted">Preview</div>
@@ -485,12 +485,12 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
                 {globalAssetKey.trim() ? `images.globalAssets.${slugify(globalAssetKey)}` : "Library-only asset"}
               </div>
             </div>
-            <span className="rounded-full bg-white/8 px-3 py-1 text-2xs uppercase tracking-label text-text-muted">
+            <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-2xs uppercase tracking-label text-text-muted">
               {variants.length} variants
             </span>
           </div>
 
-          <div className="flex min-h-[22rem] items-center justify-center overflow-hidden rounded-2xl border border-white/8 bg-[linear-gradient(180deg,rgba(34,41,60,0.8),rgba(28,34,52,0.88))] p-4">
+          <div className="flex min-h-[22rem] items-center justify-center overflow-hidden rounded-2xl border border-[var(--chrome-stroke)] bg-[linear-gradient(180deg,rgba(34,41,60,0.8),rgba(28,34,52,0.88))] p-4">
             {previewSrc ? (
               <img src={previewSrc} alt={title || "Custom asset"} className="max-h-[30rem] max-w-full rounded-2xl object-contain shadow-section" />
             ) : (
@@ -498,7 +498,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
             )}
           </div>
 
-          <div className="mt-3 rounded-2xl border border-white/8 bg-surface-scrim-light px-4 py-3">
+          <div className="mt-3 rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim-light px-4 py-3">
             <div className="text-2xs uppercase tracking-ui text-text-muted">Registration</div>
             <div className="mt-2 text-xs leading-6 text-text-secondary">
               {globalAssetKey.trim()

--- a/creator/src/components/MainArea.tsx
+++ b/creator/src/components/MainArea.tsx
@@ -12,10 +12,10 @@ class PanelErrorBoundary extends Component<{ children: ReactNode }, { error: Err
       return (
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 p-8">
           <h2 className="font-display text-lg text-status-error">Panel Crashed</h2>
-          <pre className="max-w-2xl overflow-auto rounded-lg border border-status-error/30 bg-black/30 p-4 text-xs text-text-secondary">
+          <pre className="max-w-2xl overflow-auto rounded-lg border border-status-error/30 bg-[var(--chrome-fill-strong)] p-4 text-xs text-text-secondary">
             {this.state.error.message}{"\n"}{this.state.error.stack}
           </pre>
-          <button onClick={() => this.setState({ error: null })} className="rounded-full border border-white/10 px-4 py-2 text-xs text-accent hover:bg-accent/10">
+          <button onClick={() => this.setState({ error: null })} className="rounded-full border border-[var(--chrome-stroke)] px-4 py-2 text-xs text-accent hover:bg-accent/10">
             Try Again
           </button>
         </div>

--- a/creator/src/components/MainArea.tsx
+++ b/creator/src/components/MainArea.tsx
@@ -32,6 +32,7 @@ const PlayerSpriteManager = lazy(() => import("./PlayerSpriteManager").then(m =>
 const Console = lazy(() => import("./Console").then(m => ({ default: m.Console })));
 const AdminDashboard = lazy(() => import("./admin/AdminDashboard").then(m => ({ default: m.AdminDashboard })));
 const TuningWizard = lazy(() => import("./tuning/TuningWizard").then(m => ({ default: m.TuningWizard })));
+const AppearancePanel = lazy(() => import("./AppearancePanel").then(m => ({ default: m.AppearancePanel })));
 
 function LazyFallback() {
   return (
@@ -102,6 +103,7 @@ export function MainArea({ workspace }: { workspace: Workspace }) {
           case "console": content = <Console />; break;
           case "admin": content = <AdminDashboard />; break;
           case "tuningWizard": content = <TuningWizard />; break;
+          case "appearance": content = <AppearancePanel />; break;
           default: content = null;
         }
       } else {

--- a/creator/src/components/MediaStudio.tsx
+++ b/creator/src/components/MediaStudio.tsx
@@ -130,8 +130,8 @@ export function MediaStudio({ zoneId, world, onWorldChange }: MediaStudioProps) 
 
   if (!zoneId || !world) {
     return (
-      <section className="rounded-3xl border border-white/10 bg-gradient-panel p-5 shadow-section">
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-4 py-8 text-sm text-text-muted">
+      <section className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel p-5 shadow-section">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-4 py-8 text-sm text-text-muted">
           Select a zone to shape its music, ambience, and cinematics from the studio.
         </div>
       </section>
@@ -184,7 +184,7 @@ export function MediaStudio({ zoneId, world, onWorldChange }: MediaStudioProps) 
   const roomSlots = MEDIA_SLOTS.filter((s) => s.scope === "room");
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-gradient-panel p-5 shadow-section">
+    <section className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel p-5 shadow-section">
       <div className="mb-5 flex items-center justify-between gap-4">
         <div>
           <p className="text-2xs uppercase tracking-wide-ui text-text-muted">Media studio</p>
@@ -195,7 +195,7 @@ export function MediaStudio({ zoneId, world, onWorldChange }: MediaStudioProps) 
           <select
             value={selectedRoomId ?? ""}
             onChange={(event) => setSelectedRoomId(event.target.value || null)}
-            className="rounded-full border border-white/12 bg-bg-secondary px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active [&>option]:bg-bg-secondary [&>option]:text-text-primary"
+            className="rounded-full border border-[var(--chrome-stroke-strong)] bg-bg-secondary px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active [&>option]:bg-bg-secondary [&>option]:text-text-primary"
           >
             {roomEntries.map(([roomId, room]) => (
               <option key={roomId} value={roomId}>{room.title}</option>
@@ -206,7 +206,7 @@ export function MediaStudio({ zoneId, world, onWorldChange }: MediaStudioProps) 
 
       <div className="grid gap-5 xl:grid-cols-[0.62fr_1.38fr]">
         {/* Slot list */}
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
           <div className="flex flex-col gap-2">
             <div className="mb-1 text-2xs uppercase tracking-ui text-text-muted">Zone</div>
             {zoneSlots.map((slot) => {
@@ -217,7 +217,7 @@ export function MediaStudio({ zoneId, world, onWorldChange }: MediaStudioProps) 
                   key={slot.id}
                   onClick={() => setSelectedSlotId(slot.id)}
                   className={`flex items-center gap-3 rounded-2xl border px-3 py-3 text-left transition ${
-                    selected ? "border-border-active bg-gradient-active" : "border-white/8 bg-black/10 hover:bg-white/8"
+                    selected ? "border-border-active bg-gradient-active" : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] hover:bg-[var(--chrome-highlight-strong)]"
                   }`}
                 >
                   <span className={`h-2.5 w-2.5 rounded-full ${value ? "bg-status-success" : "bg-text-muted/50"}`} />
@@ -242,7 +242,7 @@ export function MediaStudio({ zoneId, world, onWorldChange }: MediaStudioProps) 
                   key={slot.id}
                   onClick={() => setSelectedSlotId(slot.id)}
                   className={`flex items-center gap-3 rounded-2xl border px-3 py-3 text-left transition ${
-                    selected ? "border-border-active bg-gradient-active" : "border-white/8 bg-black/10 hover:bg-white/8"
+                    selected ? "border-border-active bg-gradient-active" : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] hover:bg-[var(--chrome-highlight-strong)]"
                   }`}
                 >
                   <span className={`h-2.5 w-2.5 rounded-full ${value ? "bg-status-success" : "bg-text-muted/50"}`} />
@@ -261,14 +261,14 @@ export function MediaStudio({ zoneId, world, onWorldChange }: MediaStudioProps) 
         {/* Detail panel */}
         <div className="flex flex-col gap-5">
           {/* Assignment card */}
-          <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+          <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
             <div className="flex items-start justify-between gap-4">
               <div>
                 <div className="text-2xs uppercase tracking-ui text-text-muted">{selectedSlot.scope}</div>
                 <h3 className="mt-0.5 font-display text-xl text-text-primary">{selectedSlot.label}</h3>
                 <p className="mt-1 text-xs leading-5 text-text-secondary">{selectedSlot.description}</p>
               </div>
-              <span className="rounded-full bg-white/8 px-3 py-1 text-2xs uppercase tracking-label text-text-muted">
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-2xs uppercase tracking-label text-text-muted">
                 {currentValue ? "Assigned" : "Empty"}
               </span>
             </div>
@@ -301,7 +301,7 @@ export function MediaStudio({ zoneId, world, onWorldChange }: MediaStudioProps) 
 
           {/* Generator card */}
           {selectedSlot.generatorType !== "none" && (
-            <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+            <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
               <div className="mb-3 text-2xs uppercase tracking-ui text-text-muted">
                 {selectedSlot.generatorType === "video" ? "Video generator" : "Audio generator"}
               </div>

--- a/creator/src/components/MudImportWizard.tsx
+++ b/creator/src/components/MudImportWizard.tsx
@@ -310,7 +310,7 @@ export function MudImportWizard({ onClose }: { onClose: () => void }) {
       titleId="mud-import-title"
       title="Import MUD Zone"
       subtitle="Convert DikuMUD / CircleMUD / ROM / SMAUG area files to Ambon format using AI"
-      status={<span className="rounded-full border border-white/10 bg-black/10 px-2.5 py-1 text-2xs text-text-secondary">Step {stepLabel}</span>}
+      status={<span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-2.5 py-1 text-2xs text-text-secondary">Step {stepLabel}</span>}
       widthClassName="max-w-3xl"
       onClose={converting ? undefined : onClose}
       footer={
@@ -401,7 +401,7 @@ export function MudImportWizard({ onClose }: { onClose: () => void }) {
               {files.map((file, idx) => (
                 <label
                   key={file.path}
-                  className="flex items-center gap-3 rounded-lg border border-white/6 px-3 py-2 transition hover:border-white/12 hover:bg-white/3 cursor-pointer"
+                  className="flex items-center gap-3 rounded-lg border border-[var(--chrome-stroke)] px-3 py-2 transition hover:border-[var(--chrome-stroke-strong)] hover:bg-white/3 cursor-pointer"
                 >
                   <input
                     type="checkbox"
@@ -450,7 +450,7 @@ export function MudImportWizard({ onClose }: { onClose: () => void }) {
           </div>
 
           {chunkEstimate && (
-            <div className="rounded-lg border border-white/8 bg-white/3 p-3">
+            <div className="rounded-lg border border-[var(--chrome-stroke)] bg-white/3 p-3">
               <p className="text-xs font-medium text-text-secondary">Conversion Plan</p>
               <div className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-text-muted">
                 {(Object.entries(chunkEstimate.byType) as [MudFileType, number][])
@@ -483,7 +483,7 @@ export function MudImportWizard({ onClose }: { onClose: () => void }) {
               <span>Progress</span>
               <span>{doneChunks + errorChunks} / {totalChunks}</span>
             </div>
-            <div className="h-2 rounded-full bg-white/8 overflow-hidden">
+            <div className="h-2 rounded-full bg-[var(--chrome-highlight-strong)] overflow-hidden">
               <div
                 className="h-full rounded-full bg-accent transition-[width] duration-300"
                 style={{ width: `${totalChunks > 0 ? ((doneChunks + errorChunks) / totalChunks) * 100 : 0}%` }}
@@ -517,7 +517,7 @@ export function MudImportWizard({ onClose }: { onClose: () => void }) {
           </div>
 
           {/* Log */}
-          <div className="max-h-48 overflow-y-auto rounded-lg border border-white/6 bg-black/20 p-3 font-mono text-2xs text-text-muted">
+          <div className="max-h-48 overflow-y-auto rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-strong)] p-3 font-mono text-2xs text-text-muted">
             {conversionLog.map((line, i) => (
               <div key={i}>{line}</div>
             ))}
@@ -547,7 +547,7 @@ export function MudImportWizard({ onClose }: { onClose: () => void }) {
           {/* Stats */}
           <div className="grid grid-cols-4 gap-3">
             {([["Rooms", importResult.stats.rooms], ["Mobs", importResult.stats.mobs], ["Items", importResult.stats.items], ["Shops", importResult.stats.shops]] as const).map(([label, count]) => (
-              <div key={label} className="rounded-lg border border-white/8 bg-white/3 p-3 text-center">
+              <div key={label} className="rounded-lg border border-[var(--chrome-stroke)] bg-white/3 p-3 text-center">
                 <div className="text-lg font-display text-text-primary">{count}</div>
                 <div className="text-2xs text-text-muted">{label}</div>
               </div>
@@ -560,7 +560,7 @@ export function MudImportWizard({ onClose }: { onClose: () => void }) {
               <summary className="cursor-pointer text-xs text-status-warning hover:text-status-warning">
                 {importResult.warnings.length} warning{importResult.warnings.length !== 1 ? "s" : ""} — click to expand
               </summary>
-              <div className="mt-2 max-h-36 overflow-y-auto rounded-lg border border-white/6 bg-black/20 p-3 text-2xs text-text-muted space-y-0.5">
+              <div className="mt-2 max-h-36 overflow-y-auto rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-strong)] p-3 text-2xs text-text-muted space-y-0.5">
                 {importResult.warnings.map((w, i) => (
                   <div key={i}>{w}</div>
                 ))}
@@ -573,7 +573,7 @@ export function MudImportWizard({ onClose }: { onClose: () => void }) {
             <summary className="cursor-pointer text-xs text-text-secondary hover:text-text-primary">
               Preview generated YAML
             </summary>
-            <pre className="mt-2 max-h-64 overflow-auto rounded-lg border border-white/6 bg-black/20 p-3 font-mono text-2xs text-text-muted whitespace-pre-wrap">
+            <pre className="mt-2 max-h-64 overflow-auto rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-strong)] p-3 font-mono text-2xs text-text-muted whitespace-pre-wrap">
               {importResult.yaml}
             </pre>
           </details>

--- a/creator/src/components/NewZoneDialog.tsx
+++ b/creator/src/components/NewZoneDialog.tsx
@@ -217,7 +217,7 @@ export function NewZoneDialog({ onClose }: NewZoneDialogProps) {
   // ─── Render ───────────────────────────────────────────────────────
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0">
       <div
         ref={trapRef}
         role="dialog"

--- a/creator/src/components/PlayerSpriteManager.tsx
+++ b/creator/src/components/PlayerSpriteManager.tsx
@@ -172,7 +172,7 @@ const SpriteThumbnail = memo(function SpriteThumbnail({
   const clickable = onClick && src;
   if (!src) {
     return (
-      <div className={`flex ${size} items-center justify-center rounded-lg border border-dashed border-white/12 bg-white/4 text-2xs text-text-muted`}>
+      <div className={`flex ${size} items-center justify-center rounded-lg border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] text-2xs text-text-muted`}>
         --
       </div>
     );
@@ -229,7 +229,7 @@ function SpriteLightbox({
   return (
     <div
       ref={lightboxTrapRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0"
       onClick={onClose}
     >
       <div
@@ -466,7 +466,7 @@ function RequirementRow({
   onRemove: (index: number) => void;
 }) {
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-white/8 bg-black/12 px-3 py-2">
+    <div className="flex items-center gap-2 rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-2">
       <select
         value={req.type}
         onChange={(e) => onChange(index, emptyRequirement(e.target.value as RequirementType))}
@@ -569,7 +569,7 @@ function VariantRow({
   onClickThumbnail?: () => void;
 }) {
   return (
-    <div className="flex items-start gap-3 rounded-xl border border-white/8 bg-black/12 p-3">
+    <div className="flex items-start gap-3 rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-3">
       <SpriteThumbnail fileName={assetFileName} label={variant.imageId} onClick={onClickThumbnail} />
 
       <div className="flex min-w-0 flex-1 flex-col gap-2">
@@ -908,7 +908,7 @@ function SpriteDetailEditor({
             ))}
           </div>
         ) : (
-          <div className="flex items-center gap-3 rounded-xl border border-white/8 bg-black/12 p-3">
+          <div className="flex items-center gap-3 rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-3">
             <SpriteThumbnail
               fileName={spriteAssetMap.get(id)?.fileName}
               label={id}
@@ -1453,10 +1453,10 @@ export function PlayerSpriteManager() {
               return (
                 <div
                   key={id}
-                  className={`flex w-full items-center gap-2 border-b border-white/5 px-3 py-2.5 text-left text-xs transition ${
+                  className={`flex w-full items-center gap-2 border-b border-[var(--chrome-stroke)] px-3 py-2.5 text-left text-xs transition ${
                     selectedId === id
                       ? "bg-gradient-active text-text-primary"
-                      : "text-text-secondary hover:bg-white/5"
+                      : "text-text-secondary hover:bg-[var(--chrome-highlight)]"
                   }`}
                 >
                   <input
@@ -1479,7 +1479,7 @@ export function PlayerSpriteManager() {
                           {def.requirements.map((req, i) => (
                             <span
                               key={i}
-                              className="rounded-full bg-white/8 px-1.5 py-0.5 text-3xs text-text-muted"
+                              className="rounded-full bg-[var(--chrome-highlight-strong)] px-1.5 py-0.5 text-3xs text-text-muted"
                             >
                               {requirementLabel(req)}
                             </span>

--- a/creator/src/components/PortraitStudio.tsx
+++ b/creator/src/components/PortraitStudio.tsx
@@ -59,10 +59,10 @@ function VariantCard({ entry, assetsDir, onClick }: { entry: AssetEntry; assetsD
     <button
       onClick={onClick}
       className={`relative h-16 w-16 shrink-0 overflow-hidden rounded-2xl border-2 transition ${
-        entry.is_active ? "border-accent shadow-[0_0_0_1px_var(--border-accent-ring)]" : "border-white/12 hover:border-[var(--border-glow)]"
+        entry.is_active ? "border-accent shadow-[0_0_0_1px_var(--border-accent-ring)]" : "border-[var(--chrome-stroke-strong)] hover:border-[var(--border-glow)]"
       }`}
     >
-      {thumbSrc ? <img src={thumbSrc} alt="" loading="lazy" className="h-full w-full object-cover" /> : <div className="h-full w-full bg-white/6" />}
+      {thumbSrc ? <img src={thumbSrc} alt="" loading="lazy" className="h-full w-full object-cover" /> : <div className="h-full w-full bg-[var(--chrome-highlight)]" />}
     </button>
   );
 }
@@ -321,7 +321,7 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
   }
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-gradient-panel p-5 shadow-section">
+    <section className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel p-5 shadow-section">
       <div className="mb-5 flex items-center justify-between gap-4">
         <div>
           <h2 className="font-display text-xl text-text-primary">Portrait studio</h2>
@@ -331,21 +331,21 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
           <button
             onClick={generateTemplateAction}
             disabled={!hasLlmKey || generatingTemplate}
-            className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+            className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
           >
             {generatingTemplate ? <span className="flex items-center gap-1.5"><Spinner />Generating template</span> : template ? "Regenerate template" : "Generate template"}
           </button>
           <button
             onClick={() => handleBatchGenerate("race")}
             disabled={!hasImageKey || batchGenerating !== null}
-            className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+            className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
           >
             {batchGenerating === "race" ? <span className="flex items-center gap-1.5"><Spinner />Generating races</span> : "Generate all races"}
           </button>
           <button
             onClick={() => handleBatchGenerate("class")}
             disabled={!hasImageKey || batchGenerating !== null}
-            className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+            className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
           >
             {batchGenerating === "class" ? <span className="flex items-center gap-1.5"><Spinner />Generating classes</span> : "Generate all classes"}
           </button>
@@ -353,12 +353,12 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
       </div>
 
       {!selectedTarget ? (
-        <div className="rounded-2xl border border-dashed border-white/12 bg-black/12 px-4 py-8 text-sm text-text-muted">
+        <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-fill)] px-4 py-8 text-sm text-text-muted">
           Define races or classes in config to start generating portraits.
         </div>
       ) : (
         <div className="grid gap-5 xl:grid-cols-[0.62fr_1.38fr]">
-          <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+          <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
             <div className="max-h-[44rem] overflow-y-auto pr-1">
               {(["race", "class"] as PortraitKind[]).map((kind) => (
                 <div key={kind} className="mb-4">
@@ -375,7 +375,7 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
                           key={key}
                           onClick={() => setSelectedKey(key)}
                           className={`flex items-center gap-3 rounded-2xl border px-3 py-3 text-left transition ${
-                            selected ? "border-border-active bg-gradient-active" : "border-white/8 bg-black/10 hover:bg-white/8"
+                            selected ? "border-border-active bg-gradient-active" : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] hover:bg-[var(--chrome-highlight-strong)]"
                           }`}
                         >
                           <span className={`h-2.5 w-2.5 rounded-full ${target.image ? "bg-status-success" : "bg-text-muted/50"}`} />
@@ -394,9 +394,9 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
 
           <div className="flex flex-col gap-5">
             {/* Preview row — wide horizontal card */}
-            <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+            <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
               <div className="flex gap-5">
-                <div className="flex shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-white/8 bg-[linear-gradient(180deg,rgba(34,41,60,0.8),rgba(28,34,52,0.88))] p-3" style={{ width: "12rem", height: "16rem" }}>
+                <div className="flex shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-[var(--chrome-stroke)] bg-[linear-gradient(180deg,rgba(34,41,60,0.8),rgba(28,34,52,0.88))] p-3" style={{ width: "12rem", height: "16rem" }}>
                   {selectedSrc ? <img src={selectedSrc} alt={selectedTarget.label} className="max-h-full max-w-full rounded-xl object-contain shadow-section" /> : <div className="text-center text-xs text-text-muted">No portrait yet</div>}
                 </div>
 
@@ -407,7 +407,7 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
                       <h3 className="mt-0.5 font-display text-xl text-text-primary">{selectedTarget.label}</h3>
                       <div className="mt-0.5 text-xs text-text-secondary">{selectedTarget.id}</div>
                     </div>
-                    <span className="rounded-full bg-white/8 px-3 py-1 text-2xs uppercase tracking-label text-text-muted">{variants.length} variants</span>
+                    <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-2xs uppercase tracking-label text-text-muted">{variants.length} variants</span>
                   </div>
 
                   {variants.length > 0 && (
@@ -425,7 +425,7 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
             </div>
 
             {/* Prompt engineering — full width */}
-            <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+            <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
               <div className="mb-3 text-2xs uppercase tracking-ui text-text-muted">Prompt engineering</div>
 
               <div className="grid gap-4 lg:grid-cols-[1fr_1fr]">
@@ -433,18 +433,18 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
                   value={promptDraft}
                   onChange={(event) => setPromptDraft(event.target.value)}
                   rows={8}
-                  className="w-full resize-y rounded-2xl border border-white/10 bg-surface-scrim px-4 py-3 font-mono text-xs leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+                  className="w-full resize-y rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim px-4 py-3 font-mono text-xs leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
                   placeholder="Generate a portrait prompt..."
                 />
 
                 <div className="flex flex-col gap-3">
                   {vibe && (
-                    <div className="rounded-2xl border border-white/8 bg-surface-scrim-light px-4 py-3">
+                    <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim-light px-4 py-3">
                       <div className="text-2xs uppercase tracking-ui text-text-muted">Portrait vibe context</div>
                       <div className="mt-1.5 max-h-24 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-text-secondary">{vibe}</div>
                     </div>
                   )}
-                  <div className="rounded-2xl border border-white/8 bg-surface-scrim-light px-4 py-3">
+                  <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim-light px-4 py-3">
                     <div className="text-2xs uppercase tracking-ui text-text-muted">Portrait context</div>
                     <div className="mt-1.5 max-h-24 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-text-secondary">{selectedTarget.context}</div>
                   </div>
@@ -454,7 +454,7 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
               <div className="mt-4 flex flex-wrap gap-2">
                 <button
                   onClick={handleGeneratePrompt}
-                  className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition hover:bg-white/10"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition hover:bg-[var(--chrome-highlight-strong)]"
                 >
                   Generate prompt
                 </button>

--- a/creator/src/components/RenameZoneDialog.tsx
+++ b/creator/src/components/RenameZoneDialog.tsx
@@ -71,7 +71,7 @@ export function RenameZoneDialog({ zoneId, onClose }: RenameZoneDialogProps) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0">
       <div ref={trapRef} role="dialog" aria-modal="true" aria-labelledby="rename-zone-dialog-title" className="mx-4 w-96 rounded-lg border border-border-default bg-bg-secondary shadow-xl">
         <div className="border-b border-border-default px-5 py-3">
           <h2 id="rename-zone-dialog-title" className="font-display text-sm tracking-wide text-text-primary">

--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -143,7 +143,7 @@ function ZoneTree({
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
           aria-label={expanded ? "Collapse zone" : "Expand zone"}
-          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-2xs text-text-muted transition hover:bg-white/8 hover:text-text-primary"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
         >
           {expanded ? "\u25BE" : "\u25B8"}
         </button>
@@ -152,7 +152,7 @@ function ZoneTree({
           className={`min-w-0 flex-1 rounded-2xl border px-3 py-2 text-left text-sm transition ${
             isActive
               ? "border-border-active bg-gradient-active text-text-primary"
-              : "border-white/8 bg-black/10 text-text-secondary hover:bg-white/8 hover:text-text-primary"
+              : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-secondary hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
           }`}
         >
           <span className="truncate font-medium" title={zoneState.data.zone || zoneId}>{zoneState.data.zone || zoneId}</span>
@@ -161,7 +161,7 @@ function ZoneTree({
         </button>
         <button
           onClick={() => onRename(zoneId)}
-          className="shrink-0 rounded-full border border-white/8 px-2.5 py-1.5 text-2xs text-text-muted opacity-0 transition hover:border-accent/40 hover:text-accent focus:opacity-100 group-hover/zone:opacity-100 group-focus-within/zone:opacity-100"
+          className="shrink-0 rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1.5 text-2xs text-text-muted opacity-0 transition hover:border-accent/40 hover:text-accent focus:opacity-100 group-hover/zone:opacity-100 group-focus-within/zone:opacity-100"
           title="Rename zone"
           aria-label="Rename zone"
         >
@@ -169,7 +169,7 @@ function ZoneTree({
         </button>
         <button
           onClick={() => onDelete(zoneId)}
-          className="shrink-0 rounded-full border border-white/8 px-2.5 py-1.5 text-2xs text-text-muted opacity-0 transition hover:border-status-danger/40 hover:text-status-danger focus:opacity-100 group-hover/zone:opacity-100 group-focus-within/zone:opacity-100"
+          className="shrink-0 rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1.5 text-2xs text-text-muted opacity-0 transition hover:border-status-danger/40 hover:text-status-danger focus:opacity-100 group-hover/zone:opacity-100 group-focus-within/zone:opacity-100"
           title="Delete zone"
           aria-label="Delete zone"
         >
@@ -185,7 +185,7 @@ function ZoneTree({
             if (entries.length === 0 && !cat.addFn) return null;
 
             return (
-              <div key={cat.key} className="border-t border-white/5 pt-2 first:border-t-0 first:pt-0">
+              <div key={cat.key} className="border-t border-[var(--chrome-stroke)] pt-2 first:border-t-0 first:pt-0">
                 <div className="flex items-center gap-2">
                   <span className="font-display font-semibold text-2xs uppercase tracking-label text-text-secondary">
                     {cat.label}
@@ -196,7 +196,7 @@ function ZoneTree({
                   {cat.addFn && (
                     <button
                       onClick={() => handleAdd(cat)}
-                      className="ml-auto rounded-full border border-white/8 px-2 py-1 text-2xs text-text-muted transition hover:bg-white/8 hover:text-text-primary"
+                      className="ml-auto rounded-full border border-[var(--chrome-stroke)] px-2 py-1 text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
                       title={`Add ${cat.label.replace(/s$/, "").toLowerCase()}`}
                       aria-label={`Add ${cat.label.replace(/s$/, "").toLowerCase()}`}
                     >
@@ -268,8 +268,8 @@ function PanelPill({ panel, activeTabId, openTab, compact }: {
         compact ? "px-2 py-1.5 text-3xs" : "px-2.5 py-2 text-2xs"
       } ${
         isActive
-          ? "border-[var(--border-glow-strong)] bg-[linear-gradient(135deg,rgba(168,151,210,0.25),rgba(140,174,201,0.15))] text-text-primary shadow-glow"
-          : "border-white/8 bg-white/[0.04] text-text-muted hover:border-white/14 hover:bg-white/8 hover:text-text-primary"
+          ? "border-[var(--border-glow-strong)] bg-[linear-gradient(135deg,rgb(var(--accent-rgb)/0.25),rgb(var(--accent-rgb)/0.12))] text-text-primary shadow-glow"
+          : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] text-text-muted hover:border-[var(--chrome-stroke-strong)] hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
       }`}
     >
       {panel.label}
@@ -333,7 +333,7 @@ function PanelButtonGrid({
         return (
           <section
             key={group.id}
-            className={`border-t border-white/8 pt-1.5 first:border-t-0 first:pt-0 ${
+            className={`border-t border-[var(--chrome-stroke)] pt-1.5 first:border-t-0 first:pt-0 ${
               isActiveSection ? "border-l-2 border-l-accent/30 pl-1" : ""
             }`}
           >
@@ -342,7 +342,7 @@ function PanelButtonGrid({
               onClick={() => toggleSection(group.id)}
               aria-expanded={!isCollapsed}
               aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${group.label}`}
-              className="mb-1 flex w-full items-center gap-1.5 rounded-md px-1 py-1 transition hover:bg-white/4"
+              className="mb-1 flex w-full items-center gap-1.5 rounded-md px-1 py-1 transition hover:bg-[var(--chrome-highlight)]"
             >
               <svg
                 className={`h-3 w-3 shrink-0 text-text-muted transition-transform duration-150 ${isCollapsed ? "" : "rotate-90"}`}
@@ -364,9 +364,9 @@ function PanelButtonGrid({
                     <div key={subGroup ?? "_"}>
                       {subGroup && (
                         <div className="mb-1 mt-0.5 flex items-center gap-2">
-                          <div className="h-px flex-1 bg-white/6" />
+                          <div className="h-px flex-1 bg-[var(--chrome-highlight)]" />
                           <span className="text-3xs uppercase tracking-label text-text-muted/50">{subGroup}</span>
-                          <div className="h-px flex-1 bg-white/6" />
+                          <div className="h-px flex-1 bg-[var(--chrome-highlight)]" />
                         </div>
                       )}
                       <div className="flex flex-wrap gap-1">
@@ -388,7 +388,7 @@ function PanelButtonGrid({
                       onClick={(e) => { e.stopPropagation(); setExpandedGroups((s) => new Set(s).add(group.id)); }}
                       aria-label={`Show ${hiddenCount} more panels`}
                       aria-expanded={false}
-                      className="rounded-full border border-dashed border-white/10 px-2.5 py-1.5 text-2xs text-text-muted transition hover:border-white/20 hover:text-text-secondary"
+                      className="rounded-full border border-dashed border-[var(--chrome-stroke)] px-2.5 py-1.5 text-2xs text-text-muted transition hover:border-[var(--chrome-stroke-emphasis)] hover:text-text-secondary"
                     >
                       +{hiddenCount} more
                     </button>
@@ -399,7 +399,7 @@ function PanelButtonGrid({
                         e.stopPropagation();
                         setExpandedGroups((s) => { const next = new Set(s); next.delete(group.id); return next; });
                       }}
-                      className="rounded-full border border-dashed border-white/10 px-2.5 py-1.5 text-2xs text-text-muted transition hover:border-white/20 hover:text-text-secondary"
+                      className="rounded-full border border-dashed border-[var(--chrome-stroke)] px-2.5 py-1.5 text-2xs text-text-muted transition hover:border-[var(--chrome-stroke-emphasis)] hover:text-text-secondary"
                     >
                       Less
                     </button>
@@ -470,7 +470,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
   );
 
   return (
-    <aside className="relative flex w-full shrink-0 flex-col overflow-hidden rounded-3xl border border-white/10 bg-gradient-panel shadow-[0_18px_56px_rgba(8,10,18,0.32)] lg:h-full lg:w-[23rem]">
+    <aside className="relative flex min-h-0 w-full shrink-0 flex-col overflow-hidden rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel shadow-panel lg:w-[23rem]">
       <div className="pointer-events-none absolute inset-x-0 top-0 h-48 bg-gradient-glow-top" />
 
       <div className="relative z-10 shrink-0 px-4 pt-4">
@@ -484,7 +484,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
       </div>
 
       <div
-        className="relative z-10 min-h-0 max-h-[22rem] shrink overflow-y-auto border-b border-white/10 px-4 py-4 lg:max-h-[45%]"
+        className="relative z-10 min-h-0 max-h-[22rem] shrink overflow-y-auto border-b border-[var(--chrome-stroke)] px-4 py-4 lg:max-h-[45%]"
         style={{ maskImage: "linear-gradient(to bottom, transparent 0, black 8px, black calc(100% - 16px), transparent 100%)", WebkitMaskImage: "linear-gradient(to bottom, transparent 0, black 8px, black calc(100% - 16px), transparent 100%)" }}
       >
         {workspace === "worldmaker" ? (
@@ -541,7 +541,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
         {isSearching ? (
           <div className="py-2">
             {grouped.size === 0 ? (
-              <p className="rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-6 text-sm text-text-muted">
+              <p className="rounded-2xl border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-6 text-sm text-text-muted">
                 Nothing matches that query across your zones.
               </p>
             ) : (
@@ -562,9 +562,9 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
                             }
                             clearQuery();
                           }}
-                          className="flex w-full items-center gap-2 rounded-2xl border border-white/8 bg-black/10 px-3 py-2 text-left text-xs transition hover:bg-white/8 hover:text-text-primary"
+                          className="flex w-full items-center gap-2 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-2 text-left text-xs transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
                         >
-                          <span className="shrink-0 rounded-full bg-white/8 px-2 py-1 font-mono text-2xs text-text-muted">
+                          <span className="shrink-0 rounded-full bg-[var(--chrome-highlight-strong)] px-2 py-1 font-mono text-2xs text-text-muted">
                             {ENTITY_TYPE_LABELS[entry.entityType]}
                           </span>
                           <span className="truncate" title={entry.displayName}>{entry.displayName}</span>
@@ -590,7 +590,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
               ) : null}
             </div>
             {sortedZones.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-5 text-sm text-text-muted">
+              <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-5 text-sm text-text-muted">
                 {hasProject ? (
                   <>
                     <p className="mb-3 leading-relaxed">
@@ -638,7 +638,7 @@ export function Sidebar({ workspace }: { workspace: Workspace }) {
         )}
       </div>
 
-      <div className="relative z-10 border-t border-white/10 px-4 py-3 text-2xs text-text-muted">
+      <div className="relative z-10 border-t border-[var(--chrome-stroke)] px-4 py-3 text-2xs text-text-muted">
         `Ctrl+K` command palette | `Ctrl+S` commit | `Ctrl+,` tune the instrument
       </div>
 

--- a/creator/src/components/SketchImportWizard.tsx
+++ b/creator/src/components/SketchImportWizard.tsx
@@ -278,7 +278,7 @@ export function SketchImportWizard({ onClose }: SketchImportWizardProps) {
   }, [parseResult, gridBounds]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0">
       <div
         ref={trapRef}
         role="dialog"

--- a/creator/src/components/StatusBar.tsx
+++ b/creator/src/components/StatusBar.tsx
@@ -26,7 +26,7 @@ export function StatusBar() {
           World pulse
         </span>
 
-        <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-text-muted">
+        <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-text-muted">
           {totalZones} zone{totalZones !== 1 ? "s" : ""} loaded
         </span>
 
@@ -83,7 +83,7 @@ export function StatusBar() {
                 ? "border-server-error/20 bg-server-error/15 text-server-error"
                 : adminStatus === "connecting"
                   ? "border-server-starting/20 bg-server-starting/15 text-server-starting"
-                  : "border-white/10 bg-black/10 text-text-muted"
+                  : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-muted"
           }`}
         >
           {adminStatus === "connected"

--- a/creator/src/components/StudioWorkspace.tsx
+++ b/creator/src/components/StudioWorkspace.tsx
@@ -62,7 +62,7 @@ function ZoneSelector({
         className={`focus-ring flex items-center gap-2 rounded-full border px-4 py-2 text-left transition ${
           open
             ? "border-border-active bg-gradient-active"
-            : "border-white/10 bg-white/[0.04] hover:bg-white/7"
+            : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] hover:bg-[var(--chrome-highlight)]"
         }`}
       >
         <span className="text-2xs uppercase tracking-ui text-text-muted">Zone</span>
@@ -78,9 +78,9 @@ function ZoneSelector({
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full z-20 mt-1 w-80 rounded-2xl border border-white/12 bg-bg-secondary shadow-xl">
+        <div className="absolute right-0 top-full z-20 mt-1 w-80 rounded-2xl border border-[var(--chrome-stroke-strong)] bg-bg-secondary shadow-xl">
           {zones.length > 6 && (
-            <div className="border-b border-white/8 px-3 py-2">
+            <div className="border-b border-[var(--chrome-stroke)] px-3 py-2">
               <input
                 autoFocus
                 value={search}
@@ -106,7 +106,7 @@ function ZoneSelector({
                     className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition ${
                       selected
                         ? "bg-gradient-active text-text-primary"
-                        : "text-text-secondary hover:bg-white/6"
+                        : "text-text-secondary hover:bg-[var(--chrome-highlight)]"
                     }`}
                   >
                     <div className="min-w-0 flex-1">
@@ -193,7 +193,7 @@ export function StudioWorkspace({ panelId }: { panelId: string }) {
                   className={`focus-ring rounded-full border px-4 py-2 text-xs font-medium transition ${
                     artSubTab === tab.id
                       ? "border-[var(--border-glow-strong)] bg-[linear-gradient(135deg,rgba(168,151,210,0.25),rgba(140,174,201,0.15))] text-text-primary shadow-glow"
-                      : "border-white/8 bg-white/[0.04] text-text-muted hover:border-white/14 hover:bg-white/8 hover:text-text-primary"
+                      : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] text-text-muted hover:border-[var(--chrome-stroke-strong)] hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
                   }`}
                 >
                   {tab.label}

--- a/creator/src/components/TabBar.tsx
+++ b/creator/src/components/TabBar.tsx
@@ -60,7 +60,7 @@ export function TabBar({ workspace }: { workspace: Workspace }) {
   if (tabs.length === 0) return null;
 
   return (
-    <div className="relative shrink-0 border-b border-white/6 bg-bg-secondary/40 px-3 py-1.5">
+    <div className="relative shrink-0 border-b border-[var(--chrome-stroke)] bg-bg-secondary/40 px-3 py-1.5">
       {hasOverflow && (
         <div className="pointer-events-none absolute right-0 top-0 z-10 h-full w-10 bg-gradient-to-l from-bg-secondary/80 to-transparent" />
       )}
@@ -76,7 +76,7 @@ export function TabBar({ workspace }: { workspace: Workspace }) {
             onClick={closeAllTabs}
             title="Close all tabs"
             aria-label="Close all tabs"
-            className="focus-ring flex shrink-0 items-center rounded-lg px-2 py-1.5 text-text-muted transition hover:bg-white/4 hover:text-text-primary"
+            className="focus-ring flex shrink-0 items-center rounded-lg px-2 py-1.5 text-text-muted transition hover:bg-[var(--chrome-highlight)] hover:text-text-primary"
           >
             <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
               <path d="M3 3l6 6M9 3l-6 6" />
@@ -94,10 +94,10 @@ export function TabBar({ workspace }: { workspace: Workspace }) {
               key={tab.id}
               className={`group flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5 transition ${
                 isActive
-                  ? "bg-white/8 shadow-sm"
+                  ? "bg-[var(--chrome-highlight-strong)] shadow-sm"
                   : inWorkspace
-                    ? "hover:bg-white/4"
-                    : "opacity-40 hover:bg-white/4 hover:opacity-70"
+                    ? "hover:bg-[var(--chrome-highlight)]"
+                    : "opacity-40 hover:bg-[var(--chrome-highlight)] hover:opacity-70"
               }`}
             >
               <button
@@ -136,7 +136,7 @@ export function TabBar({ workspace }: { workspace: Workspace }) {
               </button>
               <button
                 aria-label={`Close ${tab.label}`}
-                className="focus-ring rounded-full p-0.5 text-text-muted opacity-0 transition-opacity hover:bg-white/10 hover:text-text-primary group-hover:opacity-70 group-focus-within:opacity-70"
+                className="focus-ring rounded-full p-0.5 text-text-muted opacity-0 transition-opacity hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary group-hover:opacity-70 group-focus-within:opacity-70"
                 onClick={() => closeTab(tab.id)}
               >
                 <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">

--- a/creator/src/components/TierSpriteScaffold.tsx
+++ b/creator/src/components/TierSpriteScaffold.tsx
@@ -236,7 +236,7 @@ export function TierSpriteScaffold({ onClose, onComplete }: TierSpriteScaffoldPr
 
   if (!config || !gaps) {
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0">
         <div className="rounded-lg border border-border-default bg-bg-secondary p-6 text-sm text-text-secondary">
           No config loaded.
         </div>
@@ -250,7 +250,7 @@ export function TierSpriteScaffold({ onClose, onComplete }: TierSpriteScaffoldPr
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0"
       onClick={phase === "running" ? undefined : onClose}
     >
       <div

--- a/creator/src/components/Toolbar.tsx
+++ b/creator/src/components/Toolbar.tsx
@@ -165,7 +165,7 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
     <>
       <div className="relative z-20 flex shrink-0 items-center px-4 pt-3">
         <div className="instrument-panel relative min-w-0 flex-1 rounded-3xl px-5 py-3">
-          <div className="pointer-events-none absolute right-[-8rem] top-[-6rem] h-[20rem] w-[20rem] rounded-full bg-[radial-gradient(circle,rgba(168,151,210,0.16),transparent_72%)] blur-3xl" />
+          <div className="pointer-events-none absolute right-[-8rem] top-[-6rem] h-[20rem] w-[20rem] rounded-full bg-[radial-gradient(circle,rgb(var(--accent-rgb)/0.16),transparent_72%)] blur-3xl" />
           <div className="relative flex flex-wrap items-center gap-4">
             <div className="mr-auto flex min-w-0 items-center gap-3">
               <div className="min-w-0">
@@ -212,8 +212,8 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                     }}
                     className={`focus-ring rounded-full px-4 py-1.5 font-display text-sm transition ${
                       workspace === entry.id
-                        ? "bg-white/10 text-accent shadow-glow"
-                        : "text-text-secondary hover:bg-white/5 hover:text-text-primary"
+                        ? "bg-[var(--chrome-fill)] text-accent shadow-glow"
+                        : "text-text-secondary hover:bg-[var(--chrome-highlight)] hover:text-text-primary"
                     }`}
                   >
                     {entry.label}
@@ -254,7 +254,7 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                               setShowUtilityMenu(false);
                               handleOpenAdmin();
                             }}
-                            className="focus-ring flex min-h-11 items-center justify-between rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-left text-sm text-text-secondary transition hover:border-white/14 hover:bg-white/6 hover:text-text-primary"
+                            className="chrome-menu-item focus-ring flex min-h-11 items-center justify-between rounded-2xl px-4 py-3 text-left text-sm"
                           >
                             <span>Runtime Admin</span>
                             <span className="text-2xs uppercase tracking-label text-text-muted">
@@ -269,7 +269,7 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                                 handleOpenHandoff();
                               }}
                               disabled={!hasConfig}
-                              className="focus-ring flex min-h-11 items-center rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-left text-sm text-text-secondary transition hover:border-white/14 hover:bg-white/6 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+                              className="chrome-menu-item focus-ring flex min-h-11 items-center rounded-2xl px-4 py-3 text-left text-sm disabled:cursor-not-allowed disabled:opacity-40"
                             >
                               Export Runtime
                             </button>
@@ -297,7 +297,7 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                               setShowUtilityMenu(false);
                             }}
                             disabled={zones.size === 0 && !hasConfig}
-                            className="focus-ring flex min-h-11 items-center rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-left text-sm text-text-secondary transition hover:border-white/14 hover:bg-white/6 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+                            className="chrome-menu-item focus-ring flex min-h-11 items-center rounded-2xl px-4 py-3 text-left text-sm disabled:cursor-not-allowed disabled:opacity-40"
                           >
                             Run Validation
                           </button>
@@ -314,7 +314,7 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                               void handleExportShowcase();
                             }}
                             disabled={!hasLore || exporting}
-                            className="focus-ring flex min-h-11 items-center rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-left text-sm text-text-secondary transition hover:border-white/14 hover:bg-white/6 hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+                            className="chrome-menu-item focus-ring flex min-h-11 items-center rounded-2xl px-4 py-3 text-left text-sm disabled:cursor-not-allowed disabled:opacity-40"
                           >
                             {exporting ? "Publishing Lore..." : "Publish Lore Atlas"}
                           </button>
@@ -324,7 +324,7 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                               setShowUtilityMenu(false);
                               setShowLegacyImport(true);
                             }}
-                            className="focus-ring flex min-h-11 items-center rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-left text-sm text-text-secondary transition hover:border-white/14 hover:bg-white/6 hover:text-text-primary"
+                            className="chrome-menu-item focus-ring flex min-h-11 items-center rounded-2xl px-4 py-3 text-left text-sm"
                           >
                             Restore Legacy Media
                           </button>
@@ -334,7 +334,7 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                               setShowUtilityMenu(false);
                               setShowSketchImport(true);
                             }}
-                            className="focus-ring flex min-h-11 items-center rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-left text-sm text-text-secondary transition hover:border-white/14 hover:bg-white/6 hover:text-text-primary"
+                            className="chrome-menu-item focus-ring flex min-h-11 items-center rounded-2xl px-4 py-3 text-left text-sm"
                           >
                             Import From Sketch
                           </button>
@@ -344,7 +344,7 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                               setShowUtilityMenu(false);
                               setShowMudImport(true);
                             }}
-                            className="focus-ring flex min-h-11 items-center rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-left text-sm text-text-secondary transition hover:border-white/14 hover:bg-white/6 hover:text-text-primary"
+                            className="chrome-menu-item focus-ring flex min-h-11 items-center rounded-2xl px-4 py-3 text-left text-sm"
                           >
                             Import MUD Zone
                           </button>
@@ -354,7 +354,7 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                               setShowUtilityMenu(false);
                               openGallery();
                             }}
-                            className="focus-ring flex min-h-11 items-center rounded-2xl border border-white/8 bg-black/12 px-4 py-3 text-left text-sm text-text-secondary transition hover:border-white/14 hover:bg-white/6 hover:text-text-primary"
+                            className="chrome-menu-item focus-ring flex min-h-11 items-center rounded-2xl px-4 py-3 text-left text-sm"
                           >
                             Browse Asset Gallery
                           </button>
@@ -380,7 +380,7 @@ export function Toolbar({ workspace, setWorkspace }: ToolbarProps) {
                 </ActionButton>
               )}
 
-              <div className="rounded-3xl border border-[var(--border-accent-ring)] bg-[linear-gradient(145deg,rgba(28,34,52,0.94),rgba(18,23,38,0.94))] px-3 py-2 shadow-glow">
+              <div className="rounded-3xl border border-[var(--border-accent-ring)] bg-[linear-gradient(145deg,rgb(var(--surface-rgb)/0.94),rgb(var(--bg-rgb)/0.94))] px-3 py-2 shadow-glow">
                 <p className="text-[9px] uppercase tracking-wide-ui text-text-muted">
                   {saved ? "Session committed" : dirtyCount > 0 || configDirty ? "Unsaved work" : "Session stable"}
                 </p>

--- a/creator/src/components/ValidationPanel.tsx
+++ b/creator/src/components/ValidationPanel.tsx
@@ -19,7 +19,7 @@ export function ValidationPanel() {
   const isClean = totalErrors === 0 && totalWarnings === 0;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0">
       <div ref={trapRef} role="dialog" aria-modal="true" aria-labelledby="validation-dialog-title" className="mx-4 flex max-h-[80vh] w-full max-w-xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border-default px-5 py-3">

--- a/creator/src/components/WelcomeScreen.tsx
+++ b/creator/src/components/WelcomeScreen.tsx
@@ -73,7 +73,7 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
               </p>
             </div>
 
-            <div className="rounded-3xl border border-white/10 bg-[linear-gradient(155deg,rgba(54,63,90,0.9),rgba(37,45,68,0.92))] p-6 shadow-panel">
+            <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[linear-gradient(155deg,rgba(54,63,90,0.9),rgba(37,45,68,0.92))] p-6 shadow-panel">
               <div className="mt-1 flex flex-col gap-4">
                 <button
                   onClick={onNewProject}
@@ -82,10 +82,10 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
                   <div className="font-display text-xl">Create new project</div>
                   <div className="mt-2 text-xs font-normal leading-6 text-text-secondary">Lay down a fresh scaffold, then move directly into worldmaking.</div>
                 </button>
-                <div className="space-y-2 border-t border-white/10 pt-4">
+                <div className="space-y-2 border-t border-[var(--chrome-stroke)] pt-4">
                   <button
                     onClick={handleOpen}
-                    className="flex w-full items-start justify-between gap-4 rounded-2xl px-3 py-3 text-left text-sm font-medium text-text-primary transition hover:bg-white/8"
+                    className="flex w-full items-start justify-between gap-4 rounded-2xl px-3 py-3 text-left text-sm font-medium text-text-primary transition hover:bg-[var(--chrome-highlight-strong)]"
                   >
                     <div>
                       <div>Open existing project</div>
@@ -95,7 +95,7 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
                   </button>
                   <button
                     onClick={() => setShowR2Import(true)}
-                    className="flex w-full items-start justify-between gap-4 rounded-2xl px-3 py-3 text-left text-sm font-medium text-text-primary transition hover:bg-white/8"
+                    className="flex w-full items-start justify-between gap-4 rounded-2xl px-3 py-3 text-left text-sm font-medium text-text-primary transition hover:bg-[var(--chrome-highlight-strong)]"
                   >
                     <div>
                       <div>Import from R2</div>
@@ -108,7 +108,7 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
             </div>
           </div>
 
-          <div className="min-h-0 rounded-3xl border border-white/10 bg-[linear-gradient(155deg,rgba(54,63,90,0.9),rgba(37,45,68,0.92))] p-6 shadow-panel">
+          <div className="min-h-0 rounded-3xl border border-[var(--chrome-stroke)] bg-[linear-gradient(155deg,rgba(54,63,90,0.9),rgba(37,45,68,0.92))] p-6 shadow-panel">
             <div className="mb-5 flex items-center justify-between gap-4">
               <div>
                 <h2 className="font-display text-3xl text-text-primary">Continue where you left off</h2>
@@ -138,7 +138,7 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
                     {recentProjects.slice(1).map((project) => (
                       <li
                         key={project.path}
-                        className="group flex items-center gap-2 rounded-3xl border border-white/8 bg-black/12 px-4 py-3 transition hover:bg-white/8"
+                        className="group flex items-center gap-2 rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3 transition hover:bg-[var(--chrome-highlight-strong)]"
                       >
                         <button
                           onClick={() => handleOpenRecent(project)}
@@ -157,7 +157,7 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
                             e.stopPropagation();
                             handleRemoveRecent(project.path);
                           }}
-                          className="shrink-0 rounded-full border border-white/8 px-2 py-1 text-xs text-text-muted opacity-0 transition hover:border-status-error/40 hover:text-status-error group-hover:opacity-100 focus:opacity-100"
+                          className="shrink-0 rounded-full border border-[var(--chrome-stroke)] px-2 py-1 text-xs text-text-muted opacity-0 transition hover:border-status-error/40 hover:text-status-error group-hover:opacity-100 focus:opacity-100"
                           title="Remove from recent"
                         >
                           Remove
@@ -166,13 +166,13 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
                     ))}
                   </ul>
                 ) : (
-                  <div className="rounded-3xl border border-dashed border-white/10 bg-black/12 px-4 py-6 text-sm leading-7 text-text-muted">
+                  <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-6 text-sm leading-7 text-text-muted">
                     No older worlds are on hand yet. Your latest project is ready above.
                   </div>
                 )}
               </div>
             ) : (
-              <div className="rounded-3xl border border-dashed border-white/10 bg-black/12 px-4 py-8 text-sm leading-7 text-text-muted">
+              <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-8 text-sm leading-7 text-text-muted">
                 Your recent projects will appear here once you start building.
               </div>
             )}

--- a/creator/src/components/admin/AdminAbilityList.tsx
+++ b/creator/src/components/admin/AdminAbilityList.tsx
@@ -4,7 +4,7 @@ import type { AbilityEntry } from "@/types/admin";
 
 const StatRow = memo(function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
       <span className="text-xs text-text-muted">{label}</span>
       <span className="text-xs text-text-primary">{value}</span>
     </div>
@@ -13,7 +13,7 @@ const StatRow = memo(function StatRow({ label, value }: { label: string; value: 
 
 const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-3xl border border-white/10 bg-gradient-panel-light p-4 shadow-section">
+    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
       <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
       {children}
     </div>
@@ -30,7 +30,7 @@ const AbilityRow = memo(function AbilityRow({
   return (
     <button
       onClick={() => onSelect(ability.id)}
-      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+      className="flex w-full items-center gap-3 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
@@ -70,7 +70,7 @@ function AbilityDetail({
       <div className="flex items-center gap-3">
         <button
           onClick={onBack}
-          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+          className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
         >
           &#x2190; Back
         </button>
@@ -129,7 +129,7 @@ export function AdminAbilityList() {
       </div>
 
       {abilities.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-12 text-center">
           <p className="font-display text-base text-text-secondary">No abilities found</p>
           <p className="mt-1 text-sm text-text-muted">
             The server has no abilities registered.

--- a/creator/src/components/admin/AdminAchievementList.tsx
+++ b/creator/src/components/admin/AdminAchievementList.tsx
@@ -4,7 +4,7 @@ import type { AchievementEntry } from "@/types/admin";
 
 const StatRow = memo(function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
       <span className="text-xs text-text-muted">{label}</span>
       <span className="text-xs text-text-primary">{value}</span>
     </div>
@@ -13,7 +13,7 @@ const StatRow = memo(function StatRow({ label, value }: { label: string; value: 
 
 const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-3xl border border-white/10 bg-gradient-panel-light p-4 shadow-section">
+    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
       <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
       {children}
     </div>
@@ -30,7 +30,7 @@ const AchievementRow = memo(function AchievementRow({
   return (
     <button
       onClick={() => onSelect(achievement.id)}
-      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+      className="flex w-full items-center gap-3 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
@@ -41,7 +41,7 @@ const AchievementRow = memo(function AchievementRow({
             {achievement.category}
           </span>
           {achievement.hidden && (
-            <span className="rounded-full bg-black/20 px-2 py-0.5 text-2xs text-text-muted">
+            <span className="rounded-full bg-[var(--chrome-fill-strong)] px-2 py-0.5 text-2xs text-text-muted">
               Hidden
             </span>
           )}
@@ -68,7 +68,7 @@ function AchievementDetail({
       <div className="flex items-center gap-3">
         <button
           onClick={onBack}
-          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+          className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
         >
           &#x2190; Back
         </button>
@@ -79,7 +79,7 @@ function AchievementDetail({
           {achievement.category}
         </span>
         {achievement.hidden && (
-          <span className="rounded-full bg-black/20 px-2 py-0.5 text-2xs text-text-muted">
+          <span className="rounded-full bg-[var(--chrome-fill-strong)] px-2 py-0.5 text-2xs text-text-muted">
             Hidden
           </span>
         )}
@@ -100,7 +100,7 @@ function AchievementDetail({
             {achievement.criteria.map((c, i) => (
               <div
                 key={i}
-                className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3"
+                className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3"
               >
                 <div className="flex items-center gap-2">
                   <span className="rounded-full bg-stellar-blue/12 px-2 py-0.5 text-2xs text-stellar-blue">
@@ -174,7 +174,7 @@ export function AdminAchievementList() {
       </div>
 
       {achievements.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-12 text-center">
           <p className="font-display text-base text-text-secondary">
             No achievements found
           </p>

--- a/creator/src/components/admin/AdminActionsPanel.tsx
+++ b/creator/src/components/admin/AdminActionsPanel.tsx
@@ -5,7 +5,7 @@ export function AdminActionsPanel() {
   return (
     <div className="flex flex-col gap-8">
       <AdminReloadPanel />
-      <div className="h-px bg-white/8" />
+      <div className="h-px bg-[var(--chrome-highlight-strong)]" />
       <AdminBroadcastPanel />
     </div>
   );

--- a/creator/src/components/admin/AdminBroadcastPanel.tsx
+++ b/creator/src/components/admin/AdminBroadcastPanel.tsx
@@ -68,7 +68,7 @@ export function AdminBroadcastPanel() {
           onChange={(e) => setMessage(e.target.value.slice(0, MAX_LENGTH))}
           placeholder="Enter your message to the world..."
           rows={3}
-          className="w-full resize-none rounded-xl border border-white/10 bg-black/15 px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-border-active focus:outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+          className="w-full resize-none rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-border-active focus:outline-none focus-visible:ring-2 focus-visible:ring-border-active"
         />
         <div className="mt-1 text-right text-2xs text-text-muted">
           {message.length}/{MAX_LENGTH}

--- a/creator/src/components/admin/AdminConnectionBar.tsx
+++ b/creator/src/components/admin/AdminConnectionBar.tsx
@@ -42,7 +42,7 @@ export function AdminConnectionBar() {
     <div className={`rounded-3xl border p-4 shadow-section transition-colors duration-500 ${
       isConnected
         ? "border-accent/20 bg-gradient-to-r from-accent/[0.05] via-bg-elevated/80 to-bg-elevated/80"
-        : "border-white/10 bg-gradient-panel-light"
+        : "border-[var(--chrome-stroke)] bg-gradient-panel-light"
     }`}>
       <div className="flex items-center gap-3">
         <div className={`h-2.5 w-2.5 shrink-0 rounded-full ${STATUS_STYLES[connectionStatus]}`} />
@@ -75,7 +75,7 @@ export function AdminConnectionBar() {
             onChange={(e) => setUrl(e.target.value)}
             placeholder="http://localhost:9091"
             disabled={isConnected || isConnecting}
-            className="h-9 w-full rounded-xl border border-white/10 bg-black/15 px-3 text-sm text-text-primary placeholder:text-text-muted focus:border-border-active focus:outline-none focus-visible:ring-2 focus-visible:ring-border-active disabled:opacity-50"
+            className="h-9 w-full rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 text-sm text-text-primary placeholder:text-text-muted focus:border-border-active focus:outline-none focus-visible:ring-2 focus-visible:ring-border-active disabled:opacity-50"
           />
         </div>
 
@@ -91,7 +91,7 @@ export function AdminConnectionBar() {
               onChange={(e) => setToken(e.target.value)}
               placeholder="admin token"
               disabled={isConnected || isConnecting}
-              className="h-9 w-full rounded-xl border border-white/10 bg-black/15 px-3 pr-8 text-sm text-text-primary placeholder:text-text-muted focus:border-border-active focus:outline-none focus-visible:ring-2 focus-visible:ring-border-active disabled:opacity-50"
+              className="h-9 w-full rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 pr-8 text-sm text-text-primary placeholder:text-text-muted focus:border-border-active focus:outline-none focus-visible:ring-2 focus-visible:ring-border-active disabled:opacity-50"
             />
             <button
               type="button"
@@ -108,7 +108,7 @@ export function AdminConnectionBar() {
         {isConnected ? (
           <button
             onClick={handleDisconnect}
-            className="h-9 rounded-xl border border-white/10 bg-black/10 px-4 text-xs font-medium text-text-primary transition hover:bg-white/10 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+            className="h-9 rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 text-xs font-medium text-text-primary transition hover:bg-[var(--chrome-highlight-strong)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
           >
             Disconnect
           </button>

--- a/creator/src/components/admin/AdminDashboard.tsx
+++ b/creator/src/components/admin/AdminDashboard.tsx
@@ -151,8 +151,8 @@ export function AdminDashboard() {
       <div className="relative z-10 min-h-0 flex-1 overflow-y-auto">
         <div id="admin-panel" role="tabpanel" aria-labelledby={`admin-tab-${adminSubView}`} className="mx-auto w-full max-w-5xl px-6 py-4 pb-8">
           {!isConnected ? (
-            <div className="flex flex-col items-center gap-6 rounded-3xl border border-white/8 bg-gradient-panel px-8 py-16 text-center shadow-section">
-              <div className="flex h-14 w-14 items-center justify-center rounded-full border border-white/10 bg-black/20">
+            <div className="flex flex-col items-center gap-6 rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel px-8 py-16 text-center shadow-section">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-strong)]">
                 <div className="h-3 w-3 rounded-full bg-server-stopped" />
               </div>
               <div>
@@ -166,21 +166,21 @@ export function AdminDashboard() {
 
               {/* Setup guidance */}
               <div className="mt-2 grid max-w-lg gap-3 text-left">
-                <div className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3">
+                <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3">
                   <p className="text-2xs uppercase tracking-ui text-text-muted">1. Start the admin server</p>
                   <p className="mt-1 text-xs leading-5 text-text-secondary">
                     Set <span className="font-mono text-stellar-blue">ambonmud.admin.enabled: true</span> and
                     a <span className="font-mono text-stellar-blue">token</span> in your server config.
                   </p>
                 </div>
-                <div className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3">
+                <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3">
                   <p className="text-2xs uppercase tracking-ui text-text-muted">2. Connect from here</p>
                   <p className="mt-1 text-xs leading-5 text-text-secondary">
                     Enter the admin URL (default <span className="font-mono text-text-muted">http://localhost:9091</span>) and
                     the token you configured.
                   </p>
                 </div>
-                <div className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3">
+                <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3">
                   <p className="text-2xs uppercase tracking-ui text-text-muted">3. Observe and reshape</p>
                   <p className="mt-1 text-xs leading-5 text-text-secondary">
                     Monitor players, inspect zones, and hot-reload world data without restarting the server.

--- a/creator/src/components/admin/AdminEffectList.tsx
+++ b/creator/src/components/admin/AdminEffectList.tsx
@@ -4,7 +4,7 @@ import type { EffectEntry } from "@/types/admin";
 
 const StatRow = memo(function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
       <span className="text-xs text-text-muted">{label}</span>
       <span className="text-xs text-text-primary">{value}</span>
     </div>
@@ -13,7 +13,7 @@ const StatRow = memo(function StatRow({ label, value }: { label: string; value: 
 
 const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-3xl border border-white/10 bg-gradient-panel-light p-4 shadow-section">
+    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
       <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
       {children}
     </div>
@@ -30,7 +30,7 @@ const EffectRow = memo(function EffectRow({
   return (
     <button
       onClick={() => onSelect(effect.id)}
-      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+      className="flex w-full items-center gap-3 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
@@ -67,7 +67,7 @@ function EffectDetail({
       <div className="flex items-center gap-3">
         <button
           onClick={onBack}
-          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+          className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
         >
           &#x2190; Back
         </button>
@@ -133,7 +133,7 @@ export function AdminEffectList() {
       </div>
 
       {effects.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-12 text-center">
           <p className="font-display text-base text-text-secondary">No effects found</p>
           <p className="mt-1 text-sm text-text-muted">
             The server has no status effects registered.

--- a/creator/src/components/admin/AdminItemList.tsx
+++ b/creator/src/components/admin/AdminItemList.tsx
@@ -4,7 +4,7 @@ import type { ItemEntry } from "@/types/admin";
 
 const ItemRow = memo(function ItemRow({ item }: { item: ItemEntry }) {
   return (
-    <div className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 transition-colors duration-200">
+    <div className="flex w-full items-center gap-3 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3 transition-colors duration-200">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="truncate font-display text-sm text-text-primary">
@@ -64,7 +64,7 @@ export function AdminItemList() {
       </div>
 
       {items.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-12 text-center">
           <p className="font-display text-base text-text-secondary">No items found</p>
           <p className="mt-1 text-sm text-text-muted">
             The server has no items registered.

--- a/creator/src/components/admin/AdminMobDetail.tsx
+++ b/creator/src/components/admin/AdminMobDetail.tsx
@@ -3,7 +3,7 @@ import { useAdminStore } from "@/stores/adminStore";
 
 const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-3xl border border-white/10 bg-gradient-panel-light p-4 shadow-section">
+    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
       <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
       {children}
     </div>
@@ -12,7 +12,7 @@ const Section = memo(function Section({ title, children }: { title: string; chil
 
 const StatRow = memo(function StatRow({ label, value, valueClass }: { label: string; value: string | number; valueClass?: string }) {
   return (
-    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
       <span className="text-xs capitalize text-text-muted">{label}</span>
       <span className={`text-xs ${valueClass ?? "text-text-primary"}`}>{value}</span>
     </div>
@@ -34,11 +34,11 @@ const VitalBar = memo(function VitalBar({
 }) {
   const pct = max > 0 ? Math.round((current / max) * 100) : 0;
   return (
-    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
       <span className="text-xs text-text-muted">{label}</span>
       <div className="flex items-center gap-2">
         <div
-          className="h-1.5 w-14 overflow-hidden rounded-full bg-white/10"
+          className="h-1.5 w-14 overflow-hidden rounded-full bg-[var(--chrome-highlight-strong)]"
           role="progressbar"
           aria-valuenow={current}
           aria-valuemin={0}
@@ -70,7 +70,7 @@ export function AdminMobDetail() {
       <div className="flex items-center gap-3">
         <button
           onClick={clearSelectedMob}
-          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+          className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
         >
           &#x2190; Back
         </button>

--- a/creator/src/components/admin/AdminMobList.tsx
+++ b/creator/src/components/admin/AdminMobList.tsx
@@ -10,7 +10,7 @@ const HpBar = memo(function HpBar({ hp, maxHp }: { hp: number; maxHp: number }) 
   return (
     <div className="flex items-center gap-2">
       <div
-        className="h-1.5 w-16 overflow-hidden rounded-full bg-white/10"
+        className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--chrome-highlight-strong)]"
         role="progressbar"
         aria-valuenow={hp}
         aria-valuemin={0}
@@ -36,7 +36,7 @@ const MobRow = memo(function MobRow({
   return (
     <button
       onClick={() => onSelect(mob.id)}
-      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+      className="flex w-full items-center gap-3 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
@@ -88,7 +88,7 @@ export function AdminMobList() {
             <select
               value={zoneFilter}
               onChange={(e) => setZoneFilter(e.target.value)}
-              className="rounded-full border border-white/10 bg-black/40 px-3 py-1.5 text-xs text-text-secondary transition focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+              className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-strong)] px-3 py-1.5 text-xs text-text-secondary transition focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
               aria-label="Filter by zone"
             >
               <option value="">All zones</option>
@@ -106,7 +106,7 @@ export function AdminMobList() {
       </div>
 
       {filteredMobs.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-12 text-center">
           <p className="font-display text-base text-text-secondary">No creatures stir</p>
           <p className="mt-1 text-sm text-text-muted">
             {zoneFilter

--- a/creator/src/components/admin/AdminPlayerDetail.tsx
+++ b/creator/src/components/admin/AdminPlayerDetail.tsx
@@ -4,7 +4,7 @@ import type { PlayerDetail } from "@/types/admin";
 
 const StatRow = memo(function StatRow({ label, value, valueClass }: { label: string; value: string | number; valueClass?: string }) {
   return (
-    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
       <span className="text-xs capitalize text-text-muted">{label}</span>
       <span className={`text-xs ${valueClass ?? "text-text-primary"}`}>{value}</span>
     </div>
@@ -26,11 +26,11 @@ const VitalBar = memo(function VitalBar({
 }) {
   const pct = max > 0 ? Math.round((current / max) * 100) : 0;
   return (
-    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
       <span className="text-xs text-text-muted">{label}</span>
       <div className="flex items-center gap-2">
         <div
-          className="h-1.5 w-14 overflow-hidden rounded-full bg-white/10"
+          className="h-1.5 w-14 overflow-hidden rounded-full bg-[var(--chrome-highlight-strong)]"
           role="progressbar"
           aria-valuenow={current}
           aria-valuemin={0}
@@ -49,7 +49,7 @@ const VitalBar = memo(function VitalBar({
 
 const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-3xl border border-white/10 bg-gradient-panel-light p-4 shadow-section">
+    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
       <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
       {children}
     </div>
@@ -71,7 +71,7 @@ export function AdminPlayerDetail({
       <div className="flex items-center gap-3">
         <button
           onClick={onBack}
-          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+          className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
         >
           &#x2190; Back
         </button>
@@ -88,7 +88,7 @@ export function AdminPlayerDetail({
           className={`ml-auto rounded-full px-2.5 py-0.5 text-2xs ${
             player.isOnline
               ? "bg-status-success/15 text-status-success"
-              : "bg-black/10 text-text-muted"
+              : "bg-[var(--chrome-fill)] text-text-muted"
           }`}
         >
           {player.isOnline ? "Online" : "Offline"}
@@ -241,7 +241,7 @@ function StaffToggleSection({ playerName, isStaff }: { playerName: string; isSta
                 ? "border-status-warning/50 bg-status-warning/15 text-status-warning"
                 : isStaff
                   ? "border-status-error/30 bg-status-error/10 text-status-error hover:bg-status-error/20"
-                  : "border-white/10 bg-black/10 text-text-primary hover:bg-white/10"
+                  : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-primary hover:bg-[var(--chrome-highlight-strong)]"
             }`}
           >
             {loading ? "..." : confirming ? "Confirm" : isStaff ? "Revoke staff" : "Grant staff"}

--- a/creator/src/components/admin/AdminPlayerList.tsx
+++ b/creator/src/components/admin/AdminPlayerList.tsx
@@ -11,7 +11,7 @@ function HpBar({ hp, maxHp }: { hp: number; maxHp: number }) {
   return (
     <div className="flex items-center gap-2">
       <div
-        className="h-1.5 w-16 overflow-hidden rounded-full bg-white/10"
+        className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--chrome-highlight-strong)]"
         role="progressbar"
         aria-valuenow={hp}
         aria-valuemin={0}
@@ -37,7 +37,7 @@ function PlayerRow({
   return (
     <button
       onClick={() => onSelect(player.name)}
-      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+      className="flex w-full items-center gap-3 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
@@ -113,12 +113,12 @@ export function AdminPlayerList() {
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search by name (online or offline)..."
-          className="h-9 min-w-0 flex-1 rounded-xl border border-white/10 bg-black/15 px-3 text-sm text-text-primary placeholder:text-text-muted focus:border-border-active focus:outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+          className="h-9 min-w-0 flex-1 rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 text-sm text-text-primary placeholder:text-text-muted focus:border-border-active focus:outline-none focus-visible:ring-2 focus-visible:ring-border-active"
         />
         <button
           type="submit"
           disabled={!searchQuery.trim()}
-          className="h-9 rounded-xl border border-white/10 bg-black/10 px-4 text-xs font-medium text-text-primary transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+          className="h-9 rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 text-xs font-medium text-text-primary transition hover:bg-[var(--chrome-highlight-strong)] disabled:cursor-not-allowed disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
         >
           Search
         </button>
@@ -128,7 +128,7 @@ export function AdminPlayerList() {
       )}
 
       {players.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-12 text-center">
           <p className="font-display text-base text-text-secondary">The world is still</p>
           <p className="mt-1 text-sm text-text-muted">No souls walk the land at this moment. Use search to find offline players.</p>
         </div>

--- a/creator/src/components/admin/AdminQuestList.tsx
+++ b/creator/src/components/admin/AdminQuestList.tsx
@@ -4,7 +4,7 @@ import type { QuestEntry } from "@/types/admin";
 
 const StatRow = memo(function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
       <span className="text-xs text-text-muted">{label}</span>
       <span className="text-xs text-text-primary">{value}</span>
     </div>
@@ -13,7 +13,7 @@ const StatRow = memo(function StatRow({ label, value }: { label: string; value: 
 
 const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-3xl border border-white/10 bg-gradient-panel-light p-4 shadow-section">
+    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
       <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
       {children}
     </div>
@@ -30,7 +30,7 @@ const QuestRow = memo(function QuestRow({
   return (
     <button
       onClick={() => onSelect(quest.id)}
-      className="flex w-full items-center gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+      className="flex w-full items-center gap-3 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
@@ -68,7 +68,7 @@ function QuestDetail({
       <div className="flex items-center gap-3">
         <button
           onClick={onBack}
-          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+          className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
         >
           &#x2190; Back
         </button>
@@ -90,7 +90,7 @@ function QuestDetail({
             {quest.objectives.map((obj, i) => (
               <div
                 key={i}
-                className="rounded-2xl border border-white/8 bg-white/[0.03] px-4 py-3"
+                className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-3"
               >
                 <div className="flex items-center gap-2">
                   <span className="rounded-full bg-stellar-blue/12 px-2 py-0.5 text-2xs text-stellar-blue">
@@ -158,7 +158,7 @@ export function AdminQuestList() {
       </div>
 
       {quests.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-12 text-center">
           <p className="font-display text-base text-text-secondary">No quests found</p>
           <p className="mt-1 text-sm text-text-muted">
             The server has no quests registered.

--- a/creator/src/components/admin/AdminReloadPanel.tsx
+++ b/creator/src/components/admin/AdminReloadPanel.tsx
@@ -86,7 +86,7 @@ export function AdminReloadPanel() {
             className={`rounded-2xl border px-4 py-3 text-left transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none ${
               selectedTarget === t.id
                 ? "border-border-active bg-gradient-active-strong shadow-sm shadow-accent/10"
-                : "border-white/8 bg-white/4 hover:border-white/15 hover:bg-white/7"
+                : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] hover:border-[var(--chrome-stroke-strong)] hover:bg-[var(--chrome-highlight)]"
             }`}
           >
             <div className="font-display text-sm text-text-primary">{t.label}</div>

--- a/creator/src/components/admin/AdminRoomDetail.tsx
+++ b/creator/src/components/admin/AdminRoomDetail.tsx
@@ -3,7 +3,7 @@ import { useAdminStore } from "@/stores/adminStore";
 
 const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-3xl border border-white/10 bg-gradient-panel-light p-4 shadow-section">
+    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
       <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
       {children}
     </div>
@@ -12,7 +12,7 @@ const Section = memo(function Section({ title, children }: { title: string; chil
 
 const StatRow = memo(function StatRow({ label, value, valueClass }: { label: string; value: string | number; valueClass?: string }) {
   return (
-    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
       <span className="text-xs capitalize text-text-muted">{label}</span>
       <span className={`text-xs ${valueClass ?? "text-text-primary"}`}>{value}</span>
     </div>
@@ -24,11 +24,11 @@ const HpBar = memo(function HpBar({ label, current, max }: { label: string; curr
   const pct = Math.round((current / max) * 100);
   const color = pct > 60 ? "bg-status-success" : pct > 25 ? "bg-status-warning" : "bg-status-error";
   return (
-    <div className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0">
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
       <span className="text-xs text-text-muted">{label}</span>
       <div className="flex items-center gap-2">
         <div
-          className="h-1.5 w-16 overflow-hidden rounded-full bg-white/10"
+          className="h-1.5 w-16 overflow-hidden rounded-full bg-[var(--chrome-highlight-strong)]"
           role="progressbar"
           aria-valuenow={current}
           aria-valuemin={0}
@@ -60,7 +60,7 @@ export function AdminRoomDetail() {
       <div className="flex items-center gap-3">
         <button
           onClick={clearSelectedRoom}
-          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+          className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
         >
           &#x2190; Back
         </button>
@@ -69,7 +69,7 @@ export function AdminRoomDetail() {
           <p className="mt-0.5 font-mono text-2xs text-text-muted">{room.id}</p>
         </div>
         {hasCoords && (
-          <span className="shrink-0 rounded-full bg-black/15 px-2.5 py-0.5 font-mono text-2xs text-text-muted">
+          <span className="shrink-0 rounded-full bg-[var(--chrome-fill)] px-2.5 py-0.5 font-mono text-2xs text-text-muted">
             ({room.mapX}, {room.mapY})
           </span>
         )}
@@ -77,7 +77,7 @@ export function AdminRoomDetail() {
 
       {/* Description */}
       {room.description && (
-        <div className="rounded-3xl border border-white/10 bg-gradient-panel-light p-4 shadow-section">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
           <p className="text-sm leading-6 text-text-secondary">{room.description}</p>
         </div>
       )}
@@ -90,7 +90,7 @@ export function AdminRoomDetail() {
               {room.exits.map((exit) => (
                 <div
                   key={exit.direction}
-                  className="flex items-center justify-between border-b border-white/6 py-2 last:border-b-0"
+                  className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0"
                 >
                   <span className="text-xs font-medium text-stellar-blue">{exit.direction}</span>
                   <span className="font-mono text-xs text-text-secondary">{exit.target}</span>
@@ -147,7 +147,7 @@ export function AdminRoomDetail() {
             {room.features.map((feature) => (
               <span
                 key={feature}
-                className="rounded-full bg-black/15 px-2.5 py-1 text-2xs text-text-muted"
+                className="rounded-full bg-[var(--chrome-fill)] px-2.5 py-1 text-2xs text-text-muted"
               >
                 {feature}
               </span>

--- a/creator/src/components/admin/AdminShopList.tsx
+++ b/creator/src/components/admin/AdminShopList.tsx
@@ -6,7 +6,7 @@ const ShopRow = memo(function ShopRow({ shop }: { shop: ShopEntry }) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="rounded-2xl border border-white/8 bg-white/4 transition-colors duration-200">
+    <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] transition-colors duration-200">
       <button
         onClick={() => setExpanded(!expanded)}
         className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors duration-200 hover:bg-accent/[0.04] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none rounded-2xl"
@@ -32,12 +32,12 @@ const ShopRow = memo(function ShopRow({ shop }: { shop: ShopEntry }) {
       </button>
 
       {expanded && shop.items.length > 0 && (
-        <div className="border-t border-white/6 px-4 pb-3 pt-2">
+        <div className="border-t border-[var(--chrome-stroke)] px-4 pb-3 pt-2">
           <div className="flex flex-col gap-1">
             {shop.items.map((item) => (
               <div
                 key={item.id}
-                className="flex items-center justify-between rounded-xl bg-white/[0.02] px-3 py-2"
+                className="flex items-center justify-between rounded-xl bg-[var(--chrome-highlight)] px-3 py-2"
               >
                 <div className="flex items-center gap-2">
                   <span className="text-xs text-text-primary">{item.displayName}</span>
@@ -82,7 +82,7 @@ export function AdminShopList() {
       </div>
 
       {shops.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-12 text-center">
           <p className="font-display text-base text-text-secondary">No shops found</p>
           <p className="mt-1 text-sm text-text-muted">
             The server has no shops registered.

--- a/creator/src/components/admin/AdminZoneDetail.tsx
+++ b/creator/src/components/admin/AdminZoneDetail.tsx
@@ -22,7 +22,7 @@ export function AdminZoneDetail({
       <div className="flex items-center gap-3">
         <button
           onClick={onBack}
-          className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-xs text-text-muted transition hover:bg-white/10 hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+          className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
         >
           &#x2190; Back
         </button>
@@ -42,7 +42,7 @@ export function AdminZoneDetail({
             className={`w-full rounded-2xl border px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none ${
               room.players.length > 0
                 ? "border-accent/15 bg-accent/[0.03]"
-                : "border-white/8 bg-white/4"
+                : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)]"
             }`}
           >
             <div className="flex items-start justify-between gap-3">
@@ -54,7 +54,7 @@ export function AdminZoneDetail({
               </div>
               <div className="flex shrink-0 flex-wrap gap-1 text-2xs text-text-muted">
                 {room.exits.map((exit) => (
-                  <span key={exit} className="rounded-full bg-black/15 px-2 py-0.5">
+                  <span key={exit} className="rounded-full bg-[var(--chrome-fill)] px-2 py-0.5">
                     {exit}
                   </span>
                 ))}

--- a/creator/src/components/admin/AdminZoneList.tsx
+++ b/creator/src/components/admin/AdminZoneList.tsx
@@ -15,14 +15,14 @@ function ZoneRow({
       className={`flex w-full items-center gap-3 rounded-2xl border px-4 py-3 text-left transition-colors duration-200 hover:border-accent/20 hover:bg-accent/[0.04] hover:shadow-[inset_3px_0_0_var(--color-accent)] focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none ${
         zone.playersOnline > 0
           ? "border-accent/15 bg-accent/[0.03]"
-          : "border-white/8 bg-white/4"
+          : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)]"
       }`}
     >
       <div className="min-w-0 flex-1">
         <span className="truncate font-display text-sm text-text-primary">{zone.name}</span>
       </div>
       <div className="flex shrink-0 gap-3 text-2xs text-text-muted">
-        <span className="rounded-full bg-black/15 px-2 py-1">
+        <span className="rounded-full bg-[var(--chrome-fill)] px-2 py-1">
           {zone.roomCount} room{zone.roomCount !== 1 ? "s" : ""}
         </span>
         {zone.playersOnline > 0 && (
@@ -30,7 +30,7 @@ function ZoneRow({
             {zone.playersOnline} player{zone.playersOnline !== 1 ? "s" : ""}
           </span>
         )}
-        <span className="rounded-full bg-black/15 px-2 py-1">
+        <span className="rounded-full bg-[var(--chrome-fill)] px-2 py-1">
           {zone.mobsAlive} mob{zone.mobsAlive !== 1 ? "s" : ""}
         </span>
       </div>
@@ -61,7 +61,7 @@ export function AdminZoneList() {
       </div>
 
       {zones.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-12 text-center">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-12 text-center">
           <p className="font-display text-base text-text-secondary">No regions manifest</p>
           <p className="mt-1 text-sm text-text-muted">The server has no zones loaded.</p>
         </div>

--- a/creator/src/components/config/AbilityDesigner.tsx
+++ b/creator/src/components/config/AbilityDesigner.tsx
@@ -141,7 +141,7 @@ export function AbilityDesigner({
 
   return (
     <div className="grid gap-5 xl:grid-cols-[20rem_minmax(0,1fr)]">
-      <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+      <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
         <div className="mb-4">
           <p className="text-2xs uppercase tracking-ui text-text-muted">Ability roster</p>
           <h4 className="mt-2 font-display text-xl text-text-primary">{Object.keys(config.abilities).length} abilities</h4>
@@ -155,11 +155,11 @@ export function AbilityDesigner({
               if (event.key === "Enter") addAbility();
             }}
             placeholder="New ability id"
-            className="min-w-0 flex-1 rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+            className="min-w-0 flex-1 rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
           />
           <button
             onClick={addAbility}
-            className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary transition hover:bg-white/12"
+            className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary transition hover:bg-[var(--chrome-highlight-strong)]"
           >
             Add
           </button>
@@ -169,7 +169,7 @@ export function AbilityDesigner({
           value={search}
           onChange={(event) => setSearch(event.target.value)}
           placeholder="Search abilities"
-          className="mt-3 w-full rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+          className="mt-3 w-full rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
         />
 
         <div className="mt-4 flex max-h-[38rem] flex-col gap-2 overflow-y-auto pr-1">
@@ -187,7 +187,7 @@ export function AbilityDesigner({
                 className={`rounded-2xl border px-4 py-3 text-left transition ${
                   selectedCard
                     ? "border-border-active bg-gradient-active"
-                    : "border-white/8 bg-white/4 hover:bg-white/8"
+                    : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] hover:bg-[var(--chrome-highlight-strong)]"
                 }`}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -212,7 +212,7 @@ export function AbilityDesigner({
             );
           })}
           {abilityIds.length === 0 && (
-            <div className="rounded-2xl border border-dashed border-white/12 bg-white/4 px-4 py-6 text-sm text-text-muted">
+            <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-4 py-6 text-sm text-text-muted">
               No abilities match the current search.
             </div>
           )}
@@ -220,8 +220,8 @@ export function AbilityDesigner({
       </div>
 
       {selectedId && selected ? (
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
-          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-white/8 pb-4">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
+          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-[var(--chrome-stroke)] pb-4">
             <div>
               <p className="text-2xs uppercase tracking-ui text-text-muted">Ability designer</p>
               <h4 className="mt-2 font-display text-3xl text-text-primary">{selected.displayName}</h4>
@@ -230,10 +230,10 @@ export function AbilityDesigner({
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">{selected.effect.type}</span>
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">{selected.targetType}</span>
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">Mana {selected.manaCost}</span>
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">CD {selected.cooldownMs}ms</span>
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">{selected.effect.type}</span>
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">{selected.targetType}</span>
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">Mana {selected.manaCost}</span>
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">CD {selected.cooldownMs}ms</span>
             </div>
           </div>
 
@@ -247,12 +247,12 @@ export function AbilityDesigner({
                     if (event.key === "Enter") commitRename();
                     if (event.key === "Escape") setRenaming(false);
                   }}
-                  className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
                 />
-                <button onClick={commitRename} title="Confirm rename" className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary hover:bg-white/12">
+                <button onClick={commitRename} title="Confirm rename" className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary hover:bg-[var(--chrome-highlight-strong)]">
                   Rename
                 </button>
-                <button onClick={() => setRenaming(false)} title="Cancel rename" className="rounded-full border border-white/10 bg-transparent px-4 py-2 text-xs text-text-secondary hover:bg-white/8">
+                <button onClick={() => setRenaming(false)} title="Cancel rename" className="rounded-full border border-[var(--chrome-stroke)] bg-transparent px-4 py-2 text-xs text-text-secondary hover:bg-[var(--chrome-highlight-strong)]">
                   Cancel
                 </button>
               </>
@@ -263,7 +263,7 @@ export function AbilityDesigner({
                     setRenameValue(selectedId);
                     setRenaming(true);
                   }}
-                  className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary hover:bg-white/12"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary hover:bg-[var(--chrome-highlight-strong)]"
                 >
                   Rename ID
                 </button>
@@ -291,7 +291,7 @@ export function AbilityDesigner({
           </div>
         </div>
       ) : (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-10 text-sm text-text-muted">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-10 text-sm text-text-muted">
           Create an ability to start designing it.
         </div>
       )}

--- a/creator/src/components/config/CharacterCreationStudio.tsx
+++ b/creator/src/components/config/CharacterCreationStudio.tsx
@@ -47,7 +47,7 @@ export function CharacterCreationStudio({
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
+      <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
         <p className="text-2xs uppercase tracking-ui text-text-muted">Character creation</p>
         <h4 className="mt-2 font-display text-2xl text-text-primary">Starting resources</h4>
         <p className="mt-2 max-w-3xl text-sm leading-7 text-text-secondary">
@@ -64,7 +64,7 @@ export function CharacterCreationStudio({
         </div>
       </div>
 
-      <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
+      <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
         <p className="text-2xs uppercase tracking-ui text-text-muted">Character creation</p>
         <h4 className="mt-2 font-display text-2xl text-text-primary">New-player defaults</h4>
         <p className="mt-2 max-w-3xl text-sm leading-7 text-text-secondary">

--- a/creator/src/components/config/ClassDesigner.tsx
+++ b/creator/src/components/config/ClassDesigner.tsx
@@ -92,7 +92,7 @@ export function ClassDesigner({
 
   return (
     <div className="grid gap-5 xl:grid-cols-[20rem_minmax(0,1fr)]">
-      <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+      <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
         <div className="mb-4">
           <p className="text-2xs uppercase tracking-ui text-text-muted">Class roster</p>
           <h4 className="mt-2 font-display text-xl text-text-primary">{Object.keys(config.classes).length} classes</h4>
@@ -106,11 +106,11 @@ export function ClassDesigner({
               if (event.key === "Enter") addClass();
             }}
             placeholder="New class id"
-            className="min-w-0 flex-1 rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+            className="min-w-0 flex-1 rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
           />
           <button
             onClick={addClass}
-            className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary transition hover:bg-white/12"
+            className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary transition hover:bg-[var(--chrome-highlight-strong)]"
           >
             Add
           </button>
@@ -120,7 +120,7 @@ export function ClassDesigner({
           value={search}
           onChange={(event) => setSearch(event.target.value)}
           placeholder="Search classes"
-          className="mt-3 w-full rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+          className="mt-3 w-full rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
         />
 
         <div className="mt-4 flex max-h-[38rem] flex-col gap-2 overflow-y-auto pr-1">
@@ -137,7 +137,7 @@ export function ClassDesigner({
                 className={`rounded-2xl border px-4 py-3 text-left transition ${
                   selectedCard
                     ? "border-border-active bg-gradient-active"
-                    : "border-white/8 bg-white/4 hover:bg-white/8"
+                    : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] hover:bg-[var(--chrome-highlight-strong)]"
                 }`}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -156,7 +156,7 @@ export function ClassDesigner({
             );
           })}
           {classIds.length === 0 && (
-            <div className="rounded-2xl border border-dashed border-white/12 bg-white/4 px-4 py-6 text-sm text-text-muted">
+            <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-4 py-6 text-sm text-text-muted">
               No classes match the current search.
             </div>
           )}
@@ -164,8 +164,8 @@ export function ClassDesigner({
       </div>
 
       {selectedId && selected ? (
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
-          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-white/8 pb-4">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
+          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-[var(--chrome-stroke)] pb-4">
             <div>
               <p className="text-2xs uppercase tracking-ui text-text-muted">Class designer</p>
               <h4 className="mt-2 font-display text-3xl text-text-primary">{selected.displayName}</h4>
@@ -174,9 +174,9 @@ export function ClassDesigner({
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">HP +{selected.hpPerLevel}</span>
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">Mana +{selected.manaPerLevel}</span>
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">{selected.primaryStat ?? "No primary stat"}</span>
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">HP +{selected.hpPerLevel}</span>
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">Mana +{selected.manaPerLevel}</span>
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">{selected.primaryStat ?? "No primary stat"}</span>
             </div>
           </div>
 
@@ -190,12 +190,12 @@ export function ClassDesigner({
                     if (event.key === "Enter") commitRename();
                     if (event.key === "Escape") setRenaming(false);
                   }}
-                  className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
                 />
-                <button onClick={commitRename} title="Confirm rename" className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary hover:bg-white/12">
+                <button onClick={commitRename} title="Confirm rename" className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary hover:bg-[var(--chrome-highlight-strong)]">
                   Rename
                 </button>
-                <button onClick={() => setRenaming(false)} title="Cancel rename" className="rounded-full border border-white/10 bg-transparent px-4 py-2 text-xs text-text-secondary hover:bg-white/8">
+                <button onClick={() => setRenaming(false)} title="Cancel rename" className="rounded-full border border-[var(--chrome-stroke)] bg-transparent px-4 py-2 text-xs text-text-secondary hover:bg-[var(--chrome-highlight-strong)]">
                   Cancel
                 </button>
               </>
@@ -206,7 +206,7 @@ export function ClassDesigner({
                     setRenameValue(selectedId);
                     setRenaming(true);
                   }}
-                  className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary hover:bg-white/12"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary hover:bg-[var(--chrome-highlight-strong)]"
                 >
                   Rename ID
                 </button>
@@ -234,7 +234,7 @@ export function ClassDesigner({
           </div>
         </div>
       ) : (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-10 text-sm text-text-muted">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-10 text-sm text-text-muted">
           Create a class to start designing it.
         </div>
       )}

--- a/creator/src/components/config/ConfigPanelHost.tsx
+++ b/creator/src/components/config/ConfigPanelHost.tsx
@@ -260,7 +260,7 @@ export function ConfigPanelHost({ panelId }: { panelId: string }) {
                 onClick={handleSave}
                 disabled={!dirty || saving}
                 aria-label={saving ? "Saving configuration" : "Save configuration"}
-                className="focus-ring rounded-full border border-white/10 bg-bg-primary/80 px-3 py-1 text-2xs font-medium text-accent shadow-md backdrop-blur-sm transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
+                className="focus-ring rounded-full border border-[var(--chrome-stroke)] bg-bg-primary/80 px-3 py-1 text-2xs font-medium text-accent shadow-md backdrop-blur-sm transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {saving ? <span className="flex items-center gap-1.5"><Spinner />Saving</span> : "Save Config"}
               </button>

--- a/creator/src/components/config/CraftingStudio.tsx
+++ b/creator/src/components/config/CraftingStudio.tsx
@@ -23,7 +23,7 @@ export function CraftingStudio({
   return (
     <div className="flex flex-col gap-6">
       <div className="grid gap-5 xl:grid-cols-2">
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
           <p className="text-2xs uppercase tracking-ui text-text-muted">Progression</p>
           <h4 className="mt-2 font-display text-2xl text-text-primary">Skill curve</h4>
           <p className="mt-2 text-sm leading-7 text-text-secondary">
@@ -55,7 +55,7 @@ export function CraftingStudio({
           </div>
         </div>
 
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
           <p className="text-2xs uppercase tracking-ui text-text-muted">Gathering loop</p>
           <h4 className="mt-2 font-display text-2xl text-text-primary">Harvest pacing</h4>
           <p className="mt-2 text-sm leading-7 text-text-secondary">

--- a/creator/src/components/config/DefinitionWorkbench.tsx
+++ b/creator/src/components/config/DefinitionWorkbench.tsx
@@ -129,7 +129,7 @@ export function DefinitionWorkbench<T>({
                 className={`rounded-2xl border px-4 py-3 text-left transition ${
                   selectedCard
                     ? "border-border-active bg-gradient-active"
-                    : "border-white/8 bg-white/4 hover:bg-white/8"
+                    : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] hover:bg-[var(--chrome-highlight-strong)]"
                 }`}
               >
                 <div className="min-w-0">
@@ -151,7 +151,7 @@ export function DefinitionWorkbench<T>({
             );
           })}
           {itemIds.length === 0 && (
-            <div className="rounded-2xl border border-dashed border-white/12 bg-white/4 px-4 py-6 text-sm text-text-muted">
+            <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-4 py-6 text-sm text-text-muted">
               {emptyMessage}
             </div>
           )}
@@ -160,7 +160,7 @@ export function DefinitionWorkbench<T>({
 
       {selectedId && selected ? (
         <div className="panel-surface rounded-3xl p-5">
-          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-white/8 pb-4">
+          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-[var(--chrome-stroke)] pb-4">
             <div>
               <p className="text-2xs uppercase tracking-ui text-text-muted">{title}</p>
               <h4 className="mt-2 font-display text-3xl text-text-primary">{getDisplayName(selected)}</h4>

--- a/creator/src/components/config/GuildDesigner.tsx
+++ b/creator/src/components/config/GuildDesigner.tsx
@@ -40,7 +40,7 @@ export function GuildDesigner({
   return (
     <div className="flex flex-col gap-6">
       {showGroups && <div className="grid gap-5 xl:grid-cols-3">
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
           <p className="text-2xs uppercase tracking-ui text-text-muted">Group rules</p>
           <h4 className="mt-2 font-display text-2xl text-text-primary">Party pacing</h4>
           <div className="mt-4 flex flex-col gap-1.5">
@@ -69,7 +69,7 @@ export function GuildDesigner({
           </div>
         </div>
 
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
           <p className="text-2xs uppercase tracking-ui text-text-muted">Friends</p>
           <h4 className="mt-2 font-display text-2xl text-text-primary">Social reach</h4>
           <div className="mt-4 flex flex-col gap-1.5">
@@ -83,7 +83,7 @@ export function GuildDesigner({
           </div>
         </div>
 
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
           <p className="text-2xs uppercase tracking-ui text-text-muted">Guild defaults</p>
           <h4 className="mt-2 font-display text-2xl text-text-primary">Rank assignment</h4>
           <div className="mt-4 flex flex-col gap-1.5">

--- a/creator/src/components/config/RaceDesigner.tsx
+++ b/creator/src/components/config/RaceDesigner.tsx
@@ -91,7 +91,7 @@ export function RaceDesigner({
 
   return (
     <div className="grid gap-5 xl:grid-cols-[20rem_minmax(0,1fr)]">
-      <div className="flex max-h-[calc(100vh-10rem)] flex-col rounded-3xl border border-white/8 bg-black/12 p-4">
+      <div className="flex max-h-[calc(100vh-10rem)] flex-col rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
         <div className="mb-4 shrink-0">
           <p className="text-2xs uppercase tracking-ui text-text-muted">Race roster</p>
           <h4 className="mt-2 font-display text-xl text-text-primary">{Object.keys(config.races).length} races</h4>
@@ -105,11 +105,11 @@ export function RaceDesigner({
               if (event.key === "Enter") addRace();
             }}
             placeholder="New race id"
-            className="min-w-0 flex-1 rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+            className="min-w-0 flex-1 rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
           />
           <button
             onClick={addRace}
-            className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary transition hover:bg-white/12"
+            className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary transition hover:bg-[var(--chrome-highlight-strong)]"
           >
             Add
           </button>
@@ -119,7 +119,7 @@ export function RaceDesigner({
           value={search}
           onChange={(event) => setSearch(event.target.value)}
           placeholder="Search races"
-          className="mt-3 w-full rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+          className="mt-3 w-full rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
         />
 
         <div className="mt-4 flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-1">
@@ -136,7 +136,7 @@ export function RaceDesigner({
                 className={`rounded-2xl border px-4 py-3 text-left transition ${
                   selectedCard
                     ? "border-border-active bg-gradient-active"
-                    : "border-white/8 bg-white/4 hover:bg-white/8"
+                    : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] hover:bg-[var(--chrome-highlight-strong)]"
                 }`}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -155,7 +155,7 @@ export function RaceDesigner({
             );
           })}
           {raceIds.length === 0 && (
-            <div className="rounded-2xl border border-dashed border-white/12 bg-white/4 px-4 py-6 text-sm text-text-muted">
+            <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-4 py-6 text-sm text-text-muted">
               No races match the current search.
             </div>
           )}
@@ -163,8 +163,8 @@ export function RaceDesigner({
       </div>
 
       {selectedId && selected ? (
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
-          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-white/8 pb-4">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
+          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-[var(--chrome-stroke)] pb-4">
             <div>
               <p className="text-2xs uppercase tracking-ui text-text-muted">Race designer</p>
               <h4 className="mt-2 font-display text-3xl text-text-primary">{selected.displayName}</h4>
@@ -173,13 +173,13 @@ export function RaceDesigner({
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">
                 {selected.traits?.length ?? 0} traits
               </span>
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">
                 {selected.abilities?.length ?? 0} abilities
               </span>
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">
                 Net stat mod {netStatMods(selected.statMods) >= 0 ? "+" : ""}{netStatMods(selected.statMods)}
               </span>
             </div>
@@ -195,12 +195,12 @@ export function RaceDesigner({
                     if (event.key === "Enter") commitRename();
                     if (event.key === "Escape") setRenaming(false);
                   }}
-                  className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
                 />
-                <button onClick={commitRename} title="Confirm rename" className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary hover:bg-white/12">
+                <button onClick={commitRename} title="Confirm rename" className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary hover:bg-[var(--chrome-highlight-strong)]">
                   Rename
                 </button>
-                <button onClick={() => setRenaming(false)} title="Cancel rename" className="rounded-full border border-white/10 bg-transparent px-4 py-2 text-xs text-text-secondary hover:bg-white/8">
+                <button onClick={() => setRenaming(false)} title="Cancel rename" className="rounded-full border border-[var(--chrome-stroke)] bg-transparent px-4 py-2 text-xs text-text-secondary hover:bg-[var(--chrome-highlight-strong)]">
                   Cancel
                 </button>
               </>
@@ -211,7 +211,7 @@ export function RaceDesigner({
                     setRenameValue(selectedId);
                     setRenaming(true);
                   }}
-                  className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary hover:bg-white/12"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary hover:bg-[var(--chrome-highlight-strong)]"
                 >
                   Rename ID
                 </button>
@@ -236,7 +236,7 @@ export function RaceDesigner({
           </div>
         </div>
       ) : (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-10 text-sm text-text-muted">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-10 text-sm text-text-muted">
           Create a race to start designing it.
         </div>
       )}

--- a/creator/src/components/config/RuntimeHandoffStudio.tsx
+++ b/creator/src/components/config/RuntimeHandoffStudio.tsx
@@ -41,7 +41,7 @@ interface StepState {
 const EXPORT_DIR_KEY = "arcanum-runtime-export-dir";
 
 const STATUS_STYLES: Record<StepStatus, string> = {
-  idle: "border-white/10 bg-black/10 text-text-secondary",
+  idle: "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-secondary",
   running: "border-border-active bg-status-info/15 text-text-primary",
   success: "border-status-success/30 bg-status-success/10 text-status-success",
   warning: "border-status-warning/30 bg-status-warning/10 text-status-warning",
@@ -73,7 +73,7 @@ function StepCard({
   children?: ReactNode;
 }) {
   return (
-    <section className="rounded-3xl border border-white/10 bg-gradient-panel-light p-4 shadow-section">
+    <section className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <h3 className="font-display text-xl text-text-primary">{title}</h3>
@@ -90,7 +90,7 @@ function StepCard({
         <button
           onClick={() => void onAction()}
           disabled={disabled || state.status === "running"}
-          className="rounded-full border border-white/10 bg-black/10 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:cursor-not-allowed disabled:opacity-40"
         >
           {state.status === "running" ? "Working..." : actionLabel}
         </button>
@@ -98,7 +98,7 @@ function StepCard({
       </div>
 
       {state.errors.length > 0 && (
-        <div className="mt-3 rounded-2xl border border-status-error/20 bg-black/10 p-3 text-2xs text-status-error">
+        <div className="mt-3 rounded-2xl border border-status-error/20 bg-[var(--chrome-fill)] p-3 text-2xs text-status-error">
           {state.errors.slice(0, 5).map((error, index) => (
             <div key={index}>{error}</div>
           ))}
@@ -499,7 +499,7 @@ export function RuntimeHandoffStudio() {
 
   if (!project || !config) {
     return (
-      <div className="rounded-3xl border border-white/10 bg-black/10 p-5 text-sm text-text-secondary">
+      <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5 text-sm text-text-secondary">
         Open a world project before using the deployment pipeline.
       </div>
     );
@@ -507,7 +507,7 @@ export function RuntimeHandoffStudio() {
 
   return (
     <div className="flex flex-col gap-4">
-      <section className="rounded-3xl border border-white/10 bg-[linear-gradient(145deg,rgba(73,84,118,0.94),rgba(49,60,90,0.92))] p-4 shadow-[0_18px_60px_rgba(9,12,24,0.32)]">
+      <section className="rounded-3xl border border-[var(--chrome-stroke)] bg-[linear-gradient(145deg,rgba(73,84,118,0.94),rgba(49,60,90,0.92))] p-4 shadow-[0_18px_60px_rgba(9,12,24,0.32)]">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <p className="text-2xs uppercase tracking-wide-ui text-text-muted">Handoff</p>
@@ -526,7 +526,7 @@ export function RuntimeHandoffStudio() {
             </button>
             <button
               onClick={openValidationResults}
-              className="rounded-full border border-white/10 bg-black/10 px-4 py-2 text-xs font-medium text-text-primary transition hover:bg-white/10"
+              className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-2 text-xs font-medium text-text-primary transition hover:bg-[var(--chrome-highlight-strong)]"
             >
               Open validation
             </button>
@@ -534,26 +534,26 @@ export function RuntimeHandoffStudio() {
         </div>
 
         <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-2xl border border-white/10 bg-black/10 p-3">
+          <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-3">
             <p className="text-2xs uppercase tracking-ui text-text-muted">Project</p>
             <p className="mt-2 text-sm text-text-primary">{project.mudDir}</p>
             <p className="mt-2 text-xs text-text-secondary">
               {zones.size} loaded zone{zones.size !== 1 ? "s" : ""} | {dirtyZones} dirty
             </p>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-black/10 p-3">
+          <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-3">
             <p className="text-2xs uppercase tracking-ui text-text-muted">R2 delivery</p>
             <p className="mt-2 text-sm text-text-primary">{settings?.r2_bucket || "No bucket configured"}</p>
             <p className="mt-2 text-xs text-text-secondary">
               {settings?.r2_custom_domain || "No custom domain"} | {hasR2 ? "ready" : "credentials incomplete"}
             </p>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-black/10 p-3">
+          <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-3">
             <p className="text-2xs uppercase tracking-ui text-text-muted">Curated assets</p>
             <p className="mt-2 text-sm text-text-primary">{curatedAssetCount} active assets</p>
             <p className="mt-2 text-xs text-text-secondary">{unsyncedCuratedAssetCount} not yet synced to R2</p>
           </div>
-          <div className="rounded-2xl border border-white/10 bg-black/10 p-3">
+          <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-3">
             <p className="text-2xs uppercase tracking-ui text-text-muted">Config state</p>
             <p className="mt-2 text-sm text-text-primary">{configDirty ? "Config has unsaved edits" : "Config is clean"}</p>
             <p className="mt-2 text-xs text-text-secondary">{globalAssetCount} registered global asset keys</p>
@@ -561,7 +561,7 @@ export function RuntimeHandoffStudio() {
         </div>
 
         {workflowMessage && (
-          <div className="mt-3 rounded-2xl border border-white/10 bg-black/10 px-4 py-3 text-sm text-text-secondary">
+          <div className="mt-3 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3 text-sm text-text-secondary">
             {workflowMessage}
           </div>
         )}
@@ -589,7 +589,7 @@ export function RuntimeHandoffStudio() {
               value={deployCommitMsg}
               onChange={(e) => setDeployCommitMsg(e.target.value)}
               placeholder="Commit message"
-              className="w-full rounded-full border border-white/10 bg-black/10 px-4 py-2 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+              className="w-full rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-2 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
             />
           </StepCard>
         )}
@@ -615,11 +615,11 @@ export function RuntimeHandoffStudio() {
               value={exportDir}
               onChange={(event) => setExportDir(event.target.value)}
               placeholder="Choose a MUD checkout directory"
-              className="min-w-[18rem] flex-1 rounded-full border border-white/10 bg-black/10 px-4 py-2 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+              className="min-w-[18rem] flex-1 rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-2 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
             />
             <button
               onClick={() => void handleChooseExportDir()}
-              className="rounded-full border border-white/10 bg-black/10 px-4 py-2 text-xs font-medium text-text-primary transition hover:bg-white/10"
+              className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-2 text-xs font-medium text-text-primary transition hover:bg-[var(--chrome-highlight-strong)]"
             >
               Choose folder
             </button>
@@ -640,7 +640,7 @@ export function RuntimeHandoffStudio() {
               <select
                 value={syncScope}
                 onChange={(event) => setSyncScope(event.target.value as SyncScope)}
-                className="rounded-full border border-white/10 bg-black/10 px-3 py-1.5 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+                className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1.5 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
               >
                 <option value="approved">Approved only</option>
                 <option value="all">Everything</option>
@@ -649,13 +649,13 @@ export function RuntimeHandoffStudio() {
             <button
               onClick={() => void handleExportLocal()}
               disabled={exportingLocal}
-              className="rounded-full border border-white/10 bg-black/10 px-4 py-2 text-xs font-medium text-text-primary transition hover:bg-white/10 disabled:opacity-40"
+              className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-2 text-xs font-medium text-text-primary transition hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-40"
             >
               {exportingLocal ? "Exporting..." : "Export images locally"}
             </button>
           </div>
           {localExportResult && (
-            <div className="mt-2 rounded-2xl border border-white/10 bg-black/10 px-4 py-3 text-xs text-text-secondary">
+            <div className="mt-2 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3 text-xs text-text-secondary">
               Exported {localExportResult.copied} images ({localExportResult.skipped} already present, {localExportResult.errors.length} errors)
               {localExportResult.errors.length > 0 && (
                 <ul className="mt-1 text-status-error">

--- a/creator/src/components/config/StatusEffectDesigner.tsx
+++ b/creator/src/components/config/StatusEffectDesigner.tsx
@@ -127,7 +127,7 @@ export function StatusEffectDesigner({
 
   return (
     <div className="grid gap-5 xl:grid-cols-[20rem_minmax(0,1fr)]">
-      <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+      <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
         <div className="mb-4">
           <p className="text-2xs uppercase tracking-ui text-text-muted">Condition roster</p>
           <h4 className="mt-2 font-display text-xl text-text-primary">{Object.keys(config.statusEffects).length} conditions</h4>
@@ -141,11 +141,11 @@ export function StatusEffectDesigner({
               if (event.key === "Enter") addStatusEffect();
             }}
             placeholder="New condition id"
-            className="min-w-0 flex-1 rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+            className="min-w-0 flex-1 rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
           />
           <button
             onClick={addStatusEffect}
-            className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary transition hover:bg-white/12"
+            className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary transition hover:bg-[var(--chrome-highlight-strong)]"
           >
             Add
           </button>
@@ -155,7 +155,7 @@ export function StatusEffectDesigner({
           value={search}
           onChange={(event) => setSearch(event.target.value)}
           placeholder="Search conditions"
-          className="mt-3 w-full rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+          className="mt-3 w-full rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
         />
 
         <div className="mt-4 flex max-h-[38rem] flex-col gap-2 overflow-y-auto pr-1">
@@ -172,7 +172,7 @@ export function StatusEffectDesigner({
                 className={`rounded-2xl border px-4 py-3 text-left transition ${
                   selectedCard
                     ? "border-border-active bg-gradient-active"
-                    : "border-white/8 bg-white/4 hover:bg-white/8"
+                    : "border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] hover:bg-[var(--chrome-highlight-strong)]"
                 }`}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -197,7 +197,7 @@ export function StatusEffectDesigner({
             );
           })}
           {effectIds.length === 0 && (
-            <div className="rounded-2xl border border-dashed border-white/12 bg-white/4 px-4 py-6 text-sm text-text-muted">
+            <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-4 py-6 text-sm text-text-muted">
               No conditions match the current search.
             </div>
           )}
@@ -205,8 +205,8 @@ export function StatusEffectDesigner({
       </div>
 
       {selectedId && selected ? (
-        <div className="rounded-3xl border border-white/8 bg-black/12 p-5">
-          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-white/8 pb-4">
+        <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
+          <div className="flex flex-wrap items-start justify-between gap-4 border-b border-[var(--chrome-stroke)] pb-4">
             <div>
               <p className="text-2xs uppercase tracking-ui text-text-muted">Condition designer</p>
               <h4 className="mt-2 font-display text-3xl text-text-primary">{selected.displayName}</h4>
@@ -215,11 +215,11 @@ export function StatusEffectDesigner({
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">{selected.effectType}</span>
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">{selected.stackBehavior ?? "REFRESH"}</span>
-              <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">{selected.durationMs}ms</span>
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">{selected.effectType}</span>
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">{selected.stackBehavior ?? "REFRESH"}</span>
+              <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">{selected.durationMs}ms</span>
               {selected.tickIntervalMs ? (
-                <span className="rounded-full bg-white/8 px-3 py-1 text-xs text-text-secondary">Tick {selected.tickIntervalMs}ms</span>
+                <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">Tick {selected.tickIntervalMs}ms</span>
               ) : null}
             </div>
           </div>
@@ -234,12 +234,12 @@ export function StatusEffectDesigner({
                     if (event.key === "Enter") commitRename();
                     if (event.key === "Escape") setRenaming(false);
                   }}
-                  className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
                 />
-                <button onClick={commitRename} title="Confirm rename" className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary hover:bg-white/12">
+                <button onClick={commitRename} title="Confirm rename" className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary hover:bg-[var(--chrome-highlight-strong)]">
                   Rename
                 </button>
-                <button onClick={() => setRenaming(false)} title="Cancel rename" className="rounded-full border border-white/10 bg-transparent px-4 py-2 text-xs text-text-secondary hover:bg-white/8">
+                <button onClick={() => setRenaming(false)} title="Cancel rename" className="rounded-full border border-[var(--chrome-stroke)] bg-transparent px-4 py-2 text-xs text-text-secondary hover:bg-[var(--chrome-highlight-strong)]">
                   Cancel
                 </button>
               </>
@@ -250,7 +250,7 @@ export function StatusEffectDesigner({
                     setRenameValue(selectedId);
                     setRenaming(true);
                   }}
-                  className="rounded-full border border-white/10 bg-white/8 px-4 py-2 text-xs text-text-primary hover:bg-white/12"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight-strong)] px-4 py-2 text-xs text-text-primary hover:bg-[var(--chrome-highlight-strong)]"
                 >
                   Rename ID
                 </button>
@@ -275,7 +275,7 @@ export function StatusEffectDesigner({
           </div>
         </div>
       ) : (
-        <div className="rounded-3xl border border-dashed border-white/12 bg-white/4 px-6 py-10 text-sm text-text-muted">
+        <div className="rounded-3xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-highlight)] px-6 py-10 text-sm text-text-muted">
           Create a condition to start designing it.
         </div>
       )}

--- a/creator/src/components/config/panels/AdminConfigPanel.tsx
+++ b/creator/src/components/config/panels/AdminConfigPanel.tsx
@@ -39,7 +39,7 @@ export function AdminConfigPanel({ config, onChange }: ConfigPanelProps) {
             label="Auth Token"
             hint="Managed by the mud deployment layer. Arcanum writes a blank token to project YAML and expects the runtime token to come from SSM or environment variables."
           >
-            <div className="rounded-xl border border-white/10 bg-black/15 px-3 py-2 text-sm leading-6 text-text-secondary">
+            <div className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-2 text-sm leading-6 text-text-secondary">
               Runtime-managed via <span className="font-mono text-stellar-blue">AMBONMUD_ADMIN_TOKEN</span>.
             </div>
           </FieldRow>

--- a/creator/src/components/config/panels/ApiSettingsPanel.tsx
+++ b/creator/src/components/config/panels/ApiSettingsPanel.tsx
@@ -521,7 +521,7 @@ export function ApiSettingsPanel({
               </div>
 
               {showDeploymentActions && (
-                <div className="mt-1 rounded-2xl border border-white/10 bg-black/10 px-4 py-3 text-2xs leading-6 text-text-secondary">
+                <div className="mt-1 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3 text-2xs leading-6 text-text-secondary">
                   Runtime publishing now lives in Operations / Handoff.
                 </div>
               )}

--- a/creator/src/components/config/panels/DailyQuestsPanel.tsx
+++ b/creator/src/components/config/panels/DailyQuestsPanel.tsx
@@ -116,7 +116,7 @@ function PoolEditor({
         <button
           onClick={addPool}
           disabled={!newPoolName.trim()}
-          className="focus-ring rounded border border-white/10 bg-bg-tertiary px-3 py-1.5 text-2xs font-medium text-accent transition hover:bg-bg-tertiary/80 disabled:cursor-not-allowed disabled:opacity-40"
+          className="focus-ring rounded border border-[var(--chrome-stroke)] bg-bg-tertiary px-3 py-1.5 text-2xs font-medium text-accent transition hover:bg-bg-tertiary/80 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Add Pool
         </button>

--- a/creator/src/components/config/panels/EmotePresetsPanel.tsx
+++ b/creator/src/components/config/panels/EmotePresetsPanel.tsx
@@ -36,7 +36,7 @@ export function EmotePresetsPanel({ config, onChange }: ConfigPanelProps) {
         {presets.map((preset, i) => (
           <div
             key={i}
-            className="rounded-xl border border-white/8 bg-black/12 p-4"
+            className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4"
           >
             <div className="mb-2 flex items-center justify-between">
               <span className="text-xs font-medium text-text-secondary">

--- a/creator/src/components/config/panels/EquipmentSlotsPanel.tsx
+++ b/creator/src/components/config/panels/EquipmentSlotsPanel.tsx
@@ -187,11 +187,11 @@ export function EquipmentSlotsPanel({ config, onChange }: ConfigPanelProps) {
               className={`group focus-ring flex min-h-11 cursor-pointer items-center gap-3 rounded-2xl px-3 py-2 text-sm transition ${
                 selectedId === id
                   ? "border border-[var(--border-glow-strong)] bg-[linear-gradient(145deg,rgba(168,151,210,0.18),rgba(42,50,71,0.9))] text-text-primary shadow-glow"
-                  : "border border-transparent text-text-secondary hover:bg-white/6 hover:text-text-primary"
+                  : "border border-transparent text-text-secondary hover:bg-[var(--chrome-highlight)] hover:text-text-primary"
               }`}
               aria-label={`${slot.displayName} slot`}
             >
-              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-white/8 bg-black/12 text-2xs text-text-muted">
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-2xs text-text-muted">
                 {slot.order}
               </span>
               <span className="font-mono text-2xs text-text-muted">{id}</span>

--- a/creator/src/components/config/panels/GlobalAssetGeneratorModal.tsx
+++ b/creator/src/components/config/panels/GlobalAssetGeneratorModal.tsx
@@ -230,7 +230,7 @@ export function GlobalAssetGeneratorModal({ asset, onClose, onComplete }: Props)
       widthClassName="max-w-3xl"
       onClose={onClose}
       status={
-        <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs text-text-secondary">
+        <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs text-text-secondary">
           {STAGE_LABEL[stage]}
         </span>
       }
@@ -268,7 +268,7 @@ export function GlobalAssetGeneratorModal({ asset, onClose, onComplete }: Props)
         <div className="grid gap-5">
           <section className="panel-surface-light rounded-3xl p-5">
             <div className="grid gap-5">
-              <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+              <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
                 <p className="text-2xs uppercase tracking-wide-ui text-text-muted">
                   Global asset key
                 </p>
@@ -299,7 +299,7 @@ export function GlobalAssetGeneratorModal({ asset, onClose, onComplete }: Props)
                 </p>
               </div>
 
-              <label className="flex cursor-pointer items-start gap-3 rounded-2xl border border-white/8 bg-black/12 p-4">
+              <label className="flex cursor-pointer items-start gap-3 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
                 <input
                   type="checkbox"
                   checked={removeBg}
@@ -332,7 +332,7 @@ export function GlobalAssetGeneratorModal({ asset, onClose, onComplete }: Props)
       )}
 
       {(stage === "generating" || stage === "removing_bg") && (
-        <div className="relative overflow-hidden rounded-3xl border border-white/8">
+        <div className="relative overflow-hidden rounded-3xl border border-[var(--chrome-stroke)]">
           <div className="relative flex min-h-[20rem] flex-col items-center justify-center gap-5 px-6 py-12 text-center">
             <Spinner className="h-8 w-8 border-2" />
             <p className="font-display text-lg text-text-primary">
@@ -352,14 +352,14 @@ export function GlobalAssetGeneratorModal({ asset, onClose, onComplete }: Props)
       {stage === "preview" && result && (
         <div className="grid gap-5">
           <section className="panel-surface-light rounded-3xl p-5">
-            <div className="overflow-hidden rounded-3xl border border-white/8 bg-[color-mix(in_srgb,var(--accent)_8%,transparent)]">
+            <div className="overflow-hidden rounded-3xl border border-[var(--chrome-stroke)] bg-[color-mix(in_srgb,var(--accent)_8%,transparent)]">
               <img src={result.data_url} alt="Generated global asset" className="w-full" />
             </div>
             <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-text-muted">
-              <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1">
+              <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1">
                 {result.width}x{result.height}
               </span>
-              <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1">
+              <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1">
                 {result.model.split("/").pop()}
               </span>
               {removeBg && (

--- a/creator/src/components/config/panels/ImagesPanel.tsx
+++ b/creator/src/components/config/panels/ImagesPanel.tsx
@@ -63,7 +63,7 @@ export function ImagesPanel({ config, onChange }: ConfigPanelProps) {
               </button>
             </span>
           ))}
-          <span className="flex items-center rounded-full border border-white/10 bg-white/4 px-3 py-1 text-xs text-text-muted">
+          <span className="flex items-center rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-3 py-1 text-xs text-text-muted">
             <span className="font-mono">tstaff</span>
           </span>
 

--- a/creator/src/components/config/panels/LoggingPanel.tsx
+++ b/creator/src/components/config/panels/LoggingPanel.tsx
@@ -85,7 +85,7 @@ export function LoggingPanel({ config, onChange }: ConfigPanelProps) {
             <button
               onClick={addPackageLevel}
               disabled={!newPkg.trim()}
-              className="shrink-0 rounded-xl border border-white/10 bg-black/10 px-3 py-1 text-2xs text-text-primary transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
+              className="shrink-0 rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs text-text-primary transition hover:bg-[var(--chrome-highlight-strong)] disabled:cursor-not-allowed disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-border-active focus-visible:outline-none"
             >
               Add
             </button>

--- a/creator/src/components/config/panels/RegistryPanel.tsx
+++ b/creator/src/components/config/panels/RegistryPanel.tsx
@@ -40,7 +40,7 @@ export function RegistryPanel<T>({
   getDisplayName,
   onRenameId,
 }: RegistryPanelProps<T>) {
-  const allIds = Object.keys(items);
+  const allIds = items ? Object.keys(items) : [];
   const [expanded, setExpanded] = useState<string | null>(null);
   const [newId, setNewId] = useState("");
   const [search, setSearch] = useState("");

--- a/creator/src/components/config/panels/VersionControlPanel.tsx
+++ b/creator/src/components/config/panels/VersionControlPanel.tsx
@@ -55,7 +55,7 @@ export function VersionControlPanel() {
   // Format guard
   if (!project || project.format !== "standalone") {
     return (
-      <div className="rounded-2xl border border-white/10 bg-black/10 px-6 py-8 text-center text-sm text-text-muted">
+      <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-6 py-8 text-center text-sm text-text-muted">
         Version control is available for standalone projects only.
       </div>
     );
@@ -116,7 +116,7 @@ export function VersionControlPanel() {
           <div className="flex items-center gap-3">
             <div className="flex items-center gap-1.5">
               <span className="text-2xs uppercase tracking-wider text-text-muted">Branch</span>
-              <span className="rounded bg-white/8 px-2 py-0.5 font-mono text-xs text-text-primary">
+              <span className="rounded bg-[var(--chrome-highlight-strong)] px-2 py-0.5 font-mono text-xs text-text-primary">
                 {status?.branch || "—"}
               </span>
             </div>
@@ -139,7 +139,7 @@ export function VersionControlPanel() {
           <button
             onClick={refresh}
             disabled={loading}
-            className="rounded px-2 py-1 text-2xs text-text-muted transition hover:bg-white/5 hover:text-text-primary disabled:opacity-50"
+            className="rounded px-2 py-1 text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight)] hover:text-text-primary disabled:opacity-50"
           >
             {loading ? <Spinner /> : "Refresh"}
           </button>
@@ -166,7 +166,7 @@ export function VersionControlPanel() {
                 if (remoteUrl.trim()) setRemote(mudDir, remoteUrl.trim());
               }}
               disabled={!remoteUrl.trim()}
-              className="shrink-0 rounded bg-white/8 px-3 py-1.5 text-xs text-text-primary transition hover:bg-white/12 disabled:opacity-50"
+              className="shrink-0 rounded bg-[var(--chrome-highlight-strong)] px-3 py-1.5 text-xs text-text-primary transition hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
             >
               Set Remote
             </button>
@@ -214,7 +214,7 @@ export function VersionControlPanel() {
             <button
               onClick={() => push(mudDir)}
               disabled={pushing || !hasPat}
-              className="rounded bg-white/8 px-4 py-1.5 text-xs text-text-primary transition hover:bg-white/12 disabled:opacity-50"
+              className="rounded bg-[var(--chrome-highlight-strong)] px-4 py-1.5 text-xs text-text-primary transition hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
             >
               {pushing ? <><Spinner className="mr-1.5" /> Pushing...</> : "Push"}
               {(status?.ahead ?? 0) > 0 && (
@@ -226,7 +226,7 @@ export function VersionControlPanel() {
             <button
               onClick={() => pull(mudDir)}
               disabled={pulling || !hasPat}
-              className="rounded bg-white/8 px-4 py-1.5 text-xs text-text-primary transition hover:bg-white/12 disabled:opacity-50"
+              className="rounded bg-[var(--chrome-highlight-strong)] px-4 py-1.5 text-xs text-text-primary transition hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
             >
               {pulling ? <><Spinner className="mr-1.5" /> Pulling...</> : "Pull"}
               {(status?.behind ?? 0) > 0 && (
@@ -306,7 +306,7 @@ export function VersionControlPanel() {
             href={prResult.pr_url}
             target="_blank"
             rel="noopener noreferrer"
-            className="mt-2 inline-block rounded bg-white/8 px-3 py-1.5 text-xs text-accent transition hover:bg-white/12"
+            className="mt-2 inline-block rounded bg-[var(--chrome-highlight-strong)] px-3 py-1.5 text-xs text-accent transition hover:bg-[var(--chrome-highlight-strong)]"
           >
             Open PR on GitHub &rarr;
           </a>
@@ -340,7 +340,7 @@ export function VersionControlPanel() {
 
 function Card({ children, className }: { children: React.ReactNode; className?: string }) {
   return (
-    <div className={`rounded-2xl border border-white/10 bg-black/10 px-5 py-4 ${className ?? ""}`}>
+    <div className={`rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-5 py-4 ${className ?? ""}`}>
       {children}
     </div>
   );

--- a/creator/src/components/lore/ArticleArtSection.tsx
+++ b/creator/src/components/lore/ArticleArtSection.tsx
@@ -18,16 +18,16 @@ function GalleryThumbnail({
   const src = useImageSrc(filename);
 
   return (
-    <div className="group relative h-16 w-16 shrink-0 overflow-hidden rounded-lg border border-white/10 bg-black/20">
+    <div className="group relative h-16 w-16 shrink-0 overflow-hidden rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-strong)]">
       {src ? (
         <img src={src} alt="" className="h-full w-full object-cover" />
       ) : (
         <div className="flex h-full w-full items-center justify-center text-2xs text-text-muted">...</div>
       )}
-      <div className="absolute inset-0 flex items-center justify-center gap-1 bg-black/60 opacity-0 transition group-hover:opacity-100">
+      <div className="absolute inset-0 flex items-center justify-center gap-1 bg-[var(--chrome-fill-soft)]0 opacity-0 transition group-hover:opacity-100">
         <button
           onClick={onPromote}
-          className="rounded-full bg-white/15 p-1 text-3xs text-text-primary hover:bg-white/25"
+          className="rounded-full bg-[var(--chrome-highlight-strong)] p-1 text-3xs text-text-primary hover:bg-[var(--chrome-highlight-strong)]"
           title="Set as primary image"
           aria-label="Set as primary image"
         >
@@ -35,7 +35,7 @@ function GalleryThumbnail({
         </button>
         <button
           onClick={onRemove}
-          className="rounded-full bg-white/15 p-1 text-3xs text-status-danger hover:bg-status-danger/30"
+          className="rounded-full bg-[var(--chrome-highlight-strong)] p-1 text-3xs text-status-danger hover:bg-status-danger/30"
           title="Remove from gallery"
           aria-label="Remove from gallery"
         >
@@ -113,14 +113,14 @@ export function ArticleArtSection({
         />
 
         {/* Gallery */}
-        <div className="mt-2 border-t border-white/8 pt-3">
+        <div className="mt-2 border-t border-[var(--chrome-stroke)] pt-3">
           <div className="mb-2 flex items-center justify-between">
             <p className="text-2xs font-medium uppercase tracking-ui text-text-muted">
               Gallery{gallery.length > 0 ? ` (${gallery.length})` : ""}
             </p>
             <button
               onClick={() => setShowGalleryGenerator((v) => !v)}
-              className="rounded-full border border-white/8 px-2 py-0.5 text-2xs text-text-secondary transition hover:border-white/14 hover:bg-white/8 hover:text-text-primary"
+              className="rounded-full border border-[var(--chrome-stroke)] px-2 py-0.5 text-2xs text-text-secondary transition hover:border-[var(--chrome-stroke-strong)] hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
             >
               {showGalleryGenerator ? "Hide" : "Add Art"}
             </button>

--- a/creator/src/components/lore/ArticleEditor.tsx
+++ b/creator/src/components/lore/ArticleEditor.tsx
@@ -245,7 +245,7 @@ export function ArticleEditor({ articleId }: { articleId: string }) {
           <button
             onClick={() => setShowRewrite(true)}
             title="Rewrite article with specific instructions"
-            className="rounded-full border border-white/8 px-2.5 py-1 text-2xs text-text-secondary hover:bg-white/8 hover:text-text-primary"
+            className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-secondary hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
           >
             Rewrite
           </button>
@@ -253,7 +253,7 @@ export function ArticleEditor({ articleId }: { articleId: string }) {
             onClick={() => {
               duplicateArticle(articleId);
             }}
-            className="focus-ring rounded-full border border-white/10 px-3 py-1 text-2xs font-medium text-text-secondary transition hover:bg-white/8 hover:text-text-primary"
+            className="focus-ring rounded-full border border-[var(--chrome-stroke)] px-3 py-1 text-2xs font-medium text-text-secondary transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
             title="Duplicate this article"
           >
             Duplicate

--- a/creator/src/components/lore/ArticleGenerator.tsx
+++ b/creator/src/components/lore/ArticleGenerator.tsx
@@ -42,7 +42,7 @@ export function ArticleGenerator({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0"
       onClick={(e) => {
         if (e.target === e.currentTarget && !generating) onClose();
       }}
@@ -52,7 +52,7 @@ export function ArticleGenerator({
         role="dialog"
         aria-modal="true"
         aria-labelledby="gen-article-title"
-        className="relative w-full max-w-lg rounded-3xl border border-white/10 bg-bg-secondary p-6 shadow-panel"
+        className="relative w-full max-w-lg rounded-3xl border border-[var(--chrome-stroke)] bg-bg-secondary p-6 shadow-panel"
       >
         <h3 id="gen-article-title" className="font-display text-xl text-text-primary">Generate Article</h3>
         <p className="mt-1 text-xs text-text-muted">

--- a/creator/src/components/lore/ArticleTree.tsx
+++ b/creator/src/components/lore/ArticleTree.tsx
@@ -119,7 +119,7 @@ function Node({ node, style, dragHandle }: NodeRendererProps<TreeNode>) {
           className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border text-3xs transition ${
             isMultiSelected
               ? "border-accent/50 bg-accent/20 text-accent"
-              : "border-white/20 bg-white/5 text-transparent hover:border-white/30"
+              : "border-[var(--chrome-stroke-emphasis)] bg-[var(--chrome-highlight)] text-transparent hover:border-white/30"
           }`}
           aria-label={isMultiSelected ? "Deselect" : "Select"}
         >
@@ -290,7 +290,7 @@ export function ArticleTree() {
                   selectArticle(r.articleId);
                   openTab(panelTab("lore"));
                 }}
-                className="rounded-lg border border-white/6 bg-black/10 px-3 py-2 text-left transition hover:bg-white/6"
+                className="rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-2 text-left transition hover:bg-[var(--chrome-highlight)]"
               >
                 <div className="flex items-center gap-1.5">
                   <span
@@ -305,7 +305,7 @@ export function ArticleTree() {
                   <span className="truncate text-xs text-text-primary">
                     {r.title}
                   </span>
-                  <span className="ml-auto shrink-0 rounded bg-white/8 px-1.5 py-0.5 text-[9px] text-text-muted">
+                  <span className="ml-auto shrink-0 rounded bg-[var(--chrome-highlight-strong)] px-1.5 py-0.5 text-[9px] text-text-muted">
                     {r.matchIn}
                   </span>
                 </div>

--- a/creator/src/components/lore/AuditPanel.tsx
+++ b/creator/src/components/lore/AuditPanel.tsx
@@ -65,7 +65,7 @@ export function AuditPanel() {
           {visibleWithIndex.map(({ issue, idx }) => {
             const style = SEVERITY_STYLES[issue.severity]!;
             return (
-              <div key={idx} className="rounded-xl border border-white/8 bg-black/10 px-4 py-3">
+              <div key={idx} className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3">
                 <div className="mb-1 flex items-center gap-2">
                   <span className={`rounded-full px-2 py-0.5 text-3xs font-medium ${style.bg} ${style.text}`}>
                     {style.label}
@@ -85,7 +85,7 @@ export function AuditPanel() {
                   ))}
                   <button
                     onClick={() => setDismissed((s) => new Set(s).add(idx))}
-                    className="ml-auto rounded-full border border-white/8 px-2 py-0.5 text-3xs text-text-muted transition hover:bg-white/8"
+                    className="ml-auto rounded-full border border-[var(--chrome-stroke)] px-2 py-0.5 text-3xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)]"
                   >
                     Dismiss
                   </button>

--- a/creator/src/components/lore/BulkActionsBar.tsx
+++ b/creator/src/components/lore/BulkActionsBar.tsx
@@ -128,35 +128,35 @@ export function BulkActionsBar() {
       <button
         onClick={() => bulkSetDraft(ids, true)}
         aria-label="Mark selected as draft"
-        className="rounded-full border border-white/8 px-2 py-0.5 text-3xs text-text-secondary hover:bg-white/8"
+        className="rounded-full border border-[var(--chrome-stroke)] px-2 py-0.5 text-3xs text-text-secondary hover:bg-[var(--chrome-highlight-strong)]"
       >
         Draft
       </button>
       <button
         onClick={() => bulkSetDraft(ids, false)}
         aria-label="Publish selected"
-        className="rounded-full border border-white/8 px-2 py-0.5 text-3xs text-text-secondary hover:bg-white/8"
+        className="rounded-full border border-[var(--chrome-stroke)] px-2 py-0.5 text-3xs text-text-secondary hover:bg-[var(--chrome-highlight-strong)]"
       >
         Publish
       </button>
       <button
         onClick={() => setShowTag(true)}
         aria-label="Tag selected articles"
-        className="rounded-full border border-white/8 px-2 py-0.5 text-3xs text-text-secondary hover:bg-white/8"
+        className="rounded-full border border-[var(--chrome-stroke)] px-2 py-0.5 text-3xs text-text-secondary hover:bg-[var(--chrome-highlight-strong)]"
       >
         Tag
       </button>
       <button
         onClick={() => setShowTemplate(true)}
         aria-label="Change template of selected articles"
-        className="rounded-full border border-white/8 px-2 py-0.5 text-3xs text-text-secondary hover:bg-white/8"
+        className="rounded-full border border-[var(--chrome-stroke)] px-2 py-0.5 text-3xs text-text-secondary hover:bg-[var(--chrome-highlight-strong)]"
       >
         Template
       </button>
       <button
         onClick={() => setShowDelete(true)}
         aria-label="Delete selected articles"
-        className="rounded-full border border-white/8 px-2 py-0.5 text-3xs text-status-danger hover:bg-status-danger/10"
+        className="rounded-full border border-[var(--chrome-stroke)] px-2 py-0.5 text-3xs text-status-danger hover:bg-status-danger/10"
       >
         Delete
       </button>
@@ -169,7 +169,7 @@ export function BulkActionsBar() {
       </button>
 
       {showTag && (
-        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-white/10 bg-bg-primary p-3 shadow-lg">
+        <div className="absolute left-0 right-0 top-full z-10 mt-1 rounded-lg border border-[var(--chrome-stroke)] bg-bg-primary p-3 shadow-lg">
           <div className="flex gap-1.5">
             <input
               value={tagInput}

--- a/creator/src/components/lore/DocumentLibraryPanel.tsx
+++ b/creator/src/components/lore/DocumentLibraryPanel.tsx
@@ -64,7 +64,7 @@ function LoreBibleExport() {
   };
 
   return (
-    <div className="rounded-xl border border-white/8 bg-black/10 p-4">
+    <div className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
       <h3 className="mb-2 font-display text-sm text-text-primary">Lore Bible</h3>
       <p className="mb-3 text-2xs text-text-secondary">
         Export the entire lore corpus as a readable Markdown document.
@@ -180,7 +180,7 @@ export function DocumentLibraryPanel() {
           </button>
           <button
             onClick={() => setShowImportWizard(true)}
-            className="focus-ring rounded-full border border-white/10 px-3 py-1.5 text-xs font-medium text-text-secondary transition hover:bg-white/8 hover:text-text-primary"
+            className="focus-ring rounded-full border border-[var(--chrome-stroke)] px-3 py-1.5 text-xs font-medium text-text-secondary transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
           >
             Import Markdown
           </button>

--- a/creator/src/components/lore/EntityOverlay.tsx
+++ b/creator/src/components/lore/EntityOverlay.tsx
@@ -70,7 +70,7 @@ function RemoveButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       type="button"
-      className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-black/60 hover:bg-black/80 opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+      className="absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-[var(--chrome-fill-soft)]0 hover:bg-[var(--chrome-fill-soft)]0 opacity-0 group-hover:opacity-100 transition-opacity duration-150"
       onClick={(e) => {
         e.stopPropagation();
         onClick();

--- a/creator/src/components/lore/GapAnalysisPanel.tsx
+++ b/creator/src/components/lore/GapAnalysisPanel.tsx
@@ -65,7 +65,7 @@ export function GapAnalysisPanel() {
             return (
               <div
                 key={idx}
-                className="rounded-xl border border-white/8 bg-black/10 px-4 py-3"
+                className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3"
               >
                 <div className="mb-1 flex items-center gap-2">
                   <span className="rounded-full bg-status-warning/15 px-2 py-0.5 text-3xs font-medium text-status-warning">
@@ -97,7 +97,7 @@ export function GapAnalysisPanel() {
                     onClick={() =>
                       setDismissed((s) => new Set(s).add(idx))
                     }
-                    className="ml-auto rounded-full border border-white/8 px-2 py-0.5 text-3xs text-text-muted transition hover:bg-white/8"
+                    className="ml-auto rounded-full border border-[var(--chrome-stroke)] px-2 py-0.5 text-3xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)]"
                   >
                     Dismiss
                   </button>

--- a/creator/src/components/lore/ImportWizard.tsx
+++ b/creator/src/components/lore/ImportWizard.tsx
@@ -152,7 +152,7 @@ export function ImportWizard({ onClose }: { onClose: () => void }) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 bg-[var(--chrome-fill-soft)]0 backdrop-blur-sm"
         onClick={onClose}
       />
       <div
@@ -160,10 +160,10 @@ export function ImportWizard({ onClose }: { onClose: () => void }) {
         role="dialog"
         aria-modal="true"
         aria-label="Import Markdown files"
-        className="relative flex w-full max-w-2xl max-h-[80vh] flex-col overflow-hidden rounded-2xl border border-white/10 bg-bg-primary shadow-[0_24px_80px_rgba(8,10,18,0.6)]"
+        className="relative flex w-full max-w-2xl max-h-[80vh] flex-col overflow-hidden rounded-2xl border border-[var(--chrome-stroke)] bg-bg-primary shadow-[0_24px_80px_rgba(8,10,18,0.6)]"
       >
         {/* Header */}
-        <div className="shrink-0 border-b border-white/8 px-6 py-4">
+        <div className="shrink-0 border-b border-[var(--chrome-stroke)] px-6 py-4">
           <h2 className="font-display text-lg text-text-primary">
             Import Markdown
           </h2>
@@ -217,7 +217,7 @@ export function ImportWizard({ onClose }: { onClose: () => void }) {
                   className={`flex items-center gap-3 rounded-xl border px-4 py-3 ${
                     c.selected
                       ? "border-accent/20 bg-accent/5"
-                      : "border-white/6 bg-black/10 opacity-50"
+                      : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] opacity-50"
                   }`}
                 >
                   <input
@@ -275,7 +275,7 @@ export function ImportWizard({ onClose }: { onClose: () => void }) {
         </div>
 
         {/* Footer */}
-        <div className="shrink-0 border-t border-white/8 px-6 py-3 flex items-center justify-between">
+        <div className="shrink-0 border-t border-[var(--chrome-stroke)] px-6 py-3 flex items-center justify-between">
           <button
             onClick={onClose}
             className="text-xs text-text-muted hover:text-text-primary transition"

--- a/creator/src/components/lore/LorePanelHost.tsx
+++ b/creator/src/components/lore/LorePanelHost.tsx
@@ -135,7 +135,7 @@ export function LorePanelHost({ panelId }: { panelId: string }) {
                 onClick={handleSave}
                 disabled={!dirty || saving}
                 aria-label={saving ? "Saving lore" : "Save lore"}
-                className="focus-ring rounded-full border border-white/10 bg-bg-primary/80 px-3 py-1 text-2xs font-medium text-accent shadow-md backdrop-blur-sm transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
+                className="focus-ring rounded-full border border-[var(--chrome-stroke)] bg-bg-primary/80 px-3 py-1 text-2xs font-medium text-accent shadow-md backdrop-blur-sm transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {saving ? <span className="flex items-center gap-1.5"><Spinner />Saving</span> : "Save Lore"}
               </button>

--- a/creator/src/components/lore/MapAnalysisPanel.tsx
+++ b/creator/src/components/lore/MapAnalysisPanel.tsx
@@ -73,7 +73,7 @@ export function MapAnalysisPanel({
   );
 
   return (
-    <div className="rounded-xl border border-white/8 bg-black/10 p-4">
+    <div className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
       <div className="mb-3 flex items-center gap-3">
         <button
           onClick={handleAnalyze}
@@ -113,7 +113,7 @@ export function MapAnalysisPanel({
             return (
               <div
                 key={i}
-                className="flex items-center gap-2 rounded-lg border border-white/6 bg-black/10 px-3 py-2"
+                className="flex items-center gap-2 rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-2"
               >
                 <div className="min-w-0 flex-1">
                   <span className="text-xs text-text-primary">{s.label}</span>
@@ -133,8 +133,8 @@ export function MapAnalysisPanel({
                     s.confidence === "high"
                       ? "bg-accent/15 text-accent"
                       : s.confidence === "medium"
-                        ? "bg-white/8 text-text-secondary"
-                        : "bg-white/5 text-text-muted"
+                        ? "bg-[var(--chrome-highlight-strong)] text-text-secondary"
+                        : "bg-[var(--chrome-highlight)] text-text-muted"
                   }`}
                 >
                   {s.confidence}
@@ -149,7 +149,7 @@ export function MapAnalysisPanel({
                   onClick={() =>
                     setDismissed((prev) => new Set(prev).add(i))
                   }
-                  className="rounded-full border border-white/8 px-2 py-0.5 text-3xs text-text-muted hover:bg-white/8"
+                  className="rounded-full border border-[var(--chrome-stroke)] px-2 py-0.5 text-3xs text-text-muted hover:bg-[var(--chrome-highlight-strong)]"
                 >
                   Skip
                 </button>

--- a/creator/src/components/lore/MapEnhancer.tsx
+++ b/creator/src/components/lore/MapEnhancer.tsx
@@ -185,7 +185,7 @@ export function MapEnhancer({
         aria-modal="true"
         aria-labelledby="map-enhance-title"
         aria-describedby="map-enhance-description"
-        className="relative flex max-h-[90vh] w-full max-w-4xl flex-col gap-4 overflow-y-auto rounded-3xl border border-white/10 bg-bg-secondary p-6 shadow-panel"
+        className="relative flex max-h-[90vh] w-full max-w-4xl flex-col gap-4 overflow-y-auto rounded-3xl border border-[var(--chrome-stroke)] bg-bg-secondary p-6 shadow-panel"
       >
         <div className="flex items-center justify-between">
           <h3 id="map-enhance-title" className="font-display text-xl text-text-primary">Enhance Map Region</h3>

--- a/creator/src/components/lore/MapPanel.tsx
+++ b/creator/src/components/lore/MapPanel.tsx
@@ -64,13 +64,13 @@ function ColorPalettePicker({
                 onClick={() => onChange(cl.color)}
                 className={`flex items-center gap-1.5 rounded px-1.5 py-0.5 text-2xs transition ${
                   value === cl.color
-                    ? "bg-white/10 text-text-primary"
-                    : "text-text-secondary hover:bg-white/5 hover:text-text-primary"
+                    ? "bg-[var(--chrome-highlight-strong)] text-text-primary"
+                    : "text-text-secondary hover:bg-[var(--chrome-highlight)] hover:text-text-primary"
                 }`}
                 title={cl.name}
               >
                 <span
-                  className="inline-block h-3 w-3 shrink-0 rounded-sm border border-white/20"
+                  className="inline-block h-3 w-3 shrink-0 rounded-sm border border-[var(--chrome-stroke-emphasis)]"
                   style={{ backgroundColor: cl.color }}
                 />
                 {editingId === cl.id ? (
@@ -111,7 +111,7 @@ function ColorPalettePicker({
                   updateColorLabel(cl.id, { color: e.target.value });
                   if (value === cl.color) onChange(e.target.value);
                 }}
-                className="h-10 w-10 shrink-0 cursor-pointer rounded-full border border-white/10 bg-transparent p-1 opacity-0 transition group-hover:opacity-100"
+                className="h-10 w-10 shrink-0 cursor-pointer rounded-full border border-[var(--chrome-stroke)] bg-transparent p-1 opacity-0 transition group-hover:opacity-100"
                 title="Change color"
               />
               <button
@@ -133,7 +133,7 @@ function ColorPalettePicker({
             type="color"
             value={newColor}
             onChange={(e) => setNewColor(e.target.value)}
-            className="h-11 w-11 shrink-0 cursor-pointer rounded-full border border-white/10 bg-transparent p-1"
+            className="h-11 w-11 shrink-0 cursor-pointer rounded-full border border-[var(--chrome-stroke)] bg-transparent p-1"
           />
           <input
             ref={nameRef}
@@ -171,7 +171,7 @@ function ColorPalettePicker({
           type="color"
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="h-11 w-11 cursor-pointer rounded-full border border-white/10 bg-bg-primary p-1"
+          className="h-11 w-11 cursor-pointer rounded-full border border-[var(--chrome-stroke)] bg-bg-primary p-1"
         />
         <span className="text-2xs text-text-muted">Custom</span>
       </div>
@@ -252,7 +252,7 @@ function ArticleCombobox({
 
       {open && (
         <div className="absolute left-0 right-0 top-full z-50 mt-1 flex max-h-60 flex-col overflow-hidden rounded-lg border border-border-default bg-bg-secondary shadow-lg">
-          <div className="shrink-0 border-b border-white/6 p-1.5">
+          <div className="shrink-0 border-b border-[var(--chrome-stroke)] p-1.5">
             <input
               ref={inputRef}
               type="text"
@@ -266,7 +266,7 @@ function ArticleCombobox({
             <button
               onClick={() => { onChange(undefined); setOpen(false); setFilter(""); }}
               className={`w-full rounded px-2 py-1 text-left text-xs transition ${
-                !value ? "bg-white/10 text-text-primary" : "text-text-muted hover:bg-white/5 hover:text-text-secondary"
+                !value ? "bg-[var(--chrome-highlight-strong)] text-text-primary" : "text-text-muted hover:bg-[var(--chrome-highlight)] hover:text-text-secondary"
               }`}
             >
               Unmarked
@@ -282,8 +282,8 @@ function ArticleCombobox({
                     onClick={() => { onChange(a.id); setOpen(false); setFilter(""); }}
                     className={`w-full rounded px-2 py-1 text-left text-xs transition ${
                       value === a.id
-                        ? "bg-white/10 text-text-primary"
-                        : "text-text-secondary hover:bg-white/5 hover:text-text-primary"
+                        ? "bg-[var(--chrome-highlight-strong)] text-text-primary"
+                        : "text-text-secondary hover:bg-[var(--chrome-highlight)] hover:text-text-primary"
                     }`}
                   >
                     {a.title}
@@ -325,7 +325,7 @@ function PinEditor({
         <h4 className="font-display text-sm text-text-primary">Edit Pin</h4>
         <button
           onClick={onClose}
-          className="focus-ring flex h-11 w-11 items-center justify-center rounded-full text-xs text-text-muted hover:bg-white/6 hover:text-text-primary"
+          className="focus-ring flex h-11 w-11 items-center justify-center rounded-full text-xs text-text-muted hover:bg-[var(--chrome-highlight)] hover:text-text-primary"
         >
           Done
         </button>
@@ -597,7 +597,7 @@ export function MapPanel() {
           </div>
 
           {/* Pin sidebar */}
-          <div className="rounded-2xl border border-white/8 bg-black/12 p-4">
+          <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
             {selectedPinId && selectedMap ? (
               <PinEditor
                 map={selectedMap}

--- a/creator/src/components/lore/MentionSuggestionsPanel.tsx
+++ b/creator/src/components/lore/MentionSuggestionsPanel.tsx
@@ -60,7 +60,7 @@ export function MentionSuggestionsPanel() {
       </div>
 
       {scanned && visible.length === 0 && (
-        <p className="rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-6 text-sm text-text-muted">
+        <p className="rounded-2xl border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-6 text-sm text-text-muted">
           No missing mentions found. All plain-text references are already
           linked.
         </p>
@@ -71,7 +71,7 @@ export function MentionSuggestionsPanel() {
           {visible.map((s) => (
             <div
               key={`${s.sourceId}:${s.targetId}`}
-              className="rounded-xl border border-white/8 bg-black/10 px-4 py-3"
+              className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3"
             >
               <div className="mb-1 flex items-center gap-2">
                 <button
@@ -91,7 +91,7 @@ export function MentionSuggestionsPanel() {
                   className={`ml-auto rounded-full px-2 py-0.5 text-3xs ${
                     s.quality === "exact"
                       ? "bg-accent/15 text-accent"
-                      : "bg-white/8 text-text-muted"
+                      : "bg-[var(--chrome-highlight-strong)] text-text-muted"
                   }`}
                 >
                   {s.quality}
@@ -103,7 +103,7 @@ export function MentionSuggestionsPanel() {
               <div className="flex gap-2">
                 <button
                   onClick={() => handleDismiss(s.sourceId, s.targetId)}
-                  className="rounded-full border border-white/8 px-2.5 py-1 text-2xs text-text-muted transition hover:bg-white/8 hover:text-text-primary"
+                  className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
                 >
                   Dismiss
                 </button>

--- a/creator/src/components/lore/RelationInferencePanel.tsx
+++ b/creator/src/components/lore/RelationInferencePanel.tsx
@@ -75,7 +75,7 @@ export function RelationInferencePanel() {
         {scanned && visible.length > 0 && highCount > 0 && (
           <button
             onClick={handleAcceptAllHigh}
-            className="focus-ring rounded-full border border-white/10 px-3 py-1.5 text-2xs text-text-secondary transition hover:bg-white/8"
+            className="focus-ring rounded-full border border-[var(--chrome-stroke)] px-3 py-1.5 text-2xs text-text-secondary transition hover:bg-[var(--chrome-highlight-strong)]"
           >
             Accept All High ({highCount})
           </button>
@@ -88,7 +88,7 @@ export function RelationInferencePanel() {
       </div>
 
       {scanned && visible.length === 0 && (
-        <p className="rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-6 text-center text-sm text-text-muted">
+        <p className="rounded-2xl border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-6 text-center text-sm text-text-muted">
           {accepted.size > 0
             ? `All done! ${accepted.size} relation${accepted.size !== 1 ? "s" : ""} accepted.`
             : "No missing relations detected."}
@@ -100,13 +100,13 @@ export function RelationInferencePanel() {
           {visible.map((s) => (
             <div
               key={suggestionKey(s)}
-              className="rounded-xl border border-white/8 bg-black/10 px-4 py-3"
+              className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3"
             >
               <div className="mb-1 flex items-center gap-2">
                 <span className="text-xs text-text-primary">
                   {articles[s.sourceId]?.title ?? s.sourceId}
                 </span>
-                <span className="rounded bg-white/10 px-1.5 py-0.5 text-3xs text-text-muted">
+                <span className="rounded bg-[var(--chrome-highlight-strong)] px-1.5 py-0.5 text-3xs text-text-muted">
                   {s.label ?? s.type}
                 </span>
                 <span className="text-2xs text-text-muted">&rarr;</span>
@@ -117,7 +117,7 @@ export function RelationInferencePanel() {
                   className={`ml-auto rounded-full px-2 py-0.5 text-3xs ${
                     s.confidence === "high"
                       ? "bg-accent/15 text-accent"
-                      : "bg-white/8 text-text-muted"
+                      : "bg-[var(--chrome-highlight-strong)] text-text-muted"
                   }`}
                 >
                   {s.confidence}
@@ -133,7 +133,7 @@ export function RelationInferencePanel() {
                 </button>
                 <button
                   onClick={() => handleDismiss(s)}
-                  className="rounded-full border border-white/8 px-2.5 py-1 text-2xs text-text-muted transition hover:bg-white/8"
+                  className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)]"
                 >
                   Dismiss
                 </button>

--- a/creator/src/components/lore/SceneInfoBadges.tsx
+++ b/creator/src/components/lore/SceneInfoBadges.tsx
@@ -77,7 +77,7 @@ function MiniMap({
     : null;
 
   return (
-    <div className="relative h-20 w-28 overflow-hidden rounded border border-white/20 shadow-lg">
+    <div className="relative h-20 w-28 overflow-hidden rounded border border-[var(--chrome-stroke-emphasis)] shadow-lg">
       <img src={src} alt="" className="h-full w-full object-cover" draggable={false} />
       {xPct !== null && yPct !== null && (
         <span
@@ -101,7 +101,7 @@ function ArticleBadgeChip({ articleId }: { articleId: string }) {
   if (!article) return null;
   return (
     <div
-      className="flex items-center gap-1.5 rounded-full border border-white/20 bg-black/75 px-2 py-0.5"
+      className="flex items-center gap-1.5 rounded-full border border-[var(--chrome-stroke-emphasis)] bg-black/75 px-2 py-0.5"
       title={article.title}
     >
       {src ? (
@@ -161,7 +161,7 @@ export function SceneInfoBadges({ scene, mode = "ambient" }: SceneInfoBadgesProp
     >
       {/* Top-left: year/era badge */}
       {timeline && (
-        <div className="absolute left-3 top-3 flex flex-col items-start gap-0.5 rounded border border-warm/40 bg-black/80 px-2 py-1">
+        <div className="absolute left-3 top-3 flex flex-col items-start gap-0.5 rounded border border-warm/40 bg-[var(--chrome-fill-soft)]0 px-2 py-1">
           <span
             className="font-display text-base leading-none tracking-[0.18em] text-warm"
             style={{ textShadow: "0 1px 3px rgba(0,0,0,0.6)" }}

--- a/creator/src/components/lore/StorySettingsSection.tsx
+++ b/creator/src/components/lore/StorySettingsSection.tsx
@@ -34,7 +34,7 @@ function CoverImage({
           <Spinner />
         </div>
       )}
-      <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+      <div className="absolute inset-0 flex items-center justify-center bg-[var(--chrome-fill-strong)] opacity-0 transition-opacity group-hover:opacity-100">
         <span className="text-sm font-medium text-white">Change</span>
       </div>
     </button>

--- a/creator/src/components/lore/TemplateEditorPanel.tsx
+++ b/creator/src/components/lore/TemplateEditorPanel.tsx
@@ -168,7 +168,7 @@ function TemplateForm({
           </button>
         </div>
         {draft.fields.length === 0 ? (
-          <p className="rounded-lg border border-dashed border-white/10 bg-black/10 px-4 py-6 text-center text-xs text-text-muted">
+          <p className="rounded-lg border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-6 text-center text-xs text-text-muted">
             No fields yet. Articles of this template will only have a title and body text.
           </p>
         ) : (
@@ -248,7 +248,7 @@ export function TemplateEditorPanel() {
       {/* Custom templates */}
       <Section title="Custom Templates">
         {customTemplates.length === 0 && !creating ? (
-          <p className="rounded-lg border border-dashed border-white/10 bg-black/10 px-4 py-6 text-center text-xs text-text-muted">
+          <p className="rounded-lg border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-6 text-center text-xs text-text-muted">
             No custom templates yet. Create one to add new article types.
           </p>
         ) : (
@@ -282,13 +282,13 @@ export function TemplateEditorPanel() {
                     </div>
                     <button
                       onClick={() => { setEditing(t.id); setCreating(false); }}
-                      className="rounded-full border border-white/8 px-2.5 py-1 text-2xs text-text-secondary hover:bg-white/8"
+                      className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-secondary hover:bg-[var(--chrome-highlight-strong)]"
                     >
                       Edit
                     </button>
                     <button
                       onClick={() => deleteCustomTemplate(t.id)}
-                      className="rounded-full border border-white/8 px-2.5 py-1 text-2xs text-text-muted hover:text-status-danger"
+                      className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted hover:text-status-danger"
                     >
                       Delete
                     </button>

--- a/creator/src/components/lore/TimelineInferencePanel.tsx
+++ b/creator/src/components/lore/TimelineInferencePanel.tsx
@@ -88,7 +88,7 @@ export function TimelineInferencePanel() {
       {error && <p className="mb-3 text-xs text-status-danger">{error}</p>}
 
       {suggestions.length > 0 && visible.length === 0 && !loading && (
-        <p className="rounded-2xl border border-dashed border-white/10 bg-black/10 px-4 py-6 text-sm text-text-muted">
+        <p className="rounded-2xl border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-6 text-sm text-text-muted">
           All suggestions processed. {accepted.size} accepted.
         </p>
       )}
@@ -100,16 +100,16 @@ export function TimelineInferencePanel() {
             return (
               <div
                 key={i}
-                className="rounded-xl border border-white/8 bg-black/10 px-4 py-3"
+                className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3"
               >
                 <div className="mb-1 flex flex-wrap items-center gap-2">
                   <span className="text-xs font-medium text-text-primary">
                     {s.title}
                   </span>
-                  <span className="rounded bg-white/10 px-1.5 py-0.5 text-3xs text-text-muted">
+                  <span className="rounded bg-[var(--chrome-highlight-strong)] px-1.5 py-0.5 text-3xs text-text-muted">
                     Year {s.year}
                   </span>
-                  <span className="rounded bg-white/10 px-1.5 py-0.5 text-3xs text-text-muted">
+                  <span className="rounded bg-[var(--chrome-highlight-strong)] px-1.5 py-0.5 text-3xs text-text-muted">
                     {s.eraName}
                   </span>
                   <span
@@ -117,8 +117,8 @@ export function TimelineInferencePanel() {
                       s.importance === "legendary"
                         ? "bg-accent/20 text-accent"
                         : s.importance === "major"
-                          ? "bg-white/10 text-text-primary"
-                          : "bg-white/5 text-text-muted"
+                          ? "bg-[var(--chrome-highlight-strong)] text-text-primary"
+                          : "bg-[var(--chrome-highlight)] text-text-muted"
                     }`}
                   >
                     {s.importance}
@@ -145,7 +145,7 @@ export function TimelineInferencePanel() {
                       onClick={() =>
                         setDismissed((prev) => new Set(prev).add(i))
                       }
-                      className="rounded-full border border-white/8 px-2.5 py-1 text-2xs text-text-muted hover:bg-white/8"
+                      className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted hover:bg-[var(--chrome-highlight-strong)]"
                     >
                       Dismiss
                     </button>

--- a/creator/src/components/lore/TimelinePanel.tsx
+++ b/creator/src/components/lore/TimelinePanel.tsx
@@ -74,7 +74,7 @@ function CalendarEditor({
           <div className="flex items-center justify-between gap-2">
             <input
               aria-label="Calendar name"
-              className="ornate-input min-h-11 min-w-0 flex-1 rounded-2xl bg-black/10 px-4 py-3 font-display text-sm text-text-primary"
+              className="ornate-input min-h-11 min-w-0 flex-1 rounded-2xl bg-[var(--chrome-fill)] px-4 py-3 font-display text-sm text-text-primary"
               value={cal.name}
               onChange={(e) => patchCalendar(cal.id, { name: e.target.value })}
             />
@@ -93,7 +93,7 @@ function CalendarEditor({
                     aria-label={`Color for ${era.name}`}
                     value={era.color || "#a897d2"}
                     onChange={(e) => patchEra(cal.id, era.id, { color: e.target.value })}
-                    className="h-11 w-11 cursor-pointer rounded-full border border-white/10 bg-transparent p-1"
+                    className="h-11 w-11 cursor-pointer rounded-full border border-[var(--chrome-stroke)] bg-transparent p-1"
                     title="Era color"
                   />
                   <input

--- a/creator/src/components/lore/WorldPlannerPanel.tsx
+++ b/creator/src/components/lore/WorldPlannerPanel.tsx
@@ -55,7 +55,7 @@ function GenerationControls({
   disabled: boolean;
 }) {
   return (
-    <div className="rounded-2xl border border-white/8 bg-black/15 p-4">
+    <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
       <h3 className="mb-3 font-display text-sm text-text-primary">
         Generate Zones from Map
       </h3>
@@ -194,7 +194,7 @@ function SuggestionReview({
           {visible.map((s) => (
             <div
               key={s.tempId}
-              className="rounded-lg border border-white/8 bg-black/15 p-3"
+              className="rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-3"
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0 flex-1">
@@ -303,7 +303,7 @@ function ZonePlanEditor({
         <h4 className="font-display text-sm text-text-primary">Edit Zone</h4>
         <button
           onClick={onClose}
-          className="focus-ring flex h-8 items-center justify-center rounded-full px-3 text-2xs text-text-muted hover:bg-white/6 hover:text-text-primary"
+          className="focus-ring flex h-8 items-center justify-center rounded-full px-3 text-2xs text-text-muted hover:bg-[var(--chrome-highlight)] hover:text-text-primary"
         >
           Done
         </button>
@@ -368,7 +368,7 @@ function ZonePlanEditor({
             {otherPlans.map((p) => (
               <label
                 key={p.id}
-                className="flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-2xs text-text-secondary hover:bg-white/5"
+                className="flex cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-2xs text-text-secondary hover:bg-[var(--chrome-highlight)]"
               >
                 <input
                   type="checkbox"
@@ -384,14 +384,14 @@ function ZonePlanEditor({
       </div>
 
       {plan.region && (
-        <div className="rounded-lg border border-white/6 bg-black/15 p-2 text-2xs text-text-muted">
+        <div className="rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-2 text-2xs text-text-muted">
           Region: {Math.round(plan.region.x)},{Math.round(plan.region.y)} ·{" "}
           {Math.round(plan.region.w)}×{Math.round(plan.region.h)}px
         </div>
       )}
 
       {/* Zone scaffold link */}
-      <div className="rounded-lg border border-white/6 bg-black/15 p-2.5">
+      <div className="rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-2.5">
         <div className="mb-1.5 text-2xs uppercase tracking-wider text-text-muted">
           Linked Zone
         </div>
@@ -621,7 +621,7 @@ export function WorldPlannerPanel() {
 
       {/* Map preview */}
       {sourceMap && mapImage && (
-        <div className="overflow-hidden rounded-xl border border-white/8 bg-black/30">
+        <div className="overflow-hidden rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-strong)]">
           <img
             src={mapImage}
             alt={sourceMap.title}
@@ -703,7 +703,7 @@ export function WorldPlannerPanel() {
           selectedId={selectedPlanId}
           onSelect={setSelectedPlanId}
         />
-        <div className="rounded-2xl border border-white/8 bg-black/12 p-4">
+        <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
           {selectedPlan ? (
             <ZonePlanEditor
               plan={selectedPlan}

--- a/creator/src/components/lore/WorldSeedWizard.tsx
+++ b/creator/src/components/lore/WorldSeedWizard.tsx
@@ -64,7 +64,7 @@ export function WorldSeedWizard({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0"
       onClick={(e) => {
         if (e.target === e.currentTarget && !generating) onClose();
       }}
@@ -74,7 +74,7 @@ export function WorldSeedWizard({
         role="dialog"
         aria-modal="true"
         aria-labelledby="seed-wizard-title"
-        className="relative w-full max-w-xl rounded-3xl border border-white/10 bg-bg-secondary p-6 shadow-panel"
+        className="relative w-full max-w-xl rounded-3xl border border-[var(--chrome-stroke)] bg-bg-secondary p-6 shadow-panel"
       >
         <h3 id="seed-wizard-title" className="font-display text-xl text-text-primary">Seed a World</h3>
         <p className="mt-1 text-xs text-text-muted">

--- a/creator/src/components/lore/ZonePlanGraph.tsx
+++ b/creator/src/components/lore/ZonePlanGraph.tsx
@@ -155,7 +155,7 @@ export function ZonePlanGraph({
 
   return (
     <div
-      className="rounded-xl border border-white/8 bg-black/20"
+      className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-strong)]"
       style={{ height: "min(60vh, 500px)" }}
     >
       <ReactFlowProvider>

--- a/creator/src/components/tuning/TuningWizard.tsx
+++ b/creator/src/components/tuning/TuningWizard.tsx
@@ -221,7 +221,7 @@ export function TuningWizard() {
           <button
             onClick={handleSave}
             disabled={!dirty || saving}
-            className="focus-ring rounded-full border border-white/10 bg-bg-primary/80 px-4 py-1.5 text-sm font-medium text-accent shadow-md backdrop-blur-sm transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
+            className="focus-ring rounded-full border border-[var(--chrome-stroke)] bg-bg-primary/80 px-4 py-1.5 text-sm font-medium text-accent shadow-md backdrop-blur-sm transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
           >
             {saving ? <span className="flex items-center gap-1.5"><Spinner />Saving</span> : "Save Changes"}
           </button>

--- a/creator/src/components/ui/AssetPickerModal.tsx
+++ b/creator/src/components/ui/AssetPickerModal.tsx
@@ -86,7 +86,7 @@ export function AssetPickerModal({ onSelect, onClose }: AssetPickerModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}

--- a/creator/src/components/ui/BulkBgRemoval.tsx
+++ b/creator/src/components/ui/BulkBgRemoval.tsx
@@ -240,6 +240,6 @@ function StatusDot({ status }: { status: TargetState["status"] }) {
     status === "error" ? "bg-status-error" :
     status === "processing" ? "bg-status-warning animate-pulse" :
     status === "skipped" ? "bg-white/20" :
-    "bg-white/10";
+    "bg-[var(--chrome-highlight-strong)]";
   return <span className={`h-2 w-2 shrink-0 rounded-full ${cls}`} />;
 }

--- a/creator/src/components/ui/CommandPalette.tsx
+++ b/creator/src/components/ui/CommandPalette.tsx
@@ -136,7 +136,7 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
       article: "bg-accent/15 text-accent",
       zone: "bg-status-success/20 text-status-success",
     };
-    return colors[type] ?? "bg-white/10 text-text-muted";
+    return colors[type] ?? "bg-[var(--chrome-highlight-strong)] text-text-muted";
   };
 
   const typeGlyph = (type: string) => {
@@ -153,13 +153,13 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
       className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
       onClick={onClose}
     >
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+      <div className="absolute inset-0 bg-[var(--chrome-fill-soft)]0 backdrop-blur-sm" />
       <div
         ref={trapRef}
         role="dialog"
         aria-modal="true"
         aria-label="Command palette"
-        className="relative w-full max-w-lg rounded-2xl border border-white/10 bg-bg-primary shadow-[0_24px_80px_rgba(8,10,18,0.6)]"
+        className="relative w-full max-w-lg rounded-2xl border border-[var(--chrome-stroke)] bg-bg-primary shadow-[0_24px_80px_rgba(8,10,18,0.6)]"
         onClick={(e) => e.stopPropagation()}
       >
         <input
@@ -176,7 +176,7 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
           aria-describedby={statusId}
           aria-expanded={filtered.length > 0}
           aria-activedescendant={activeOptionId}
-          className="w-full rounded-t-2xl border-b border-white/8 bg-transparent px-5 py-4 text-sm text-text-primary placeholder:text-text-muted outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+          className="w-full rounded-t-2xl border-b border-[var(--chrome-stroke)] bg-transparent px-5 py-4 text-sm text-text-primary placeholder:text-text-muted outline-none focus-visible:ring-2 focus-visible:ring-border-active"
         />
         <p id={statusId} role="status" aria-live="polite" className="sr-only">
           {filtered.length === 0
@@ -206,7 +206,7 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
                 aria-selected={i === selectedIndex}
                 tabIndex={-1}
                 className={`flex w-full items-center gap-3 px-5 py-2.5 text-left transition ${
-                  i === selectedIndex ? "bg-white/8" : "hover:bg-white/4"
+                  i === selectedIndex ? "bg-[var(--chrome-highlight-strong)]" : "hover:bg-[var(--chrome-highlight)]"
                 }`}
               >
                 <span
@@ -229,13 +229,13 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
             ))
           )}
         </div>
-        <div className="border-t border-white/6 px-5 py-2 text-3xs text-text-muted">
-          <kbd className="rounded bg-white/8 px-1.5 py-0.5">&uarr;&darr;</kbd>{" "}
+        <div className="border-t border-[var(--chrome-stroke)] px-5 py-2 text-3xs text-text-muted">
+          <kbd className="rounded bg-[var(--chrome-highlight-strong)] px-1.5 py-0.5">&uarr;&darr;</kbd>{" "}
           navigate
           <span className="mx-2">&middot;</span>
-          <kbd className="rounded bg-white/8 px-1.5 py-0.5">&crarr;</kbd> open
+          <kbd className="rounded bg-[var(--chrome-highlight-strong)] px-1.5 py-0.5">&crarr;</kbd> open
           <span className="mx-2">&middot;</span>
-          <kbd className="rounded bg-white/8 px-1.5 py-0.5">esc</kbd> close
+          <kbd className="rounded bg-[var(--chrome-highlight-strong)] px-1.5 py-0.5">esc</kbd> close
         </div>
       </div>
     </div>

--- a/creator/src/components/ui/DiffModal.tsx
+++ b/creator/src/components/ui/DiffModal.tsx
@@ -37,7 +37,7 @@ export function DiffModal({ onConfirm, onCancel }: DiffModalProps) {
       widthClassName="max-w-4xl"
       onClose={onCancel}
       status={
-        <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs text-text-secondary">
+        <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs text-text-secondary">
           {diffs ? `${diffs.length} file${diffs.length !== 1 ? "s" : ""}` : "Reading changes"}
         </span>
       }
@@ -77,11 +77,11 @@ export function DiffModal({ onConfirm, onCancel }: DiffModalProps) {
           <section key={diff.label} className="panel-surface-light rounded-3xl p-4">
             <div className="mb-3 flex flex-wrap items-center gap-2">
               <h3 className="font-display text-sm text-text-primary">{diff.label}</h3>
-              <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs text-text-secondary">
+              <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs text-text-secondary">
                 {diff.changeCount} change{diff.changeCount !== 1 ? "s" : ""}
               </span>
             </div>
-            <div className="max-h-72 overflow-auto rounded-2xl border border-white/8 bg-[rgba(8,12,28,0.42)] font-mono text-2xs leading-5">
+            <div className="max-h-72 overflow-auto rounded-2xl border border-[var(--chrome-stroke)] bg-[rgba(8,12,28,0.42)] font-mono text-2xs leading-5">
               {diff.lines.map((line, index) => (
                 <div
                   key={index}

--- a/creator/src/components/ui/FormWidgets.tsx
+++ b/creator/src/components/ui/FormWidgets.tsx
@@ -135,7 +135,7 @@ export function EditableField({
   if (!editing) {
     return (
       <div
-        className={`focus-ring cursor-text rounded border-b border-dashed border-white/10 px-1 -mx-1 hover:border-white/20 hover:bg-bg-tertiary ${className ?? ""}`}
+        className={`focus-ring cursor-text rounded border-b border-dashed border-[var(--chrome-stroke)] px-1 -mx-1 hover:border-[var(--chrome-stroke-emphasis)] hover:bg-bg-tertiary ${className ?? ""}`}
         role="button"
         tabIndex={0}
         aria-expanded={editing}
@@ -200,7 +200,7 @@ export function EditableTextArea({
   if (!editing) {
     return (
       <div
-        className="focus-ring cursor-text rounded border-b border-dashed border-white/10 px-1 -mx-1 text-xs leading-relaxed text-text-secondary hover:border-white/20 hover:bg-bg-tertiary"
+        className="focus-ring cursor-text rounded border-b border-dashed border-[var(--chrome-stroke)] px-1 -mx-1 text-xs leading-relaxed text-text-secondary hover:border-[var(--chrome-stroke-emphasis)] hover:bg-bg-tertiary"
         role="button"
         tabIndex={0}
         aria-expanded={editing}

--- a/creator/src/components/ui/ShortcutsHelp.tsx
+++ b/creator/src/components/ui/ShortcutsHelp.tsx
@@ -21,7 +21,7 @@ export function ShortcutsHelp({ onClose }: ShortcutsHelpProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0"
       onClick={onClose}
     >
       <div

--- a/creator/src/components/wizard/ProjectWizard.tsx
+++ b/creator/src/components/wizard/ProjectWizard.tsx
@@ -88,7 +88,7 @@ export function ProjectWizard({ onClose }: ProjectWizardProps) {
                 Choose a location, seed the world from a template, and set the first thematic constraints before opening the workspace.
               </p>
             </div>
-            <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs text-text-secondary">
+            <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs text-text-secondary">
               Step {step} of {STEP_COUNT}
             </span>
           </div>

--- a/creator/src/components/zone/BatchArtGenerator.tsx
+++ b/creator/src/components/zone/BatchArtGenerator.tsx
@@ -123,7 +123,7 @@ export function BatchArtGenerator({
             </p>
           </div>
           <div className="flex shrink-0 flex-col items-end gap-2 text-right">
-            <span className="rounded-full border border-white/10 bg-black/10 px-3 py-1 text-2xs text-text-secondary">
+            <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs text-text-secondary">
               {checkedTargets.length} of {targets.length} selected
             </span>
             {!running && doneCount === 0 && (

--- a/creator/src/components/zone/DirectionPicker.tsx
+++ b/creator/src/components/zone/DirectionPicker.tsx
@@ -65,7 +65,7 @@ export function DirectionPicker({
   }, [onCancel]);
 
   return (
-    <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
+    <div className="absolute inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-strong)]">
       <div
         ref={trapRef}
         role="dialog"

--- a/creator/src/components/zone/RoomNode.tsx
+++ b/creator/src/components/zone/RoomNode.tsx
@@ -69,7 +69,7 @@ function SpriteThumb({ sprite }: { sprite: EntitySprite }) {
       src={src}
       alt={sprite.name}
       title={`${sprite.kind}: ${sprite.name}`}
-      className="h-6 w-6 rounded-sm border border-white/20 object-cover"
+      className="h-6 w-6 rounded-sm border border-[var(--chrome-stroke-emphasis)] object-cover"
     />
   );
 }

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -251,7 +251,7 @@ export function RoomPanel({
       {/* Exits */}
       <Section title="Exits">
         {exits.length === 0 ? (
-          <p className="rounded-lg border border-dashed border-white/8 bg-black/6 px-3 py-2 text-center text-xs italic text-text-muted">No exits</p>
+          <p className="rounded-lg border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-3 py-2 text-center text-xs italic text-text-muted">No exits</p>
         ) : (
           <table className="w-full text-xs">
             <tbody>
@@ -334,7 +334,7 @@ export function RoomPanel({
         actions={<IconButton onClick={handleAddMob} title="Add mob">+</IconButton>}
       >
         {mobs.length === 0 ? (
-          <p className="rounded-lg border border-dashed border-white/8 bg-black/6 px-3 py-2 text-center text-xs italic text-text-muted">No mobs in this room</p>
+          <p className="rounded-lg border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-3 py-2 text-center text-xs italic text-text-muted">No mobs in this room</p>
         ) : (
           <ul className="flex flex-col gap-0.5">
             {mobs.map(([id, mob]) => (
@@ -363,7 +363,7 @@ export function RoomPanel({
         actions={<IconButton onClick={handleAddItem} title="Add item">+</IconButton>}
       >
         {items.length === 0 ? (
-          <p className="rounded-lg border border-dashed border-white/8 bg-black/6 px-3 py-2 text-center text-xs italic text-text-muted">No items in this room</p>
+          <p className="rounded-lg border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-3 py-2 text-center text-xs italic text-text-muted">No items in this room</p>
         ) : (
           <ul className="flex flex-col gap-0.5">
             {items.map(([id, item]) => (
@@ -392,7 +392,7 @@ export function RoomPanel({
         actions={<IconButton onClick={handleAddShop} title="Add shop">+</IconButton>}
       >
         {shops.length === 0 ? (
-          <p className="rounded-lg border border-dashed border-white/8 bg-black/6 px-3 py-2 text-center text-xs italic text-text-muted">No shops in this room</p>
+          <p className="rounded-lg border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-3 py-2 text-center text-xs italic text-text-muted">No shops in this room</p>
         ) : (
           <ul className="flex flex-col gap-0.5">
             {shops.map(([id, shop]) => (
@@ -421,7 +421,7 @@ export function RoomPanel({
         actions={<IconButton onClick={handleAddTrainer} title="Add trainer">+</IconButton>}
       >
         {trainers.length === 0 ? (
-          <p className="rounded-lg border border-dashed border-white/8 bg-black/6 px-3 py-2 text-center text-xs italic text-text-muted">No trainers in this room</p>
+          <p className="rounded-lg border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-3 py-2 text-center text-xs italic text-text-muted">No trainers in this room</p>
         ) : (
           <ul className="flex flex-col gap-0.5">
             {trainers.map(([id, trainer]) => (
@@ -454,7 +454,7 @@ export function RoomPanel({
         }
       >
         {gatheringNodes.length === 0 ? (
-          <p className="rounded-lg border border-dashed border-white/8 bg-black/6 px-3 py-2 text-center text-xs italic text-text-muted">No gathering nodes</p>
+          <p className="rounded-lg border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-3 py-2 text-center text-xs italic text-text-muted">No gathering nodes</p>
         ) : (
           <ul className="flex flex-col gap-0.5">
             {gatheringNodes.map(([id, node]) => (
@@ -477,7 +477,7 @@ export function RoomPanel({
       {/* Quests */}
       <Section title={`Quests (${quests.length})`} defaultExpanded={false}>
         {quests.length === 0 ? (
-          <p className="rounded-lg border border-dashed border-white/8 bg-black/6 px-3 py-2 text-center text-xs italic text-text-muted">No quests from this room</p>
+          <p className="rounded-lg border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-3 py-2 text-center text-xs italic text-text-muted">No quests from this room</p>
         ) : (
           <ul className="flex flex-col gap-0.5">
             {quests.map(([id, quest]) => (

--- a/creator/src/components/zone/ZoneAssetWorkbench.tsx
+++ b/creator/src/components/zone/ZoneAssetWorkbench.tsx
@@ -144,10 +144,10 @@ const VariantCard = memo(function VariantCard({ entry, assetsDir, onClick }: { e
     <button
       onClick={onClick}
       className={`relative h-16 w-16 shrink-0 overflow-hidden rounded-2xl border-2 transition ${
-        entry.is_active ? "border-accent shadow-[0_0_0_1px_var(--border-accent-ring)]" : "border-white/12 hover:border-[var(--border-glow)]"
+        entry.is_active ? "border-accent shadow-[0_0_0_1px_var(--border-accent-ring)]" : "border-[var(--chrome-stroke-strong)] hover:border-[var(--border-glow)]"
       }`}
     >
-      {thumbSrc ? <img src={thumbSrc} alt="" loading="lazy" className="h-full w-full object-cover" /> : <div className="h-full w-full bg-white/6" />}
+      {thumbSrc ? <img src={thumbSrc} alt="" loading="lazy" className="h-full w-full object-cover" /> : <div className="h-full w-full bg-[var(--chrome-highlight)]" />}
     </button>
   );
 });
@@ -443,7 +443,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
   const completion = totalSlots > 0 ? Math.round(((completedEntityCount + completedDefaultCount) / totalSlots) * 100) : 0;
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-gradient-panel p-5 shadow-section">
+    <section className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel p-5 shadow-section">
       <div className="mb-5 flex items-center justify-between gap-4">
         <div>
           <h2 className="font-display text-xl text-text-primary">Zone assets</h2>
@@ -456,19 +456,19 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
             <span>Coverage</span>
             <span>{completion}%</span>
           </div>
-          <div className="h-2 overflow-hidden rounded-full bg-black/14">
+          <div className="h-2 overflow-hidden rounded-full bg-[var(--chrome-fill)]">
             <div className="h-full rounded-full bg-[linear-gradient(90deg,rgba(168,151,210,0.95),rgba(140,174,201,0.9))]" style={{ width: `${completion}%` }} />
           </div>
         </div>
       </div>
 
       {!selectedTarget ? (
-        <div className="rounded-2xl border border-dashed border-white/12 bg-black/12 px-4 py-8 text-sm text-text-muted">
+        <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-fill)] px-4 py-8 text-sm text-text-muted">
           Select a zone with entities to start generating and reviewing art.
         </div>
       ) : (
         <div className="grid gap-5 xl:grid-cols-[0.62fr_1.38fr]">
-          <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+          <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
             <div className="max-h-[44rem] overflow-y-auto pr-1">
               <div className="mb-5">
                 <div className="mb-2 flex items-center justify-between">
@@ -486,7 +486,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                         key={kind}
                         onClick={() => setSelectedKey(key)}
                         className={`flex items-center gap-3 rounded-2xl border px-3 py-3 text-left transition ${
-                          selected ? "border-border-active bg-gradient-active" : "border-white/8 bg-black/10 hover:bg-white/8"
+                          selected ? "border-border-active bg-gradient-active" : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] hover:bg-[var(--chrome-highlight-strong)]"
                         }`}
                       >
                         <span className={`h-2.5 w-2.5 rounded-full ${hasImage ? "bg-status-success" : "bg-text-muted/50"}`} />
@@ -520,7 +520,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                             key={key}
                             onClick={() => setSelectedKey(key)}
                             className={`flex items-center gap-3 rounded-2xl border px-3 py-3 text-left transition ${
-                              selected ? "border-border-active bg-gradient-active" : "border-white/8 bg-black/10 hover:bg-white/8"
+                              selected ? "border-border-active bg-gradient-active" : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] hover:bg-[var(--chrome-highlight-strong)]"
                             }`}
                           >
                             <span className={`h-2.5 w-2.5 rounded-full ${entity.image ? "bg-status-success" : "bg-text-muted/50"}`} />
@@ -540,10 +540,10 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
 
           <div className="flex flex-col gap-5">
             {/* Preview row — wide horizontal card */}
-            <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+            <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
               <div className="flex gap-5">
                 {/* Image preview */}
-                <div className="flex shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-white/8 bg-[linear-gradient(180deg,rgba(34,41,60,0.8),rgba(28,34,52,0.88))] p-3" style={{ width: "16rem", height: "10rem" }}>
+                <div className="flex shrink-0 items-center justify-center overflow-hidden rounded-2xl border border-[var(--chrome-stroke)] bg-[linear-gradient(180deg,rgba(34,41,60,0.8),rgba(28,34,52,0.88))] p-3" style={{ width: "16rem", height: "10rem" }}>
                   {selectedSrc ? (
                     <img src={selectedSrc} alt={targetTitle(selectedTarget)} className="max-h-full max-w-full rounded-xl object-contain shadow-section" />
                   ) : (
@@ -561,7 +561,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                       <h3 className="mt-0.5 font-display text-xl text-text-primary">{targetTitle(selectedTarget)}</h3>
                       <div className="mt-0.5 text-xs text-text-secondary">{targetSubtitle(selectedTarget, world)}</div>
                     </div>
-                    <span className="rounded-full bg-white/8 px-3 py-1 text-2xs uppercase tracking-label text-text-muted">
+                    <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-2xs uppercase tracking-label text-text-muted">
                       {variants.length} variants
                     </span>
                   </div>
@@ -587,7 +587,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
             </div>
 
             {/* Prompt engineering — full width */}
-            <div className="rounded-3xl border border-white/8 bg-black/12 p-4">
+            <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4">
               <div className="mb-3 text-2xs uppercase tracking-ui text-text-muted">Prompt engineering</div>
 
               <div className="grid gap-4 lg:grid-cols-[1fr_1fr]">
@@ -604,7 +604,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                     <button
                       onClick={handleGeneratePrompt}
                       disabled={!hasLlmKey || generatingPrompt || generatingImage || removingBg}
-                      className="rounded-full border border-white/10 bg-white/6 px-3 py-1 text-2xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+                      className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-3 py-1 text-2xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
                     >
                       {generatingPrompt ? (
                         <span className="flex items-center gap-1.5"><Spinner />Enhancing</span>
@@ -622,19 +622,19 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                       setPromptGeneratedByLlm(false);
                     }}
                     rows={8}
-                    className="w-full flex-1 resize-y rounded-2xl border border-white/10 bg-surface-scrim px-4 py-3 font-mono text-xs leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
+                    className="w-full flex-1 resize-y rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim px-4 py-3 font-mono text-xs leading-6 text-text-secondary outline-none transition focus:border-border-active focus-visible:ring-2 focus-visible:ring-border-active"
                     placeholder={selectedTarget.mode === "default" ? "Describe the fallback for this zone asset, then click Enhance prompt..." : "Describe this entity, then click Enhance prompt..."}
                   />
                 </div>
 
                 <div className="flex flex-col gap-3">
                   {zoneVibe && (
-                    <div className="rounded-2xl border border-white/8 bg-surface-scrim-light px-4 py-3">
+                    <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim-light px-4 py-3">
                       <div className="text-2xs uppercase tracking-ui text-text-muted">Zone vibe</div>
                       <div className="mt-1.5 max-h-24 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-text-secondary">{zoneVibe}</div>
                     </div>
                   )}
-                  <div className="rounded-2xl border border-white/8 bg-surface-scrim-light px-4 py-3">
+                  <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim-light px-4 py-3">
                     <div className="text-2xs uppercase tracking-ui text-text-muted">
                       {selectedTarget.mode === "default" ? "Zone default context" : "Entity context"}
                     </div>
@@ -650,7 +650,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                   onChange={(event) => setBatchCount(Number(event.target.value))}
                   disabled={!hasImageKey || generatingPrompt || generatingImage || removingBg}
                   aria-label="Number of variants to generate"
-                  className="rounded-full border border-white/10 bg-white/6 px-3 py-2 text-xs font-medium text-text-primary outline-none transition focus-visible:ring-2 focus-visible:ring-border-active disabled:opacity-50"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-3 py-2 text-xs font-medium text-text-primary outline-none transition focus-visible:ring-2 focus-visible:ring-border-active disabled:opacity-50"
                 >
                   <option value={1} className="bg-bg-primary">×1</option>
                   <option value={2} className="bg-bg-primary">×2</option>
@@ -675,18 +675,18 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                     "Generate image"
                   )}
                 </button>
-                <span className="mx-1 h-6 w-px bg-white/10" aria-hidden="true" />
+                <span className="mx-1 h-6 w-px bg-[var(--chrome-highlight-strong)]" aria-hidden="true" />
                 <button
                   onClick={handleImport}
                   disabled={importing || generatingPrompt || generatingImage || removingBg}
-                  className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
                 >
                   {importing ? <span className="flex items-center gap-1.5"><Spinner />Importing</span> : "Import image"}
                 </button>
                 <button
                   onClick={handleRemoveBg}
                   disabled={removingBg || generatingImage || !previewEntry || !selectedSrc || !selectedKind || !shouldRemoveBg(assetTypeForKind(selectedKind))}
-                  className="rounded-full border border-white/10 bg-white/6 px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-white/10 disabled:opacity-50"
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-4 py-2 text-xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
                 >
                   {removingBg ? <span className="flex items-center gap-1.5"><Spinner />Removing BG</span> : "Remove BG"}
                 </button>

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -377,7 +377,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
         <img src={subtoolbarBg} alt="" className="pointer-events-none absolute inset-0 h-full w-full object-cover opacity-[0.10]" />
 
         {/* Undo / Redo */}
-        <div className="flex items-center gap-0.5 border-r border-white/8 pr-3 max-[1180px]:pr-0 max-[1180px]:border-r-0">
+        <div className="flex items-center gap-0.5 border-r border-[var(--chrome-stroke)] pr-3 max-[1180px]:pr-0 max-[1180px]:border-r-0">
           <button
             onClick={() => { undo(zoneId); useToastStore.getState().show("Change undone"); }}
             disabled={!canUndo}
@@ -445,7 +445,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
         </label>
 
         {/* Zone name */}
-        <div className="ml-auto flex min-w-0 items-center gap-2 border-l border-white/8 pl-3 max-[1180px]:order-4 max-[1180px]:ml-0 max-[1180px]:w-full max-[1180px]:border-l-0 max-[1180px]:pl-0 max-[1180px]:pt-1">
+        <div className="ml-auto flex min-w-0 items-center gap-2 border-l border-[var(--chrome-stroke)] pl-3 max-[1180px]:order-4 max-[1180px]:ml-0 max-[1180px]:w-full max-[1180px]:border-l-0 max-[1180px]:pl-0 max-[1180px]:pt-1">
           <span className="truncate font-display text-sm font-semibold uppercase tracking-widest text-text-primary">
             {zoneState.data.zone}
           </span>
@@ -503,7 +503,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
             ))}
           </div>
 
-          <div className="flex items-center gap-2 border-l border-white/8 pl-3 max-[1180px]:w-full max-[1180px]:flex-wrap max-[1180px]:justify-end max-[1180px]:border-l-0 max-[1180px]:pl-0">
+          <div className="flex items-center gap-2 border-l border-[var(--chrome-stroke)] pl-3 max-[1180px]:w-full max-[1180px]:flex-wrap max-[1180px]:justify-end max-[1180px]:border-l-0 max-[1180px]:pl-0">
             <button
               onClick={() => setShowBatchArt(true)}
               className="h-6 rounded px-2 text-xs text-stellar-blue transition-colors hover:bg-stellar-blue/10 max-[1180px]:h-9"
@@ -514,7 +514,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
             </button>
             <button
               onClick={() => setShowBulkBgRemoval(true)}
-              className="h-6 rounded px-2 text-xs text-text-secondary transition-colors hover:bg-white/6 hover:text-text-primary max-[1180px]:h-9"
+              className="h-6 rounded px-2 text-xs text-text-secondary transition-colors hover:bg-[var(--chrome-highlight)] hover:text-text-primary max-[1180px]:h-9"
               title="Remove backgrounds from mob and item images"
               aria-label="Bulk remove backgrounds"
             >
@@ -523,7 +523,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
             <button
               onClick={handleRelayout}
               disabled={roomCount === 0}
-              className="h-6 rounded px-2 text-xs text-text-secondary transition-colors hover:bg-white/6 hover:text-text-primary disabled:opacity-30 max-[1180px]:h-9"
+              className="h-6 rounded px-2 text-xs text-text-secondary transition-colors hover:bg-[var(--chrome-highlight)] hover:text-text-primary disabled:opacity-30 max-[1180px]:h-9"
               title="Re-run BFS layout and fit view"
               aria-label="Re-layout rooms"
             >
@@ -658,7 +658,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
             {/* First-zone onboarding hint */}
             {roomCount <= 1 && !hintDismissed && viewMode === "map" && (
               <div className="pointer-events-auto absolute inset-x-0 bottom-4 z-[2] flex justify-center">
-                <div className="flex items-center gap-4 rounded-2xl border border-white/10 bg-bg-secondary/95 px-5 py-3 shadow-section">
+                <div className="flex items-center gap-4 rounded-2xl border border-[var(--chrome-stroke)] bg-bg-secondary/95 px-5 py-3 shadow-section">
                   <div>
                     <p className="text-sm text-text-primary">
                       Click the <span className="font-mono text-accent">+</span> handles on a room's edges to create exits to new rooms.
@@ -672,7 +672,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
                       setHintDismissed(true);
                       localStorage.setItem("arcanum:zone-hint-dismissed", "1");
                     }}
-                    className="shrink-0 rounded-full border border-white/10 px-3 py-1.5 text-xs text-text-muted transition hover:bg-white/8 hover:text-text-primary"
+                    className="shrink-0 rounded-full border border-[var(--chrome-stroke)] px-3 py-1.5 text-xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
                   >
                     Got it
                   </button>

--- a/creator/src/components/zone/ZoneVibePanel.tsx
+++ b/creator/src/components/zone/ZoneVibePanel.tsx
@@ -45,13 +45,13 @@ function DefaultThumb({ fileName, label, generating }: { fileName?: string; labe
 
   return (
     <>
-      <div className="rounded-2xl border border-white/8 bg-surface-scrim-light p-2">
+      <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-surface-scrim-light p-2">
         <div className="mb-2 text-2xs uppercase tracking-ui text-text-muted">{label}</div>
         <button
           type="button"
           onClick={() => { if (src && !generating) setExpanded(true); }}
           disabled={!src || generating}
-          className="flex aspect-square w-full items-center justify-center overflow-hidden rounded-xl border border-white/8 bg-black/20 transition-opacity enabled:cursor-pointer enabled:hover:opacity-80"
+          className="flex aspect-square w-full items-center justify-center overflow-hidden rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-strong)] transition-opacity enabled:cursor-pointer enabled:hover:opacity-80"
         >
           {generating ? (
             <div className="h-5 w-5 rounded-full border-2 border-accent border-t-transparent animate-spin" />
@@ -65,7 +65,7 @@ function DefaultThumb({ fileName, label, generating }: { fileName?: string; labe
 
       {expanded && src && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--chrome-fill-soft)]0"
           onClick={() => setExpanded(false)}
         >
           <div className="relative mx-8 max-h-[85vh] max-w-[85vw]">
@@ -75,13 +75,13 @@ function DefaultThumb({ fileName, label, generating }: { fileName?: string; labe
               className="max-h-[85vh] max-w-[85vw] cursor-pointer rounded-lg object-contain shadow-2xl"
             />
             <div className="absolute left-0 right-0 top-full mt-3 text-center">
-              <span className="rounded-full bg-black/60 px-3 py-1 text-2xs uppercase tracking-ui text-text-muted backdrop-blur-sm">
+              <span className="rounded-full bg-[var(--chrome-fill-soft)]0 px-3 py-1 text-2xs uppercase tracking-ui text-text-muted backdrop-blur-sm">
                 {label}
               </span>
             </div>
             <button
               onClick={() => setExpanded(false)}
-              className="absolute -right-3 -top-3 flex h-7 w-7 items-center justify-center rounded-full border border-white/15 bg-bg-secondary text-sm text-text-muted transition-colors hover:text-text-primary"
+              className="absolute -right-3 -top-3 flex h-7 w-7 items-center justify-center rounded-full border border-[var(--chrome-stroke-strong)] bg-bg-secondary text-sm text-text-muted transition-colors hover:text-text-primary"
             >
               &times;
             </button>

--- a/creator/src/index.css
+++ b/creator/src/index.css
@@ -2,6 +2,19 @@
 @import "tippy.js/dist/tippy.css";
 
 @theme {
+  /* ─── Mode flag (overridden by JS theme system) ─── */
+  --theme-mode: dark;
+
+  /* ─── RGB tuples for synthesized rgba() values ─── */
+  /* Override these via the JS theme system; defaults match the dark Arcanum palette. */
+  --bg-rgb: 34 41 60;
+  --surface-rgb: 49 58 86;
+  --text-rgb: 219 227 248;
+  --accent-rgb: 168 151 210;
+  --abyss-rgb: 28 33 49;
+  --stroke-rgb: 255 255 255;
+  --fill-rgb: 8 12 28;
+
   /* ─── Typography ─── */
   --font-sans: 'Crimson Pro', Georgia, serif;
   --font-display: 'Cinzel', Palatino, serif;
@@ -36,6 +49,22 @@
   --color-text-secondary: #aebada;
   --color-text-muted:     #95a0bf;
   --color-text-link:      #b88faa;
+  --color-text-on-accent: #22293c;
+
+  /* ─── Chrome (mode-aware overlays) ─── */
+  /* These reference the *-rgb tuples above so the JS theme system can flip them
+     for light themes by changing --stroke-rgb / --fill-rgb. */
+  --chrome-stroke:          rgb(var(--stroke-rgb) / 0.10);
+  --chrome-stroke-strong:   rgb(var(--stroke-rgb) / 0.16);
+  --chrome-stroke-emphasis: rgb(var(--stroke-rgb) / 0.22);
+  --chrome-fill:            rgb(var(--fill-rgb) / 0.16);
+  --chrome-fill-soft:       rgb(var(--fill-rgb) / 0.08);
+  --chrome-fill-strong:     rgb(var(--fill-rgb) / 0.32);
+  --chrome-highlight:       rgb(var(--stroke-rgb) / 0.06);
+  --chrome-highlight-strong: rgb(var(--stroke-rgb) / 0.12);
+
+  /* ─── Surfaces ─── */
+  --color-surface-card: rgb(var(--surface-rgb) / 0.6);
 
   /* ─── Accent — Aurum (the creative force) ─── */
   --color-accent:          #a897d2;
@@ -71,11 +100,11 @@
   --color-server-error:    #dbb8b8;
 
   /* ─── Active/Selected State ─── */
-  --color-border-active: rgba(184, 216, 232, 0.35);
+  --color-border-active: rgb(var(--accent-rgb) / 0.35);
 
   /* ─── Surface Overlays ─── */
-  --color-surface-scrim:       rgba(24, 30, 45, 0.72);
-  --color-surface-scrim-light: rgba(24, 30, 45, 0.46);
+  --color-surface-scrim:       rgb(var(--bg-rgb) / 0.72);
+  --color-surface-scrim-light: rgb(var(--bg-rgb) / 0.46);
 
   /* ─── Diff (Code Review) ─── */
   --color-diff-add-bg:   #0a2a2a;
@@ -128,19 +157,21 @@
 }
 
 /* ─── Arcanum Design Tokens ─── */
+/* All rgba values reference the *-rgb tuples in the @theme block, so the JS
+   theme system can swap them by setting just a handful of variables on :root. */
 :root {
   /* Glows */
-  --glow-accent:        0 0 32px rgba(168, 151, 210, 0.28);
-  --glow-accent-strong: 0 0 48px rgba(184, 216, 232, 0.32);
-  --glow-warm:         0 0 32px rgba(200, 164, 106, 0.32);
-  --glow-warm-strong:  0 0 48px rgba(226, 200, 154, 0.42);
-  --glow-violet:       0 0 28px rgba(168, 151, 210, 0.24);
-  --glow-blue:         0 0 24px rgba(140, 174, 201, 0.22);
+  --glow-accent:        0 0 32px rgb(var(--accent-rgb) / 0.28);
+  --glow-accent-strong: 0 0 48px rgb(var(--text-rgb) / 0.32);
+  --glow-warm:          0 0 32px rgb(var(--accent-rgb) / 0.32);
+  --glow-warm-strong:   0 0 48px rgb(var(--accent-rgb) / 0.42);
+  --glow-violet:        0 0 28px rgb(var(--accent-rgb) / 0.24);
+  --glow-blue:          0 0 24px rgb(var(--accent-rgb) / 0.22);
 
   /* Shadows */
-  --shadow-section:  0 16px 44px rgba(9, 12, 24, 0.24);
-  --shadow-panel:    0 18px 60px rgba(8, 10, 18, 0.38);
-  --shadow-glow:     0 10px 26px rgba(137, 155, 214, 0.22);
+  --shadow-section:  0 16px 44px rgb(var(--fill-rgb) / 0.24);
+  --shadow-panel:    0 18px 60px rgb(var(--fill-rgb) / 0.38);
+  --shadow-glow:     0 10px 26px rgb(var(--accent-rgb) / 0.22);
 
   /* Easing */
   --ease-unfurl:   cubic-bezier(0.16, 1, 0.3, 1);
@@ -148,32 +179,34 @@
   --ease-cosmic:   cubic-bezier(0.4, 0, 0.2, 1);
 
   /* Accent border variants */
-  --border-accent-ring:   rgba(168, 151, 210, 0.45);
-  --border-accent-subtle: rgba(168, 151, 210, 0.35);
-  --border-glow:          rgba(184, 216, 232, 0.25);
-  --border-glow-strong:   rgba(184, 216, 232, 0.48);
+  --border-accent-ring:   rgb(var(--accent-rgb) / 0.45);
+  --border-accent-subtle: rgb(var(--accent-rgb) / 0.35);
+  --border-glow:          rgb(var(--text-rgb) / 0.25);
+  --border-glow-strong:   rgb(var(--text-rgb) / 0.48);
 
   /* Accent background variants */
-  --bg-accent-subtle:  rgba(168, 151, 210, 0.14);
-  --bg-accent-hover:   rgba(168, 151, 210, 0.20);
+  --bg-accent-subtle:  rgb(var(--accent-rgb) / 0.14);
+  --bg-accent-hover:   rgb(var(--accent-rgb) / 0.20);
 
   /* Gradient backgrounds */
-  --bg-active:        linear-gradient(135deg, rgba(168,151,210,0.16), rgba(140,174,201,0.12));
-  --bg-active-strong: linear-gradient(135deg, rgba(168,151,210,0.18), rgba(140,174,201,0.14));
-  --bg-panel:         linear-gradient(160deg, rgba(54,63,90,0.95), rgba(42,53,79,0.92));
-  --bg-panel-light:   linear-gradient(160deg, rgba(56,66,96,0.9), rgba(39,48,72,0.92));
-  --bg-glow-top:      linear-gradient(180deg, rgba(168,151,210,0.18), transparent);
-  --graph-minimap-mask: rgba(8, 12, 28, 0.8);
+  --bg-active:        linear-gradient(135deg, rgb(var(--accent-rgb) / 0.16), rgb(var(--accent-rgb) / 0.10));
+  --bg-active-strong: linear-gradient(135deg, rgb(var(--accent-rgb) / 0.22), rgb(var(--accent-rgb) / 0.14));
+  --bg-panel:         linear-gradient(160deg, rgb(var(--surface-rgb) / 0.95), rgb(var(--bg-rgb) / 0.92));
+  --bg-panel-light:   linear-gradient(160deg, rgb(var(--surface-rgb) / 0.85), rgb(var(--bg-rgb) / 0.85));
+  --bg-glow-top:      linear-gradient(180deg, rgb(var(--accent-rgb) / 0.18), transparent);
+  --graph-minimap-mask: rgb(var(--fill-rgb) / 0.8);
+
+  /* Body background — themed via the JS system, with a sensible default. */
+  --body-bg:
+    radial-gradient(circle at 14% 12%, rgb(var(--accent-rgb) / 0.18), transparent 36%),
+    radial-gradient(circle at 84% 14%, rgb(var(--accent-rgb) / 0.10), transparent 34%),
+    linear-gradient(180deg, rgb(var(--bg-rgb) / 1) 0%, rgb(var(--abyss-rgb) / 1) 100%);
 }
 
 body {
   margin: 0;
   padding: 0;
-  background:
-    radial-gradient(circle at 14% 12%, rgba(168, 151, 210, 0.22), transparent 36%),
-    radial-gradient(circle at 84% 14%, rgba(140, 174, 201, 0.18), transparent 34%),
-    radial-gradient(circle at 52% 100%, rgba(184, 143, 170, 0.12), transparent 42%),
-    linear-gradient(180deg, #2a3149 0%, #22293c 100%);
+  background: var(--body-bg);
   color: var(--color-text-primary);
   font-family: 'Crimson Pro', Georgia, serif;
   font-size: 15px;
@@ -219,20 +252,20 @@ select,
 }
 
 .room-handle-plus:hover {
-  background: rgba(168, 151, 210, 0.4) !important;
-  border-color: rgba(168, 151, 210, 0.7) !important;
-  color: rgba(219, 227, 248, 0.9) !important;
+  background: rgb(var(--accent-rgb) / 0.4) !important;
+  border-color: rgb(var(--accent-rgb) / 0.7) !important;
+  color: rgb(var(--text-rgb) / 0.9) !important;
 }
 
 /* ─── Animation Keyframes ─── */
 @keyframes aurum-pulse {
-  0%, 100% { opacity: 0.7; box-shadow: 0 0 8px rgba(168, 151, 210, 0.3); }
-  50%      { opacity: 1;   box-shadow: 0 0 20px rgba(168, 151, 210, 0.6); }
+  0%, 100% { opacity: 0.7; box-shadow: 0 0 8px rgb(var(--accent-rgb) / 0.3); }
+  50%      { opacity: 1;   box-shadow: 0 0 20px rgb(var(--accent-rgb) / 0.6); }
 }
 
 @keyframes crimson-pulse {
-  0%, 100% { opacity: 0.7; box-shadow: 0 0 6px rgba(197, 168, 168, 0.2); }
-  50%      { opacity: 1;   box-shadow: 0 0 16px rgba(197, 168, 168, 0.5); }
+  0%, 100% { opacity: 0.7; box-shadow: 0 0 6px rgb(var(--accent-rgb) / 0.2); }
+  50%      { opacity: 1;   box-shadow: 0 0 16px rgb(var(--accent-rgb) / 0.5); }
 }
 
 @keyframes slow-rotate {
@@ -282,8 +315,8 @@ select,
 }
 
 @keyframes warm-breathe {
-  0%, 100% { box-shadow: 0 0 12px rgba(200, 164, 106, 0.2); }
-  50%      { box-shadow: 0 0 20px rgba(200, 164, 106, 0.4); }
+  0%, 100% { box-shadow: 0 0 12px rgb(var(--accent-rgb) / 0.2); }
+  50%      { box-shadow: 0 0 20px rgb(var(--accent-rgb) / 0.4); }
 }
 
 .animate-warm-breathe {
@@ -293,12 +326,12 @@ select,
 .focus-ring:focus-visible {
   outline: none;
   box-shadow:
-    0 0 0 2px rgba(219, 227, 248, 0.18),
-    0 0 0 4px rgba(168, 151, 210, 0.42);
+    0 0 0 2px rgb(var(--text-rgb) / 0.18),
+    0 0 0 4px rgb(var(--accent-rgb) / 0.42);
 }
 
 .ornate-input {
-  border: 1px solid rgba(86, 97, 125, 0.88);
+  border: 1px solid var(--color-border-default);
   background: var(--color-surface-scrim);
   color: var(--color-text-primary);
   transition:
@@ -312,20 +345,20 @@ select,
 }
 
 .ornate-input:hover {
-  border-color: rgba(184, 216, 232, 0.28);
+  border-color: rgb(var(--accent-rgb) / 0.28);
 }
 
 .ornate-input:focus-visible {
   border-color: var(--color-border-focus);
   outline: none;
   box-shadow:
-    0 0 0 2px rgba(184, 143, 170, 0.12),
-    0 0 0 4px rgba(168, 151, 210, 0.34);
+    0 0 0 2px rgb(var(--accent-rgb) / 0.12),
+    0 0 0 4px rgb(var(--accent-rgb) / 0.34);
 }
 
 .shell-pill {
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(8, 12, 28, 0.16);
+  border: 1px solid var(--chrome-stroke);
+  background: var(--chrome-fill);
   color: var(--color-text-primary);
   transition:
     background-color 160ms var(--ease-unfurl),
@@ -335,8 +368,8 @@ select,
 }
 
 .shell-pill:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.08);
-  border-color: rgba(184, 216, 232, 0.18);
+  background: var(--chrome-highlight-strong);
+  border-color: var(--chrome-stroke-emphasis);
   transform: translateY(-1px);
 }
 
@@ -361,7 +394,7 @@ select,
   min-width: 2.75rem;
   padding-inline: 1rem;
   border-radius: 9999px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--chrome-stroke);
   font-size: 0.75rem;
   font-weight: 500;
   line-height: 1;
@@ -400,75 +433,75 @@ select,
 }
 
 .action-button-primary {
-  border-color: rgba(200, 164, 106, 0.42);
+  border-color: rgb(var(--accent-rgb) / 0.45);
   background:
-    radial-gradient(circle at top right, rgba(226, 200, 154, 0.16), transparent 54%),
-    linear-gradient(145deg, rgba(200, 164, 106, 0.26), rgba(43, 52, 76, 0.92));
-  color: var(--color-warm-pale);
-  box-shadow: 0 10px 26px rgba(200, 164, 106, 0.20);
+    radial-gradient(circle at top right, rgb(var(--accent-rgb) / 0.20), transparent 54%),
+    linear-gradient(145deg, rgb(var(--accent-rgb) / 0.30), rgb(var(--surface-rgb) / 0.92));
+  color: var(--color-text-on-accent);
+  box-shadow: 0 10px 26px rgb(var(--accent-rgb) / 0.20);
 }
 
 .action-button-primary:hover:not(:disabled) {
-  box-shadow: 0 10px 26px rgba(200, 164, 106, 0.32);
+  box-shadow: 0 10px 26px rgb(var(--accent-rgb) / 0.32);
 }
 
 .action-button-secondary {
-  border-color: rgba(255, 255, 255, 0.1);
+  border-color: var(--chrome-stroke);
   background:
-    linear-gradient(145deg, rgba(13, 18, 34, 0.66), rgba(27, 34, 54, 0.84));
+    linear-gradient(145deg, rgb(var(--bg-rgb) / 0.66), rgb(var(--surface-rgb) / 0.84));
 }
 
 .action-button-secondary:hover:not(:disabled) {
-  border-color: rgba(184, 216, 232, 0.18);
+  border-color: var(--chrome-stroke-emphasis);
   background:
-    linear-gradient(145deg, rgba(20, 26, 44, 0.76), rgba(34, 43, 66, 0.9));
+    linear-gradient(145deg, rgb(var(--bg-rgb) / 0.76), rgb(var(--surface-rgb) / 0.9));
 }
 
 .action-button-ghost {
-  border-color: rgba(255, 255, 255, 0.08);
-  background: rgba(8, 12, 28, 0.16);
+  border-color: var(--chrome-stroke);
+  background: var(--chrome-fill);
   color: var(--color-text-secondary);
 }
 
 .action-button-ghost:hover:not(:disabled) {
-  border-color: rgba(184, 216, 232, 0.16);
-  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--chrome-stroke-strong);
+  background: var(--chrome-highlight);
   color: var(--color-text-primary);
 }
 
 .action-button-danger {
-  border-color: rgba(219, 184, 184, 0.28);
+  border-color: rgb(220 100 110 / 0.35);
   background:
-    linear-gradient(145deg, rgba(72, 29, 39, 0.7), rgba(43, 18, 26, 0.82));
+    linear-gradient(145deg, rgb(220 60 80 / 0.20), rgb(var(--surface-rgb) / 0.85));
   color: var(--color-status-error);
 }
 
 .action-button-danger:hover:not(:disabled) {
-  border-color: rgba(219, 184, 184, 0.42);
+  border-color: rgb(220 100 110 / 0.50);
   background:
-    linear-gradient(145deg, rgba(84, 35, 46, 0.78), rgba(53, 22, 31, 0.88));
+    linear-gradient(145deg, rgb(220 60 80 / 0.28), rgb(var(--surface-rgb) / 0.9));
 }
 
 .action-button-utility {
-  border-color: rgba(140, 174, 201, 0.28);
+  border-color: rgb(var(--accent-rgb) / 0.28);
   background:
-    linear-gradient(145deg, rgba(140, 174, 201, 0.14), rgba(27, 34, 54, 0.84));
-  color: var(--color-stellar-blue);
+    linear-gradient(145deg, rgb(var(--accent-rgb) / 0.14), rgb(var(--surface-rgb) / 0.84));
+  color: var(--color-text-primary);
 }
 
 .action-button-utility:hover:not(:disabled) {
-  border-color: rgba(140, 174, 201, 0.38);
+  border-color: rgb(var(--accent-rgb) / 0.38);
   background:
-    linear-gradient(145deg, rgba(140, 174, 201, 0.20), rgba(34, 43, 66, 0.9));
+    linear-gradient(145deg, rgb(var(--accent-rgb) / 0.20), rgb(var(--surface-rgb) / 0.9));
 }
 
 .segmented-control {
   display: flex;
   gap: 0.25rem;
   padding: 0.25rem;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--chrome-stroke);
   border-radius: 9999px;
-  background: rgba(8, 12, 28, 0.2);
+  background: var(--chrome-fill-strong);
 }
 
 .segmented-button {
@@ -483,7 +516,7 @@ select,
 }
 
 .segmented-button:hover:not(:disabled) {
-  border-color: rgba(255, 255, 255, 0.08);
+  border-color: var(--chrome-stroke);
   color: var(--color-text-secondary);
 }
 
@@ -495,14 +528,14 @@ select,
 }
 
 .panel-surface {
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--chrome-stroke);
   background: var(--bg-panel);
   box-shadow: var(--shadow-section);
 }
 
 .panel-surface-light {
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(8, 12, 28, 0.14);
+  border: 1px solid var(--chrome-stroke);
+  background: var(--chrome-fill);
   box-shadow: var(--shadow-section);
 }
 
@@ -515,8 +548,8 @@ select,
   justify-content: center;
   padding: 1.25rem;
   background:
-    radial-gradient(circle at top, rgba(168, 151, 210, 0.12), transparent 34%),
-    rgba(7, 9, 18, 0.76);
+    radial-gradient(circle at top, rgb(var(--accent-rgb) / 0.12), transparent 34%),
+    rgb(var(--abyss-rgb) / 0.76);
   backdrop-filter: blur(14px);
 }
 
@@ -524,12 +557,12 @@ select,
   position: relative;
   overflow: hidden;
   border-radius: 2rem;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--chrome-stroke);
   background:
-    radial-gradient(circle at top right, rgba(184, 216, 232, 0.1), transparent 30%),
-    linear-gradient(160deg, rgba(43, 51, 78, 0.96), rgba(19, 25, 41, 0.96));
+    radial-gradient(circle at top right, rgb(var(--accent-rgb) / 0.12), transparent 30%),
+    linear-gradient(160deg, rgb(var(--surface-rgb) / 0.96), rgb(var(--bg-rgb) / 0.96));
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 var(--chrome-highlight),
     var(--shadow-panel);
 }
 
@@ -539,7 +572,7 @@ select,
   inset-inline: 1.75rem;
   top: 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(184, 216, 232, 0.44), transparent);
+  background: linear-gradient(90deg, transparent, rgb(var(--accent-rgb) / 0.44), transparent);
   opacity: 0.7;
 }
 
@@ -549,8 +582,8 @@ select,
   justify-content: space-between;
   gap: 1rem;
   padding: 1.5rem 1.75rem 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent);
+  border-bottom: 1px solid var(--chrome-stroke);
+  background: linear-gradient(180deg, var(--chrome-highlight), transparent);
 }
 
 .dialog-title {
@@ -581,17 +614,17 @@ select,
   justify-content: flex-end;
   gap: 0.75rem;
   padding: 1rem 1.75rem 1.5rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(180deg, transparent, rgba(8, 12, 28, 0.12));
+  border-top: 1px solid var(--chrome-stroke);
+  background: linear-gradient(180deg, transparent, var(--chrome-fill-soft));
 }
 
 .instrument-panel {
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--chrome-stroke);
   background:
-    linear-gradient(160deg, rgba(43, 51, 78, 0.9), rgba(23, 29, 48, 0.92)),
+    linear-gradient(160deg, rgb(var(--surface-rgb) / 0.9), rgb(var(--bg-rgb) / 0.92)),
     var(--bg-panel);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    inset 0 1px 0 var(--chrome-highlight),
     var(--shadow-panel);
 }
 
@@ -607,23 +640,23 @@ select,
 }
 
 .world-lens:hover:not(:disabled) {
-  border-color: rgba(255, 255, 255, 0.10);
-  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--chrome-stroke);
+  background: var(--chrome-highlight);
   transform: translateY(-1px);
 }
 
 .world-lens[data-active="true"] {
   border-color: var(--border-accent-subtle);
   background:
-    radial-gradient(circle at top right, rgba(184, 216, 232, 0.16), transparent 48%),
-    linear-gradient(145deg, rgba(168, 151, 210, 0.2), rgba(42, 50, 71, 0.9));
+    radial-gradient(circle at top right, rgb(var(--accent-rgb) / 0.16), transparent 48%),
+    linear-gradient(145deg, rgb(var(--accent-rgb) / 0.20), rgb(var(--surface-rgb) / 0.9));
   box-shadow: var(--shadow-glow);
 }
 
 .orbital-tab {
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--chrome-stroke);
   background:
-    linear-gradient(155deg, rgba(17, 22, 38, 0.72), rgba(8, 12, 28, 0.8));
+    linear-gradient(155deg, rgb(var(--surface-rgb) / 0.72), rgb(var(--bg-rgb) / 0.8));
   transition:
     border-color 160ms var(--ease-unfurl),
     background-color 160ms var(--ease-unfurl),
@@ -632,24 +665,24 @@ select,
 }
 
 .orbital-tab:hover {
-  border-color: rgba(255, 255, 255, 0.16);
+  border-color: var(--chrome-stroke-strong);
   transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(8, 10, 18, 0.3);
+  box-shadow: 0 8px 24px rgb(var(--fill-rgb) / 0.3);
 }
 
 .orbital-tab[data-active="true"] {
   border-color: var(--border-accent-subtle);
   background:
-    radial-gradient(circle at top right, rgba(184, 216, 232, 0.14), transparent 44%),
-    linear-gradient(145deg, rgba(168, 151, 210, 0.18), rgba(32, 40, 61, 0.92));
+    radial-gradient(circle at top right, rgb(var(--accent-rgb) / 0.14), transparent 44%),
+    linear-gradient(145deg, rgb(var(--accent-rgb) / 0.18), rgb(var(--surface-rgb) / 0.92));
   box-shadow: var(--shadow-glow);
   transform: translateY(-1px);
 }
 
 .atlas-link {
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--chrome-stroke);
   background:
-    linear-gradient(145deg, rgba(13, 18, 34, 0.56), rgba(27, 34, 54, 0.78));
+    linear-gradient(145deg, rgb(var(--bg-rgb) / 0.56), rgb(var(--surface-rgb) / 0.78));
   transition:
     border-color 160ms var(--ease-unfurl),
     background-color 160ms var(--ease-unfurl),
@@ -658,9 +691,26 @@ select,
 }
 
 .atlas-link:hover {
-  border-color: rgba(184, 216, 232, 0.22);
+  border-color: rgb(var(--accent-rgb) / 0.22);
   transform: translateY(-2px);
   box-shadow: var(--shadow-glow);
+}
+
+/* Chrome menu item — used in dropdowns/menus that need a token-driven tint. */
+.chrome-menu-item {
+  border: 1px solid var(--chrome-stroke);
+  background: var(--chrome-fill);
+  color: var(--color-text-secondary);
+  transition:
+    border-color 160ms var(--ease-unfurl),
+    background-color 160ms var(--ease-unfurl),
+    color 160ms var(--ease-unfurl);
+}
+
+.chrome-menu-item:hover:not(:disabled) {
+  border-color: var(--chrome-stroke-strong);
+  background: var(--chrome-highlight);
+  color: var(--color-text-primary);
 }
 
 /* ─── Hidden Scrollbar ─── */
@@ -746,7 +796,7 @@ select,
   transform: translateX(-50%);
   width: 10rem;
   height: 1px;
-  background: linear-gradient(to right, transparent, rgba(168, 151, 210, 0.3) 20%, rgba(168, 151, 210, 0.3) 80%, transparent);
+  background: linear-gradient(to right, transparent, rgb(var(--accent-rgb) / 0.3) 20%, rgb(var(--accent-rgb) / 0.3) 80%, transparent);
 }
 
 .ornate-divider::after {
@@ -771,7 +821,7 @@ textarea:focus-visible,
 [role="option"]:focus-visible,
 [role="combobox"]:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(168, 151, 210, 0.5);
+  box-shadow: 0 0 0 2px rgb(var(--accent-rgb) / 0.5);
   transition: box-shadow 200ms var(--ease-unfurl);
 }
 
@@ -884,7 +934,7 @@ textarea:focus-visible,
 
 .lore-editor-content .mention {
   color: var(--color-accent);
-  background: rgba(168, 151, 210, 0.12);
+  background: rgb(var(--accent-rgb) / 0.12);
   border-radius: 4px;
   padding: 0 3px;
   font-weight: 500;
@@ -910,11 +960,11 @@ textarea:focus-visible,
 
 /* ─── Panel Area Identity ─── */
 .lore-panel-header-accent {
-  border-left: 3px solid rgba(200, 164, 106, 0.55);
+  border-left: 3px solid rgb(var(--accent-rgb) / 0.55);
 }
 
 .config-panel-header-accent {
-  border-left: 3px solid rgba(140, 174, 201, 0.55);
+  border-left: 3px solid rgb(var(--accent-rgb) / 0.55);
 }
 
 /* ─── Leaflet Overrides ─── */

--- a/creator/src/lib/panelRegistry.ts
+++ b/creator/src/lib/panelRegistry.ts
@@ -112,6 +112,7 @@ const LORE_PANELS: PanelDef[] = [
 // ─── Operations panels ──────────────────────────────────────────────
 
 const OPERATIONS_PANELS: PanelDef[] = [
+  { id: "appearance", label: "Appearance", group: "operations", host: "command", kicker: "Operations", title: "Appearance", description: "Theme color palette — pick or paste 4 colors to retheme the app.", maxWidth: "max-w-5xl" },
   { id: "services", label: "Services", group: "operations", host: "config", kicker: "Operations", title: "Services", description: "API keys, image providers, and LLM settings.", maxWidth: "max-w-5xl" },
   { id: "deployment", label: "Deployment", group: "operations", host: "config", kicker: "Operations", title: "Deployment", description: "Export, sync, and deploy your MUD.", maxWidth: "max-w-5xl" },
   { id: "sharedAssets", label: "Shared Assets", group: "operations", host: "config", kicker: "Operations", title: "Shared assets", description: "Global asset keys and image configuration.", maxWidth: "max-w-5xl" },

--- a/creator/src/lib/theme.ts
+++ b/creator/src/lib/theme.ts
@@ -31,6 +31,13 @@ export const DEFAULT_THEME: ThemePalette = {
 export const PRESET_THEMES: ThemePalette[] = [
   DEFAULT_THEME,
   {
+    name: "Parchment (light)",
+    background: "#f4ede0",
+    surface: "#e6dcc6",
+    text: "#2a2418",
+    accent: "#8a5a2b",
+  },
+  {
     name: "Aurum Dusk",
     background: "#1a1410",
     surface: "#2e241c",
@@ -92,6 +99,12 @@ export function rgba(hex: string, alpha: number): string {
   return `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${alpha})`;
 }
 
+/** Space-separated R G B tuple suitable for `rgb(var(--xxx-rgb) / alpha)` syntax. */
+export function rgbTuple(hex: string): string {
+  const { r, g, b } = hexToRgb(hex);
+  return `${Math.round(r)} ${Math.round(g)} ${Math.round(b)}`;
+}
+
 /** Linearly mix two hex colors. t=0 → a, t=1 → b. */
 export function mix(a: string, b: string, t: number): string {
   const ra = hexToRgb(a);
@@ -122,21 +135,27 @@ export function themeToVars(theme: ThemePalette): Record<string, string> {
   const text = theme.text;
   const accent = theme.accent;
 
-  // Background ramp: darker than bg for the abyss, then surface, with lighter
-  // variants mixed toward the surface color.
-  const abyss = mix(bg, "#000000", 0.18);
+  // Detect light vs dark theme so chrome stroke/fill colors flip orientation.
+  // For a dark theme we use white-tinted strokes and dark fills; for a light
+  // theme we use dark-tinted strokes and light fills.
+  const bgLum = luminance(bg);
+  const isLight = bgLum > 0.5;
+
+  // Background ramp: darker (or lighter) than bg for the abyss, then surface,
+  // with lighter variants mixed toward the surface color.
+  const abyss = isLight ? mix(bg, "#ffffff", 0.18) : mix(bg, "#000000", 0.18);
   const bgPrimary = bg;
   const bgSecondary = mix(bg, surface, 0.4);
   const bgTertiary = surface;
   const bgElevated = surface;
   const bgHover = mix(surface, text, 0.08);
 
-  // Borders: from muted (closer to surface) to default (mid) to accent-tinted focus.
+  // Borders.
   const borderMuted = mix(surface, text, 0.05);
   const borderDefault = mix(surface, text, 0.18);
   const borderFocus = accent;
 
-  // Text ramp: primary is the literal text color, lower tiers mix toward bg.
+  // Text ramp.
   const textPrimary = text;
   const textSecondary = mix(text, bg, 0.22);
   const textMuted = mix(text, bg, 0.42);
@@ -145,9 +164,7 @@ export function themeToVars(theme: ThemePalette): Record<string, string> {
   const accentMuted = mix(accent, bg, 0.22);
   const accentEmphasis = text;
 
-  // Warm: a tonally shifted version of the accent — slightly toward the
-  // complementary warm side. We just use accent-mixed-with-text for a softer
-  // glow band when the accent itself is cool.
+  // Warm: tracks accent (since 4-color palettes give us only one pop color).
   const warm = accent;
   const warmPale = mix(accent, text, 0.38);
   const warmDeep = mix(accent, bg, 0.42);
@@ -156,14 +173,37 @@ export function themeToVars(theme: ThemePalette): Record<string, string> {
   const scrim = rgba(bg, 0.72);
   const scrimLight = rgba(bg, 0.46);
 
-  // Graph backgrounds — keep them tied to bg ramp.
-  const graphBg = mix(bg, "#000000", 0.32);
+  // Graph backgrounds.
+  const graphBg = isLight ? mix(bg, "#ffffff", 0.18) : mix(bg, "#000000", 0.32);
   const graphGrid = mix(bg, surface, 0.5);
   const graphNode = surface;
   const graphEdge = mix(surface, text, 0.32);
   const graphEdgeUp = accent;
 
+  // Pick a text color that contrasts with accent for "on accent" surfaces
+  // (e.g. primary buttons that fill with accent).
+  const accentLum = luminance(accent);
+  const textOnAccent = accentLum > 0.55 ? bg : text;
+
+  // Chrome stroke/fill orientation. On dark themes, strokes are light overlays
+  // and fills are dark overlays (using #ffffff and #000000). On light themes
+  // we flip both.
+  const strokeColor = isLight ? "#000000" : "#ffffff";
+  const fillColor = isLight ? "#ffffff" : "#000000";
+
   return {
+    // ─── Mode flag ──────────────────────────────────────────
+    "--theme-mode": isLight ? "light" : "dark",
+
+    // ─── RGB tuples (used with `rgb(var(--x-rgb) / alpha)`) ─
+    "--bg-rgb": rgbTuple(bg),
+    "--surface-rgb": rgbTuple(surface),
+    "--text-rgb": rgbTuple(text),
+    "--accent-rgb": rgbTuple(accent),
+    "--abyss-rgb": rgbTuple(abyss),
+    "--stroke-rgb": rgbTuple(strokeColor),
+    "--fill-rgb": rgbTuple(fillColor),
+
     // ─── Backgrounds ─────────────────────────────────────
     "--color-bg-abyss": abyss,
     "--color-bg-primary": bgPrimary,
@@ -184,6 +224,7 @@ export function themeToVars(theme: ThemePalette): Record<string, string> {
     "--color-text-muted": textMuted,
     "--color-text-link": accent,
     "--color-text-dirty": mix(accent, text, 0.3),
+    "--color-text-on-accent": textOnAccent,
 
     // ─── Accent ──────────────────────────────────────────
     "--color-accent": accent,
@@ -198,6 +239,20 @@ export function themeToVars(theme: ThemePalette): Record<string, string> {
     // ─── Surfaces ────────────────────────────────────────
     "--color-surface-scrim": scrim,
     "--color-surface-scrim-light": scrimLight,
+    "--color-surface-card": rgba(mix(surface, text, 0.05), 0.6),
+
+    // ─── Chrome (mode-aware overlays) ────────────────────
+    // Borders / strokes
+    "--chrome-stroke": `rgb(var(--stroke-rgb) / 0.10)`,
+    "--chrome-stroke-strong": `rgb(var(--stroke-rgb) / 0.16)`,
+    "--chrome-stroke-emphasis": `rgb(var(--stroke-rgb) / 0.22)`,
+    // Fills
+    "--chrome-fill": `rgb(var(--fill-rgb) / 0.16)`,
+    "--chrome-fill-soft": `rgb(var(--fill-rgb) / 0.08)`,
+    "--chrome-fill-strong": `rgb(var(--fill-rgb) / 0.32)`,
+    // Highlights (top edges, hover lifts) — always biased to the strong side
+    "--chrome-highlight": `rgb(var(--stroke-rgb) / 0.06)`,
+    "--chrome-highlight-strong": `rgb(var(--stroke-rgb) / 0.12)`,
 
     // ─── Graph (zone map) ────────────────────────────────
     "--color-graph-bg": graphBg,
@@ -207,27 +262,30 @@ export function themeToVars(theme: ThemePalette): Record<string, string> {
     "--color-graph-edge-up": graphEdgeUp,
 
     // ─── Derived rgba tokens (the :root block) ───────────
-    "--glow-accent": `0 0 32px ${rgba(accent, 0.28)}`,
-    "--glow-accent-strong": `0 0 48px ${rgba(text, 0.32)}`,
-    "--glow-warm": `0 0 32px ${rgba(warm, 0.32)}`,
+    "--glow-accent": `0 0 32px rgb(var(--accent-rgb) / 0.28)`,
+    "--glow-accent-strong": `0 0 48px rgb(var(--text-rgb) / 0.32)`,
+    "--glow-warm": `0 0 32px rgb(var(--accent-rgb) / 0.32)`,
     "--glow-warm-strong": `0 0 48px ${rgba(warmPale, 0.42)}`,
-    "--glow-violet": `0 0 28px ${rgba(accent, 0.24)}`,
-    "--glow-blue": `0 0 24px ${rgba(mix(accent, text, 0.4), 0.22)}`,
+    "--glow-violet": `0 0 28px rgb(var(--accent-rgb) / 0.24)`,
+    "--glow-blue": `0 0 24px rgb(var(--accent-rgb) / 0.22)`,
 
-    "--border-accent-ring": rgba(accent, 0.45),
-    "--border-accent-subtle": rgba(accent, 0.35),
-    "--border-glow": rgba(text, 0.25),
-    "--border-glow-strong": rgba(text, 0.48),
+    "--border-accent-ring": `rgb(var(--accent-rgb) / 0.45)`,
+    "--border-accent-subtle": `rgb(var(--accent-rgb) / 0.35)`,
+    "--border-glow": `rgb(var(--text-rgb) / 0.25)`,
+    "--border-glow-strong": `rgb(var(--text-rgb) / 0.48)`,
 
-    "--bg-accent-subtle": rgba(accent, 0.14),
-    "--bg-accent-hover": rgba(accent, 0.2),
+    "--bg-accent-subtle": `rgb(var(--accent-rgb) / 0.14)`,
+    "--bg-accent-hover": `rgb(var(--accent-rgb) / 0.20)`,
 
-    "--bg-active": `linear-gradient(135deg, ${rgba(accent, 0.16)}, ${rgba(mix(accent, text, 0.4), 0.12)})`,
-    "--bg-active-strong": `linear-gradient(135deg, ${rgba(accent, 0.18)}, ${rgba(mix(accent, text, 0.4), 0.14)})`,
-    "--bg-panel": `linear-gradient(160deg, ${rgba(mix(surface, text, 0.05), 0.95)}, ${rgba(bgPrimary, 0.92)})`,
-    "--bg-panel-light": `linear-gradient(160deg, ${rgba(mix(surface, text, 0.08), 0.9)}, ${rgba(mix(bgPrimary, surface, 0.4), 0.92)})`,
-    "--bg-glow-top": `linear-gradient(180deg, ${rgba(accent, 0.18)}, transparent)`,
+    "--bg-active": `linear-gradient(135deg, rgb(var(--accent-rgb) / 0.16), rgb(var(--accent-rgb) / 0.10))`,
+    "--bg-active-strong": `linear-gradient(135deg, rgb(var(--accent-rgb) / 0.22), rgb(var(--accent-rgb) / 0.14))`,
+    "--bg-panel": `linear-gradient(160deg, rgb(var(--surface-rgb) / 0.95), rgb(var(--bg-rgb) / 0.92))`,
+    "--bg-panel-light": `linear-gradient(160deg, rgb(var(--surface-rgb) / 0.85), rgb(var(--bg-rgb) / 0.85))`,
+    "--bg-glow-top": `linear-gradient(180deg, rgb(var(--accent-rgb) / 0.18), transparent)`,
     "--graph-minimap-mask": rgba(graphBg, 0.8),
+
+    // ─── Body background gradients ───────────────────────
+    "--body-bg": `radial-gradient(circle at 14% 12%, rgb(var(--accent-rgb) / 0.18), transparent 36%), radial-gradient(circle at 84% 14%, rgb(var(--accent-rgb) / 0.10), transparent 34%), linear-gradient(180deg, ${bgPrimary} 0%, ${abyss} 100%)`,
   };
 }
 

--- a/creator/src/lib/theme.ts
+++ b/creator/src/lib/theme.ts
@@ -1,0 +1,309 @@
+// ─── Theme system ───────────────────────────────────────────────────
+// 4-color theme palettes derive the full set of CSS custom properties used
+// throughout the app. The user picks (or pastes) Background, Surface, Text,
+// and Accent — everything else is derived from those four anchors.
+//
+// Status colors, class identity colors, lore template colors, diff colors,
+// and chart colors are intentionally NOT themed — they are semantic.
+
+export interface ThemePalette {
+  /** Name shown in the UI. */
+  name: string;
+  /** Darkest color — drives the abyss / page background. */
+  background: string;
+  /** Mid surface — drives panels, sections, hover states, borders. */
+  surface: string;
+  /** Light color — drives primary text. */
+  text: string;
+  /** Saturated pop — drives accent, links, glows, active states. */
+  accent: string;
+}
+
+export const DEFAULT_THEME: ThemePalette = {
+  name: "Arcanum (default)",
+  background: "#22293c",
+  surface: "#313a56",
+  text: "#dbe3f8",
+  accent: "#a897d2",
+};
+
+/** Built-in palettes the user can apply with one click. */
+export const PRESET_THEMES: ThemePalette[] = [
+  DEFAULT_THEME,
+  {
+    name: "Aurum Dusk",
+    background: "#1a1410",
+    surface: "#2e241c",
+    text: "#f0e4d0",
+    accent: "#c8a46a",
+  },
+  {
+    name: "Verdant Hollow",
+    background: "#0f1a14",
+    surface: "#1d2e23",
+    text: "#dbe8d6",
+    accent: "#8da97b",
+  },
+  {
+    name: "Cinder Rose",
+    background: "#1a0f14",
+    surface: "#2c1a23",
+    text: "#f3dde2",
+    accent: "#d68aa0",
+  },
+  {
+    name: "Tidepool",
+    background: "#0c1820",
+    surface: "#162a36",
+    text: "#d6e8f0",
+    accent: "#6fb5c7",
+  },
+  {
+    name: "Lichen",
+    background: "#13181a",
+    surface: "#222b2c",
+    text: "#dde6e2",
+    accent: "#a3c48e",
+  },
+];
+
+// ─── Color math ─────────────────────────────────────────────────────
+
+export interface RGB {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export function hexToRgb(hex: string): RGB {
+  const m = hex.replace("#", "").trim();
+  const v = m.length === 3 ? m.split("").map((c) => c + c).join("") : m;
+  const n = parseInt(v, 16);
+  return { r: (n >> 16) & 0xff, g: (n >> 8) & 0xff, b: n & 0xff };
+}
+
+export function rgbToHex({ r, g, b }: RGB): string {
+  const c = (x: number) => Math.max(0, Math.min(255, Math.round(x)));
+  return "#" + [c(r), c(g), c(b)].map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+export function rgba(hex: string, alpha: number): string {
+  const { r, g, b } = hexToRgb(hex);
+  return `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${alpha})`;
+}
+
+/** Linearly mix two hex colors. t=0 → a, t=1 → b. */
+export function mix(a: string, b: string, t: number): string {
+  const ra = hexToRgb(a);
+  const rb = hexToRgb(b);
+  return rgbToHex({
+    r: ra.r + (rb.r - ra.r) * t,
+    g: ra.g + (rb.g - ra.g) * t,
+    b: ra.b + (rb.b - ra.b) * t,
+  });
+}
+
+/** Relative luminance (0..1) for a hex color, per WCAG. */
+export function luminance(hex: string): number {
+  const { r, g, b } = hexToRgb(hex);
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+// ─── Derivation ─────────────────────────────────────────────────────
+
+/** Build the full CSS-variable map from a 4-color palette. */
+export function themeToVars(theme: ThemePalette): Record<string, string> {
+  const bg = theme.background;
+  const surface = theme.surface;
+  const text = theme.text;
+  const accent = theme.accent;
+
+  // Background ramp: darker than bg for the abyss, then surface, with lighter
+  // variants mixed toward the surface color.
+  const abyss = mix(bg, "#000000", 0.18);
+  const bgPrimary = bg;
+  const bgSecondary = mix(bg, surface, 0.4);
+  const bgTertiary = surface;
+  const bgElevated = surface;
+  const bgHover = mix(surface, text, 0.08);
+
+  // Borders: from muted (closer to surface) to default (mid) to accent-tinted focus.
+  const borderMuted = mix(surface, text, 0.05);
+  const borderDefault = mix(surface, text, 0.18);
+  const borderFocus = accent;
+
+  // Text ramp: primary is the literal text color, lower tiers mix toward bg.
+  const textPrimary = text;
+  const textSecondary = mix(text, bg, 0.22);
+  const textMuted = mix(text, bg, 0.42);
+
+  // Accent variants.
+  const accentMuted = mix(accent, bg, 0.22);
+  const accentEmphasis = text;
+
+  // Warm: a tonally shifted version of the accent — slightly toward the
+  // complementary warm side. We just use accent-mixed-with-text for a softer
+  // glow band when the accent itself is cool.
+  const warm = accent;
+  const warmPale = mix(accent, text, 0.38);
+  const warmDeep = mix(accent, bg, 0.42);
+
+  // Surface scrims (panel backdrops).
+  const scrim = rgba(bg, 0.72);
+  const scrimLight = rgba(bg, 0.46);
+
+  // Graph backgrounds — keep them tied to bg ramp.
+  const graphBg = mix(bg, "#000000", 0.32);
+  const graphGrid = mix(bg, surface, 0.5);
+  const graphNode = surface;
+  const graphEdge = mix(surface, text, 0.32);
+  const graphEdgeUp = accent;
+
+  return {
+    // ─── Backgrounds ─────────────────────────────────────
+    "--color-bg-abyss": abyss,
+    "--color-bg-primary": bgPrimary,
+    "--color-bg-secondary": bgSecondary,
+    "--color-bg-tertiary": bgTertiary,
+    "--color-bg-elevated": bgElevated,
+    "--color-bg-hover": bgHover,
+
+    // ─── Borders ─────────────────────────────────────────
+    "--color-border-default": borderDefault,
+    "--color-border-muted": borderMuted,
+    "--color-border-focus": borderFocus,
+    "--color-border-active": rgba(accent, 0.35),
+
+    // ─── Text ────────────────────────────────────────────
+    "--color-text-primary": textPrimary,
+    "--color-text-secondary": textSecondary,
+    "--color-text-muted": textMuted,
+    "--color-text-link": accent,
+    "--color-text-dirty": mix(accent, text, 0.3),
+
+    // ─── Accent ──────────────────────────────────────────
+    "--color-accent": accent,
+    "--color-accent-muted": accentMuted,
+    "--color-accent-emphasis": accentEmphasis,
+
+    // ─── Warm (decorative, tracks accent) ────────────────
+    "--color-warm": warm,
+    "--color-warm-pale": warmPale,
+    "--color-warm-deep": warmDeep,
+
+    // ─── Surfaces ────────────────────────────────────────
+    "--color-surface-scrim": scrim,
+    "--color-surface-scrim-light": scrimLight,
+
+    // ─── Graph (zone map) ────────────────────────────────
+    "--color-graph-bg": graphBg,
+    "--color-graph-grid": graphGrid,
+    "--color-graph-node": graphNode,
+    "--color-graph-edge": graphEdge,
+    "--color-graph-edge-up": graphEdgeUp,
+
+    // ─── Derived rgba tokens (the :root block) ───────────
+    "--glow-accent": `0 0 32px ${rgba(accent, 0.28)}`,
+    "--glow-accent-strong": `0 0 48px ${rgba(text, 0.32)}`,
+    "--glow-warm": `0 0 32px ${rgba(warm, 0.32)}`,
+    "--glow-warm-strong": `0 0 48px ${rgba(warmPale, 0.42)}`,
+    "--glow-violet": `0 0 28px ${rgba(accent, 0.24)}`,
+    "--glow-blue": `0 0 24px ${rgba(mix(accent, text, 0.4), 0.22)}`,
+
+    "--border-accent-ring": rgba(accent, 0.45),
+    "--border-accent-subtle": rgba(accent, 0.35),
+    "--border-glow": rgba(text, 0.25),
+    "--border-glow-strong": rgba(text, 0.48),
+
+    "--bg-accent-subtle": rgba(accent, 0.14),
+    "--bg-accent-hover": rgba(accent, 0.2),
+
+    "--bg-active": `linear-gradient(135deg, ${rgba(accent, 0.16)}, ${rgba(mix(accent, text, 0.4), 0.12)})`,
+    "--bg-active-strong": `linear-gradient(135deg, ${rgba(accent, 0.18)}, ${rgba(mix(accent, text, 0.4), 0.14)})`,
+    "--bg-panel": `linear-gradient(160deg, ${rgba(mix(surface, text, 0.05), 0.95)}, ${rgba(bgPrimary, 0.92)})`,
+    "--bg-panel-light": `linear-gradient(160deg, ${rgba(mix(surface, text, 0.08), 0.9)}, ${rgba(mix(bgPrimary, surface, 0.4), 0.92)})`,
+    "--bg-glow-top": `linear-gradient(180deg, ${rgba(accent, 0.18)}, transparent)`,
+    "--graph-minimap-mask": rgba(graphBg, 0.8),
+  };
+}
+
+/** Apply a theme by writing every derived variable onto :root. */
+export function applyTheme(theme: ThemePalette): void {
+  const vars = themeToVars(theme);
+  const root = document.documentElement;
+  for (const [k, v] of Object.entries(vars)) {
+    root.style.setProperty(k, v);
+  }
+}
+
+/** Reset all theme variables (falls back to the @theme block in index.css). */
+export function clearTheme(): void {
+  const root = document.documentElement;
+  for (const k of Object.keys(themeToVars(DEFAULT_THEME))) {
+    root.style.removeProperty(k);
+  }
+}
+
+// ─── Persistence ────────────────────────────────────────────────────
+
+const STORAGE_KEY = "arcanum.theme.v1";
+
+export function loadStoredTheme(): ThemePalette | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ThemePalette>;
+    if (
+      typeof parsed.background === "string" &&
+      typeof parsed.surface === "string" &&
+      typeof parsed.text === "string" &&
+      typeof parsed.accent === "string"
+    ) {
+      return {
+        name: typeof parsed.name === "string" ? parsed.name : "Custom",
+        background: parsed.background,
+        surface: parsed.surface,
+        text: parsed.text,
+        accent: parsed.accent,
+      };
+    }
+  } catch (err) {
+    console.error("Failed to read stored theme:", err);
+  }
+  return null;
+}
+
+export function saveStoredTheme(theme: ThemePalette | null): void {
+  try {
+    if (theme === null) {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(theme));
+    }
+  } catch (err) {
+    console.error("Failed to write stored theme:", err);
+  }
+}
+
+/** Validate a hex color string. */
+export function isValidHex(s: string): boolean {
+  return /^#?[0-9a-fA-F]{6}$/.test(s.trim()) || /^#?[0-9a-fA-F]{3}$/.test(s.trim());
+}
+
+/** Normalize to a #rrggbb 7-char string. */
+export function normalizeHex(s: string): string {
+  const t = s.trim().replace(/^#/, "");
+  const full = t.length === 3 ? t.split("").map((c) => c + c).join("") : t;
+  return "#" + full.toLowerCase();
+}
+
+/** Parse a free-form palette paste (whitespace, commas, newlines) into 4 hexes. */
+export function parsePalettePaste(input: string): string[] | null {
+  const tokens = input.match(/#?[0-9a-fA-F]{6}/g);
+  if (!tokens || tokens.length < 4) return null;
+  return tokens.slice(0, 4).map(normalizeHex);
+}

--- a/creator/src/main.tsx
+++ b/creator/src/main.tsx
@@ -14,6 +14,10 @@ import "@fontsource/jetbrains-mono/500.css";
 
 import { App } from "./App";
 import "./index.css";
+import { bootstrapTheme } from "./stores/themeStore";
+
+// Apply persisted theme before first render to avoid a flash of defaults.
+bootstrapTheme();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/creator/src/stores/themeStore.ts
+++ b/creator/src/stores/themeStore.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+import {
+  DEFAULT_THEME,
+  applyTheme,
+  clearTheme,
+  loadStoredTheme,
+  saveStoredTheme,
+  type ThemePalette,
+} from "@/lib/theme";
+
+interface ThemeStore {
+  /** The currently applied theme. Null means "use index.css defaults". */
+  theme: ThemePalette | null;
+  /** Set and persist a custom theme. Pass null to revert to defaults. */
+  setTheme: (theme: ThemePalette | null) => void;
+  /** Live-preview a theme without persisting it. */
+  previewTheme: (theme: ThemePalette) => void;
+  /** Cancel an in-progress preview and re-apply the persisted theme. */
+  cancelPreview: () => void;
+}
+
+export const useThemeStore = create<ThemeStore>((set, get) => ({
+  theme: null,
+
+  setTheme: (theme) => {
+    if (theme === null) {
+      clearTheme();
+    } else {
+      applyTheme(theme);
+    }
+    saveStoredTheme(theme);
+    set({ theme });
+  },
+
+  previewTheme: (theme) => {
+    applyTheme(theme);
+  },
+
+  cancelPreview: () => {
+    const persisted = get().theme;
+    if (persisted === null) {
+      clearTheme();
+    } else {
+      applyTheme(persisted);
+    }
+  },
+}));
+
+/**
+ * Read the persisted theme from localStorage and apply it. Call once at app
+ * startup before first paint to avoid a flash of the default theme.
+ */
+export function bootstrapTheme(): void {
+  const stored = loadStoredTheme();
+  if (stored) {
+    applyTheme(stored);
+    useThemeStore.setState({ theme: stored });
+  }
+}
+
+export { DEFAULT_THEME };


### PR DESCRIPTION
## Summary
- Migrate ~870 hardcoded `bg-white/N`, `border-white/N`, `bg-black/N` tints across 100+ components to semantic chrome tokens, so the JS theme picker actually rethemes the whole app (not just the `@theme` block)
- Add `*-rgb` tuple tokens + mode-aware `--chrome-stroke` / `--chrome-fill` / `--chrome-highlight` that auto-flip orientation for light themes
- Derive `--color-text-on-accent` per theme and add a "Parchment (light)" preset
- Refactor body background, all utility classes (`shell-pill`, `action-button` variants, `panel-surface`, `dialog-shell`, `instrument-panel`, `world-lens`, `orbital-tab`, etc.) and all keyframes to use only tokens
- Fix pre-existing scrolling bug: `AppShell` was using `min-h-screen` instead of `h-screen`, so the flex chain had no definite parent height for the inner `overflow-y-auto` containers; also removed a redundant outer aside wrapper around Sidebar
- Guard `RegistryPanel` against undefined `items` (Object.keys crash)

## Test plan
- [ ] Open Appearance panel, click "Parchment (light)" preset → entire app rethemes to light, including the toolbar banner, sidebar pills, World Tools dropdown, and all action buttons
- [ ] Switch to "Aurum Dusk" → confirm warm gold theme applies cleanly
- [ ] Open the Tuning Wizard, Deployment, and Services panels → confirm both the sidebar and main area scroll independently when content overflows
- [ ] Confirm semantic colors (status badges, class identity colors, lore template tags) stay fixed across themes
- [ ] Confirm theme persists across reload with no flash