### PR TITLE
Show map-image-not-found error state with Replace action

### DIFF
--- a/creator/src/components/lore/MapPanel.tsx
+++ b/creator/src/components/lore/MapPanel.tsx
@@ -2,19 +2,13 @@ import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useLoreStore, selectArticles, selectMaps, selectColorLabels } from "@/stores/loreStore";
-import { useImageSrc } from "@/lib/useImageSrc";
+import { useImageSrcStatus } from "@/lib/useImageSrc";
 import type { LoreMap, Article } from "@/types/lore";
 import { TEMPLATE_SCHEMAS } from "@/lib/loreTemplates";
 import { ActionButton, FieldRow, TextInput } from "@/components/ui/FormWidgets";
 import { MapViewer } from "./MapViewer";
 import { MapEnhancer } from "./MapEnhancer";
 import { MapAnalysisPanel } from "./MapAnalysisPanel";
-
-// ─── Map image hook ─────────────────────────────────────────────────
-
-function useMapImage(imageAsset: string | undefined): string | null {
-  return useImageSrc(imageAsset);
-}
 
 // ─── Color palette picker ──────────────────────────────────────────
 
@@ -394,7 +388,7 @@ export function MapPanel() {
     [maps, selectedMapId],
   );
 
-  const mapImage = useMapImage(selectedMap?.imageAsset);
+  const { src: mapImage, status: mapImageStatus } = useImageSrcStatus(selectedMap?.imageAsset);
 
   const handleUploadMap = useCallback(async () => {
     try {
@@ -635,6 +629,26 @@ export function MapPanel() {
               </div>
             )}
           </div>
+        </div>
+      ) : selectedMap && mapImageStatus === "error" ? (
+        <div className="flex h-64 flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-status-danger/50 px-6 text-center text-sm text-text-muted">
+          <p className="font-display text-base text-status-danger">
+            Map image not found in asset cache
+          </p>
+          <p className="max-w-md text-xs text-text-muted">
+            The file <code className="font-mono text-2xs text-text-secondary">{selectedMap.imageAsset}</code> is
+            referenced by this map but no longer exists locally. Use{" "}
+            <span className="text-text-secondary">Replace Image</span> above to re-import it
+            (uploading the same source file will restore it with the same hash).
+          </p>
+          <ActionButton
+            onClick={handleReplaceImage}
+            disabled={replacing}
+            variant="primary"
+            size="sm"
+          >
+            {replacing ? "Replacing..." : "Replace Image"}
+          </ActionButton>
         </div>
       ) : selectedMap && !mapImage ? (
         <div className="flex h-64 items-center justify-center rounded-lg border border-dashed border-border-muted text-sm text-text-muted">

--- a/creator/src/lib/useImageSrc.ts
+++ b/creator/src/lib/useImageSrc.ts
@@ -18,17 +18,25 @@ export function isLegacyImagePath(path: string | undefined): boolean {
   return true;
 }
 
+export type ImageLoadStatus = "idle" | "loading" | "loaded" | "error";
+
+export interface ImageLoadResult {
+  src: string | null;
+  status: ImageLoadStatus;
+}
+
 /**
- * Load an image from a local file path via IPC, returning a data URL.
+ * Load an image from a local file path via IPC, returning a data URL plus status.
  * Handles three kinds of paths:
  * - R2 hash filenames (e.g. "abc123...def.png") → resolve from local asset cache
  * - Legacy relative paths (e.g. "zone/image.png") → resolve from MUD images dir
  * - Absolute paths → load directly
  */
-export function useImageSrc(filePath: string | undefined): string | null {
+export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult {
   const mudDir = useProjectStore((s) => s.project?.mudDir);
   const assetsDir = useAssetStore((s) => s.assetsDir);
   const [src, setSrc] = useState<string | null>(null);
+  const [status, setStatus] = useState<ImageLoadStatus>("idle");
 
   const candidates = useMemo(() => {
     if (!filePath) return [];
@@ -51,32 +59,51 @@ export function useImageSrc(filePath: string | undefined): string | null {
   }, [filePath, mudDir, assetsDir]);
 
   useEffect(() => {
-    if (candidates.length === 0) {
+    if (!filePath) {
       setSrc(null);
+      setStatus("idle");
+      return;
+    }
+    if (candidates.length === 0) {
+      // We have a filePath but cannot construct any candidate (e.g. assetsDir
+      // not loaded yet). Stay in "loading" until candidates resolve.
+      setSrc(null);
+      setStatus("loading");
       return;
     }
 
     let cancelled = false;
+    setStatus("loading");
 
-    // Try each candidate path in order
     (async () => {
       for (const path of candidates) {
         if (cancelled) return;
         try {
           const dataUrl = await invoke<string>("read_image_data_url", { path });
-          if (!cancelled) setSrc(dataUrl);
+          if (!cancelled) {
+            setSrc(dataUrl);
+            setStatus("loaded");
+          }
           return;
         } catch {
           // Try next candidate
         }
       }
-      if (!cancelled) setSrc(null);
+      if (!cancelled) {
+        setSrc(null);
+        setStatus("error");
+      }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [candidates]);
+  }, [candidates, filePath]);
 
-  return src;
+  return { src, status };
+}
+
+/** Backwards-compatible thin wrapper that returns just the data URL. */
+export function useImageSrc(filePath: string | undefined): string | null {
+  return useImageSrcStatus(filePath).src;
 }


### PR DESCRIPTION
## Summary
When a \`LoreMap\` references an image asset that no longer exists in the local cache (e.g. after a clean clone or an asset prune), \`MapPanel\` would get stuck on "Loading map image..." forever. The hook only returned \`src | null\` and had no way to signal "we tried and failed" vs "still loading".

- New **\`useImageSrcStatus\`** hook returns \`{ src, status }\` where status is \`"idle" | "loading" | "loaded" | "error"\`. Kept \`useImageSrc\` as a thin backwards-compat wrapper so the rest of the codebase doesn't need to migrate.
- **MapPanel** uses the new hook — when \`status === "error"\` it renders a dedicated panel explaining the file is missing, names the referenced filename, and offers a **Replace Image** button. Re-importing the same source file restores it with the same hash.

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] Already tested manually by the author