### PR TITLE
Stop SceneTemplateEditor infinite re-render loop

### DIFF
--- a/creator/src/components/lore/SceneTemplateEditorPanel.tsx
+++ b/creator/src/components/lore/SceneTemplateEditorPanel.tsx
@@ -14,6 +14,10 @@ const PALETTE = [
   "#b88faa", "#95a0bf", "#d4c8a0", "#7a8a6e", "#6e5a8a",
 ];
 
+// Stable empty fallback so the selector below doesn't return a fresh array
+// every render and trigger an infinite re-render via useSyncExternalStore.
+const EMPTY_TEMPLATES: CustomSceneTemplate[] = [];
+
 function generateId(label: string): string {
   return label
     .toLowerCase()
@@ -160,7 +164,7 @@ function TemplateEditor({
 // ─── Main panel ────────────────────────────────────────────────────
 
 export function SceneTemplateEditorPanel() {
-  const customTemplates = useLoreStore((s) => s.lore?.customSceneTemplates ?? []);
+  const customTemplates = useLoreStore((s) => s.lore?.customSceneTemplates) ?? EMPTY_TEMPLATES;
   const addCustomSceneTemplate = useLoreStore((s) => s.addCustomSceneTemplate);
   const updateCustomSceneTemplate = useLoreStore((s) => s.updateCustomSceneTemplate);
   const deleteCustomSceneTemplate = useLoreStore((s) => s.deleteCustomSceneTemplate);


### PR DESCRIPTION
## Summary
The Zustand selector \`(s) => s.lore?.customSceneTemplates ?? []\` returned a **fresh \`[]\`** on every render when \`customSceneTemplates\` was undefined. Zustand uses strict equality to decide whether to re-render subscribers, so each fresh \`[]\` looked like a change and kicked off another render. On a project without custom templates, opening the panel produced an **infinite render loop** via \`useSyncExternalStore\`.

## Fix
Select the raw value and apply the fallback outside the selector, using a module-level \`EMPTY_TEMPLATES\` constant so repeat reads return the same reference.

\`\`\`diff
-  const customTemplates = useLoreStore((s) => s.lore?.customSceneTemplates ?? []);
+  const customTemplates = useLoreStore((s) => s.lore?.customSceneTemplates) ?? EMPTY_TEMPLATES;
\`\`\`

## Test plan
- [x] \`bunx tsc --noEmit\` clean
- [x] Already tested manually by the author — panel opens without looping on projects that have no custom scene templates