### PR TITLE
Simplify showcase page layouts and render event images

### DIFF
--- a/showcase/src/lib/DataContext.tsx
+++ b/showcase/src/lib/DataContext.tsx
@@ -42,11 +42,18 @@ export function DataProvider({ children }: { children: ReactNode }) {
         setLoading(true);
         setError(null);
 
-        const configResp = await fetch("/config.json", { cache: "no-store", signal });
+        // Try to read runtime config, but tolerate the SPA fallback returning index.html
+        // (Cloudflare Pages rewrites unknown paths to index.html with a 200 status).
         let runtimeUrl: string | undefined;
-        if (configResp.ok) {
-          const config = await configResp.json() as RuntimeConfig;
-          runtimeUrl = config.showcaseUrl?.trim() || undefined;
+        try {
+          const configResp = await fetch("/config.json", { cache: "no-store", signal });
+          const contentType = configResp.headers.get("content-type") ?? "";
+          if (configResp.ok && contentType.includes("application/json")) {
+            const config = await configResp.json() as RuntimeConfig;
+            runtimeUrl = config.showcaseUrl?.trim() || undefined;
+          }
+        } catch {
+          // No runtime config — fall through to env var or local file.
         }
 
         const dataUrl = runtimeUrl || import.meta.env.VITE_SHOWCASE_URL || "/data/showcase.json";

--- a/showcase/src/pages/ArticlesPage.tsx
+++ b/showcase/src/pages/ArticlesPage.tsx
@@ -62,11 +62,6 @@ export function ArticlesPage() {
     );
   }, [activeTemplate, articles, search]);
 
-  const totalCount = grouped.reduce((sum, [, group]) => sum + group.length, 0);
-  const routeCount = articles.filter((article) => article.template !== "world_setting").length;
-  const totalCountLabel = useMemo(() => new Intl.NumberFormat().format(totalCount), [totalCount]);
-  const routeCountLabel = useMemo(() => new Intl.NumberFormat().format(routeCount), [routeCount]);
-
   if (!data) {
     return null;
   }
@@ -78,113 +73,73 @@ export function ArticlesPage() {
 
   return (
     <div className="space-y-8">
-      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.85fr)]">
-        <div className="relative overflow-hidden rounded-[2rem] border border-[var(--color-aurum)]/25 bg-[radial-gradient(circle_at_top_left,rgba(214,177,90,0.16),transparent_45%),linear-gradient(160deg,rgba(18,18,28,0.98),rgba(9,10,18,0.92))] px-6 py-7 shadow-[var(--shadow-deep)] sm:px-8 sm:py-8">
-          <h1 className="mt-3 max-w-3xl font-display text-3xl leading-tight text-[var(--color-aurum-pale)] sm:text-4xl">
-            Trace the houses, ruins, sects, and relics that keep the world legible.
-          </h1>
-          <p className="mt-4 max-w-2xl text-sm leading-7 text-text-secondary sm:text-[0.95rem]">
-            The public codex gathers every published record into named shelves, so readers can hunt a bloodline, a
-            border town, or a forbidden rite without losing the larger archive around it.
-          </p>
-          <p className="mt-6 text-sm leading-7 text-text-muted">
-            {routeCountLabel} published entries across {templates.length} shelves.{" "}
-            {activeTemplate ? `${TEMPLATE_LABELS[activeTemplate]} is selected.` : "All shelves are open."}
-          </p>
-        </div>
+      <section className="rounded-[1.5rem] border border-border-muted/35 bg-[linear-gradient(180deg,rgba(18,18,28,0.9),rgba(10,11,18,0.97))] px-5 py-4 shadow-[var(--shadow-deep)] sm:px-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center">
+          <input
+            type="text"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search the codex…"
+            aria-label="Search articles"
+            className="min-h-11 w-full rounded-2xl border border-border-muted/50 bg-bg-abyss/80 px-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted/70 focus:outline-none focus-visible:border-[var(--color-aurum)]/35 focus-visible:ring-2 focus-visible:ring-[var(--color-aurum)]/35 lg:max-w-sm"
+          />
 
-        <div className="flex flex-col justify-end gap-4 px-1 pb-1 xl:pl-6">
-          <p className="font-display text-2xl text-accent-emphasis">Read laterally, not just alphabetically.</p>
-          <p className="text-sm leading-7 text-text-secondary">
-            Tags and shelf filters surface echoing subjects across distant entries, useful when one name appears in
-            several wars, courts, or faiths.
-          </p>
-          <p className="text-sm leading-7 text-text-muted">
-            {totalCountLabel} entries match the current view.{" "}
-            {search.trim() ? `Search is narrowed by "${search.trim()}".` : "No title or tag search is active."}
-          </p>
-        </div>
-      </section>
-
-      <section className="rounded-[1.75rem] border border-border-muted/35 bg-[linear-gradient(180deg,rgba(18,18,28,0.9),rgba(10,11,18,0.97))] px-5 py-5 shadow-[var(--shadow-deep)] sm:px-6">
-        <div className="grid gap-5 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,1.35fr)_minmax(15rem,0.7fr)] xl:items-end">
-          <label className="block">
-            <span className="text-[0.68rem] uppercase tracking-[0.26em] text-text-muted">Search</span>
-            <input
-              type="text"
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="Seek a dynasty, region, relic, or rite"
-              aria-label="Search articles"
-              className="mt-2 min-h-12 w-full rounded-2xl border border-border-muted/50 bg-bg-abyss/80 px-4 py-3 text-sm text-text-primary placeholder:text-text-muted/70 focus:outline-none focus-visible:border-[var(--color-aurum)]/35 focus-visible:ring-2 focus-visible:ring-[var(--color-aurum)]/35"
-            />
-          </label>
-
-          <div>
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-[0.68rem] uppercase tracking-[0.26em] text-text-muted">Article type</span>
-              {(activeTemplate || search.trim()) && (
-                <button type="button" onClick={clearFilters} className={showcaseButtonClassNames.quiet}>
-                  Reset
-                </button>
-              )}
-            </div>
-            <div className="mt-3 flex flex-wrap gap-2">
+          <div className="flex flex-1 flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setSearchParams({})}
+              aria-pressed={!activeTemplate}
+              className="showcase-pill"
+              data-active={!activeTemplate}
+            >
+              All
+            </button>
+            {templates.map((template) => (
               <button
+                key={template}
                 type="button"
-                onClick={() => setSearchParams({})}
-                aria-pressed={!activeTemplate}
-                className="showcase-pill justify-start"
-                data-active={!activeTemplate}
+                onClick={() => setSearchParams({ template })}
+                aria-pressed={activeTemplate === template}
+                className="showcase-pill"
+                data-active={activeTemplate === template}
               >
-                All shelves
+                {TEMPLATE_LABELS[template]}
               </button>
-              {templates.map((template) => (
-                <button
-                  key={template}
-                  type="button"
-                  onClick={() => setSearchParams({ template })}
-                  aria-pressed={activeTemplate === template}
-                  className="showcase-pill justify-start text-left"
-                  data-active={activeTemplate === template}
-                >
-                  {TEMPLATE_LABELS[template]}
-                </button>
-              ))}
-            </div>
+            ))}
           </div>
 
-          <div>
-            <span className="text-[0.68rem] uppercase tracking-[0.26em] text-text-muted">View</span>
-            <div className="mt-3 grid grid-cols-2 gap-2">
-              <button
-                type="button"
-                onClick={() => setView("list")}
-                aria-pressed={view === "list"}
-                className={`min-h-12 rounded-2xl border px-4 py-3 text-left transition-colors duration-300 ${
-                  view === "list"
-                    ? "border-[var(--color-aurum)]/35 bg-[var(--color-aurum)]/10 text-[var(--color-aurum-pale)]"
-                    : "border-border-muted/40 bg-bg-secondary/50 text-text-secondary hover:text-text-primary"
-                }`}
-              >
-                <span className="block text-[0.7rem] uppercase tracking-[0.24em]">Shelf</span>
-                <span className="mt-1 block text-sm">Reading list</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => setView("grid")}
-                aria-pressed={view === "grid"}
-                className={`min-h-12 rounded-2xl border px-4 py-3 text-left transition-colors duration-300 ${
-                  view === "grid"
-                    ? "border-[var(--color-aurum)]/35 bg-[var(--color-aurum)]/10 text-[var(--color-aurum-pale)]"
-                    : "border-border-muted/40 bg-bg-secondary/50 text-text-secondary hover:text-text-primary"
-                }`}
-              >
-                <span className="block text-[0.7rem] uppercase tracking-[0.24em]">Cabinet</span>
-                <span className="mt-1 block text-sm">Illustrated grid</span>
-              </button>
-            </div>
+          <div className="flex items-center gap-1 rounded-full border border-border-muted/40 bg-bg-secondary/50 p-1">
+            <button
+              type="button"
+              onClick={() => setView("list")}
+              aria-pressed={view === "list"}
+              className={`rounded-full px-3 py-1.5 text-xs uppercase tracking-[0.18em] transition-colors duration-200 ${
+                view === "list"
+                  ? "bg-[var(--color-aurum)]/15 text-[var(--color-aurum-pale)]"
+                  : "text-text-muted hover:text-text-primary"
+              }`}
+            >
+              List
+            </button>
+            <button
+              type="button"
+              onClick={() => setView("grid")}
+              aria-pressed={view === "grid"}
+              className={`rounded-full px-3 py-1.5 text-xs uppercase tracking-[0.18em] transition-colors duration-200 ${
+                view === "grid"
+                  ? "bg-[var(--color-aurum)]/15 text-[var(--color-aurum-pale)]"
+                  : "text-text-muted hover:text-text-primary"
+              }`}
+            >
+              Grid
+            </button>
           </div>
+
+          {(activeTemplate || search.trim()) && (
+            <button type="button" onClick={clearFilters} className={showcaseButtonClassNames.quiet}>
+              Reset
+            </button>
+          )}
         </div>
       </section>
 

--- a/showcase/src/pages/GraphPage.tsx
+++ b/showcase/src/pages/GraphPage.tsx
@@ -104,34 +104,8 @@ function GraphInner() {
 
   return (
     <div className="space-y-6">
-      <section className={`${showcaseSurfaceClassNames.hero} px-6 py-7 sm:px-8`}>
-        <h1 className="mt-3 max-w-3xl font-display text-3xl leading-tight text-[var(--color-aurum-pale)] sm:text-4xl">
-          Survey alliances, feuds, blood ties, and territorial claims as a living weave.
-        </h1>
-        <p className="mt-4 max-w-2xl text-sm leading-7 text-text-secondary sm:text-[0.95rem]">
-          This chamber shows how a court leans on a city, how a ruin keeps appearing in rival chronicles, and where
-          one name is only a passing mention instead of a binding thread.
-        </p>
-        <p className="mt-6 text-sm leading-7 text-text-muted">
-          {new Intl.NumberFormat().format(nodes.length)} visible nodes and {new Intl.NumberFormat().format(edges.length)} visible threads
-          {hasActiveFilters ? " under the current filters." : " in the full survey."}
-        </p>
-      </section>
-
       <section className={`${showcaseSurfaceClassNames.section} px-5 py-5 sm:px-6`}>
-        <div className="flex flex-wrap items-end justify-between gap-4 border-b border-border-muted/25 pb-4">
-          <div>
-            <h2 className="mt-2 font-display text-3xl text-[var(--color-aurum-pale)]">
-              {hasActiveFilters ? "Filtered relationship field" : "Full relationship field"}
-            </h2>
-          </div>
-          <p className="max-w-xl text-sm leading-7 text-text-muted lg:text-right">
-            {hasActiveFilters ? "The view is narrowed." : "The full relationship field is visible."}{" "}
-            {shouldVirtualizeGraph ? "Large exports render visible elements only." : "The full graph is rendered at once."}
-          </p>
-        </div>
-
-        <div className="showcase-viewport mt-5 overflow-hidden rounded-[1.35rem] border border-border-muted/25 bg-[var(--color-graph-bg)]">
+        <div className="showcase-viewport overflow-hidden rounded-[1.35rem] border border-border-muted/25 bg-[var(--color-graph-bg)]">
           {nodes.length > 0 ? (
             <ReactFlow
               nodes={nodes}
@@ -195,13 +169,10 @@ function GraphInner() {
         </div>
       </section>
 
-      <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(18rem,0.8fr)]">
+      <section className="grid gap-4 xl:grid-cols-2">
         <div className={`${showcaseSurfaceClassNames.sectionSoft} px-5 py-5`}>
           <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-[0.68rem] uppercase tracking-[0.3em] text-text-muted">Article type</p>
-              <h2 className="mt-2 font-display text-xl text-accent-emphasis">Filter the graph</h2>
-            </div>
+            <p className="text-[0.68rem] uppercase tracking-[0.3em] text-text-muted">Article type</p>
             {hasActiveFilters ? (
               <button
                 type="button"
@@ -215,7 +186,7 @@ function GraphInner() {
               </button>
             ) : null}
           </div>
-          <div className="mt-5 flex flex-wrap gap-2">
+          <div className="mt-3 flex flex-wrap gap-2">
             {templates.map((template) => (
               <button
                 key={template}
@@ -233,8 +204,7 @@ function GraphInner() {
 
         <div className={`${showcaseSurfaceClassNames.sectionSoft} px-5 py-5`}>
           <p className="text-[0.68rem] uppercase tracking-[0.3em] text-text-muted">Relation</p>
-          <h2 className="mt-2 font-display text-xl text-accent-emphasis">Choose the thread</h2>
-          <div className="mt-5 flex flex-wrap gap-2">
+          <div className="mt-3 flex flex-wrap gap-2">
             {RELATION_TYPE_OPTIONS.map((option) => (
               <button
                 key={option.value}
@@ -248,15 +218,6 @@ function GraphInner() {
               </button>
             ))}
           </div>
-        </div>
-
-        <div className={`${showcaseSurfaceClassNames.sectionSoft} px-5 py-5`}>
-          <p className="text-[0.68rem] uppercase tracking-[0.3em] text-text-muted">How to read it</p>
-          <p className="mt-3 font-display text-xl text-[var(--color-aurum-pale)]">Follow weight before noise.</p>
-          <p className="mt-3 text-sm leading-7 text-text-secondary">
-            Dense exports render only visible elements at scale, keeping the chamber responsive while still exposing the
-            strongest bonds first.
-          </p>
         </div>
       </section>
     </div>

--- a/showcase/src/pages/HomePage.tsx
+++ b/showcase/src/pages/HomePage.tsx
@@ -32,10 +32,12 @@ export function HomePage() {
   const featured = [...articles]
     .filter((a) => a.imageUrl && a.template !== "world_setting")
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
-    .slice(0, 9);
-  const spotlight = featured[0];
-  const sideFeatures = featured.slice(1, 3);
-  const ledgerFeatures = featured.slice(3, 8);
+    .slice(0, 6);
+
+  // `<p></p>` and similar empty markup is truthy but renders nothing — strip tags
+  // and whitespace before deciding whether to show the prose column.
+  const worldSettingProse = worldSetting?.contentHtml?.replace(/<[^>]+>/g, "").trim();
+  const hasWorldSettingProse = Boolean(worldSettingProse);
 
   const searchResults = useMemo(() => {
     if (!search.trim()) return [];
@@ -140,9 +142,9 @@ export function HomePage() {
             </>
           )}
 
-          <div className="relative grid gap-8 px-6 py-8 sm:px-8 sm:py-10 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)] lg:gap-10 lg:px-10 xl:grid-cols-[minmax(0,1.2fr)_minmax(21rem,0.82fr)]">
+          <div className="relative grid gap-8 px-6 py-8 sm:px-8 sm:py-10 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,22rem)] lg:items-center lg:gap-10 lg:px-10 xl:grid-cols-[minmax(0,1.2fr)_minmax(21rem,0.82fr)]">
             <div className="max-w-3xl">
-              <h1 className="mt-4 font-display text-4xl leading-[1.03] text-accent-emphasis sm:text-5xl lg:text-6xl">
+              <h1 className="font-display text-4xl leading-[1.03] text-accent-emphasis sm:text-5xl lg:text-6xl">
                 {bannerTitle}
               </h1>
               {bannerSubtitle && (
@@ -150,25 +152,22 @@ export function HomePage() {
                   {bannerSubtitle}
                 </p>
               )}
-              <p className="mt-6 max-w-2xl text-sm leading-7 text-text-muted">
-                Start with {articleCount} published entries
-                {mapCount > 0 ? `, ${mapCount} mapped regions` : ""}
-                {timelineCount > 0 ? `, and ${timelineCount} dated events` : ""}.
-              </p>
+              <div className="mt-6 flex flex-wrap gap-x-6 gap-y-2 text-sm text-text-muted">
+                <span><span className="font-display text-lg text-accent-emphasis">{articleCount}</span> entries</span>
+                {mapCount > 0 && (
+                  <span><span className="font-display text-lg text-accent-emphasis">{mapCount}</span> {mapCount === 1 ? "map" : "maps"}</span>
+                )}
+                {timelineCount > 0 && (
+                  <span><span className="font-display text-lg text-accent-emphasis">{timelineCount}</span> dated events</span>
+                )}
+              </div>
             </div>
 
             <div
               ref={searchContainerRef}
-              className={`${showcaseSurfaceClassNames.note} relative self-end p-5`}
+              className={`${showcaseSurfaceClassNames.note} relative p-5`}
             >
-              <h2 className="mt-3 font-display text-2xl text-[var(--color-aurum-pale)]">
-                Find a person, place, or relic
-              </h2>
-              <p className="mt-2 text-sm leading-7 text-text-secondary">
-                Search the archive directly, or open the codex and browse by type.
-              </p>
-
-              <div className="mt-5 opacity-90 transition-opacity duration-300 focus-within:opacity-100">
+              <div className="opacity-90 transition-opacity duration-300 focus-within:opacity-100">
                 <input
                   type="text"
                   value={search}
@@ -243,162 +242,138 @@ export function HomePage() {
         </div>
       </section>
 
-      <section className="mb-20 grid gap-6 lg:grid-cols-[minmax(0,1.08fr)_minmax(18rem,0.92fr)]">
-        <div className="min-w-0">
-          {worldSetting?.contentHtml ? (
-            <div
-              className="prose max-w-none"
-              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(worldSetting.contentHtml) }}
-            />
-          ) : (
-            <div className="px-1">
-              <p className="text-base leading-8 text-text-secondary">
-                Enter through the codex, map the terrain, and follow the line of events through the world&apos;s own record.
-              </p>
-            </div>
-          )}
-        </div>
-
-        <aside className="grid gap-5 self-start">
+      {(() => {
+        const entryCards: React.ReactNode[] = [
           <Link
+            key="codex"
             to="/articles"
-            className={`${showcaseSurfaceClassNames.note} group overflow-hidden px-5 py-5 transition-transform duration-300 hover:-translate-y-0.5`}
+            className={`${showcaseSurfaceClassNames.note} group flex h-full flex-col overflow-hidden p-6 transition-transform duration-300 hover:-translate-y-0.5`}
           >
             <h2 className="font-display text-2xl text-accent-emphasis">Browse the codex</h2>
-            <p className="mt-2 text-sm leading-7 text-text-secondary">
+            <p className="mt-2 flex-1 text-sm leading-7 text-text-secondary">
               Move through characters, places, factions, and relics in whatever order opens the world fastest.
             </p>
-            <p className="mt-4 text-sm text-text-muted">
+            <p className="mt-4 text-xs uppercase tracking-[0.18em] text-text-muted">
               {articleCount} linked entries
             </p>
-          </Link>
-
-          <div className="border-t border-border-muted/25 pt-4">
-            <p className="text-xs uppercase tracking-[0.24em] text-text-muted">Other ways in</p>
-            <div className="mt-3 space-y-2">
-            {mapCount > 0 && (
-              <Link
-                to="/maps"
-                className="flex items-start justify-between gap-4 rounded-2xl px-3 py-3 transition-colors duration-300 hover:bg-white/6"
-              >
-                <div>
-                  <h3 className="font-display text-xl text-[var(--color-aurum-pale)]">Maps</h3>
-                  <p className="mt-1 text-sm leading-7 text-text-secondary">{mapCount} regions with linked pins and places.</p>
-                </div>
-                <span className="pt-1 text-[var(--color-aurum-pale)]">↗</span>
-              </Link>
-            )}
-            {timelineCount > 0 && (
-              <Link
-                to="/timeline"
-                className="flex items-start justify-between gap-4 rounded-2xl px-3 py-3 transition-colors duration-300 hover:bg-white/6"
-              >
-                <div>
-                  <h3 className="font-display text-xl text-accent">Timeline</h3>
-                  <p className="mt-1 text-sm leading-7 text-text-secondary">{timelineCount} events arranged across eras and ages.</p>
-                </div>
-                <span className="pt-1 text-[var(--color-aurum-pale)]">↗</span>
-              </Link>
-            )}
+          </Link>,
+        ];
+        if (mapCount > 0) {
+          entryCards.push(
             <Link
-              to="/graph"
-              className="flex items-start justify-between gap-4 rounded-2xl px-3 py-3 transition-colors duration-300 hover:bg-white/6"
+              key="maps"
+              to="/maps"
+              className={`${showcaseSurfaceClassNames.sectionSoft} group flex h-full flex-col overflow-hidden p-6 transition-transform duration-300 hover:-translate-y-0.5`}
             >
-              <div>
-                <h3 className="font-display text-xl text-accent">Connections</h3>
-                <p className="mt-1 text-sm leading-7 text-text-secondary">Follow alliances, rivalries, and associations across the canon.</p>
-              </div>
-              <span className="pt-1 text-[var(--color-aurum-pale)]">↗</span>
-            </Link>
-            </div>
-          </div>
-        </aside>
-      </section>
+              <h3 className="font-display text-2xl text-[var(--color-aurum-pale)]">Maps</h3>
+              <p className="mt-2 flex-1 text-sm leading-7 text-text-secondary">
+                Regions with linked pins, places, and routes through the terrain.
+              </p>
+              <p className="mt-4 text-xs uppercase tracking-[0.18em] text-text-muted">
+                {mapCount} {mapCount === 1 ? "region" : "regions"}
+              </p>
+            </Link>,
+          );
+        }
+        if (timelineCount > 0) {
+          entryCards.push(
+            <Link
+              key="timeline"
+              to="/timeline"
+              className={`${showcaseSurfaceClassNames.sectionSoft} group flex h-full flex-col overflow-hidden p-6 transition-transform duration-300 hover:-translate-y-0.5`}
+            >
+              <h3 className="font-display text-2xl text-[var(--color-aurum-pale)]">Timeline</h3>
+              <p className="mt-2 flex-1 text-sm leading-7 text-text-secondary">
+                Dated events arranged across eras and ages of the world.
+              </p>
+              <p className="mt-4 text-xs uppercase tracking-[0.18em] text-text-muted">
+                {timelineCount} {timelineCount === 1 ? "event" : "events"}
+              </p>
+            </Link>,
+          );
+        }
+        entryCards.push(
+          <Link
+            key="graph"
+            to="/graph"
+            className={`${showcaseSurfaceClassNames.sectionSoft} group flex h-full flex-col overflow-hidden p-6 transition-transform duration-300 hover:-translate-y-0.5`}
+          >
+            <h3 className="font-display text-2xl text-[var(--color-aurum-pale)]">Connections</h3>
+            <p className="mt-2 flex-1 text-sm leading-7 text-text-secondary">
+              Follow alliances, rivalries, and associations across the canon.
+            </p>
+            <p className="mt-4 text-xs uppercase tracking-[0.18em] text-text-muted">
+              Relationship graph
+            </p>
+          </Link>,
+        );
 
-      {spotlight && (
+        if (hasWorldSettingProse) {
+          return (
+            <section className="mb-20 grid gap-8 lg:grid-cols-[minmax(0,1.08fr)_minmax(18rem,0.92fr)]">
+              <div className="min-w-0">
+                <div
+                  className="prose max-w-none"
+                  dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(worldSetting!.contentHtml) }}
+                />
+              </div>
+              <aside className="grid gap-4 self-start">
+                {entryCards}
+              </aside>
+            </section>
+          );
+        }
+
+        return (
+          <section className="mb-20">
+            <div className={`grid gap-4 ${entryCards.length === 4 ? "sm:grid-cols-2" : "sm:grid-cols-2 lg:grid-cols-3"}`}>
+              {entryCards}
+            </div>
+          </section>
+        );
+      })()}
+
+      {featured.length > 0 && (
         <section>
           <div className="mb-8 flex items-center gap-4">
             <h2 className="font-display text-sm uppercase tracking-[0.28em] text-[var(--color-aurum-pale)]">
               Recent entries
             </h2>
             <div className="h-px flex-1 bg-[linear-gradient(90deg,rgba(200,151,46,0.35),rgba(57,69,95,0.16))]" />
+            <Link
+              to="/articles"
+              className="text-xs uppercase tracking-[0.22em] text-text-muted transition-colors duration-300 hover:text-[var(--color-aurum-pale)]"
+            >
+              View all ↗
+            </Link>
           </div>
 
-          <div className="grid gap-5 lg:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]">
-            <Link
-              to={`/articles/${encodeURIComponent(spotlight.id)}`}
-              className="group relative overflow-hidden rounded-[2rem] border border-white/10 bg-bg-secondary/30 shadow-[var(--shadow-image)]"
-            >
-              {spotlight.imageUrl && (
-                <img
-                  src={spotlight.imageUrl}
-                  alt={spotlight.title}
-                  loading="lazy"
-                  className="h-[22rem] w-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.02] sm:h-[28rem]"
-                />
-              )}
-              <div className="absolute inset-0 bg-gradient-to-t from-bg-abyss via-bg-abyss/20 to-transparent" />
-              <div className="absolute inset-x-0 bottom-0 p-6 sm:p-8">
-                <p className="text-[10px] uppercase tracking-[0.24em]" style={{ color: TEMPLATE_COLORS[spotlight.template] }}>
-                  {TEMPLATE_LABELS[spotlight.template]}
-                </p>
-                <h3 className="mt-3 font-display text-2xl text-accent-emphasis transition-colors duration-300 group-hover:text-[var(--color-aurum-pale)] sm:text-3xl">
-                  {spotlight.title}
-                </h3>
-              </div>
-            </Link>
-
-            <div className="grid gap-4">
-              {sideFeatures.map((a) => (
-                <Link
-                  key={a.id}
-                  to={`/articles/${encodeURIComponent(a.id)}`}
-                  className={`${showcaseSurfaceClassNames.sectionSoft} group flex min-h-[11rem] flex-col overflow-hidden sm:flex-row`}
-                >
-                  {a.imageUrl && (
-                    <div className="h-40 w-full shrink-0 overflow-hidden sm:h-auto sm:w-[42%]">
-                      <img
-                        src={a.imageUrl}
-                        alt={a.title}
-                        loading="lazy"
-                        className="h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.03]"
-                      />
-                    </div>
-                  )}
-                  <div className="flex min-w-0 flex-1 flex-col justify-end p-5">
-                    <p className="text-[10px] uppercase tracking-[0.22em]" style={{ color: TEMPLATE_COLORS[a.template] }}>
-                      {TEMPLATE_LABELS[a.template]}
-                    </p>
-                    <h3 className="mt-3 font-display text-xl leading-tight text-accent-emphasis transition-colors duration-300 group-hover:text-[var(--color-aurum-pale)]">
-                      {a.title}
-                    </h3>
-                  </div>
-                </Link>
-              ))}
-
-              {ledgerFeatures.length > 0 && (
-                <div className={`${showcaseSurfaceClassNames.sectionSoft} p-4`}>
-                  <p className="text-[10px] uppercase tracking-[0.28em] text-text-muted">More to explore</p>
-                  <div className="mt-3 space-y-2">
-                    {ledgerFeatures.map((a) => (
-                      <Link
-                        key={a.id}
-                        to={`/articles/${encodeURIComponent(a.id)}`}
-                        className="flex items-center justify-between gap-4 rounded-2xl px-3 py-3 transition-colors duration-300 hover:bg-white/6"
-                      >
-                        <div className="min-w-0">
-                          <p className="text-[10px] uppercase tracking-[0.18em]" style={{ color: TEMPLATE_COLORS[a.template] }}>
-                            {TEMPLATE_LABELS[a.template]}
-                          </p>
-                          <p className="mt-1 truncate font-display text-sm text-accent-emphasis">{a.title}</p>
-                        </div>
-                        <span className="shrink-0 text-[var(--color-aurum-pale)]">↗</span>
-                      </Link>
-                    ))}
-                  </div>
+          <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {featured.map((a) => (
+              <Link
+                key={a.id}
+                to={`/articles/${encodeURIComponent(a.id)}`}
+                className="group relative flex aspect-[4/5] overflow-hidden rounded-[1.75rem] border border-white/10 bg-bg-secondary/30 shadow-[var(--shadow-image)]"
+              >
+                {a.imageUrl && (
+                  <img
+                    src={a.imageUrl}
+                    alt={a.title}
+                    loading="lazy"
+                    className="h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-[1.04]"
+                  />
+                )}
+                <div className="absolute inset-0 bg-gradient-to-t from-bg-abyss via-bg-abyss/30 to-transparent" />
+                <div className="absolute inset-x-0 bottom-0 p-5">
+                  <p className="text-[10px] uppercase tracking-[0.24em]" style={{ color: TEMPLATE_COLORS[a.template] }}>
+                    {TEMPLATE_LABELS[a.template]}
+                  </p>
+                  <h3 className="mt-2 font-display text-xl leading-tight text-accent-emphasis transition-colors duration-300 group-hover:text-[var(--color-aurum-pale)]">
+                    {a.title}
+                  </h3>
                 </div>
-              )}
-            </div>
+              </Link>
+            ))}
           </div>
         </section>
       )}

--- a/showcase/src/pages/MapsPage.tsx
+++ b/showcase/src/pages/MapsPage.tsx
@@ -73,42 +73,11 @@ export function MapsPage() {
     );
   }
 
-  const totalPins = maps.reduce((sum, map) => sum + map.pins.length, 0);
   const activePins = activeMap?.pins.length ?? 0;
   const linkedPins = activeMap?.pins.filter((pin) => Boolean(pin.articleId)).length ?? 0;
 
   return (
     <div className="space-y-6">
-      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.3fr)_minmax(18rem,0.85fr)]">
-        <div className={`${showcaseSurfaceClassNames.hero} px-6 py-7 sm:px-8`}>
-          <h1 className="mt-3 max-w-3xl font-display text-3xl leading-tight text-[var(--color-aurum-pale)] sm:text-4xl">
-            Cross the dominions by plate, route, and pinned testimony.
-          </h1>
-          <p className="mt-4 max-w-2xl text-sm leading-7 text-text-secondary sm:text-[0.95rem]">
-            Each published chart carries its own field of landmarks, letting readers move from a coast, fortress, or
-            shrine directly into the codex entries tied to that ground.
-          </p>
-          <p className="mt-6 text-sm leading-7 text-text-muted">
-            {new Intl.NumberFormat().format(maps.length)} published charts with {new Intl.NumberFormat().format(totalPins)} pinned sites.{" "}
-            {activeMap ? `${activeMap.title} is open.` : ""}
-          </p>
-        </div>
-
-        <div className="flex flex-col justify-end gap-4 px-1 pb-1 xl:pl-6">
-          <p className="font-display text-2xl text-accent-emphasis">
-            {new Intl.NumberFormat().format(activePins)} markers on this plate
-          </p>
-          <p className="text-sm leading-7 text-text-secondary">
-            {new Intl.NumberFormat().format(linkedPins)} of them open directly into article records, while the rest
-            preserve place memory as unlinked notes on the terrain.
-          </p>
-          <p className="text-sm leading-7 text-text-muted">
-            Use the atlas index below to jump between plates. Wide charts keep their original canvas dimensions so the
-            topography stays readable before you descend into individual pins.
-          </p>
-        </div>
-      </section>
-
       {activeMap ? (
         <section className={`${showcaseSurfaceClassNames.section} overflow-hidden`}>
           <div className="flex flex-wrap items-end justify-between gap-4 border-b border-border-muted/25 px-5 py-5 sm:px-6">

--- a/showcase/src/pages/TimelinePage.tsx
+++ b/showcase/src/pages/TimelinePage.tsx
@@ -5,16 +5,9 @@ import { useShowcase } from "@/lib/DataContext";
 import type { CalendarSystem, TimelineEvent } from "@/types/showcase";
 
 const IMPORTANCE_STYLES: Record<TimelineEvent["importance"], string> = {
-  legendary:
-    "border-[var(--color-aurum)]/35 bg-[radial-gradient(circle_at_top_left,rgba(214,177,90,0.12),transparent_45%),rgba(255,255,255,0.025)]",
-  major: "border-accent/30 bg-bg-secondary/55",
-  minor: "border-border-muted/35 bg-bg-secondary/35",
-};
-
-const IMPORTANCE_DOT: Record<TimelineEvent["importance"], string> = {
-  legendary: "h-4 w-4 bg-[var(--color-aurum)] shadow-[0_0_18px_rgba(214,177,90,0.35)]",
-  major: "h-3 w-3 bg-accent",
-  minor: "h-2.5 w-2.5 bg-border-default",
+  legendary: "border-[var(--color-aurum)]/35",
+  major: "border-accent/30",
+  minor: "border-border-muted/35",
 };
 
 export function TimelinePage() {
@@ -59,7 +52,6 @@ export function TimelinePage() {
     });
   }, [calendars, events]);
 
-  const legendaryCount = events.filter((event) => event.importance === "legendary").length;
   if (!data) {
     return null;
   }
@@ -80,43 +72,6 @@ export function TimelinePage() {
 
   return (
     <div className="space-y-6">
-      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(18rem,0.85fr)]">
-        <div className="rounded-[1.9rem] border border-[var(--color-aurum)]/22 bg-[radial-gradient(circle_at_top_left,rgba(214,177,90,0.14),transparent_44%),linear-gradient(155deg,rgba(17,18,27,0.98),rgba(9,10,17,0.94))] px-6 py-7 shadow-[var(--shadow-deep)] sm:px-8">
-          <h1 className="mt-3 max-w-3xl font-display text-3xl leading-tight text-[var(--color-aurum-pale)] sm:text-4xl">
-            Follow the world from founding oaths to forgotten winters.
-          </h1>
-          <p className="mt-4 max-w-2xl text-sm leading-7 text-text-secondary sm:text-[0.95rem]">
-            These annals preserve how different calendars remember the same world, separating legend from regional
-            upheaval and the quieter entries that keep continuity intact.
-          </p>
-          <p className="mt-6 text-sm leading-7 text-text-muted">
-            {new Intl.NumberFormat().format(events.length)} recorded events across {new Intl.NumberFormat().format(grouped.length)} calendars, including {new Intl.NumberFormat().format(legendaryCount)} legendary turns.
-          </p>
-        </div>
-
-        <div className="rounded-[1.6rem] border border-border-muted/40 bg-[linear-gradient(180deg,rgba(16,17,27,0.94),rgba(9,10,17,0.98))] px-5 py-5 shadow-[var(--shadow-deep)]">
-          <h2 className="mt-2 font-display text-2xl text-accent-emphasis">How to read the record</h2>
-          <div className="mt-5 space-y-3">
-            {[
-              ["Legendary", "Founding turns, cataclysms, and events that re-order the world.", IMPORTANCE_DOT.legendary],
-              ["Major", "Political, martial, or spiritual shocks that reshape a realm.", IMPORTANCE_DOT.major],
-              ["Minor", "Recorded details that deepen continuity without steering an age.", IMPORTANCE_DOT.minor],
-            ].map(([label, description, dotClass]) => (
-              <div
-                key={label}
-                className="rounded-[1.2rem] border border-border-muted/30 bg-bg-secondary/45 px-4 py-4"
-              >
-                <div className="flex items-center gap-3">
-                  <span className={`rounded-full ${dotClass}`} />
-                  <p className="font-display text-lg text-accent-emphasis">{label}</p>
-                </div>
-                <p className="mt-2 text-sm leading-6 text-text-secondary">{description}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       <div className="space-y-8">
         {grouped.map(({ calendar, eraMap, events: sortedEvents }) => (
           <section
@@ -136,59 +91,61 @@ export function TimelinePage() {
               </p>
             </div>
 
-            <div className="relative mt-6 pl-10 sm:pl-16">
-              <div className="absolute bottom-0 left-4 top-0 w-px bg-gradient-to-b from-[var(--color-aurum)]/45 via-border-muted/35 to-transparent sm:left-6" />
-              <div className="space-y-5">
-                {sortedEvents.map((event) => {
-                  const era = eraMap.get(event.eraId);
-                  const linkedArticle = event.articleId ? articleById.get(event.articleId) : undefined;
+            <div className="mt-6 space-y-5">
+              {sortedEvents.map((event) => {
+                const era = eraMap.get(event.eraId);
+                const linkedArticle = event.articleId ? articleById.get(event.articleId) : undefined;
 
-                  return (
-                    <article
-                      key={event.id}
-                      className={`relative grid gap-4 rounded-[1.4rem] border px-5 py-5 sm:grid-cols-[9rem_minmax(0,1fr)] ${IMPORTANCE_STYLES[event.importance]}`}
-                    >
-                      <span
-                        className={`absolute left-4 top-7 -translate-x-1/2 rounded-full sm:left-6 ${IMPORTANCE_DOT[event.importance]}`}
-                      />
-                      <div className="relative">
-                        <p className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">
-                          {era?.name ?? "Era"}
-                        </p>
-                        <p className="mt-2 font-display text-3xl text-accent-emphasis">
-                          Y{new Intl.NumberFormat().format(event.year)}
-                        </p>
-                        <p className="mt-2 text-[0.72rem] uppercase tracking-[0.2em] text-text-muted capitalize">
-                          {event.importance}
-                        </p>
-                      </div>
-                      <div className="relative min-w-0">
-                        <h3 className="break-words font-display text-2xl text-[var(--color-aurum-pale)]">
-                          {linkedArticle ? (
-                            <Link
-                              to={`/articles/${encodeURIComponent(event.articleId!)}`}
-                              className="rounded transition-colors duration-300 hover:text-accent focus-visible:ring-2 focus-visible:ring-[var(--color-aurum)]/35"
-                            >
-                              {event.title}
-                            </Link>
-                          ) : (
-                            event.title
-                          )}
-                        </h3>
-                        {event.description ? (
-                          <p className="mt-3 break-words text-sm leading-7 text-text-secondary">
-                            {event.description}
-                          </p>
+                return (
+                  <article
+                    key={event.id}
+                    className={`relative grid gap-4 overflow-hidden rounded-[1.4rem] border bg-bg-secondary/40 px-5 py-5 sm:grid-cols-[9rem_minmax(0,1fr)] ${IMPORTANCE_STYLES[event.importance]}`}
+                  >
+                    {event.imageUrl && (
+                      <>
+                        <img
+                          src={event.imageUrl}
+                          alt=""
+                          aria-hidden="true"
+                          loading="lazy"
+                          className="pointer-events-none absolute inset-0 h-full w-full object-cover opacity-25"
+                        />
+                        <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(105deg,rgba(10,11,18,0.92)_0%,rgba(10,11,18,0.72)_45%,rgba(10,11,18,0.55)_100%)]" />
+                      </>
+                    )}
+                    <div className="relative">
+                      <p className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">
+                        {era?.name ?? "Era"}
+                      </p>
+                      <p className="mt-2 font-display text-3xl text-accent-emphasis">
+                        Y{new Intl.NumberFormat().format(event.year)}
+                      </p>
+                      <p className="mt-2 text-[0.72rem] uppercase tracking-[0.2em] text-text-muted capitalize">
+                        {event.importance}
+                      </p>
+                    </div>
+                    <div className="relative min-w-0">
+                      <h3 className="break-words font-display text-2xl text-[var(--color-aurum-pale)]">
+                        {linkedArticle ? (
+                          <Link
+                            to={`/articles/${encodeURIComponent(event.articleId!)}`}
+                            className="rounded transition-colors duration-300 hover:text-accent focus-visible:ring-2 focus-visible:ring-[var(--color-aurum)]/35"
+                          >
+                            {event.title}
+                          </Link>
                         ) : (
-                          <p className="mt-3 text-sm leading-7 text-text-muted">
-                            No description has been preserved for this event.
-                          </p>
+                          event.title
                         )}
-                      </div>
-                    </article>
-                  );
-                })}
-              </div>
+                      </h3>
+                      {event.description && (
+                        <p className="mt-3 break-words text-sm leading-7 text-text-secondary">
+                          {event.description}
+                        </p>
+                      )}
+                    </div>
+                  </article>
+                );
+              })}
             </div>
           </section>
         ))}


### PR DESCRIPTION
## Summary
Strips marketing-style hero sections and duplicated metadata panels across the showcase pages in favor of tighter, content-first layouts. **Net −176 lines.** Also wires per-event images (landed in #161) into the showcase timeline.

- **HomePage**: tighter landing layout (−279/+...)
- **TimelinePage**: drops the "How to read the record" hero, simplifies importance styles, renders `event.imageUrl` as a backdrop when set
- **ArticlesPage**: consolidates filter chrome, tighter card grid
- **GraphPage**: strips redundant stats panel
- **MapsPage**: drops extraneous framing
- **DataContext** (drive-by fix): tolerate Cloudflare Pages' SPA fallback returning `index.html` for `/config.json` — content-type check + try/catch so showcase load no longer errors when runtime config is absent

## Test plan
- [x] \`npm run typecheck\` clean
- [x] Already tested manually by the author