### PR TITLE
Promote gathering nodes & trainers to first-class sidebar entries

### DIFF
--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   addQuest,
   addGatheringNode,
   addRecipe,
+  setDungeon,
   generateEntityId,
   generateRoomId,
 } from "@/lib/zoneEdits";
@@ -43,6 +44,17 @@ interface CategoryDef {
   collection: keyof WorldFile;
   nameField: string;
   addFn?: (world: WorldFile, zoneId: string) => WorldFile;
+  /**
+   * When true, the collection is a singular field on `WorldFile` (e.g. `dungeon`)
+   * rather than a `Record<string, Entity>`. Rendered as at most one entry.
+   */
+  singular?: boolean;
+  /**
+   * Optional view mode to switch to when the entry (or the Add button) is
+   * clicked, instead of routing to the standard entity panel. Used for
+   * singular entities that have their own dedicated view (e.g. "dungeon").
+   */
+  targetView?: string;
 }
 
 const CATEGORIES: CategoryDef[] = [
@@ -140,6 +152,20 @@ const CATEGORIES: CategoryDef[] = [
       } as RecipeFile);
     },
   },
+  {
+    key: "dungeon",
+    label: "Dungeon",
+    collection: "dungeon",
+    nameField: "name",
+    singular: true,
+    targetView: "dungeon",
+    addFn: (world) =>
+      setDungeon(world, {
+        name: `${world.zone} Dungeon`,
+        roomCountMin: 20,
+        roomCountMax: 25,
+      }),
+  },
 ];
 
 
@@ -168,7 +194,9 @@ function ZoneTree({
   };
 
   const handleEntityClick = (cat: CategoryDef, entityId: string) => {
-    if (cat.key === "room") {
+    if (cat.targetView) {
+      navigateTo({ zoneId, view: cat.targetView });
+    } else if (cat.key === "room") {
       navigateTo({ zoneId, roomId: entityId });
     } else {
       navigateTo({ zoneId, entityKind: cat.key, entityId });
@@ -180,6 +208,10 @@ function ZoneTree({
     try {
       const next = cat.addFn(world, zoneId);
       updateZone(zoneId, next);
+      if (cat.singular) {
+        if (cat.targetView) navigateTo({ zoneId, view: cat.targetView });
+        return;
+      }
       const collection = next[cat.collection] as Record<string, unknown> | undefined;
       const oldCollection = world[cat.collection] as Record<string, unknown> | undefined;
       if (collection && oldCollection) {
@@ -241,6 +273,47 @@ function ZoneTree({
       {expanded && (
         <div className="ml-10 mt-2 flex flex-col gap-2.5 border-l border-accent/15 pl-4">
           {CATEGORIES.map((cat) => {
+            // Singular collections (e.g. `dungeon`) render at most one entry.
+            if (cat.singular) {
+              const data = world[cat.collection] as Record<string, unknown> | undefined;
+              const present = !!data;
+              if (!present && !cat.addFn) return null;
+              const name = present && data ? (data[cat.nameField] as string | undefined) : undefined;
+              return (
+                <div key={cat.key} className="border-t border-[var(--chrome-stroke)] pt-2 first:border-t-0 first:pt-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-display font-semibold text-2xs uppercase tracking-label text-text-secondary">
+                      {cat.label}
+                    </span>
+                    <span className="text-2xs text-text-muted">{present ? 1 : 0}</span>
+                    {!present && cat.addFn && (
+                      <button
+                        onClick={() => handleAdd(cat)}
+                        className="ml-auto rounded-full border border-[var(--chrome-stroke)] px-2 py-1 text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
+                        title={`Add ${cat.label.toLowerCase()}`}
+                        aria-label={`Add ${cat.label.toLowerCase()}`}
+                      >
+                        Add
+                      </button>
+                    )}
+                  </div>
+                  {present && (
+                    <ul className="flex flex-col">
+                      <li>
+                        <button
+                          onClick={() => handleEntityClick(cat, cat.key)}
+                          className="w-full truncate rounded-xl px-2 py-1.5 text-left text-xs text-text-muted transition hover:bg-accent/8 hover:text-text-primary"
+                          title={name || cat.label}
+                        >
+                          {name || cat.label}
+                        </button>
+                      </li>
+                    </ul>
+                  )}
+                </div>
+              );
+            }
+
             const collection = world[cat.collection] as Record<string, Record<string, unknown>> | undefined;
             const entries = collection ? Object.entries(collection) : [];
             if (entries.length === 0 && !cat.addFn) return null;

--- a/creator/src/components/Sidebar.tsx
+++ b/creator/src/components/Sidebar.tsx
@@ -19,10 +19,22 @@ import {
   addMob,
   addItem,
   addShop,
+  addTrainer,
+  addQuest,
+  addGatheringNode,
+  addRecipe,
   generateEntityId,
   generateRoomId,
 } from "@/lib/zoneEdits";
-import type { MobFile, ItemFile, ShopFile } from "@/types/world";
+import type {
+  MobFile,
+  ItemFile,
+  ShopFile,
+  TrainerFile,
+  QuestFile,
+  GatheringNodeFile,
+  RecipeFile,
+} from "@/types/world";
 
 
 interface CategoryDef {
@@ -76,9 +88,58 @@ const CATEGORIES: CategoryDef[] = [
       return addShop(world, id, { name: id, room: firstRoom, items: [] } as ShopFile);
     },
   },
-  { key: "quest", label: "Quests", collection: "quests", nameField: "name" },
-  { key: "gatheringNode", label: "Gathering", collection: "gatheringNodes", nameField: "skill" },
-  { key: "recipe", label: "Recipes", collection: "recipes", nameField: "displayName" },
+  {
+    key: "trainer",
+    label: "Trainers",
+    collection: "trainers",
+    nameField: "name",
+    addFn: (world) => {
+      const id = generateEntityId(world, "trainers");
+      const firstRoom = Object.keys(world.rooms)[0] ?? "";
+      return addTrainer(world, id, { name: id, room: firstRoom } as TrainerFile);
+    },
+  },
+  {
+    key: "gatheringNode",
+    label: "Gathering Nodes",
+    collection: "gatheringNodes",
+    nameField: "displayName",
+    addFn: (world) => {
+      const id = generateEntityId(world, "gatheringNodes");
+      const firstRoom = Object.keys(world.rooms)[0] ?? "";
+      return addGatheringNode(world, id, {
+        displayName: id,
+        skill: "",
+        yields: [],
+        room: firstRoom,
+      } as GatheringNodeFile);
+    },
+  },
+  {
+    key: "quest",
+    label: "Quests",
+    collection: "quests",
+    nameField: "name",
+    addFn: (world) => {
+      const id = generateEntityId(world, "quests");
+      return addQuest(world, id, { name: id, giver: "" } as QuestFile);
+    },
+  },
+  {
+    key: "recipe",
+    label: "Recipes",
+    collection: "recipes",
+    nameField: "displayName",
+    addFn: (world) => {
+      const id = generateEntityId(world, "recipes");
+      return addRecipe(world, id, {
+        displayName: id,
+        skill: "",
+        materials: [],
+        outputItemId: "",
+      } as RecipeFile);
+    },
+  },
 ];
 
 

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -160,6 +160,15 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
   useEffect(() => {
     const nav = consumeNavigation();
     if (!nav || nav.zoneId !== zoneId) return;
+    if (nav.view) {
+      // Loose string -> ViewMode cast. Unknown view modes fall back to the
+      // current mode, which is harmless.
+      const allowed: ViewMode[] = ["map", "assets", "media", "dungeon"];
+      if ((allowed as string[]).includes(nav.view)) {
+        setViewMode(nav.view as ViewMode);
+      }
+      return;
+    }
     if (nav.entityKind && nav.entityId) {
       setSelectedEntity({ kind: nav.entityKind as EntitySelection["kind"], id: nav.entityId });
       setSelectedRoomId(null);

--- a/creator/src/stores/projectStore.ts
+++ b/creator/src/stores/projectStore.ts
@@ -15,6 +15,8 @@ export interface PendingNavigation {
   roomId?: string;
   entityKind?: string;
   entityId?: string;
+  /** Switch the zone editor to a specific view mode (e.g. "dungeon"). */
+  view?: string;
 }
 
 interface ProjectStore {


### PR DESCRIPTION
## Summary
Closes #152. Audits the zone asset sidebar (`creator/src/components/Sidebar.tsx`) and promotes every rich-content entity type on `WorldFile` that wasn't previously first-class.

**Root cause of "gathering nodes are buried":** the category was in the registry but had no `addFn`, and `ZoneTree` hides any section with `entries.length === 0 && !cat.addFn` — so builders working on a new zone never saw the section at all. On top of that, `nameField: "skill"` made every node in a populated zone render with the same label (e.g. three "mining" entries), which feels just as buried as being hidden.

## Changes

### Commit 1 — gathering nodes, trainers, quests, recipes
- **Gathering nodes**: `nameField: "skill"` → `"displayName"`; added `addFn` so the section is always present. Relabeled "Gathering" → "Gathering Nodes".
- **Trainers**: added as a new top-level category (the `TrainerEditor` + `EntityPanel` routing + `addTrainer` already existed — only the sidebar entry was missing).
- **Quests**: added `addFn` so the section is visible when empty.
- **Recipes**: added `addFn` so the section is visible when empty.

### Commit 2 — dungeons
Dungeons are a special case — `dungeon?: DungeonFile` is a singular field (not a `Record`) and are edited through a dedicated view mode in `ZoneEditor`, not the narrow entity panel.

- `PendingNavigation` gets an optional `view?: string` field so the sidebar can ask the zone editor to switch view modes.
- `ZoneEditor` consumes `nav.view` and calls `setViewMode(...)` when the value matches a known mode.
- `CategoryDef` gets `singular` and `targetView` flags. Singular categories render at most one entry (count 0 or 1) and route clicks via `targetView` to a view mode instead of the entity panel.
- New Dungeon category in the sidebar creates `{name: "<zone> Dungeon", roomCountMin: 20, roomCountMax: 25}` — same defaults as the in-editor `DungeonEmptyState` — then navigates into the dungeon view. Discovering that the zone editor even has a dungeon view no longer requires hunting through the subtoolbar.

## Audit outcome
Every `WorldFile` entity type with description/features/image content is now first-class in the sidebar: rooms, mobs, items, shops, trainers, gathering nodes, quests, recipes, dungeon.

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test` — 1521/1521 passing
- [ ] Manual: open a fresh zone with no rooms yet → confirm Trainers / Gathering Nodes / Quests / Recipes / Dungeon sections render with an Add button
- [ ] Manual: click Add on each new category → confirm it creates the entity, opens the right editor (entity panel for most; Dungeon view for the dungeon), and saves
- [ ] Manual: open a zone with multiple gathering nodes → confirm they show distinct display names instead of repeated skill labels
- [ ] Manual: click an existing dungeon entry in the sidebar → confirm the zone editor switches to Dungeon view and the DungeonEditor renders