### PR TITLE
Add per-event timeline images

### DIFF
--- a/creator/src/components/lore/TimelinePanel.tsx
+++ b/creator/src/components/lore/TimelinePanel.tsx
@@ -18,6 +18,9 @@ import {
   SelectInput,
   IconButton,
 } from "@/components/ui/FormWidgets";
+import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import { getTimelineEventPrompt, getTimelineEventContext } from "@/lib/loreArtPrompts";
+import type { AssetContext } from "@/types/assets";
 import { TimelineView } from "./TimelineView";
 import { TimelineInferencePanel } from "./TimelineInferencePanel";
 
@@ -412,6 +415,37 @@ function EventInspector({
         ) : (
           <p className="mt-2 text-sm leading-6 text-text-muted">None</p>
         )}
+      </div>
+
+      <div className="mt-5 rounded-[1.2rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-4 py-4">
+        <p className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">Event Image</p>
+        <p className="mt-1 text-2xs text-text-muted/80">
+          Renders as a transparent backdrop on the timeline. Independent of any linked article.
+        </p>
+        <div className="mt-3">
+          <FieldRow label="Filename">
+            <TextInput
+              value={event.image ?? ""}
+              onCommit={(value) => onUpdate({ image: value || undefined })}
+              placeholder="None"
+            />
+          </FieldRow>
+        </div>
+        <div className="mt-3">
+          <EntityArtGenerator
+            getPrompt={(style) => getTimelineEventPrompt(event, style)}
+            entityContext={getTimelineEventContext(event)}
+            currentImage={event.image}
+            onAccept={(filePath) => onUpdate({ image: filePath })}
+            assetType="lore_event"
+            context={{
+              zone: "lore",
+              entity_type: "lore_event",
+              entity_id: event.id,
+            } satisfies AssetContext}
+            surface="lore"
+          />
+        </div>
       </div>
 
       <div className="mt-5">

--- a/creator/src/lib/exportShowcase.ts
+++ b/creator/src/lib/exportShowcase.ts
@@ -400,7 +400,10 @@ export function exportShowcaseData(
     articles,
     maps,
     calendarSystems: lore.calendarSystems,
-    timelineEvents: lore.timelineEvents,
+    timelineEvents: (lore.timelineEvents ?? []).map(({ image, ...event }) => ({
+      ...event,
+      imageUrl: resolveImage(image),
+    })),
     colorLabels: lore.colorLabels,
     stories,
   };

--- a/creator/src/lib/loreArtPrompts.ts
+++ b/creator/src/lib/loreArtPrompts.ts
@@ -1,4 +1,4 @@
-import type { Article, ArticleTemplate } from "@/types/lore";
+import type { Article, ArticleTemplate, TimelineEvent } from "@/types/lore";
 import type { ArtStyle } from "@/lib/arcanumPrompts";
 import { useLoreStore } from "@/stores/loreStore";
 import { tiptapToPlainText } from "@/lib/loreRelations";
@@ -87,6 +87,54 @@ export function getArticlePrompt(article: Article, style: ArtStyle): string {
 
   parts.push("No text, no runes, no words, no letters");
   return parts.join(". ");
+}
+
+/**
+ * Build a fallback image prompt for a timeline event.
+ */
+export function getTimelineEventPrompt(event: TimelineEvent, style: ArtStyle): string {
+  const ctx = worldContext();
+  const parts: string[] = [
+    "16:9 cinematic scene illustration, dramatic atmospheric composition, painterly historical chronicle",
+  ];
+  if (ctx) parts.push(ctx);
+  parts.push(event.title);
+  if (event.description) parts.push(event.description);
+
+  if (style === "arcanum") {
+    parts.push("Deep cosmic indigo and abyssal navy backgrounds, baroque rococo light scrollwork, golden accents");
+  } else {
+    parts.push("Soft lavender and pale blue undertones, ambient diffused lighting, dreamlike atmosphere");
+  }
+
+  parts.push("No text, no runes, no words, no letters");
+  return parts.join(". ");
+}
+
+/**
+ * Build rich entity context for LLM prompt enhancement of a timeline event.
+ */
+export function getTimelineEventContext(event: TimelineEvent): string {
+  const parts: string[] = [
+    "Article type: timeline_event",
+    `Title: ${event.title}`,
+    `Importance: ${event.importance}`,
+  ];
+  if (event.description) parts.push(`Description: ${event.description}`);
+
+  // Pull in linked article context if present
+  if (event.articleId) {
+    const articles = useLoreStore.getState().lore?.articles ?? {};
+    const linked = articles[event.articleId];
+    if (linked) {
+      parts.push(`Linked article: ${linked.title} (${linked.template})`);
+    }
+  }
+
+  const ctx = worldContext();
+  if (ctx) parts.push(`World: ${ctx}`);
+
+  return parts.join("\n");
 }
 
 /**

--- a/creator/src/types/lore.ts
+++ b/creator/src/types/lore.ts
@@ -138,6 +138,8 @@ export interface TimelineEvent {
   title: string;
   description?: string;
   importance: "minor" | "major" | "legendary";
+  /** Asset filename for the event's own background image (independent of any linked article). */
+  image?: string;
 }
 
 // ─── Documents (internal notes, lore bibles) ─────────────────────

--- a/showcase/src/types/showcase.ts
+++ b/showcase/src/types/showcase.ts
@@ -75,6 +75,8 @@ export interface TimelineEvent {
   title: string;
   description?: string;
   importance: "minor" | "major" | "legendary";
+  /** Resolved URL for the event's own background image (independent of any linked article). */
+  imageUrl?: string;
 }
 
 export interface ColorLabel {


### PR DESCRIPTION
## Summary
TimelineEvents can now carry their own image independent of any linked article. The event inspector gets a scoped EntityArtGenerator, and the showcase exporter resolves the filename to `imageUrl` for read-only consumers.

- New `TimelineEvent.image` field on the creator side and `TimelineEvent.imageUrl` on the showcase side
- `TimelinePanel` EventInspector now has an **Event Image** section with a filename field plus a scoped EntityArtGenerator (16:9 cinematic prompt, `lore_event` asset type)
- `loreArtPrompts` adds `getTimelineEventPrompt` and `getTimelineEventContext` — includes world context and the linked article's title/template when one is set
- `exportShowcase` maps `image` → `resolveImage(image)` → `imageUrl`

Rendering on the showcase timeline ships in a follow-up PR (the showcase page rewrite).

## Test plan
- [x] \`bunx tsc --noEmit\` (creator) clean
- [x] \`npm run typecheck\` (showcase) clean
- [x] Already tested manually by the author