### PR TITLE
Design pass: normalize 8 unstyled config panels

### DIFF
--- a/creator/src/components/config/panels/CurrenciesPanel.tsx
+++ b/creator/src/components/config/panels/CurrenciesPanel.tsx
@@ -1,51 +1,120 @@
 import type { ConfigPanelProps, AppConfig } from "./types";
-import { Section, FieldRow, TextInput, NumberInput, IconButton } from "@/components/ui/FormWidgets";
+import {
+  Section,
+  FieldRow,
+  TextInput,
+  NumberInput,
+  ActionButton,
+  IconButton,
+} from "@/components/ui/FormWidgets";
 
 export function CurrenciesPanel({ config, onChange }: ConfigPanelProps) {
   const currencies = { definitions: {}, ...config.currencies };
   const defs = currencies.definitions ?? {};
 
   const patchDef = (key: string, updates: Record<string, unknown>) => {
-    onChange({ currencies: { ...currencies, definitions: { ...defs, [key]: { ...defs[key], ...updates } } } } as Partial<AppConfig>);
+    onChange({
+      currencies: {
+        ...currencies,
+        definitions: { ...defs, [key]: { ...defs[key], ...updates } },
+      },
+    } as Partial<AppConfig>);
   };
 
   const deleteDef = (key: string) => {
     const next = { ...defs };
     delete next[key];
-    onChange({ currencies: { ...currencies, definitions: next } } as Partial<AppConfig>);
+    onChange({
+      currencies: { ...currencies, definitions: next },
+    } as Partial<AppConfig>);
   };
 
+  const addCurrency = () => {
+    const id = `currency_${Object.keys(defs).length + 1}`;
+    onChange({
+      currencies: {
+        ...currencies,
+        definitions: { ...defs, [id]: { displayName: id } },
+      },
+    } as Partial<AppConfig>);
+  };
+
+  const entries = Object.entries(defs);
+
   return (
-    <Section title="Secondary Currencies">
-      <div className="flex flex-col gap-3">
-        {Object.entries(defs).map(([key, def]) => (
-          <div key={key} className="flex items-start gap-2 rounded border border-border-muted bg-bg-primary p-3">
-            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-              <FieldRow label="ID">
-                <span className="text-xs font-mono text-accent">{key}</span>
-              </FieldRow>
-              <FieldRow label="Display Name">
-                <TextInput value={def.displayName} onCommit={(v) => patchDef(key, { displayName: v })} />
-              </FieldRow>
-              <FieldRow label="Description">
-                <TextInput value={def.description ?? ""} onCommit={(v) => patchDef(key, { description: v || undefined })} placeholder="Optional" />
-              </FieldRow>
-              <FieldRow label="Max Amount">
-                <NumberInput value={def.maxAmount} onCommit={(v) => patchDef(key, { maxAmount: v || undefined })} />
-              </FieldRow>
-            </div>
-            <IconButton onClick={() => deleteDef(key)} title="Delete">&times;</IconButton>
+    <Section
+      title="Secondary Currencies"
+      description="Non-gold currencies players can earn and spend: faction reputation, honor, arena tokens, raid marks, favor points, and so on. Define one record per currency type. These appear alongside gold in the player's pouch and can be used by shops, quests, and rewards."
+    >
+      <div className="flex flex-col gap-1.5">
+        {entries.length === 0 ? (
+          <p className="text-2xs text-text-muted">
+            No secondary currencies defined. Add one below to create reputation, tokens, or favor systems.
+          </p>
+        ) : (
+          <div className="flex flex-col">
+            {entries.map(([key, def]) => (
+              <div
+                key={key}
+                className="flex items-start gap-2 border-b border-border-muted/30 pb-2 pt-2 first:pt-0 last:border-0 last:pb-0"
+              >
+                <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                  <FieldRow
+                    label="ID"
+                    hint="The internal key used by quests, shops, and rewards to reference this currency. Immutable once set."
+                  >
+                    <span className="text-xs font-mono text-accent">{key}</span>
+                  </FieldRow>
+                  <FieldRow
+                    label="Display Name"
+                    hint="What players see in their pouch and in UI. Example: 'Honor', 'Arena Tokens', 'Moonfavor'."
+                  >
+                    <TextInput
+                      value={def.displayName}
+                      onCommit={(v) => patchDef(key, { displayName: v })}
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="Description"
+                    hint="Short flavor text shown when players inspect the currency. Explain where it comes from or what it buys."
+                  >
+                    <TextInput
+                      value={def.description ?? ""}
+                      onCommit={(v) =>
+                        patchDef(key, { description: v || undefined })
+                      }
+                      placeholder="Optional"
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="Max Amount"
+                    hint="Hard cap on how much of this currency a player can hold. Useful for reputation or weekly tokens that shouldn't stockpile. Leave blank for no limit."
+                  >
+                    <NumberInput
+                      value={def.maxAmount}
+                      onCommit={(v) =>
+                        patchDef(key, { maxAmount: v || undefined })
+                      }
+                      min={0}
+                    />
+                  </FieldRow>
+                </div>
+                <IconButton
+                  onClick={() => deleteDef(key)}
+                  title="Delete currency"
+                  danger
+                >
+                  &times;
+                </IconButton>
+              </div>
+            ))}
           </div>
-        ))}
-        <button
-          onClick={() => {
-            const id = `currency_${Object.keys(defs).length + 1}`;
-            onChange({ currencies: { ...currencies, definitions: { ...defs, [id]: { displayName: id } } } } as Partial<AppConfig>);
-          }}
-          className="self-start rounded border border-border-default px-3 py-1 text-2xs text-text-secondary hover:bg-bg-tertiary"
-        >
-          + Add Currency
-        </button>
+        )}
+        <div>
+          <ActionButton variant="secondary" size="sm" onClick={addCurrency}>
+            + Add Currency
+          </ActionButton>
+        </div>
       </div>
     </Section>
   );

--- a/creator/src/components/config/panels/EmotePresetsPanel.tsx
+++ b/creator/src/components/config/panels/EmotePresetsPanel.tsx
@@ -1,6 +1,12 @@
 import type { ConfigPanelProps } from "./types";
 import type { EmotePreset } from "@/types/config";
-import { Section, FieldRow, TextInput } from "@/components/ui/FormWidgets";
+import {
+  Section,
+  FieldRow,
+  TextInput,
+  ActionButton,
+  IconButton,
+} from "@/components/ui/FormWidgets";
 
 export function EmotePresetsPanel({ config, onChange }: ConfigPanelProps) {
   const presets = config.emotePresets.presets;
@@ -23,85 +29,105 @@ export function EmotePresetsPanel({ config, onChange }: ConfigPanelProps) {
     if (to < 0 || to >= presets.length) return;
     const next = [...presets];
     const [item] = next.splice(from, 1);
-    next.splice(to, 0, item!);
+    if (!item) return;
+    next.splice(to, 0, item);
     update(next);
   };
 
   return (
     <Section
       title="Emote Presets"
-      description="Quick-action emotes shown to players in the chat panel. Each preset has a label, emoji, and the action text broadcast to the room (e.g. 'waves.'). Order here matches display order in the client."
+      description="Quick-action emotes surfaced as buttons in the player's chat panel. Each preset broadcasts a short room message (e.g. 'Lira waves.') when clicked — perfect for social MUDs that want roleplay gestures a click away. The order here determines display order in the client."
     >
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        {presets.length === 0 && (
+          <p className="text-2xs text-text-muted">
+            No emote presets yet. Add one to give players a quick-action button.
+          </p>
+        )}
+
         {presets.map((preset, i) => (
           <div
             key={i}
-            className="rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-4"
+            className="flex flex-col gap-1.5 border-b border-border-muted/30 pb-2 pt-2 first:pt-0 last:border-0 last:pb-0"
           >
-            <div className="mb-2 flex items-center justify-between">
-              <span className="text-xs font-medium text-text-secondary">
-                #{i + 1}{preset.label ? ` — ${preset.label}` : ""}
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-display text-2xs uppercase tracking-widest text-text-muted">
+                #{i + 1}
+                {preset.label ? (
+                  <span className="ml-2 text-text-secondary normal-case tracking-normal">
+                    {preset.label}
+                  </span>
+                ) : null}
               </span>
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-0.5">
                 {i > 0 && (
-                  <button
+                  <IconButton
                     onClick={() => movePreset(i, i - 1)}
                     title="Move up"
-                    className="h-6 w-6 rounded text-xs text-text-muted transition-colors hover:bg-bg-elevated hover:text-text-primary"
+                    size="sm"
                   >
-                    ↑
-                  </button>
+                    &#x2191;
+                  </IconButton>
                 )}
                 {i < presets.length - 1 && (
-                  <button
+                  <IconButton
                     onClick={() => movePreset(i, i + 1)}
                     title="Move down"
-                    className="h-6 w-6 rounded text-xs text-text-muted transition-colors hover:bg-bg-elevated hover:text-text-primary"
+                    size="sm"
                   >
-                    ↓
-                  </button>
+                    &#x2193;
+                  </IconButton>
                 )}
-                <button
+                <IconButton
                   onClick={() => removePreset(i)}
-                  title="Remove"
-                  className="h-6 w-6 rounded text-xs text-text-muted transition-colors hover:bg-status-danger/10 hover:text-status-danger"
+                  title="Remove preset"
+                  danger
+                  size="sm"
                 >
-                  ✕
-                </button>
+                  &#x2715;
+                </IconButton>
               </div>
             </div>
-            <div className="flex flex-col gap-1.5">
-              <FieldRow label="Label" hint="Button text shown to the player.">
-                <TextInput
-                  value={preset.label}
-                  onCommit={(v) => patchPreset(i, { label: v })}
-                  placeholder="Wave"
-                />
-              </FieldRow>
-              <FieldRow label="Emoji" hint="Emoji shown on the button.">
-                <TextInput
-                  value={preset.emoji}
-                  onCommit={(v) => patchPreset(i, { emoji: v })}
-                  placeholder="👋"
-                />
-              </FieldRow>
-              <FieldRow label="Action" hint="Room broadcast text (e.g. 'waves.'). The player's name is prepended automatically.">
-                <TextInput
-                  value={preset.action}
-                  onCommit={(v) => patchPreset(i, { action: v })}
-                  placeholder="waves."
-                />
-              </FieldRow>
-            </div>
+
+            <FieldRow
+              label="Label"
+              hint="Button text shown to the player in the chat panel. Keep it short: a single word or two."
+            >
+              <TextInput
+                value={preset.label}
+                onCommit={(v) => patchPreset(i, { label: v })}
+                placeholder="Wave"
+              />
+            </FieldRow>
+            <FieldRow
+              label="Emoji"
+              hint="Optional emoji rendered on the button next to the label. Any single unicode glyph works."
+            >
+              <TextInput
+                value={preset.emoji}
+                onCommit={(v) => patchPreset(i, { emoji: v })}
+                placeholder="👋"
+              />
+            </FieldRow>
+            <FieldRow
+              label="Action"
+              hint="Room broadcast text. The player's name is prepended automatically, so 'waves.' becomes 'Lira waves.'"
+            >
+              <TextInput
+                value={preset.action}
+                onCommit={(v) => patchPreset(i, { action: v })}
+                placeholder="waves."
+              />
+            </FieldRow>
           </div>
         ))}
 
-        <button
-          onClick={addPreset}
-          className="self-start rounded-full border border-[rgba(184,216,232,0.28)] bg-gradient-active-strong px-4 py-2 text-xs font-medium text-text-primary transition hover:shadow-[0_10px_20px_rgba(137,155,214,0.2)]"
-        >
-          + Add Emote Preset
-        </button>
+        <div className="pt-1">
+          <ActionButton variant="secondary" size="sm" onClick={addPreset}>
+            + Add Emote Preset
+          </ActionButton>
+        </div>
       </div>
     </Section>
   );

--- a/creator/src/components/config/panels/EnchantingPanel.tsx
+++ b/creator/src/components/config/panels/EnchantingPanel.tsx
@@ -11,6 +11,7 @@ import {
   NumberInput,
   TextInput,
   SelectInput,
+  ActionButton,
   IconButton,
 } from "@/components/ui/FormWidgets";
 import { RegistryPanel } from "./RegistryPanel";
@@ -88,10 +89,16 @@ export function EnchantingPanel({ config, onChange }: ConfigPanelProps) {
   );
 
   return (
-    <div className="flex flex-col gap-6">
-      <Section title="Global Settings" defaultExpanded>
+    <>
+      <Section
+        title="Global Settings"
+        description="Enchanting lets players permanently augment gear with stat and damage bonuses. Global settings control the overall scarcity and power ceiling of enchantments across the whole game."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Max Enchantments Per Item" hint="How many enchantments a single item can hold.">
+          <FieldRow
+            label="Max Per Item"
+            hint="Upper limit on how many enchantments a single item can hold. 1 keeps builds simple and readable; 3+ encourages deep customization but can produce very powerful late-game gear."
+          >
             <NumberInput
               value={config.enchanting.maxEnchantmentsPerItem}
               onCommit={(v) => patchGlobal({ maxEnchantmentsPerItem: v ?? 1 })}
@@ -121,6 +128,35 @@ export function EnchantingPanel({ config, onChange }: ConfigPanelProps) {
           />
         )}
       />
+    </>
+  );
+}
+
+function SubGroup({
+  title,
+  description,
+  actions,
+  children,
+}: {
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mt-2 border-t border-border-muted/40 pt-2 first:mt-0 first:border-0 first:pt-0">
+      <div className="flex items-center justify-between">
+        <h5 className="font-display text-2xs uppercase tracking-widest text-text-muted">
+          {title}
+        </h5>
+        {actions}
+      </div>
+      {description && (
+        <p className="mt-0.5 text-2xs leading-snug text-text-muted/60">
+          {description}
+        </p>
+      )}
+      <div className="mt-1.5 flex flex-col gap-1.5">{children}</div>
     </div>
   );
 }
@@ -139,10 +175,17 @@ function EnchantmentDetail({
   statOptions: { value: string; label: string }[];
 }) {
   const addMaterial = () => {
-    patch({ materials: [...enchantment.materials, { itemId: "", quantity: 1 }] });
+    patch({
+      materials: [...enchantment.materials, { itemId: "", quantity: 1 }],
+    });
   };
-  const updateMaterial = (idx: number, mp: Partial<EnchantmentMaterialConfig>) => {
-    const mats = enchantment.materials.map((m, i) => (i === idx ? { ...m, ...mp } : m));
+  const updateMaterial = (
+    idx: number,
+    mp: Partial<EnchantmentMaterialConfig>,
+  ) => {
+    const mats = enchantment.materials.map((m, i) =>
+      i === idx ? { ...m, ...mp } : m,
+    );
     patch({ materials: mats });
   };
   const removeMaterial = (idx: number) => {
@@ -159,7 +202,9 @@ function EnchantmentDetail({
     const bonuses = { ...enchantment.statBonuses };
     if (oldStat !== newStat) delete bonuses[oldStat];
     bonuses[newStat] = value;
-    patch({ statBonuses: Object.keys(bonuses).length > 0 ? bonuses : undefined });
+    patch({
+      statBonuses: Object.keys(bonuses).length > 0 ? bonuses : undefined,
+    });
   };
   const removeStatBonus = (stat: string) => {
     const { [stat]: _, ...rest } = enchantment.statBonuses ?? {};
@@ -168,148 +213,197 @@ function EnchantmentDetail({
 
   return (
     <>
-      <FieldRow label="Display Name">
-        <TextInput
-          value={enchantment.displayName}
-          onCommit={(v) => patch({ displayName: v })}
-        />
-      </FieldRow>
-      <FieldRow label="Skill" hint="Which crafting skill is used.">
-        <SelectInput
-          value={enchantment.skill}
-          onCommit={(v) => patch({ skill: v })}
-          options={craftingSkillOptions}
-          allowEmpty
-          placeholder="enchanting"
-        />
-      </FieldRow>
-      <FieldRow label="Skill Required" hint="Minimum skill level to use this enchantment.">
-        <NumberInput
-          value={enchantment.skillRequired}
-          onCommit={(v) => patch({ skillRequired: v ?? 1 })}
-          min={1}
-        />
-      </FieldRow>
-      <FieldRow label="XP Reward" hint="Enchanting XP awarded on use.">
-        <NumberInput
-          value={enchantment.xpReward}
-          onCommit={(v) => patch({ xpReward: v ?? 30 })}
-          min={0}
-        />
-      </FieldRow>
+      <SubGroup
+        title="Identity & Cost"
+        description="How this enchantment presents to players and what it takes to apply. Higher skill requirements gate powerful effects behind progression; XP rewards shape how quickly enchanters level up."
+      >
+        <FieldRow
+          label="Display Name"
+          hint="The name players see in item descriptions and crafting menus. Example: 'Runes of Warding' or 'Flame Etching'."
+        >
+          <TextInput
+            value={enchantment.displayName}
+            onCommit={(v) => patch({ displayName: v })}
+          />
+        </FieldRow>
+        <FieldRow
+          label="Skill"
+          hint="Which crafting skill is trained and checked. Usually 'enchanting', but could be 'runesmithing' or another custom crafting discipline."
+        >
+          <SelectInput
+            value={enchantment.skill}
+            onCommit={(v) => patch({ skill: v })}
+            options={craftingSkillOptions}
+            allowEmpty
+            placeholder="enchanting"
+          />
+        </FieldRow>
+        <FieldRow
+          label="Skill Required"
+          hint="Minimum skill level to attempt this enchantment. Use this to gate stronger effects behind long practice — 1 for starter runes, 50+ for endgame augments."
+        >
+          <NumberInput
+            value={enchantment.skillRequired}
+            onCommit={(v) => patch({ skillRequired: v ?? 1 })}
+            min={1}
+          />
+        </FieldRow>
+        <FieldRow
+          label="XP Reward"
+          hint="Crafting XP granted each time this enchantment is successfully applied. Tune to match progression pace — weak enchantments give small amounts, rare ones give more."
+        >
+          <NumberInput
+            value={enchantment.xpReward}
+            onCommit={(v) => patch({ xpReward: v ?? 30 })}
+            min={0}
+          />
+        </FieldRow>
+      </SubGroup>
 
-      {/* ── Bonuses ── */}
-      <div className="mt-1 border-t border-border-muted pt-1.5">
-        <h5 className="mb-1 text-2xs font-display uppercase tracking-widest text-text-muted">
-          Bonuses
-        </h5>
-        <div className="flex flex-col gap-1.5">
-          <FieldRow label="Damage Bonus" hint="Extra damage added to the item.">
-            <NumberInput
-              value={enchantment.damageBonus ?? 0}
-              onCommit={(v) => patch({ damageBonus: v || undefined })}
-              min={0}
-            />
-          </FieldRow>
-          <FieldRow label="Armor Bonus" hint="Extra armor added to the item.">
-            <NumberInput
-              value={enchantment.armorBonus ?? 0}
-              onCommit={(v) => patch({ armorBonus: v || undefined })}
-              min={0}
-            />
-          </FieldRow>
-        </div>
+      <SubGroup
+        title="Flat Bonuses"
+        description="Simple additive bonuses applied to the enchanted item. Damage stacks onto weapon hits; armor stacks onto mitigation rolls."
+      >
+        <FieldRow
+          label="Damage Bonus"
+          hint="Flat damage added to each successful hit with the enchanted weapon. +1 to +3 is subtle; +5 and above noticeably shifts combat math."
+        >
+          <NumberInput
+            value={enchantment.damageBonus ?? 0}
+            onCommit={(v) => patch({ damageBonus: v || undefined })}
+            min={0}
+          />
+        </FieldRow>
+        <FieldRow
+          label="Armor Bonus"
+          hint="Flat armor added to the equipped piece. Stack multiple armor enchantments to build tank sets."
+        >
+          <NumberInput
+            value={enchantment.armorBonus ?? 0}
+            onCommit={(v) => patch({ armorBonus: v || undefined })}
+            min={0}
+          />
+        </FieldRow>
+      </SubGroup>
 
-        {/* ── Stat bonuses ── */}
-        <div className="mt-2">
-          <div className="flex items-center justify-between">
-            <span className="text-2xs text-text-muted">Stat Bonuses</span>
-            <IconButton onClick={addStatBonus} title="Add stat bonus">+</IconButton>
-          </div>
-          {Object.entries(enchantment.statBonuses ?? {}).map(([stat, val]) => (
-            <div key={stat} className="mt-1 flex items-center gap-2">
-              <SelectInput
-                value={stat}
-                onCommit={(v) => updateStatBonus(stat, v, val)}
-                options={statOptions}
-              />
-              <NumberInput
-                value={val}
-                onCommit={(v) => updateStatBonus(stat, stat, v ?? 1)}
-                min={1}
-              />
-              <IconButton onClick={() => removeStatBonus(stat)} title="Remove" danger>&times;</IconButton>
+      <SubGroup
+        title="Stat Bonuses"
+        description="Grant bonus points to any stat defined in your Stats config. Useful for class-themed enchantments (e.g. +Intelligence for mage gear)."
+        actions={
+          <ActionButton variant="secondary" size="sm" onClick={addStatBonus}>
+            + Add Stat
+          </ActionButton>
+        }
+      >
+        {Object.keys(enchantment.statBonuses ?? {}).length === 0 ? (
+          <p className="text-2xs text-text-muted">
+            No stat bonuses. Add one to boost a specific attribute.
+          </p>
+        ) : (
+          Object.entries(enchantment.statBonuses ?? {}).map(([stat, val]) => (
+            <div key={stat} className="flex items-center gap-2">
+              <div className="min-w-0 flex-1">
+                <SelectInput
+                  value={stat}
+                  onCommit={(v) => updateStatBonus(stat, v, val)}
+                  options={statOptions}
+                />
+              </div>
+              <div className="w-20 shrink-0">
+                <NumberInput
+                  value={val}
+                  onCommit={(v) => updateStatBonus(stat, stat, v ?? 1)}
+                  min={1}
+                />
+              </div>
+              <IconButton
+                onClick={() => removeStatBonus(stat)}
+                title="Remove stat bonus"
+                danger
+              >
+                &times;
+              </IconButton>
             </div>
-          ))}
-        </div>
-      </div>
+          ))
+        )}
+      </SubGroup>
 
-      {/* ── Target slots ── */}
-      <div className="mt-1 border-t border-border-muted pt-1.5">
-        <h5 className="mb-1 text-2xs font-display uppercase tracking-widest text-text-muted">
-          Target Slots
-        </h5>
-        <p className="mb-2 text-2xs text-text-muted">
-          Equipment slots this enchantment can be applied to. Leave empty for any slot.
-        </p>
+      <SubGroup
+        title="Target Slots"
+        description="Restrict which equipment slots this enchantment can be applied to. Leave all unselected to allow any slot — useful for generic enchantments like 'Minor Ward'."
+      >
         <div className="flex flex-wrap gap-1.5">
           {equipSlotOptions.map(({ value, label }) => {
             const selected = enchantment.targetSlots?.includes(value) ?? false;
             return (
               <button
                 key={value}
+                type="button"
                 onClick={() => {
                   const current = enchantment.targetSlots ?? [];
                   const next = selected
                     ? current.filter((s) => s !== value)
                     : [...current, value];
-                  patch({ targetSlots: next.length > 0 ? next : undefined });
+                  patch({
+                    targetSlots: next.length > 0 ? next : undefined,
+                  });
                 }}
-                className={`rounded-full border px-3 py-1 text-2xs transition ${
-                  selected
+                className={
+                  "focus-ring rounded-full border px-3 py-1 text-2xs transition " +
+                  (selected
                     ? "border-accent/50 bg-accent/15 text-accent"
-                    : "border-border-default bg-bg-primary text-text-muted hover:border-border-hover"
-                }`}
+                    : "border-border-muted bg-bg-primary/40 text-text-muted hover:border-border-default hover:text-text-secondary")
+                }
+                aria-pressed={selected}
               >
                 {label}
               </button>
             );
           })}
         </div>
-      </div>
+      </SubGroup>
 
-      {/* ── Materials ── */}
-      <div className="mt-1 border-t border-border-muted pt-1.5">
-        <div className="flex items-center justify-between">
-          <h5 className="text-2xs font-display uppercase tracking-widest text-text-muted">
-            Materials
-          </h5>
-          <IconButton onClick={addMaterial} title="Add material">+</IconButton>
-        </div>
+      <SubGroup
+        title="Materials"
+        description="Items consumed each time this enchantment is applied. Acts as a gold sink and creates demand for gathering and trading. Leave empty for free enchantments."
+        actions={
+          <ActionButton variant="secondary" size="sm" onClick={addMaterial}>
+            + Add Material
+          </ActionButton>
+        }
+      >
         {enchantment.materials.length === 0 ? (
-          <p className="mt-1 text-2xs text-text-muted">No materials required. Add one above.</p>
+          <p className="text-2xs text-text-muted">
+            No materials required. Add one to create a resource cost.
+          </p>
         ) : (
-          <div className="mt-1 flex flex-col gap-1.5">
-            {enchantment.materials.map((mat, i) => (
-              <div key={i} className="flex items-center gap-2">
+          enchantment.materials.map((mat, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <div className="min-w-0 flex-1">
                 <TextInput
                   value={mat.itemId}
                   onCommit={(v) => updateMaterial(i, { itemId: v })}
                   placeholder="item_id"
                 />
-                <div className="w-20 shrink-0">
-                  <NumberInput
-                    value={mat.quantity}
-                    onCommit={(v) => updateMaterial(i, { quantity: v ?? 1 })}
-                    min={1}
-                  />
-                </div>
-                <IconButton onClick={() => removeMaterial(i)} title="Remove" danger>&times;</IconButton>
               </div>
-            ))}
-          </div>
+              <div className="w-20 shrink-0">
+                <NumberInput
+                  value={mat.quantity}
+                  onCommit={(v) => updateMaterial(i, { quantity: v ?? 1 })}
+                  min={1}
+                />
+              </div>
+              <IconButton
+                onClick={() => removeMaterial(i)}
+                title="Remove material"
+                danger
+              >
+                &times;
+              </IconButton>
+            </div>
+          ))
         )}
-      </div>
+      </SubGroup>
     </>
   );
 }

--- a/creator/src/components/config/panels/FactionPanel.tsx
+++ b/creator/src/components/config/panels/FactionPanel.tsx
@@ -6,6 +6,7 @@ import {
   FieldRow,
   TextInput,
   NumberInput,
+  ActionButton,
   IconButton,
   CommitTextarea,
 } from "@/components/ui/FormWidgets";
@@ -68,60 +69,125 @@ export function FactionPanel() {
   if (!config) return null;
 
   return (
-    <div className="space-y-6">
-      <Section title="Global Settings" defaultExpanded>
+    <>
+      <Section
+        title="Global Settings"
+        description="Factions are political and social groups in your world — thieves guilds, royal courts, mercenary companies. Players earn or lose reputation by completing quests and killing mobs, which unlocks shops, quests, and areas tied to each faction."
+      >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Default Reputation" hint="Starting reputation with all factions">
-            <NumberInput value={factions.defaultReputation} onCommit={(v) => patch({ defaultReputation: v ?? 0 })} />
+          <FieldRow
+            label="Default Reputation"
+            hint="Starting reputation each new player has with every faction. 0 is neutral. Positive values make the world friendlier to newcomers; negative values create a harsher debut."
+          >
+            <NumberInput
+              value={factions.defaultReputation}
+              onCommit={(v) => patch({ defaultReputation: v ?? 0 })}
+            />
           </FieldRow>
-          <FieldRow label="Kill Penalty" hint="Base rep lost with a mob's faction per kill (scaled by level)">
-            <NumberInput value={factions.killPenalty} onCommit={(v) => patch({ killPenalty: v ?? 5 })} min={0} />
+          <FieldRow
+            label="Kill Penalty"
+            hint="Base reputation lost with a mob's own faction when a player kills it, scaled by mob level. 5 is a modest penalty — try 10 for a harsher consequence or 2 for a forgiving world."
+          >
+            <NumberInput
+              value={factions.killPenalty}
+              onCommit={(v) => patch({ killPenalty: v ?? 5 })}
+              min={0}
+            />
           </FieldRow>
-          <FieldRow label="Kill Bonus" hint="Base rep gained with enemy factions per kill (scaled by level)">
-            <NumberInput value={factions.killBonus} onCommit={(v) => patch({ killBonus: v ?? 3 })} min={0} />
+          <FieldRow
+            label="Kill Bonus"
+            hint="Base reputation gained with the mob's enemy factions per kill, scaled by level. Encourages players to pick sides. 3 is a gentle nudge; raise to speed up faction alignment."
+          >
+            <NumberInput
+              value={factions.killBonus}
+              onCommit={(v) => patch({ killBonus: v ?? 3 })}
+              min={0}
+            />
           </FieldRow>
         </div>
       </Section>
 
       <Section
         title={`Factions (${factionIds.length})`}
-        defaultExpanded
+        description="Define each faction's name, flavor text, and rival factions. Mobs and quests reference these IDs, and players accrue reputation with each one over the course of play."
         actions={
           <div className="flex items-center gap-1.5">
-            <input
+            <TextInput
               value={newFactionId}
-              onChange={(e) => setNewFactionId(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && addFaction()}
+              onCommit={setNewFactionId}
               placeholder="new_faction_id"
-              className="w-36 rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-primary outline-none placeholder:text-text-muted focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+              dense
             />
-            <IconButton onClick={addFaction} title="Add faction">+</IconButton>
+            <ActionButton
+              variant="secondary"
+              size="sm"
+              onClick={addFaction}
+              disabled={!newFactionId.trim()}
+            >
+              + Add
+            </ActionButton>
           </div>
         }
       >
         {factionIds.length === 0 ? (
-          <p className="text-xs text-text-muted">No factions defined. Add one above.</p>
+          <p className="text-2xs leading-relaxed text-text-muted/70">
+            No factions defined yet. Enter an ID above (like "thieves_guild" or "royal_court") and click Add.
+          </p>
         ) : (
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col">
             {factionIds.map((id) => {
               const def = factions.definitions[id]!;
               return (
-                <div key={id} className="rounded-lg border border-border-muted bg-bg-secondary/40 p-3 space-y-2">
+                <div
+                  key={id}
+                  className="flex flex-col gap-1.5 border-b border-border-muted/30 pb-3 pt-3 first:pt-0 last:border-0 last:pb-0"
+                >
                   <div className="flex items-center justify-between">
-                    <span className="font-mono text-xs text-text-muted">{id}</span>
-                    <IconButton onClick={() => deleteFaction(id)} title="Delete faction" danger>&times;</IconButton>
+                    <span className="font-mono text-2xs uppercase tracking-widest text-text-muted">
+                      {id}
+                    </span>
+                    <IconButton
+                      onClick={() => deleteFaction(id)}
+                      title="Delete faction"
+                      size="sm"
+                      danger
+                    >
+                      &times;
+                    </IconButton>
                   </div>
-                  <FieldRow label="Name">
-                    <TextInput value={def.name} onCommit={(v) => patchDefinition(id, { name: v })} />
+                  <FieldRow
+                    label="Name"
+                    hint="Display name shown to players in reputation readouts and quest text."
+                  >
+                    <TextInput
+                      value={def.name}
+                      onCommit={(v) => patchDefinition(id, { name: v })}
+                    />
                   </FieldRow>
-                  <FieldRow label="Description">
-                    <TextInput value={def.description ?? ""} onCommit={(v) => patchDefinition(id, { description: v || undefined })} placeholder="Faction description" />
+                  <FieldRow
+                    label="Description"
+                    hint="Short flavor summary. Shown in faction info commands and help text."
+                  >
+                    <TextInput
+                      value={def.description ?? ""}
+                      onCommit={(v) => patchDefinition(id, { description: v || undefined })}
+                      placeholder="A secretive order of..."
+                    />
                   </FieldRow>
-                  <FieldRow label="Enemies" hint="Comma-separated faction IDs">
+                  <FieldRow
+                    label="Enemies"
+                    hint="Comma-separated faction IDs. Killing a member of this faction grants reputation with its enemies, and vice versa."
+                  >
                     <TextInput
                       value={(def.enemies ?? []).join(", ")}
-                      onCommit={(v) => patchDefinition(id, { enemies: v ? v.split(",").map((s) => s.trim()).filter(Boolean) : undefined })}
-                      placeholder="faction_a, faction_b"
+                      onCommit={(v) =>
+                        patchDefinition(id, {
+                          enemies: v
+                            ? v.split(",").map((s) => s.trim()).filter(Boolean)
+                            : undefined,
+                        })
+                      }
+                      placeholder="thieves_guild, shadow_cabal"
                     />
                   </FieldRow>
                 </div>
@@ -131,38 +197,60 @@ export function FactionPanel() {
         )}
       </Section>
 
-      <Section title="Quest Rewards" defaultExpanded={false} description="Map quest IDs to faction reputation changes.">
-        <CommitTextarea
-          label="Quest Rewards (YAML)"
-          value={factions.questRewards ? Object.entries(factions.questRewards).map(([qid, rewards]) =>
-            `${qid}:\n${Object.entries(rewards).map(([fid, amt]) => `  ${fid}: ${amt}`).join("\n")}`
-          ).join("\n") : ""}
-          onCommit={(v) => {
-            // Simple key-value parser for quest rewards
-            if (!v.trim()) { patch({ questRewards: undefined }); return; }
-            try {
-              const rewards: Record<string, Record<string, number>> = {};
-              let currentQuest = "";
-              for (const line of v.split("\n")) {
-                const trimmed = line.trimEnd();
-                if (!trimmed) continue;
-                if (!trimmed.startsWith(" ")) {
-                  currentQuest = trimmed.replace(/:$/, "").trim();
-                  rewards[currentQuest] = {};
-                } else if (currentQuest) {
-                  const match = trimmed.match(/^\s+(\S+)\s*:\s*(-?\d+)/);
-                  if (match && match[1] && match[2]) rewards[currentQuest]![match[1]] = parseInt(match[2]);
-                }
-              }
-              patch({ questRewards: Object.keys(rewards).length > 0 ? rewards : undefined });
-            } catch {
-              // Ignore parse errors
+      <Section
+        title="Quest Rewards"
+        description="Map quest IDs to faction reputation changes granted on completion. Use this to push players toward or away from factions based on the jobs they take."
+        defaultExpanded={false}
+      >
+        <div className="flex flex-col gap-1.5">
+          <CommitTextarea
+            label="Rewards (YAML)"
+            value={
+              factions.questRewards
+                ? Object.entries(factions.questRewards)
+                    .map(
+                      ([qid, rewards]) =>
+                        `${qid}:\n${Object.entries(rewards)
+                          .map(([fid, amt]) => `  ${fid}: ${amt}`)
+                          .join("\n")}`,
+                    )
+                    .join("\n")
+                : ""
             }
-          }}
-          placeholder="quest_id:\n  faction_id: 100\n  other_faction: -50"
-          rows={6}
-        />
+            onCommit={(v) => {
+              // Simple key-value parser for quest rewards
+              if (!v.trim()) {
+                patch({ questRewards: undefined });
+                return;
+              }
+              try {
+                const rewards: Record<string, Record<string, number>> = {};
+                let currentQuest = "";
+                for (const line of v.split("\n")) {
+                  const trimmed = line.trimEnd();
+                  if (!trimmed) continue;
+                  if (!trimmed.startsWith(" ")) {
+                    currentQuest = trimmed.replace(/:$/, "").trim();
+                    rewards[currentQuest] = {};
+                  } else if (currentQuest) {
+                    const match = trimmed.match(/^\s+(\S+)\s*:\s*(-?\d+)/);
+                    if (match && match[1] && match[2])
+                      rewards[currentQuest]![match[1]] = parseInt(match[2]);
+                  }
+                }
+                patch({
+                  questRewards:
+                    Object.keys(rewards).length > 0 ? rewards : undefined,
+                });
+              } catch {
+                // Ignore parse errors
+              }
+            }}
+            placeholder={"rescue_the_merchant:\n  royal_court: 100\n  thieves_guild: -50"}
+            rows={6}
+          />
+        </div>
       </Section>
-    </div>
+    </>
   );
 }

--- a/creator/src/components/config/panels/GuildHallsPanel.tsx
+++ b/creator/src/components/config/panels/GuildHallsPanel.tsx
@@ -35,17 +35,18 @@ export function GuildHallsPanel({ config, onChange }: ConfigPanelProps) {
     <>
       <Section
         title="Guild Halls"
-        description="Enable guild housing and configure the base cost for purchasing a guild hall. Guild halls give guilds a shared home with expandable rooms."
+        description="Guild halls give player-run guilds a shared home base they can expand over time. Members can meet, share storage, and unlock perks tied to their hall. Toggle the system off if you don't want housing in your MUD."
       >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Enabled" hint="Toggle the guild halls system on or off.">
-            <CheckboxInput
-              checked={guildHalls.enabled}
-              onCommit={(v) => patchGuildHalls({ enabled: v })}
-              label="Guild halls enabled"
-            />
-          </FieldRow>
-          <FieldRow label="Base Cost" hint="Gold cost for a guild to purchase its initial hall.">
+          <CheckboxInput
+            checked={guildHalls.enabled}
+            onCommit={(v) => patchGuildHalls({ enabled: v })}
+            label="Enable guild halls"
+          />
+          <FieldRow
+            label="Base Cost"
+            hint="Gold a guild must pay to purchase its initial hall. Balance this against your economy — a price too low trivializes the perk, too high locks out casual guilds. Try 10000g for mid-tier MUDs."
+          >
             <NumberInput
               value={guildHalls.baseCost}
               onCommit={(v) => patchGuildHalls({ baseCost: v ?? 0 })}
@@ -57,6 +58,7 @@ export function GuildHallsPanel({ config, onChange }: ConfigPanelProps) {
 
       <RegistryPanel<GuildHallRoomTemplate>
         title="Room Templates"
+        description="Expandable rooms guilds can add to their hall — vaults, training rooms, crafting stations, libraries. Each template defines its display name, flavor text, and gold cost. Rooms unlock guild perks when added."
         items={guildHalls.roomTemplates}
         onItemsChange={(roomTemplates) => patchGuildHalls({ roomTemplates })}
         defaultItem={defaultTemplate}
@@ -64,30 +66,34 @@ export function GuildHallsPanel({ config, onChange }: ConfigPanelProps) {
         getDisplayName={(t) => t.displayName ?? ""}
         placeholder="template_id"
         renderDetail={(_id, t, patch) => (
-          <>
-            <FieldRow label="Display Name" hint="Name shown to players for this room type.">
+          <div className="flex flex-col gap-1.5">
+            <FieldRow
+              label="Display Name"
+              hint="Name shown to players when browsing available room upgrades."
+            >
               <TextInput
                 value={t.displayName ?? ""}
                 onCommit={(v) => patch({ displayName: v })}
               />
             </FieldRow>
-            <FieldRow label="Description">
-              <CommitTextarea
-                label="Description"
-                value={t.description}
-                onCommit={(v) => patch({ description: v })}
-                placeholder="Room description..."
-                rows={3}
-              />
-            </FieldRow>
-            <FieldRow label="Cost" hint="Gold cost to add this room to a guild hall.">
+            <FieldRow
+              label="Cost"
+              hint="Gold cost for a guild to add this room. Scale this against your Base Cost — room upgrades should feel like meaningful investments, not throwaway purchases."
+            >
               <NumberInput
                 value={t.cost}
                 onCommit={(v) => patch({ cost: v ?? 0 })}
                 min={0}
               />
             </FieldRow>
-          </>
+            <CommitTextarea
+              label="Description"
+              value={t.description}
+              onCommit={(v) => patch({ description: v })}
+              placeholder="A fortified vault lined with enchanted stone..."
+              rows={3}
+            />
+          </div>
         )}
       />
     </>

--- a/creator/src/components/config/panels/HousingPanel.tsx
+++ b/creator/src/components/config/panels/HousingPanel.tsx
@@ -54,17 +54,23 @@ export function HousingPanel({ config, onChange }: ConfigPanelProps) {
     <>
       <Section
         title="Housing System"
-        description="Enable player housing and configure how houses connect to the world. Each player can own one house with expandable rooms purchased from a housing broker NPC."
+        description="Player housing lets each character buy a persistent home assembled from room templates. Houses are a gold sink, a social hub, and (optionally) an offline item vault. Disable this if your MUD is purely adventure-focused."
       >
         <div className="flex flex-col gap-1.5">
-          <FieldRow label="Enabled" hint="Toggle the entire housing system on or off.">
+          <FieldRow
+            label="Enabled"
+            hint="Master switch for the entire housing system. When off, the housing broker NPC, house commands, and templates below are all inert."
+          >
             <CheckboxInput
               checked={housing.enabled}
               onCommit={(v) => patchHousing({ enabled: v })}
               label="Housing enabled"
             />
           </FieldRow>
-          <FieldRow label="Exit Direction" hint="The direction that leads out of the house entry room back to the world. Players use this exit to leave.">
+          <FieldRow
+            label="Exit Direction"
+            hint="Which cardinal direction in the house's entry room leads back out to the world. Most MUDs use 'south' so 'enter house' takes players north."
+          >
             <SelectInput
               value={housing.entryExitDirection}
               options={DIRECTION_OPTIONS}
@@ -83,44 +89,62 @@ export function HousingPanel({ config, onChange }: ConfigPanelProps) {
         getDisplayName={(t) => t.title}
         placeholder="template_id"
         renderDetail={(_id, t, patch) => (
-          <>
-            <FieldRow label="Title" hint="Default room title shown to players. They can override this.">
+          <div className="flex flex-col gap-1.5">
+            <FieldRow
+              label="Title"
+              hint="Default room name shown to players when they enter. Owners can rename their copy after purchase."
+            >
               <TextInput
                 value={t.title}
                 onCommit={(v) => patch({ title: v })}
               />
             </FieldRow>
-            <FieldRow label="Description">
+            <FieldRow
+              label="Description"
+              hint="Default prose shown when players 'look' in the room. Owners can rewrite this to personalize their home."
+            >
               <CommitTextarea
                 label="Description"
                 value={t.description}
                 onCommit={(v) => patch({ description: v })}
-                placeholder="Default room description..."
+                placeholder="A cozy chamber lit by hanging lanterns..."
                 rows={3}
               />
             </FieldRow>
-            <FieldRow label="Cost" hint="Gold cost to purchase this room.">
+            <FieldRow
+              label="Cost"
+              hint="One-time gold cost to attach this room to a house. Entry rooms are usually cheap; vaults and specialty rooms (forge, alchemy) cost more."
+            >
               <NumberInput
                 value={t.cost}
                 onCommit={(v) => patch({ cost: v ?? 0 })}
                 min={0}
               />
             </FieldRow>
-            <FieldRow label="Entry Room" hint="Exactly one template must be the entry. This is the first room when a player buys a house.">
+            <FieldRow
+              label="Entry Room"
+              hint="Exactly one template must be marked as the entry. It's the starting room every new house is seeded with when a player first buys property."
+            >
               <CheckboxInput
                 checked={t.isEntry ?? false}
                 onCommit={(v) => patch({ isEntry: v || undefined })}
                 label="This is the entry room"
               />
             </FieldRow>
-            <FieldRow label="Safe" hint="When enabled, combat is blocked in this room.">
+            <FieldRow
+              label="Safe"
+              hint="When enabled, combat cannot start or continue in this room. Useful for bedrooms, vaults, and public gathering areas."
+            >
               <CheckboxInput
                 checked={t.safe ?? false}
                 onCommit={(v) => patch({ safe: v || undefined })}
                 label="Combat blocked"
               />
             </FieldRow>
-            <FieldRow label="Vault Capacity" hint="When > 0, items dropped here persist across sessions. 0 means items are transient.">
+            <FieldRow
+              label="Vault Capacity"
+              hint="If greater than 0, items dropped here persist across server restarts up to this count. Set to 0 for regular rooms (items vanish on reset)."
+            >
               <NumberInput
                 value={t.maxDroppedItems ?? 0}
                 onCommit={(v) =>
@@ -130,21 +154,27 @@ export function HousingPanel({ config, onChange }: ConfigPanelProps) {
                 placeholder="0"
               />
             </FieldRow>
-            <FieldRow label="Station" hint="Optional crafting station type (e.g. forge, alchemy_bench).">
+            <FieldRow
+              label="Station"
+              hint="Optional crafting station this room provides (e.g. forge, alchemy bench). Players can craft at home without visiting public stations."
+            >
               <SelectInput
                 value={t.station ?? ""}
                 options={stationOptions}
                 onCommit={(v) => patch({ station: v || undefined })}
               />
             </FieldRow>
-            <FieldRow label="Image" hint="Optional room image path.">
+            <FieldRow
+              label="Image"
+              hint="Optional asset filename for this room's background art. Leave blank to use the house default."
+            >
               <TextInput
                 value={t.image ?? ""}
                 onCommit={(v) => patch({ image: v || undefined })}
                 placeholder="Optional"
               />
             </FieldRow>
-          </>
+          </div>
         )}
       />
     </>

--- a/creator/src/components/config/panels/PetsPanel.tsx
+++ b/creator/src/components/config/panels/PetsPanel.tsx
@@ -84,83 +84,111 @@ function PetDetail({
   patch: (p: Partial<PetDefinitionConfig>) => void;
 }) {
   return (
-    <>
-      <FieldRow label="Name" hint="Display name shown in-game (e.g. 'a fire familiar')">
-        <TextInput
-          value={pet.name}
-          onCommit={(v) => patch({ name: v })}
-        />
-      </FieldRow>
-      <FieldRow label="Description">
-        <TextInput
-          value={pet.description ?? ""}
-          onCommit={(v) => patch({ description: v || undefined })}
-          placeholder="Flavor text"
-        />
-      </FieldRow>
-
-      <div className="mt-1 border-t border-border-muted pt-1.5">
-        <h5 className="mb-1 text-2xs font-display uppercase tracking-widest text-text-muted">
-          Combat Stats
-        </h5>
-        <p className="mb-2 text-2xs text-text-muted">
-          Base values scaled by owner level (+10% per level above 1).
-        </p>
-        <div className="flex flex-col gap-1.5">
-          <FieldRow label="HP" hint="Base hit points">
-            <NumberInput
-              value={pet.hp}
-              onCommit={(v) => patch({ hp: v ?? 20 })}
-              min={1}
-            />
-          </FieldRow>
-          <FieldRow label="Min Damage" hint="Minimum damage roll">
-            <NumberInput
-              value={pet.minDamage}
-              onCommit={(v) => patch({ minDamage: v ?? 1 })}
-              min={0}
-            />
-          </FieldRow>
-          <FieldRow label="Max Damage" hint="Maximum damage roll">
-            <NumberInput
-              value={pet.maxDamage}
-              onCommit={(v) => patch({ maxDamage: v ?? 4 })}
-              min={0}
-            />
-          </FieldRow>
-          <FieldRow label="Armor" hint="Damage reduction">
-            <NumberInput
-              value={pet.armor}
-              onCommit={(v) => patch({ armor: v ?? 0 })}
-              min={0}
-            />
-          </FieldRow>
-        </div>
-      </div>
-
-      <div className="mt-1 border-t border-border-muted pt-1.5">
-        <h5 className="mb-1 text-2xs font-display uppercase tracking-widest text-text-muted">
-          Art
-        </h5>
-        <div className="flex flex-col gap-1.5">
-          <FieldRow label="Image">
-            <TextInput
-              value={pet.image ?? ""}
-              onCommit={(v) => patch({ image: v || undefined })}
-              placeholder="None"
-            />
-          </FieldRow>
-          <EntityArtGenerator
-            getPrompt={(style) => petPrompt(pet, style)}
-            entityContext={buildPetContext(pet)}
-            currentImage={pet.image}
-            onAccept={(filePath) => patch({ image: filePath })}
-            assetType="pet"
-            context={{ zone: "", entity_type: "pet", entity_id: id }}
-            surface="worldbuilding"
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        <FieldRow
+          label="Name"
+          hint="Display name shown in-game, including any article. Example: 'a fire familiar' or 'Sparky the wolf pup'."
+        >
+          <TextInput
+            value={pet.name}
+            onCommit={(v) => patch({ name: v })}
           />
-        </div>
+        </FieldRow>
+        <FieldRow
+          label="Description"
+          hint="Optional flavor text shown when players examine the pet. Keep it short — one or two evocative sentences."
+        >
+          <TextInput
+            value={pet.description ?? ""}
+            onCommit={(v) => patch({ description: v || undefined })}
+            placeholder="A small flame that flickers with playful intelligence..."
+          />
+        </FieldRow>
       </div>
-    </>
+
+      <div className="flex flex-col gap-1.5 border-t border-border-muted/40 pt-2">
+        <div className="flex flex-col gap-0.5">
+          <h5 className="font-display text-2xs uppercase tracking-widest text-text-muted">
+            Combat Stats
+          </h5>
+          <p className="text-2xs leading-relaxed text-text-muted/70">
+            Base combat values for a level-1 owner. Stats scale by +10% per owner
+            level above 1, so a level 5 mage gets a pet with 140% of these values.
+          </p>
+        </div>
+        <FieldRow
+          label="HP"
+          hint="Base hit points at level 1. 20 is typical for a low-tier familiar; 50+ for a tanky combat pet."
+        >
+          <NumberInput
+            value={pet.hp}
+            onCommit={(v) => patch({ hp: v ?? 20 })}
+            min={1}
+          />
+        </FieldRow>
+        <FieldRow
+          label="Min Damage"
+          hint="Minimum damage per attack. The floor of the pet's damage roll — set to 1+ to guarantee some hit."
+        >
+          <NumberInput
+            value={pet.minDamage}
+            onCommit={(v) => patch({ minDamage: v ?? 1 })}
+            min={0}
+          />
+        </FieldRow>
+        <FieldRow
+          label="Max Damage"
+          hint="Maximum damage per attack. A wider min-max gap creates more damage variance. Try 1-4 for low tier, 5-12 for mid tier."
+        >
+          <NumberInput
+            value={pet.maxDamage}
+            onCommit={(v) => patch({ maxDamage: v ?? 4 })}
+            min={0}
+          />
+        </FieldRow>
+        <FieldRow
+          label="Armor"
+          hint="Flat damage reduction subtracted from incoming hits. 0 for glass-cannon casters; 5-15 for frontline summons."
+        >
+          <NumberInput
+            value={pet.armor}
+            onCommit={(v) => patch({ armor: v ?? 0 })}
+            min={0}
+          />
+        </FieldRow>
+      </div>
+
+      <div className="flex flex-col gap-1.5 border-t border-border-muted/40 pt-2">
+        <div className="flex flex-col gap-0.5">
+          <h5 className="font-display text-2xs uppercase tracking-widest text-text-muted">
+            Art
+          </h5>
+          <p className="text-2xs leading-relaxed text-text-muted/70">
+            Optional portrait shown when the pet is summoned or examined. Generate
+            one from the entity context or reference an existing asset filename.
+          </p>
+        </div>
+        <FieldRow
+          label="Image"
+          hint="Asset filename (from the project asset manifest). Leave blank to use a default pet icon."
+        >
+          <TextInput
+            value={pet.image ?? ""}
+            onCommit={(v) => patch({ image: v || undefined })}
+            placeholder="None"
+          />
+        </FieldRow>
+        <EntityArtGenerator
+          getPrompt={(style) => petPrompt(pet, style)}
+          entityContext={buildPetContext(pet)}
+          currentImage={pet.image}
+          onAccept={(filePath) => patch({ image: filePath })}
+          assetType="pet"
+          context={{ zone: "", entity_type: "pet", entity_id: id }}
+          surface="worldbuilding"
+        />
+      </div>
+    </div>
   );
 }

--- a/creator/src/components/config/panels/RegistryPanel.tsx
+++ b/creator/src/components/config/panels/RegistryPanel.tsx
@@ -3,6 +3,8 @@ import { Section, IconButton } from "@/components/ui/FormWidgets";
 
 export interface RegistryPanelProps<T> {
   title: string;
+  /** Optional description shown under the section title. */
+  description?: string;
   items: Record<string, T>;
   onItemsChange: (items: Record<string, T>) => void;
   /** Return a string to show in the collapsed header badge area. */
@@ -29,6 +31,7 @@ export interface RegistryPanelProps<T> {
 
 export function RegistryPanel<T>({
   title,
+  description,
   items,
   onItemsChange,
   renderSummary,
@@ -86,6 +89,7 @@ export function RegistryPanel<T>({
   return (
     <Section
       title={`${title} (${allIds.length})`}
+      description={description}
       actions={
         <div className="flex items-center gap-1">
           <input
@@ -127,7 +131,7 @@ export function RegistryPanel<T>({
             return (
               <div
                 key={id}
-                className="rounded border border-border-muted bg-bg-primary"
+                className="rounded border border-border-muted/40 bg-bg-primary/30 transition-colors hover:border-border-muted/70 hover:bg-bg-primary/50"
               >
                 <button
                   type="button"
@@ -161,12 +165,12 @@ export function RegistryPanel<T>({
                   </span>
                 </button>
                 {isOpen && (
-                  <div className="border-t border-border-muted px-2 py-2">
+                  <div className="border-t border-border-muted/40 px-2 py-2">
                     <div className="flex flex-col gap-1.5">
                       {renderDetail(id, item, (p) => patch(id, p))}
                     </div>
                     {onRenameId && (
-                      <div className="mt-2 border-t border-border-muted pt-2">
+                      <div className="mt-2 border-t border-border-muted/40 pt-2">
                         {renaming === id ? (
                           <div className="flex items-center gap-1">
                             <input

--- a/creator/src/components/config/panels/WorldEventsPanel.tsx
+++ b/creator/src/components/config/panels/WorldEventsPanel.tsx
@@ -1,10 +1,7 @@
 import { useCallback } from "react";
 import type { ConfigPanelProps } from "./types";
 import type { WorldEventDefinitionConfig } from "@/types/config";
-import {
-  FieldRow,
-  TextInput,
-} from "@/components/ui/FormWidgets";
+import { FieldRow, TextInput } from "@/components/ui/FormWidgets";
 import { RegistryPanel } from "./RegistryPanel";
 
 function defaultEventDefinition(raw: string): WorldEventDefinitionConfig {
@@ -50,6 +47,7 @@ export function WorldEventsPanel({ config, onChange }: ConfigPanelProps) {
   return (
     <RegistryPanel<WorldEventDefinitionConfig>
       title="Seasonal Events"
+      description="Scheduled or permanent world events — festivals, invasions, blood moons, harvest seasons. Events expose flags that quests, mobs, and items can query to unlock seasonal content or alter behavior. Leave the schedule empty to create a flag that's always active."
       items={config.worldEvents.definitions}
       onItemsChange={patchDefs}
       onRenameId={handleRename}
@@ -73,54 +71,65 @@ function EventDetail({
   patch: (p: Partial<WorldEventDefinitionConfig>) => void;
 }) {
   return (
-    <>
-      <FieldRow label="Display Name">
-        <TextInput
-          value={event.displayName}
-          onCommit={(v) => patch({ displayName: v })}
-        />
-      </FieldRow>
-      <FieldRow label="Description">
-        <TextInput
-          value={event.description ?? ""}
-          onCommit={(v) => patch({ description: v || undefined })}
-          placeholder="Flavor text"
-        />
-      </FieldRow>
-
-      <div className="mt-1 border-t border-border-muted pt-1.5">
-        <h5 className="mb-1 text-2xs font-display uppercase tracking-widest text-text-muted">
-          Schedule
-        </h5>
-        <p className="mb-2 text-2xs text-text-muted">
-          ISO dates (yyyy-MM-dd). Leave both empty for a permanent event.
-        </p>
-        <div className="flex flex-col gap-1.5">
-          <FieldRow label="Start Date">
-            <TextInput
-              value={event.startDate ?? ""}
-              onCommit={(v) => patch({ startDate: v || undefined })}
-              placeholder="2026-03-20"
-            />
-          </FieldRow>
-          <FieldRow label="End Date">
-            <TextInput
-              value={event.endDate ?? ""}
-              onCommit={(v) => patch({ endDate: v || undefined })}
-              placeholder="2026-04-20"
-            />
-          </FieldRow>
-        </div>
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1.5">
+        <FieldRow
+          label="Display Name"
+          hint="Name shown to players in broadcast messages and event listings."
+        >
+          <TextInput
+            value={event.displayName}
+            onCommit={(v) => patch({ displayName: v })}
+          />
+        </FieldRow>
+        <FieldRow
+          label="Description"
+          hint="Short flavor summary. Shown in help text and event info commands."
+        >
+          <TextInput
+            value={event.description ?? ""}
+            onCommit={(v) => patch({ description: v || undefined })}
+            placeholder="A week of feasts and dancing..."
+          />
+        </FieldRow>
       </div>
 
-      <div className="mt-1 border-t border-border-muted pt-1.5">
-        <h5 className="mb-1 text-2xs font-display uppercase tracking-widest text-text-muted">
-          Flags
-        </h5>
-        <p className="mb-2 text-2xs text-text-muted">
-          Comma-separated flags queryable by quests, mobs, and items.
-        </p>
-        <FieldRow label="Flags">
+      <div className="flex flex-col gap-1.5">
+        <FieldGroupLabel
+          label="Schedule"
+          hint="ISO dates (yyyy-MM-dd). Leave both empty for a permanent event that's always active."
+        />
+        <FieldRow
+          label="Start Date"
+          hint="Day the event activates. Format: 2026-03-20."
+        >
+          <TextInput
+            value={event.startDate ?? ""}
+            onCommit={(v) => patch({ startDate: v || undefined })}
+            placeholder="2026-03-20"
+          />
+        </FieldRow>
+        <FieldRow
+          label="End Date"
+          hint="Day the event deactivates. Format: 2026-04-20."
+        >
+          <TextInput
+            value={event.endDate ?? ""}
+            onCommit={(v) => patch({ endDate: v || undefined })}
+            placeholder="2026-04-20"
+          />
+        </FieldRow>
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <FieldGroupLabel
+          label="Flags"
+          hint="Comma-separated tags that quests, mobs, items, and drop tables can check. Flags are the main way event state influences gameplay."
+        />
+        <FieldRow
+          label="Flags"
+          hint="Example: spring_festival, bonus_herbalism, double_xp."
+        >
           <TextInput
             value={(event.flags ?? []).join(", ")}
             onCommit={(v) =>
@@ -135,27 +144,43 @@ function EventDetail({
         </FieldRow>
       </div>
 
-      <div className="mt-1 border-t border-border-muted pt-1.5">
-        <h5 className="mb-1 text-2xs font-display uppercase tracking-widest text-text-muted">
-          Broadcast Messages
-        </h5>
-        <div className="flex flex-col gap-1.5">
-          <FieldRow label="Start Message" hint="Broadcast when the event activates.">
-            <TextInput
-              value={event.startMessage ?? ""}
-              onCommit={(v) => patch({ startMessage: v || undefined })}
-              placeholder="The festival has begun!"
-            />
-          </FieldRow>
-          <FieldRow label="End Message" hint="Broadcast when the event deactivates.">
-            <TextInput
-              value={event.endMessage ?? ""}
-              onCommit={(v) => patch({ endMessage: v || undefined })}
-              placeholder="The festival has ended."
-            />
-          </FieldRow>
-        </div>
+      <div className="flex flex-col gap-1.5">
+        <FieldGroupLabel
+          label="Broadcast Messages"
+          hint="Shown to every online player when the event toggles on or off."
+        />
+        <FieldRow
+          label="Start Message"
+          hint="Broadcast the moment the event activates. Keep it atmospheric."
+        >
+          <TextInput
+            value={event.startMessage ?? ""}
+            onCommit={(v) => patch({ startMessage: v || undefined })}
+            placeholder="The festival has begun!"
+          />
+        </FieldRow>
+        <FieldRow
+          label="End Message"
+          hint="Broadcast when the event expires."
+        >
+          <TextInput
+            value={event.endMessage ?? ""}
+            onCommit={(v) => patch({ endMessage: v || undefined })}
+            placeholder="The festival has ended."
+          />
+        </FieldRow>
       </div>
-    </>
+    </div>
+  );
+}
+
+function FieldGroupLabel({ label, hint }: { label: string; hint: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <h5 className="font-display text-2xs uppercase tracking-widest text-text-muted">
+        {label}
+      </h5>
+      <p className="text-2xs leading-relaxed text-text-muted/70">{hint}</p>
+    </div>
   );
 }


### PR DESCRIPTION
Closes #159.

## Summary
- Brings Currencies, Enchanting, Guild Halls, Factions, Emotes, Housing, Pets, and World Events panels up to the CombatPanel/EconomyPanel quality bar.
- Removes box-in-box nesting, switches bespoke add buttons to `ActionButton`, replaces heavy list-item borders with dividers, and adds `Section` descriptions + `FieldRow` hints explaining gameplay impact in plain language for MUD builders.
- Softens `RegistryPanel`'s shared list-row chrome (used by 15 panels) from a solid border + fill to a subtle translucent treatment, and adds an optional `description` prop that flows through to the Section header.

## Files
- `CurrenciesPanel.tsx`, `EnchantingPanel.tsx`, `FactionPanel.tsx`, `GuildHallsPanel.tsx`, `HousingPanel.tsx`, `PetsPanel.tsx`, `EmotePresetsPanel.tsx`, `WorldEventsPanel.tsx`
- `RegistryPanel.tsx` (shared, additive change — new optional `description` prop + softened row chrome)

## Test plan
- [x] `bunx tsc --noEmit` clean across the whole creator app
- [ ] Manual visual pass on each of the 8 panels against `CombatPanel` / `EconomyPanel` reference
- [ ] Verify add/delete/reorder still works on list-based panels (Currencies, Emotes, Factions, Enchanting materials)
- [ ] Confirm `RegistryPanel`-powered panels outside the issue scope (Classes, Races, Abilities, Status Effects, Quests, Group, Commands, Crafting, Character Creation, Achievements) still look correct with the softened row chrome