### PR TITLE
Fix stuck "Generating..." spinner in EntityArtGenerator (#155)

### DIFF
--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -98,8 +98,13 @@ export function EntityArtGenerator({
   const contextRef = useRef(context);
   contextRef.current = context;
 
-  const mountedRef = useRef(true);
+  // Track whether the component is currently mounted so handleGenerate can
+  // auto-accept results that arrive after the user navigated away. The setup
+  // body must reset this to true so StrictMode's mount→cleanup→mount cycle
+  // doesn't leave it stuck at false on a still-mounted component.
+  const mountedRef = useRef(false);
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
       const img = pendingResultRef.current;


### PR DESCRIPTION
## Summary
Fixes #155 — a stuck `Generating...` spinner in the entity art generator where the image would appear in the gallery/field but the UI spinner would persist until the user switched surfaces and back.

## Root cause
`EntityArtGenerator.tsx` tracks mount state with `mountedRef` so that `handleGenerate` can auto-accept images arriving after unmount. The ref was initialized via `useRef(true)` with a cleanup that flipped it to `false`, but the effect setup body never reset it back to `true`:

```tsx
const mountedRef = useRef(true);
useEffect(() => {
  return () => {
    mountedRef.current = false;
    // ...auto-accept pending image
  };
}, []);
```

Under React StrictMode (enabled in `main.tsx`) effects run mount → cleanup → mount. After the strict double-invoke, `mountedRef.current` is stuck at `false` on a component that is actually still mounted.

When a generation completes on that component:
1. `setStage("generating")` fires — spinner shows
2. Image returns from backend
3. `if (!mountedRef.current)` is true → calls `autoAcceptImage()` (saves asset, fires `onAccept(fileName)` so image shows in the field + gallery)
4. Early `return` — `setStage("preview")` never runs, spinner is frozen

Switching surfaces fully unmounts/remounts the component, re-running `useRef(true)` with fresh state and clearing the spinner — which matches the reported symptom exactly.

## Fix
Initialize `mountedRef` to `false` and set it to `true` in the effect setup body, so each mount reliably reflects the real mounted state and StrictMode's double-invoke lands in the correct terminal state.

## Test plan
- [ ] Open the room editor, click Generate Art on a room background image, wait for a slow generation to complete. Verify the spinner transitions to the Accept/Reject preview (previously it hung on "Generating...").
- [ ] Click Generate Art, immediately switch to another surface while the generation is in flight, then come back. Verify the image was auto-accepted and applied (previously preserved behavior).
- [ ] Accept a generated image normally and confirm nothing regressed in the background-removal / variant strip flow.