### PR TITLE
Fix zone layout centering and silent BG/relation failures

### DIFF
--- a/creator/src/components/PlayerSpriteManager.tsx
+++ b/creator/src/components/PlayerSpriteManager.tsx
@@ -221,6 +221,8 @@ function SpriteLightbox({
       const context = { zone: "sprites", entity_type: "player_sprite", entity_id: key };
       const entry = await removeBgAndSave(src, "player_sprite", context, variantGroup);
       if (entry) onRemoveBg();
+    } catch (err) {
+      console.error("[player sprite] bg removal failed:", err);
     } finally {
       setRemovingBg(false);
     }

--- a/creator/src/components/lore/RelationInferencePanel.tsx
+++ b/creator/src/components/lore/RelationInferencePanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback } from "react";
 import { useLoreStore, selectArticles } from "@/stores/loreStore";
+import { useToastStore } from "@/stores/toastStore";
 import { inferRelations, type RelationSuggestion } from "@/lib/loreRelationInference";
 
 function suggestionKey(s: RelationSuggestion) {
@@ -17,12 +18,37 @@ export function RelationInferencePanel() {
 
   const handleScan = useCallback(() => {
     setLoading(true);
+    // Defer to next tick so the button shows "Analyzing…" before the
+    // synchronous scan runs (purely cosmetic — inferRelations is sync).
     setTimeout(() => {
-      setSuggestions(inferRelations(articles));
-      setDismissed(new Set());
-      setAccepted(new Set());
-      setScanned(true);
-      setLoading(false);
+      try {
+        const result = inferRelations(articles);
+        setSuggestions(result);
+        setDismissed(new Set());
+        setAccepted(new Set());
+        setScanned(true);
+        if (result.length === 0) {
+          useToastStore.getState().show(
+            "No missing relations detected",
+          );
+        } else {
+          useToastStore.getState().show(
+            `Found ${result.length} relation suggestion${result.length !== 1 ? "s" : ""}`,
+          );
+        }
+      } catch (err) {
+        // Surface inference failures instead of leaving the button stuck
+        // on "Analyzing…". The scan previously ate exceptions silently
+        // because setLoading(false) lived on the happy path only.
+        console.error("Relation inference failed:", err);
+        const message = err instanceof Error ? err.message : String(err);
+        useToastStore.getState().show(
+          `Relation suggest failed: ${message}`,
+          4000,
+        );
+      } finally {
+        setLoading(false);
+      }
     }, 0);
   }, [articles]);
 

--- a/creator/src/components/ui/BulkBgRemoval.tsx
+++ b/creator/src/components/ui/BulkBgRemoval.tsx
@@ -93,7 +93,9 @@ export function BulkBgRemoval({
       );
 
       try {
-        // Get data URL from the resolved path
+        // Get data URL from the resolved path. This fails for newly
+        // generated images when the DB path format has drifted — the
+        // thrown error is surfaced into the row below.
         const dataUrl = await invoke<string>("read_image_data_url", {
           path: item.resolvedPath,
         });
@@ -105,16 +107,18 @@ export function BulkBgRemoval({
           item.variantGroup,
         );
 
+        // Touch `entry` so TypeScript doesn't warn about the unused binding;
+        // the real effect is that the asset was saved via the variant group,
+        // and loadAssets() below refreshes the manifest.
+        void entry;
         setItems((prev) =>
-          prev.map((t, i) =>
-            i === idx
-              ? { ...t, status: entry ? "done" : "error", error: entry ? undefined : "Removal returned null" }
-              : t,
-          ),
+          prev.map((t, i) => (i === idx ? { ...t, status: "done", error: undefined } : t)),
         );
       } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[bulk bg removal] ${item.label} failed:`, err);
         setItems((prev) =>
-          prev.map((t, i) => (i === idx ? { ...t, status: "error", error: String(err) } : t)),
+          prev.map((t, i) => (i === idx ? { ...t, status: "error", error: message } : t)),
         );
       }
     }

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -20,7 +20,7 @@ import { useProjectStore } from "@/stores/projectStore";
 import { useAssetStore } from "@/stores/assetStore";
 import { useToastStore } from "@/stores/toastStore";
 import { zoneToGraph, GRAPH } from "@/lib/zoneToGraph";
-import { compassLayout, type LayoutMeasurement } from "@/lib/dagreLayout";
+import { compassLayout, getLayoutBounds, type LayoutMeasurement } from "@/lib/dagreLayout";
 import { addRoom, addExit, deleteExit, generateRoomId } from "@/lib/zoneEdits";
 import { saveZone } from "@/lib/saveZone";
 import type { WorldFile } from "@/types/world";
@@ -38,6 +38,7 @@ import { SpringPanel } from "./SpringPanel";
 import { ZoneMediaPanel } from "./ZoneMediaPanel";
 import { DungeonEditor, DungeonEmptyState } from "@/components/editors/DungeonEditor";
 import { setDungeon, removeDungeon } from "@/lib/zoneEdits";
+import { normalizeAssetRef } from "@/lib/assetRefs";
 import builderBg from "@/assets/builder-bg.jpg";
 import subtoolbarBg from "@/assets/subtoolbar-bg.jpg";
 
@@ -65,13 +66,29 @@ interface ZoneEditorProps {
 function collectBgRemovalTargets(world: WorldFile, zoneId: string, assetsDir: string): BulkBgTarget[] {
   const targets: BulkBgTarget[] = [];
 
+  // Always run the entity image through `normalizeAssetRef` before building
+  // the absolute filesystem path. Without this, freshly generated images
+  // whose refs weren't saved yet (still carrying a legacy path prefix or a
+  // `/images/...` engine ref) produce broken resolvedPaths like
+  // `...\images\/images/foo.png`, which silently fails `read_image_data_url`.
+  const resolveImagePath = (imageRef: string): string | null => {
+    const normalized = normalizeAssetRef(imageRef);
+    if (!normalized) return null;
+    // Engine-relative refs (/images/subdir/foo.png) are never on local disk
+    // in the same place — skip them instead of producing a bad path.
+    if (normalized.startsWith("/")) return null;
+    return `${assetsDir}\\images\\${normalized}`;
+  };
+
   for (const [id, mob] of Object.entries(world.mobs ?? {})) {
     if (!mob.image) continue;
+    const resolvedPath = resolveImagePath(mob.image);
+    if (!resolvedPath) continue;
     targets.push({
       id: `mob:${id}`,
       label: `${mob.name} (mob)`,
       imagePath: mob.image,
-      resolvedPath: `${assetsDir}\\images\\${mob.image}`,
+      resolvedPath,
       assetType: "mob",
       variantGroup: `mob:${zoneId}:${id}`,
       context: { zone: zoneId, entity_type: "mob", entity_id: id },
@@ -80,11 +97,13 @@ function collectBgRemovalTargets(world: WorldFile, zoneId: string, assetsDir: st
 
   for (const [id, item] of Object.entries(world.items ?? {})) {
     if (!item.image) continue;
+    const resolvedPath = resolveImagePath(item.image);
+    if (!resolvedPath) continue;
     targets.push({
       id: `item:${id}`,
       label: `${item.displayName} (item)`,
       imagePath: item.image,
-      resolvedPath: `${assetsDir}\\images\\${item.image}`,
+      resolvedPath,
       assetType: "item",
       variantGroup: `item:${zoneId}:${id}`,
       context: { zone: zoneId, entity_type: "item", entity_id: id },
@@ -222,6 +241,12 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
   // Discard manual positions and re-run the BFS/compass layout using the
   // currently measured room sizes (so variable-height rooms don't overlap),
   // then fit the viewport to the result.
+  //
+  // We compute the target bounds from the fresh layout + current measurements
+  // and call `fitBounds` directly, instead of `fitView` on a setTimeout. The
+  // old approach was racy: `fitView` reads node measurements from the DOM,
+  // which weren't updated yet immediately after `setNodes`, so it would
+  // compute bounds from stale positions and zoom out to a lost viewport.
   const handleRelayout = useCallback(() => {
     if (!zoneState) return;
     const measurements = new Map<string, LayoutMeasurement>();
@@ -235,11 +260,65 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
     const { nodes: rawNodes } = zoneToGraph(zoneState.data);
     const fresh = compassLayout(rawNodes, zoneState.data, measurements);
     setNodes(fresh);
-    setTimeout(() => {
-      reactFlow.fitView({ padding: 0.2, duration: 400 });
-    }, 0);
+    const bounds = getLayoutBounds(fresh, measurements);
+    if (bounds && bounds.width > 0 && bounds.height > 0) {
+      reactFlow.fitBounds(bounds, { padding: 0.2, duration: 400 });
+    }
     useToastStore.getState().show("Zone re-laid out");
   }, [zoneState, setNodes, reactFlow]);
+
+  // ─── Initial fit-to-view ─────────────────────────────────────────
+  // The `fitView` prop on <ReactFlow> is unreliable here: on first mount the
+  // nodes may not yet have DOM measurements (so bounds collapse), and when
+  // the user switches view modes (map → assets → map) the ReactFlow child
+  // remounts with stale measurements from the previous mount.
+  //
+  // Instead, we run a one-shot fit whenever the map view becomes active for
+  // a given zone, using our deterministic `getLayoutBounds` helper. The ref
+  // key is `${zoneId}:${mapMountCount}` so a view-mode round trip re-fits.
+  const mapMountCountRef = useRef(0);
+  useEffect(() => {
+    if (viewMode === "map") {
+      mapMountCountRef.current += 1;
+    }
+  }, [viewMode]);
+
+  const fitDoneRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (viewMode !== "map") return;
+    if (nodes.length === 0) return;
+    const key = `${zoneId}:${mapMountCountRef.current}`;
+    if (fitDoneRef.current === key) return;
+
+    // Defer to the next frame so RoomNode has a chance to mount and measure.
+    // Two rAFs: one to let React commit, one to let ReactFlow observe DOM.
+    let cancelled = false;
+    const raf1 = requestAnimationFrame(() => {
+      if (cancelled) return;
+      const raf2 = requestAnimationFrame(() => {
+        if (cancelled) return;
+        const measured = reactFlow.getNodes();
+        const measurements = new Map<string, LayoutMeasurement>();
+        for (const node of measured) {
+          const width = node.measured?.width ?? node.width;
+          const height = node.measured?.height ?? node.height;
+          if (width && height) {
+            measurements.set(node.id, { width, height });
+          }
+        }
+        const bounds = getLayoutBounds(measured, measurements);
+        if (bounds && bounds.width > 0 && bounds.height > 0) {
+          reactFlow.fitBounds(bounds, { padding: 0.2, duration: 0 });
+          fitDoneRef.current = key;
+        }
+      });
+      return () => cancelAnimationFrame(raf2);
+    });
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf1);
+    };
+  }, [zoneId, nodes.length, reactFlow, viewMode]);
 
   const applyWorldChange = useCallback(
     (next: WorldFile) => {
@@ -623,8 +702,6 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
               onSelectionChange={onSelectionChange}
               onNodeClick={onNodeClick}
               onPaneClick={onPaneClick}
-              fitView
-              fitViewOptions={{ padding: 0.2 }}
               minZoom={0.1}
               maxZoom={2}
               proOptions={{ hideAttribution: true }}

--- a/creator/src/lib/__tests__/dagreLayout.test.ts
+++ b/creator/src/lib/__tests__/dagreLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { compassLayout, type LayoutMeasurement } from "../dagreLayout";
+import { compassLayout, getLayoutBounds, type LayoutMeasurement } from "../dagreLayout";
 import { zoneToGraph } from "../zoneToGraph";
 import type { WorldFile } from "@/types/world";
 
@@ -125,5 +125,58 @@ describe("compassLayout", () => {
     const b = laid.find((n) => n.id === "b")!;
     // Default column width 220 + 80 gutter = 300.
     expect(b.position.x - a.position.x).toBe(300);
+  });
+});
+
+describe("getLayoutBounds", () => {
+  it("returns null for an empty node list", () => {
+    expect(getLayoutBounds([])).toBeNull();
+  });
+
+  it("bounds a single default-sized node at its origin", () => {
+    const world = makeWorld({
+      solo: { title: "Solo", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+    const bounds = getLayoutBounds(laid);
+    expect(bounds).not.toBeNull();
+    // Default 220x140 node at (0,0).
+    expect(bounds).toEqual({ x: 0, y: 0, width: 220, height: 140 });
+  });
+
+  it("bounds an east-chain using supplied measurements", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { e: "b" } },
+      b: { title: "B", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const measurements = new Map<string, LayoutMeasurement>([
+      ["a", { width: 220, height: 140 }],
+      ["b", { width: 220, height: 140 }],
+    ]);
+    const laid = compassLayout(nodes, world, measurements);
+    const bounds = getLayoutBounds(laid, measurements);
+    // Two 220-wide nodes with a 80-gutter stride of 300 → total width 520,
+    // single row of height 140.
+    expect(bounds).toEqual({ x: 0, y: 0, width: 520, height: 140 });
+  });
+
+  it("prefers explicit measurements over node.measured values", () => {
+    // Simulate stale DOM measurements on a node by placing a bogus
+    // `measured` field that should be ignored in favor of the map.
+    const world = makeWorld({
+      a: { title: "A", description: "" },
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world).map((n) => ({
+      ...n,
+      measured: { width: 999, height: 999 },
+    }));
+    const overrides = new Map<string, LayoutMeasurement>([
+      ["a", { width: 100, height: 50 }],
+    ]);
+    const bounds = getLayoutBounds(laid, overrides);
+    expect(bounds).toEqual({ x: 0, y: 0, width: 100, height: 50 });
   });
 });

--- a/creator/src/lib/dagreLayout.ts
+++ b/creator/src/lib/dagreLayout.ts
@@ -175,6 +175,64 @@ export function compassLayout(
   });
 }
 
+/**
+ * Compute the bounding rectangle for a set of positioned nodes.
+ *
+ * Used to drive `reactFlow.fitBounds()` deterministically — without this,
+ * we'd have to rely on `fitView()` which reads DOM-measured dimensions and
+ * may see zero-sized or stale measurements right after a layout change.
+ *
+ * Dimensions are sourced in order of preference:
+ *   1. Explicit `measurements` map (freshest — passed by the caller)
+ *   2. Node's own `measured.width/height` (ReactFlow runtime)
+ *   3. Node's static `width/height`
+ *   4. DEFAULT_NODE_WIDTH / DEFAULT_NODE_HEIGHT
+ *
+ * Returns `null` if there are no nodes to bound.
+ */
+export function getLayoutBounds(
+  nodes: Node[],
+  measurements?: Map<string, LayoutMeasurement>,
+): { x: number; y: number; width: number; height: number } | null {
+  if (nodes.length === 0) return null;
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const node of nodes) {
+    const m = measurements?.get(node.id);
+    const width =
+      (m && m.width > 0 ? m.width : undefined) ??
+      node.measured?.width ??
+      node.width ??
+      DEFAULT_NODE_WIDTH;
+    const height =
+      (m && m.height > 0 ? m.height : undefined) ??
+      node.measured?.height ??
+      node.height ??
+      DEFAULT_NODE_HEIGHT;
+
+    const x = node.position?.x ?? 0;
+    const y = node.position?.y ?? 0;
+
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x + width > maxX) maxX = x + width;
+    if (y + height > maxY) maxY = y + height;
+  }
+
+  if (!isFinite(minX) || !isFinite(minY)) return null;
+
+  return {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+}
+
 /** Spiral outward from (x, y) to find the nearest unoccupied grid cell. */
 function findEmpty(
   x: number,

--- a/creator/src/lib/loreRelationInference.ts
+++ b/creator/src/lib/loreRelationInference.ts
@@ -18,12 +18,14 @@ export function inferRelations(
   articles: Record<string, Article>,
 ): RelationSuggestion[] {
   const suggestions: RelationSuggestion[] = [];
-  const articleList = Object.values(articles);
+  const articleList = Object.values(articles).filter(
+    (a): a is Article => a != null && typeof a.title === "string",
+  );
 
   // Build title→id map for text-field matching (leader, territory, etc.)
   const titleToId = new Map<string, string>();
   for (const a of articleList) {
-    titleToId.set(a.title.toLowerCase(), a.id);
+    if (a.title) titleToId.set(a.title.toLowerCase(), a.id);
   }
 
   for (const article of articleList) {

--- a/creator/src/lib/useBackgroundRemoval.ts
+++ b/creator/src/lib/useBackgroundRemoval.ts
@@ -52,25 +52,46 @@ export async function removeBackground(imageDataUrl: string): Promise<Blob> {
 // ─── Sequential queue ─────────────────────────────────────────────
 // Serialize requests so we don't send multiple large data URLs
 // to the worker at once (memory pressure).
+//
+// NOTE: the queue runner must never let a task throw out of the while
+// loop, because that would leave `bgQueueRunning = true` and wedge the
+// whole queue for the rest of the session. Per-task errors are surfaced
+// through the per-task promise (reject), not through the runner.
 
-type QueueEntry = { run: () => Promise<void>; resolve: () => void };
-const bgQueue: QueueEntry[] = [];
+interface QueueEntry<T> {
+  run: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+}
+
+const bgQueue: QueueEntry<unknown>[] = [];
 let bgQueueRunning = false;
 
 async function processBgQueue() {
   if (bgQueueRunning) return;
   bgQueueRunning = true;
-  while (bgQueue.length > 0) {
-    const entry = bgQueue.shift()!;
-    await entry.run();
-    entry.resolve();
+  try {
+    while (bgQueue.length > 0) {
+      const entry = bgQueue.shift()!;
+      try {
+        const value = await entry.run();
+        entry.resolve(value);
+      } catch (err) {
+        entry.reject(err);
+      }
+    }
+  } finally {
+    bgQueueRunning = false;
   }
-  bgQueueRunning = false;
 }
 
-function enqueueBgTask(run: () => Promise<void>): Promise<void> {
-  return new Promise<void>((resolve) => {
-    bgQueue.push({ run, resolve });
+function enqueueBgTask<T>(run: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    bgQueue.push({
+      run: run as () => Promise<unknown>,
+      resolve: resolve as (v: unknown) => void,
+      reject,
+    });
     processBgQueue();
   });
 }
@@ -88,44 +109,46 @@ export function shouldRemoveBg(assetType: string): boolean {
 
 /**
  * Run background removal on a data URL and save the result as an asset variant.
- * Returns the saved AssetEntry, or null if removal failed.
+ * Throws on failure so callers can surface the real error message — the old
+ * "swallow and return null" behavior made every failure look identical in
+ * the bulk UI ("Removal returned null") and hid actual causes like worker
+ * crashes or oversized input.
+ *
+ * Existing call sites that relied on null-return can still get that behavior
+ * by appending `.catch(() => null)`.
  */
 export async function removeBgAndSave(
   imageDataUrl: string,
   assetType: string,
   context?: AssetContext,
   variantGroup?: string,
-): Promise<AssetEntry | null> {
-  let result: AssetEntry | null = null;
-  await enqueueBgTask(async () => {
-    console.log(`[bg-removal] Starting for ${assetType}${variantGroup ? ` (variant: ${variantGroup})` : ""}`);
-    try {
-      const blob = await removeBackground(imageDataUrl);
-      const buffer = await blob.arrayBuffer();
-      const bytes = new Uint8Array(buffer);
-      const chunks: string[] = [];
-      const CHUNK = 8192;
-      for (let i = 0; i < bytes.length; i += CHUNK) {
-        chunks.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
-      }
-      const b64 = btoa(chunks.join(""));
-
-      const entry = await invoke<AssetEntry>("save_bytes_as_asset", {
-        bytesB64: b64,
-        assetType,
-        context: context ?? null,
-        variantGroup: variantGroup ?? null,
-      });
-      if (variantGroup) {
-        await invoke("set_active_variant", { variantGroup, assetId: entry.id });
-        console.log(`[bg-removal] Set as active variant for ${variantGroup}`);
-      }
-      result = entry;
-    } catch (e) {
-      console.error("[bg-removal] Failed:", e);
+): Promise<AssetEntry> {
+  return enqueueBgTask(async () => {
+    console.log(
+      `[bg-removal] Starting for ${assetType}${variantGroup ? ` (variant: ${variantGroup})` : ""}`,
+    );
+    const blob = await removeBackground(imageDataUrl);
+    const buffer = await blob.arrayBuffer();
+    const bytes = new Uint8Array(buffer);
+    const chunks: string[] = [];
+    const CHUNK = 8192;
+    for (let i = 0; i < bytes.length; i += CHUNK) {
+      chunks.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
     }
+    const b64 = btoa(chunks.join(""));
+
+    const entry = await invoke<AssetEntry>("save_bytes_as_asset", {
+      bytesB64: b64,
+      assetType,
+      context: context ?? null,
+      variantGroup: variantGroup ?? null,
+    });
+    if (variantGroup) {
+      await invoke("set_active_variant", { variantGroup, assetId: entry.id });
+      console.log(`[bg-removal] Set as active variant for ${variantGroup}`);
+    }
+    return entry;
   });
-  return result;
 }
 
 /** React hook for background removal with loading/error state. */


### PR DESCRIPTION
## Summary
Three P0 bugs from the latest testing session — a broken zone viewer viewport and two "fails silently" regressions in lore and asset pipelines.

### 1. Zone viewer layout centering
The initial BFS layout and the **Re-layout** button both left the map zoomed out somewhere off-screen. Root cause: `fitView` was racing DOM measurement. At mount, nodes had no measured dimensions, so bounds collapsed; on Relayout, `setTimeout(0) → fitView` fired before ReactFlow re-measured the new positions, so it fit the *previous* bounds. Now we compute bounds deterministically from our own layout output via a new `getLayoutBounds()` helper and call `fitBounds()`. A per-`(zoneId, map-mount-count)` ref re-fits whenever the user leaves the map view and comes back.

### 2. "Suggest Relations" silent failure
If `inferRelations` threw (e.g. an article with a missing title), the scan button got stuck on "Analyzing…" forever because `setLoading(false)` was only on the happy path. Wrapped in try/catch/finally, surfacing errors via toast, and added a defensive title guard in the inference pass.

### 3. Bulk BG removal failing on new images
Two compounding bugs:
- **Queue deadlock**: `processBgQueue` let exceptions escape the while loop, leaving `bgQueueRunning=true` forever. After the first failure, **every subsequent BG removal in the session was silently dropped**.
- **Swallowed errors**: `removeBgAndSave` caught the real error, logged to console, and returned `null`. The bulk UI then showed a useless "Removal returned null" message with no way to diagnose.
- **Broken path resolution**: `collectBgRemovalTargets` concatenated `mob.image` verbatim into `\${assetsDir}\images\\${mob.image}`, producing paths like `…\images\/images/foo.png` when the image ref carried a legacy prefix. This made freshly-generated images with non-bare filenames fail.

Fixes: restructured the queue so per-task errors reject per-task promises (not the runner), `removeBgAndSave` now propagates real errors, the bulk UI surfaces them per row, and `collectBgRemovalTargets` normalizes image refs via `normalizeAssetRef` before building the path.

### Related issues (follow-up, not in scope)
- jnoecker/Arcanum#152 — gathering nodes first-class treatment
- jnoecker/Arcanum#153 — gallery picker for media fields
- jnoecker/Arcanum#154 — per-asset BG removal action in gallery
- jnoecker/Arcanum#155 — image generation "Generating" state hang
- jnoecker/Arcanum#156 — zone asset view collapse + search
- jnoecker/Arcanum#157 — AI timeline suggest review queue
- jnoecker/Arcanum#159 — design pass for 8 unstyled config panels

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun run test\` — 1517/1517 pass (added 4 new \`getLayoutBounds\` tests to \`dagreLayout.test.ts\`, now 11 total)
- [ ] **Manual**: open a zone → map loads fit and centered
- [ ] **Manual**: click **Re-layout** on a zone with variable-height rooms → viewport fits the new layout
- [ ] **Manual**: switch view mode map → assets → map → viewport re-fits
- [ ] **Manual**: "Suggest Relations" in the lore Relation Graph panel → toast confirms result or surfaces error
- [ ] **Manual**: generate mob art → immediately run Bulk BG Removal → succeeds or shows the actual error
- [ ] **Manual**: trigger one BG removal failure, then another → second one still runs (queue not wedged)