### PR TITLE
Add skillPointCost field to ability definitions (#173)

### DIFF
--- a/creator/src/components/config/AbilityDesigner.tsx
+++ b/creator/src/components/config/AbilityDesigner.tsx
@@ -206,6 +206,11 @@ export function AbilityDesigner({
                   <span>{ability.targetType}</span>
                   <span>Lvl {ability.levelRequired}</span>
                   {classId && <span>{classId}</span>}
+                  {(ability.skillPointCost ?? 1) === 0 ? (
+                    <span className="text-badge-success">Auto</span>
+                  ) : (
+                    <span>{ability.skillPointCost ?? 1} SP</span>
+                  )}
                 </div>
                 <div className="mt-3 text-xs text-text-secondary">{summarizeAbility(ability)}</div>
               </button>
@@ -234,6 +239,25 @@ export function AbilityDesigner({
               <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">{selected.targetType}</span>
               <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">Mana {selected.manaCost}</span>
               <span className="rounded-full bg-[var(--chrome-highlight-strong)] px-3 py-1 text-xs text-text-secondary">CD {selected.cooldownMs}ms</span>
+              {(() => {
+                const cost = selected.skillPointCost ?? 1;
+                return (
+                  <span
+                    className={`rounded-full px-3 py-1 text-xs ${
+                      cost === 0
+                        ? "bg-badge-success-bg text-badge-success"
+                        : "bg-[var(--chrome-highlight-strong)] text-text-secondary"
+                    }`}
+                    title={
+                      cost === 0
+                        ? "Auto-learned when level, class, and prerequisites are met"
+                        : `Costs ${cost} skill ${cost === 1 ? "point" : "points"} at a trainer`
+                    }
+                  >
+                    {cost === 0 ? "Auto-learn" : `${cost} SP`}
+                  </span>
+                );
+              })()}
             </div>
           </div>
 

--- a/creator/src/components/config/panels/AbilitiesPanel.tsx
+++ b/creator/src/components/config/panels/AbilitiesPanel.tsx
@@ -247,6 +247,16 @@ export function AbilityDetail({
           min={1}
         />
       </FieldRow>
+      <FieldRow
+        label="Skill Point Cost"
+        hint="How many skill points a trainer charges for this ability. 0 = auto-learned once the player meets level, class, and prerequisite gates."
+      >
+        <NumberInput
+          value={ability.skillPointCost ?? 1}
+          onCommit={(v) => patch({ skillPointCost: v ?? 0 })}
+          min={0}
+        />
+      </FieldRow>
       <FieldRow label="Target">
         <SelectInput
           value={ability.targetType}

--- a/creator/src/lib/__tests__/exportMud.test.ts
+++ b/creator/src/lib/__tests__/exportMud.test.ts
@@ -193,6 +193,10 @@ describe("buildMonolithicConfigObject", () => {
     expect(runtime.engine.classStartRooms.BULWARK).toBe("tutorial_glade:training_grounds");
     expect(runtime.engine.statusEffects.definitions.fortress_stance.effectType).toBe("stat_buff");
     expect(runtime.engine.abilities.definitions.shield_bash.image).toBe("shield_bash.png");
+    // Unset skillPointCost is omitted so the Kotlin default of 1 applies
+    expect(
+      "skillPointCost" in runtime.engine.abilities.definitions.shield_bash,
+    ).toBe(false);
     expect(runtime.engine.achievementCategories.categories.combat.displayName).toBe("Combat");
     expect(runtime.engine.questObjectiveTypes.types.kill.displayName).toBe("Kill");
     expect(runtime.images.globalAssets).toEqual({});
@@ -216,6 +220,38 @@ describe("buildMonolithicConfigObject", () => {
     expect(runtime.engine.dailyQuests.enabled).toBe(false);
     expect(runtime.engine.dailyQuests.dailySlots).toBe(3);
     expect(runtime.engine.dailyQuests.dailyPool).toEqual([]);
+  });
+
+  it("emits non-default skillPointCost values on abilities", () => {
+    const config: AppConfig = {
+      ...BASE_CONFIG,
+      abilities: {
+        free_spark: {
+          displayName: "Free Spark",
+          manaCost: 5,
+          cooldownMs: 0,
+          levelRequired: 1,
+          targetType: "ENEMY",
+          skillPointCost: 0,
+          effect: { type: "DIRECT_DAMAGE", value: 3 },
+        },
+        pricey_blast: {
+          displayName: "Pricey Blast",
+          manaCost: 10,
+          cooldownMs: 2000,
+          levelRequired: 5,
+          targetType: "ENEMY",
+          skillPointCost: 3,
+          effect: { type: "DIRECT_DAMAGE", value: 20 },
+        },
+      },
+    };
+
+    const runtime = buildMonolithicConfigObject(config) as any;
+    const defs = runtime.engine.abilities.definitions;
+
+    expect(defs.free_spark.skillPointCost).toBe(0);
+    expect(defs.pricey_blast.skillPointCost).toBe(3);
   });
 
   it("disables global quests during export when objectives are missing", () => {
@@ -284,5 +320,45 @@ ambonmud:
 
     const parsed = parse(yaml) as any;
     expect(parsed.ambonmud.engine.achievementCategories.categories.combat.displayName).toBe("Combat");
+  });
+
+  it("preserves ability skillPointCost through parse and re-export", () => {
+    const yaml = `
+ambonmud:
+  server:
+    telnetPort: 4000
+    webPort: 8080
+  world:
+    startRoom: hub:square
+    resources: []
+  engine:
+    abilities:
+      definitions:
+        free_spark:
+          displayName: Free Spark
+          manaCost: 5
+          cooldownMs: 0
+          levelRequired: 1
+          skillPointCost: 0
+          targetType: ENEMY
+          effect: { type: DIRECT_DAMAGE, value: 3 }
+        pricey_blast:
+          displayName: Pricey Blast
+          manaCost: 10
+          cooldownMs: 2000
+          levelRequired: 5
+          skillPointCost: 3
+          targetType: ENEMY
+          effect: { type: DIRECT_DAMAGE, value: 20 }
+`;
+
+    const config = parseAppConfigYaml(yaml);
+    expect(config.abilities.free_spark?.skillPointCost).toBe(0);
+    expect(config.abilities.pricey_blast?.skillPointCost).toBe(3);
+
+    const runtime = buildMonolithicConfigObject(config) as any;
+    const defs = runtime.engine.abilities.definitions;
+    expect(defs.free_spark.skillPointCost).toBe(0);
+    expect(defs.pricey_blast.skillPointCost).toBe(3);
   });
 });

--- a/creator/src/lib/__tests__/validateConfig.test.ts
+++ b/creator/src/lib/__tests__/validateConfig.test.ts
@@ -249,6 +249,52 @@ describe("validateConfig", () => {
     expect(issues.filter((i) => i.entity.startsWith("ability:"))).toEqual([]);
   });
 
+  it("flags negative skillPointCost on an ability", () => {
+    const cfg = {
+      ...BASE_CONFIG,
+      abilities: {
+        bogus_cost: {
+          displayName: "Bogus Cost",
+          manaCost: 5,
+          cooldownMs: 0,
+          levelRequired: 1,
+          targetType: "ENEMY",
+          skillPointCost: -1,
+          effect: { type: "DIRECT_DAMAGE", value: 5 },
+        },
+      },
+    };
+    const issues = validateConfig(cfg);
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        entity: "ability:bogus_cost",
+        severity: "error",
+        message: expect.stringContaining("skillPointCost"),
+      }),
+    );
+  });
+
+  it("accepts a zero skillPointCost (auto-learned ability)", () => {
+    const cfg = {
+      ...BASE_CONFIG,
+      abilities: {
+        free_spark: {
+          displayName: "Free Spark",
+          manaCost: 5,
+          cooldownMs: 0,
+          levelRequired: 1,
+          targetType: "ENEMY",
+          skillPointCost: 0,
+          effect: { type: "DIRECT_DAMAGE", value: 3 },
+        },
+      },
+    };
+    const issues = validateConfig(cfg);
+    expect(
+      issues.filter((i) => i.entity === "ability:free_spark"),
+    ).toEqual([]);
+  });
+
   it("warns about ability with unknown class restriction", () => {
     const cfg = {
       ...BASE_CONFIG,

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -773,6 +773,7 @@ export function abilityToPlain(a: AppConfig["abilities"][string]): Record<string
   if (a.prerequisites && a.prerequisites.length > 0) obj.prerequisites = a.prerequisites;
   if (a.tree) obj.tree = a.tree;
   if (a.tier != null) obj.tier = a.tier;
+  if (a.skillPointCost != null && a.skillPointCost !== 1) obj.skillPointCost = a.skillPointCost;
   return obj;
 }
 

--- a/creator/src/lib/validateConfig.ts
+++ b/creator/src/lib/validateConfig.ts
@@ -158,6 +158,13 @@ export function validateConfig(config: AppConfig): ValidationIssue[] {
         message: `Required class "${requiredClass}" is not defined`,
       });
     }
+    if (a.skillPointCost != null && a.skillPointCost < 0) {
+      issues.push({
+        severity: "error",
+        entity: `ability:${id}`,
+        message: `skillPointCost must be >= 0 (got ${a.skillPointCost})`,
+      });
+    }
   }
 
   // ─── Status effects ──────────────────────────────────────────

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -77,6 +77,12 @@ export interface AbilityDefinitionConfig {
   tier?: number;
   /** Ability IDs that must be learned before this one */
   prerequisites?: string[];
+  /**
+   * Skill points needed to learn this ability from a trainer.
+   * Defaults to 1. A value of 0 means the ability auto-grants
+   * once the player meets level, class, and prerequisite gates.
+   */
+  skillPointCost?: number;
 }
 
 // ─── Status Effects ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the `skillPointCost` field on ability definitions so Arcanum tracks the same per-ability trainer cost the MUD now supports. Closes #173.

A cost of `0` marks an ability as **auto-learned** once the player meets level, class, and prerequisite gates; other values deduct that many skill points when the player trains the ability. The default is `1`, so existing YAML continues to behave the same and the field is only serialized when it differs from the default.

### Changes
- `AbilityDefinitionConfig.skillPointCost?: number` added to the TypeScript type
- Ability detail form gains a `Skill Point Cost` input with hint copy explaining auto-learn
- Ability Designer header badge and roster card surface the cost (or an `Auto-learn` chip when 0)
- `abilityToPlain` writes `skillPointCost` on export only when it is non-default
- `validateConfig` flags a negative cost as an error, mirroring the Kotlin loader's `require(skillPointCost >= 0)`

### Notes
- No changes to the Kotlin/MUD side — issue #173 was about mirroring schema changes that already landed there.
- Follow-ups (player auto-grant semantics, trainer UI wording, GMCP payloads) live in the MUD repo per the issue body.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test -- --run` — 1558 tests passing, including new coverage:
  - negative `skillPointCost` flagged as error
  - zero-cost ability accepted with no issues
  - explicit 0 and >1 costs survive parse → export round-trip
  - default (1) ability is exported without the field so Kotlin's default applies
- [ ] Manual: open an existing project, edit an ability's skill point cost, confirm it persists after save/reload