### PR TITLE
Improve light theme contrast handling

### DIFF
--- a/creator/src/components/AppearancePanel.tsx
+++ b/creator/src/components/AppearancePanel.tsx
@@ -3,6 +3,7 @@ import { useThemeStore } from "@/stores/themeStore";
 import {
   DEFAULT_THEME,
   PRESET_THEMES,
+  contrastRatio,
   isValidHex,
   luminance,
   normalizeHex,
@@ -11,13 +12,61 @@ import {
 } from "@/lib/theme";
 
 type Slot = "background" | "surface" | "text" | "accent";
+type PasteMode = "dark" | "light";
 
 const SLOT_META: { key: Slot; label: string; help: string }[] = [
-  { key: "background", label: "Background", help: "Page and abyss — should be the darkest swatch." },
-  { key: "surface", label: "Surface", help: "Panels, sections, hover states, borders." },
-  { key: "text", label: "Text", help: "Primary text color — should be the lightest swatch." },
-  { key: "accent", label: "Accent", help: "Links, focus rings, glows, active highlights." },
+  {
+    key: "background",
+    label: "Background",
+    help: "Page background and outer chrome. Use the lightest swatch for light themes or the darkest for dark themes.",
+  },
+  {
+    key: "surface",
+    label: "Surface",
+    help: "Panels, sections, and inputs. Keep it clearly distinct from the page background.",
+  },
+  {
+    key: "text",
+    label: "Text",
+    help: "Primary text color. It needs strong contrast against both background and surface.",
+  },
+  {
+    key: "accent",
+    label: "Accent",
+    help: "Links, focus rings, selected states, and decorative glow.",
+  },
 ];
+
+function paletteMode(theme: Pick<ThemePalette, "background" | "text">): PasteMode {
+  return luminance(theme.background) >= luminance(theme.text) ? "light" : "dark";
+}
+
+function chroma(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return Math.max(r, g, b) - Math.min(r, g, b);
+}
+
+function buildPaletteFromPaste(colors: string[], mode: PasteMode): ThemePalette {
+  const sorted = [...colors].sort((a, b) => luminance(a) - luminance(b));
+  const darkest = sorted[0]!;
+  const mid1 = sorted[1]!;
+  const mid2 = sorted[2]!;
+  const lightest = sorted[3]!;
+  const accent = chroma(mid2) > chroma(mid1) ? mid2 : mid1;
+  const surface = accent === mid1 ? mid2 : mid1;
+
+  return mode === "light"
+    ? { name: "Custom (pasted)", background: lightest, surface, text: darkest, accent }
+    : { name: "Custom (pasted)", background: darkest, surface, text: lightest, accent };
+}
+
+function textOnAccent(palette: Pick<ThemePalette, "background" | "text" | "accent">): string {
+  return contrastRatio(palette.accent, palette.text) >= contrastRatio(palette.accent, palette.background)
+    ? palette.text
+    : palette.background;
+}
 
 function PresetCard({
   preset,
@@ -49,10 +98,13 @@ function PresetCard({
           />
         ))}
       </div>
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <span className="font-display text-sm text-text-primary">{preset.name}</span>
-        {active && <span className="text-3xs uppercase tracking-ui text-accent">Active</span>}
+        <span className="text-3xs uppercase tracking-ui text-text-muted">
+          {paletteMode(preset)}
+        </span>
       </div>
+      {active && <span className="text-3xs uppercase tracking-ui text-accent">Active</span>}
     </button>
   );
 }
@@ -111,6 +163,9 @@ function SlotEditor({
 }
 
 function PreviewCard({ palette }: { palette: ThemePalette }) {
+  const mode = paletteMode(palette);
+  const onAccent = textOnAccent(palette);
+
   return (
     <div
       className="rounded-2xl border p-5"
@@ -120,17 +175,22 @@ function PreviewCard({ palette }: { palette: ThemePalette }) {
         color: palette.text,
       }}
     >
-      <p
-        className="text-3xs uppercase"
-        style={{ letterSpacing: "0.32em", color: palette.accent, opacity: 0.85 }}
-      >
-        Preview
-      </p>
+      <div className="flex items-center justify-between gap-3">
+        <p
+          className="text-3xs uppercase"
+          style={{ letterSpacing: "0.32em", color: palette.accent, opacity: 0.85 }}
+        >
+          Preview
+        </p>
+        <span className="text-3xs uppercase tracking-ui" style={{ color: palette.text, opacity: 0.65 }}>
+          {mode} theme
+        </span>
+      </div>
       <h3 className="mt-2 font-display text-2xl" style={{ color: palette.text }}>
         Aurum dusk over the abyss
       </h3>
-      <p className="mt-2 text-sm leading-6" style={{ color: palette.text, opacity: 0.7 }}>
-        Body text uses the text color at reduced opacity. Accent appears in the link below.
+      <p className="mt-2 text-sm leading-6" style={{ color: palette.text, opacity: 0.78 }}>
+        This preview shows how the page, panel, text, and accent anchors work together before you save.
       </p>
       <div className="mt-4 flex flex-wrap items-center gap-3">
         <button
@@ -138,7 +198,7 @@ function PreviewCard({ palette }: { palette: ThemePalette }) {
           className="rounded-full px-4 py-1.5 font-display text-xs"
           style={{
             background: palette.accent,
-            color: palette.background,
+            color: onAccent,
             border: `1px solid ${palette.accent}`,
           }}
         >
@@ -150,7 +210,7 @@ function PreviewCard({ palette }: { palette: ThemePalette }) {
           style={{
             background: "transparent",
             color: palette.accent,
-            border: `1px solid ${palette.accent}80`,
+            border: `1px solid ${palette.accent}66`,
           }}
         >
           Secondary
@@ -172,14 +232,13 @@ export function AppearancePanel() {
   const initial: ThemePalette = persisted ?? DEFAULT_THEME;
   const [draft, setDraft] = useState<ThemePalette>(initial);
   const [pasteValue, setPasteValue] = useState("");
+  const [pasteMode, setPasteMode] = useState<PasteMode>(paletteMode(initial));
   const [pasteError, setPasteError] = useState<string | null>(null);
 
-  // Live preview as the draft changes.
   useEffect(() => {
     previewTheme(draft);
   }, [draft, previewTheme]);
 
-  // Cancel preview if the panel unmounts without saving.
   useEffect(() => {
     return () => {
       cancelPreview();
@@ -197,14 +256,23 @@ export function AppearancePanel() {
     );
   }, [draft, persisted]);
 
-  const luminanceWarning = useMemo(() => {
-    if (luminance(draft.background) > 0.4) {
-      return "Background is quite light — Arcanum is designed for dark themes and panels may look washed out.";
+  const mode = useMemo(() => paletteMode(draft), [draft]);
+
+  const contrastWarnings = useMemo(() => {
+    const warnings: string[] = [];
+    if (contrastRatio(draft.background, draft.text) < 7) {
+      warnings.push("Background and text are too close. Large app surfaces will be tiring to read.");
     }
-    if (luminance(draft.text) < 0.5) {
-      return "Text color is dark — it may be hard to read against the background.";
+    if (contrastRatio(draft.surface, draft.text) < 4.5) {
+      warnings.push("Panel text contrast is low. Editors and form rows may become hard to scan.");
     }
-    return null;
+    if (contrastRatio(draft.accent, textOnAccent(draft)) < 4.5) {
+      warnings.push("Accent-filled buttons may not have enough contrast for their label text.");
+    }
+    if (Math.abs(luminance(draft.background) - luminance(draft.surface)) < 0.06) {
+      warnings.push("Background and surface are very close. The app may feel flat or washed out.");
+    }
+    return warnings;
   }, [draft]);
 
   const updateSlot = (slot: Slot, hex: string) => {
@@ -213,31 +281,17 @@ export function AppearancePanel() {
 
   const applyPreset = (preset: ThemePalette) => {
     setDraft({ ...preset });
+    setPasteMode(paletteMode(preset));
   };
 
   const handlePaste = () => {
     setPasteError(null);
     const parsed = parsePalettePaste(pasteValue);
     if (!parsed || parsed.length < 4) {
-      setPasteError("Need 4 hex colors. Paste them in any order — sorted by luminance.");
+      setPasteError("Need 4 hex colors. Paste them in any order.");
       return;
     }
-    // Sort by luminance: darkest → background, lightest → text. Of the middle
-    // two, the more saturated one is the accent.
-    const sorted = [...parsed].sort((a, b) => luminance(a) - luminance(b));
-    const background = sorted[0]!;
-    const text = sorted[3]!;
-    const mid1 = sorted[1]!;
-    const mid2 = sorted[2]!;
-    // Pick the more chromatic of the two mids as accent.
-    const chroma = (hex: string) => {
-      const r = parseInt(hex.slice(1, 3), 16);
-      const g = parseInt(hex.slice(3, 5), 16);
-      const b = parseInt(hex.slice(5, 7), 16);
-      return Math.max(r, g, b) - Math.min(r, g, b);
-    };
-    const [accent, surface] = chroma(mid2) > chroma(mid1) ? [mid2, mid1] : [mid1, mid2];
-    setDraft({ name: "Custom (pasted)", background, surface, text, accent });
+    setDraft(buildPaletteFromPaste(parsed, pasteMode));
     setPasteValue("");
   };
 
@@ -248,132 +302,162 @@ export function AppearancePanel() {
   const handleReset = () => {
     setTheme(null);
     setDraft({ ...DEFAULT_THEME });
+    setPasteMode(paletteMode(DEFAULT_THEME));
   };
 
   const handleRevert = () => {
-    setDraft({ ...(persisted ?? DEFAULT_THEME) });
+    const baseline = persisted ?? DEFAULT_THEME;
+    setDraft({ ...baseline });
+    setPasteMode(paletteMode(baseline));
   };
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-6 py-6">
         <header>
-        <p className="text-3xs uppercase tracking-wide-ui text-text-muted">Operations</p>
-        <h2 className="mt-2 font-display text-3xl text-text-primary">Appearance</h2>
-        <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
-          Pick a 4-color palette to retheme the entire app. Background, Surface, Text, and Accent
-          drive every UI surface — semantic colors (status, classes, lore templates) stay fixed.
-        </p>
-      </header>
-
-      <section className="panel-surface rounded-3xl p-5 shadow-section">
-        <h3 className="mb-3 font-display text-lg text-text-primary">Presets</h3>
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-3">
-          {PRESET_THEMES.map((p) => (
-            <PresetCard
-              key={p.name}
-              preset={p}
-              active={
-                draft.background === p.background &&
-                draft.surface === p.surface &&
-                draft.text === p.text &&
-                draft.accent === p.accent
-              }
-              onSelect={() => applyPreset(p)}
-            />
-          ))}
-        </div>
-      </section>
-
-      <section className="panel-surface rounded-3xl p-5 shadow-section">
-        <div className="mb-3 flex items-baseline justify-between">
-          <h3 className="font-display text-lg text-text-primary">Custom palette</h3>
-          <span className="text-3xs uppercase tracking-ui text-text-muted">{draft.name}</span>
-        </div>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {SLOT_META.map((slot) => (
-            <SlotEditor
-              key={slot.key}
-              slot={slot}
-              value={draft[slot.key]}
-              onChange={(hex) => updateSlot(slot.key, hex)}
-            />
-          ))}
-        </div>
-
-        <div className="mt-5 rounded-xl border border-border-muted bg-bg-secondary/40 p-3">
-          <label className="block text-3xs uppercase tracking-ui text-text-muted">
-            Paste a palette
-          </label>
-          <p className="mt-1 text-2xs text-text-muted">
-            Copy 4 hex codes from coolors.co, lospec, or anywhere — order doesn't matter.
+          <p className="text-3xs uppercase tracking-wide-ui text-text-muted">Operations</p>
+          <h2 className="mt-2 font-display text-3xl text-text-primary">Appearance</h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
+            Pick a 4-color palette to retheme the entire app. Background, Surface, Text, and Accent
+            drive every UI surface while semantic colors stay fixed.
           </p>
-          <div className="mt-2 flex gap-2">
-            <input
-              type="text"
-              value={pasteValue}
-              onChange={(e) => setPasteValue(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handlePaste();
-              }}
-              placeholder="#22293c #313a56 #dbe3f8 #a897d2"
-              className="ornate-input flex-1 font-mono text-xs"
-              spellCheck={false}
-            />
-            <button
-              type="button"
-              onClick={handlePaste}
-              disabled={!pasteValue.trim()}
-              className="shell-pill rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
-            >
-              Apply
-            </button>
+        </header>
+
+        <section className="panel-surface rounded-3xl p-5 shadow-section">
+          <h3 className="mb-3 font-display text-lg text-text-primary">Presets</h3>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-3">
+            {PRESET_THEMES.map((p) => (
+              <PresetCard
+                key={p.name}
+                preset={p}
+                active={
+                  draft.background === p.background &&
+                  draft.surface === p.surface &&
+                  draft.text === p.text &&
+                  draft.accent === p.accent
+                }
+                onSelect={() => applyPreset(p)}
+              />
+            ))}
           </div>
-          {pasteError && (
-            <p className="mt-2 text-2xs text-status-error">{pasteError}</p>
+        </section>
+
+        <section className="panel-surface rounded-3xl p-5 shadow-section">
+          <div className="mb-3 flex flex-wrap items-baseline justify-between gap-3">
+            <h3 className="font-display text-lg text-text-primary">Custom palette</h3>
+            <div className="flex items-center gap-3">
+              <span className="text-3xs uppercase tracking-ui text-text-muted">{draft.name}</span>
+              <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-3xs uppercase tracking-ui text-text-secondary">
+                {mode}
+              </span>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {SLOT_META.map((slot) => (
+              <SlotEditor
+                key={slot.key}
+                slot={slot}
+                value={draft[slot.key]}
+                onChange={(hex) => updateSlot(slot.key, hex)}
+              />
+            ))}
+          </div>
+
+          <div className="mt-5 rounded-xl border border-border-muted bg-bg-secondary/40 p-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <label className="block text-3xs uppercase tracking-ui text-text-muted">
+                  Paste a palette
+                </label>
+                <p className="mt-1 text-2xs text-text-muted">
+                  Copy 4 hex codes from coolors.co, lospec, or anywhere. The mode controls whether the darkest or lightest color becomes the page background.
+                </p>
+              </div>
+              <div className="segmented-control">
+                {(["dark", "light"] as const).map((option) => (
+                  <button
+                    key={option}
+                    type="button"
+                    data-active={pasteMode === option}
+                    onClick={() => setPasteMode(option)}
+                    className="segmented-button px-3 py-1.5 text-2xs uppercase tracking-ui"
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="mt-2 flex gap-2">
+              <input
+                type="text"
+                value={pasteValue}
+                onChange={(e) => setPasteValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handlePaste();
+                }}
+                placeholder="#22293c #313a56 #dbe3f8 #a897d2"
+                className="ornate-input flex-1 font-mono text-xs"
+                spellCheck={false}
+              />
+              <button
+                type="button"
+                onClick={handlePaste}
+                disabled={!pasteValue.trim()}
+                className="shell-pill rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
+              >
+                Apply
+              </button>
+            </div>
+            {pasteError && <p className="mt-2 text-2xs text-status-error">{pasteError}</p>}
+          </div>
+
+          {contrastWarnings.length > 0 && (
+            <div className="mt-4 rounded-xl border border-status-warning/30 bg-status-warning/10 p-3">
+              <p className="text-2xs uppercase tracking-ui text-status-warning">Readability check</p>
+              <div className="mt-2 flex flex-col gap-1.5">
+                {contrastWarnings.map((warning) => (
+                  <p key={warning} className="text-2xs text-status-warning">
+                    {warning}
+                  </p>
+                ))}
+              </div>
+            </div>
           )}
-        </div>
+        </section>
 
-        {luminanceWarning && (
-          <p className="mt-4 rounded-md border border-status-warning/30 bg-status-warning/10 p-2 text-2xs text-status-warning">
-            {luminanceWarning}
+        <section className="panel-surface rounded-3xl p-5 shadow-section">
+          <h3 className="mb-3 font-display text-lg text-text-primary">Live preview</h3>
+          <PreviewCard palette={draft} />
+          <p className="mt-3 text-2xs text-text-muted">
+            The whole app is previewing your draft right now. Save to keep it or revert to the stored palette.
           </p>
-        )}
-      </section>
+        </section>
 
-      <section className="panel-surface rounded-3xl p-5 shadow-section">
-        <h3 className="mb-3 font-display text-lg text-text-primary">Live preview</h3>
-        <PreviewCard palette={draft} />
-        <p className="mt-3 text-2xs text-text-muted">
-          The whole app is also previewing your draft right now — save to keep it, or revert.
-        </p>
-      </section>
-
-      <div className="sticky bottom-4 flex items-center justify-end gap-2 rounded-2xl border border-border-muted bg-bg-secondary/80 p-3 backdrop-blur">
-        <button
-          type="button"
-          onClick={handleReset}
-          className="shell-pill rounded-full px-4 py-1.5 text-xs"
-        >
-          Reset to default
-        </button>
-        <button
-          type="button"
-          onClick={handleRevert}
-          disabled={!dirty}
-          className="shell-pill rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
-        >
-          Revert
-        </button>
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={!dirty}
-          className="shell-pill-primary rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
-        >
-          Save theme
-        </button>
-      </div>
+        <div className="sticky bottom-4 flex items-center justify-end gap-2 rounded-2xl border border-border-muted bg-bg-secondary/80 p-3 backdrop-blur">
+          <button
+            type="button"
+            onClick={handleReset}
+            className="shell-pill rounded-full px-4 py-1.5 text-xs"
+          >
+            Reset to default
+          </button>
+          <button
+            type="button"
+            onClick={handleRevert}
+            disabled={!dirty}
+            className="shell-pill rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
+          >
+            Revert
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!dirty}
+            className="shell-pill-primary rounded-full px-4 py-1.5 text-xs disabled:opacity-40"
+          >
+            Save theme
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/creator/src/index.css
+++ b/creator/src/index.css
@@ -14,6 +14,9 @@
   --abyss-rgb: 28 33 49;
   --stroke-rgb: 255 255 255;
   --fill-rgb: 8 12 28;
+  --highlight-rgb: 255 255 255;
+  --shadow-rgb: 8 12 28;
+  --overlay-rgb: 28 33 49;
 
   /* ─── Typography ─── */
   --font-sans: 'Crimson Pro', Georgia, serif;
@@ -52,16 +55,16 @@
   --color-text-on-accent: #22293c;
 
   /* ─── Chrome (mode-aware overlays) ─── */
-  /* These reference the *-rgb tuples above so the JS theme system can flip them
-     for light themes by changing --stroke-rgb / --fill-rgb. */
+  /* These reference the *-rgb tuples above so the JS theme system can rebalance
+     strokes, fills, highlights, shadows, and overlays per mode. */
   --chrome-stroke:          rgb(var(--stroke-rgb) / 0.10);
   --chrome-stroke-strong:   rgb(var(--stroke-rgb) / 0.16);
   --chrome-stroke-emphasis: rgb(var(--stroke-rgb) / 0.22);
   --chrome-fill:            rgb(var(--fill-rgb) / 0.16);
   --chrome-fill-soft:       rgb(var(--fill-rgb) / 0.08);
   --chrome-fill-strong:     rgb(var(--fill-rgb) / 0.32);
-  --chrome-highlight:       rgb(var(--stroke-rgb) / 0.06);
-  --chrome-highlight-strong: rgb(var(--stroke-rgb) / 0.12);
+  --chrome-highlight:       rgb(var(--highlight-rgb) / 0.06);
+  --chrome-highlight-strong: rgb(var(--highlight-rgb) / 0.12);
 
   /* ─── Surfaces ─── */
   --color-surface-card: rgb(var(--surface-rgb) / 0.6);
@@ -169,8 +172,8 @@
   --glow-blue:          0 0 24px rgb(var(--accent-rgb) / 0.22);
 
   /* Shadows */
-  --shadow-section:  0 16px 44px rgb(var(--fill-rgb) / 0.24);
-  --shadow-panel:    0 18px 60px rgb(var(--fill-rgb) / 0.38);
+  --shadow-section:  0 16px 44px rgb(var(--shadow-rgb) / 0.24);
+  --shadow-panel:    0 18px 60px rgb(var(--shadow-rgb) / 0.38);
   --shadow-glow:     0 10px 26px rgb(var(--accent-rgb) / 0.22);
 
   /* Easing */
@@ -549,7 +552,7 @@ select,
   padding: 1.25rem;
   background:
     radial-gradient(circle at top, rgb(var(--accent-rgb) / 0.12), transparent 34%),
-    rgb(var(--abyss-rgb) / 0.76);
+    rgb(var(--overlay-rgb) / 0.72);
   backdrop-filter: blur(14px);
 }
 

--- a/creator/src/lib/__tests__/theme.test.ts
+++ b/creator/src/lib/__tests__/theme.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_THEME,
+  PRESET_THEMES,
+  contrastRatio,
+  rgbTuple,
+  themeToVars,
+} from "@/lib/theme";
+
+describe("themeToVars", () => {
+  it("keeps the default palette in dark mode", () => {
+    const vars = themeToVars(DEFAULT_THEME);
+
+    expect(vars["--theme-mode"]).toBe("dark");
+    expect(vars["--shadow-rgb"]).toBe("0 0 0");
+    expect(vars["--overlay-rgb"]).toBe(rgbTuple(vars["--color-bg-abyss"]));
+    expect(vars["--color-text-on-accent"]).toBe(DEFAULT_THEME.background);
+  });
+
+  it("derives stronger shadows and overlays for light themes", () => {
+    const parchment = PRESET_THEMES.find((theme) => theme.name === "Parchment (light)");
+    expect(parchment).toBeDefined();
+
+    const vars = themeToVars(parchment!);
+
+    expect(vars["--theme-mode"]).toBe("light");
+    expect(vars["--shadow-rgb"]).toBe(rgbTuple(parchment!.text));
+    expect(vars["--overlay-rgb"]).toBe(rgbTuple(parchment!.text));
+    expect(vars["--fill-rgb"]).not.toBe("255 255 255");
+    expect(vars["--color-text-on-accent"]).toBe(parchment!.background);
+  });
+});
+
+describe("contrastRatio", () => {
+  it("reports strong contrast for the default text/background pair", () => {
+    expect(contrastRatio(DEFAULT_THEME.background, DEFAULT_THEME.text)).toBeGreaterThan(9);
+  });
+});

--- a/creator/src/lib/theme.ts
+++ b/creator/src/lib/theme.ts
@@ -1,21 +1,21 @@
-// ─── Theme system ───────────────────────────────────────────────────
+// Theme system
 // 4-color theme palettes derive the full set of CSS custom properties used
 // throughout the app. The user picks (or pastes) Background, Surface, Text,
-// and Accent — everything else is derived from those four anchors.
+// and Accent. Everything else is derived from those four anchors.
 //
 // Status colors, class identity colors, lore template colors, diff colors,
-// and chart colors are intentionally NOT themed — they are semantic.
+// and chart colors are intentionally NOT themed. They are semantic.
 
 export interface ThemePalette {
   /** Name shown in the UI. */
   name: string;
-  /** Darkest color — drives the abyss / page background. */
+  /** Background anchor. Drives the page and large chrome surfaces. */
   background: string;
-  /** Mid surface — drives panels, sections, hover states, borders. */
+  /** Mid surface. Drives panels, sections, hover states, and borders. */
   surface: string;
-  /** Light color — drives primary text. */
+  /** Primary text anchor. */
   text: string;
-  /** Saturated pop — drives accent, links, glows, active states. */
+  /** Saturated pop. Drives accent, links, glows, and active states. */
   accent: string;
 }
 
@@ -74,7 +74,7 @@ export const PRESET_THEMES: ThemePalette[] = [
   },
 ];
 
-// ─── Color math ─────────────────────────────────────────────────────
+// Color math
 
 export interface RGB {
   r: number;
@@ -105,7 +105,7 @@ export function rgbTuple(hex: string): string {
   return `${Math.round(r)} ${Math.round(g)} ${Math.round(b)}`;
 }
 
-/** Linearly mix two hex colors. t=0 → a, t=1 → b. */
+/** Linearly mix two hex colors. t=0 -> a, t=1 -> b. */
 export function mix(a: string, b: string, t: number): string {
   const ra = hexToRgb(a);
   const rb = hexToRgb(b);
@@ -126,7 +126,14 @@ export function luminance(hex: string): number {
   return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
 }
 
-// ─── Derivation ─────────────────────────────────────────────────────
+/** WCAG contrast ratio between two hex colors. */
+export function contrastRatio(a: string, b: string): number {
+  const lighter = Math.max(luminance(a), luminance(b));
+  const darker = Math.min(luminance(a), luminance(b));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// Derivation
 
 /** Build the full CSS-variable map from a 4-color palette. */
 export function themeToVars(theme: ThemePalette): Record<string, string> {
@@ -135,67 +142,79 @@ export function themeToVars(theme: ThemePalette): Record<string, string> {
   const text = theme.text;
   const accent = theme.accent;
 
-  // Detect light vs dark theme so chrome stroke/fill colors flip orientation.
-  // For a dark theme we use white-tinted strokes and dark fills; for a light
-  // theme we use dark-tinted strokes and light fills.
+  // Determine whether the palette is light-on-dark or dark-on-light from the
+  // relationship between the background and text anchors.
   const bgLum = luminance(bg);
-  const isLight = bgLum > 0.5;
+  const textLum = luminance(text);
+  const isLight = bgLum >= textLum;
 
-  // Background ramp: darker (or lighter) than bg for the abyss, then surface,
-  // with lighter variants mixed toward the surface color.
-  const abyss = isLight ? mix(bg, "#ffffff", 0.18) : mix(bg, "#000000", 0.18);
+  // Background ramp.
+  const abyss = isLight ? mix(bg, text, 0.10) : mix(bg, "#000000", 0.18);
   const bgPrimary = bg;
-  const bgSecondary = mix(bg, surface, 0.4);
+  const bgSecondary = isLight ? mix(bg, surface, 0.62) : mix(bg, surface, 0.4);
   const bgTertiary = surface;
-  const bgElevated = surface;
-  const bgHover = mix(surface, text, 0.08);
+  const bgElevated = isLight ? mix(surface, "#ffffff", 0.14) : surface;
+  const bgHover = isLight ? mix(surface, text, 0.10) : mix(surface, text, 0.08);
 
   // Borders.
-  const borderMuted = mix(surface, text, 0.05);
-  const borderDefault = mix(surface, text, 0.18);
+  const borderMuted = isLight ? mix(surface, text, 0.10) : mix(surface, text, 0.05);
+  const borderDefault = isLight ? mix(surface, text, 0.22) : mix(surface, text, 0.18);
   const borderFocus = accent;
 
   // Text ramp.
   const textPrimary = text;
-  const textSecondary = mix(text, bg, 0.22);
-  const textMuted = mix(text, bg, 0.42);
+  const textSecondary = isLight ? mix(text, bg, 0.14) : mix(text, bg, 0.22);
+  const textMuted = isLight ? mix(text, bg, 0.32) : mix(text, bg, 0.42);
 
   // Accent variants.
-  const accentMuted = mix(accent, bg, 0.22);
+  const accentMuted = mix(accent, bg, isLight ? 0.18 : 0.22);
   const accentEmphasis = text;
 
-  // Warm: tracks accent (since 4-color palettes give us only one pop color).
+  // Warm accent follows the single accent anchor.
   const warm = accent;
   const warmPale = mix(accent, text, 0.38);
   const warmDeep = mix(accent, bg, 0.42);
 
-  // Surface scrims (panel backdrops).
-  const scrim = rgba(bg, 0.72);
-  const scrimLight = rgba(bg, 0.46);
+  // Surface scrims.
+  const scrim = isLight ? rgba(mix(surface, text, 0.08), 0.84) : rgba(bg, 0.72);
+  const scrimLight = isLight ? rgba(mix(surface, bg, 0.40), 0.72) : rgba(bg, 0.46);
 
   // Graph backgrounds.
-  const graphBg = isLight ? mix(bg, "#ffffff", 0.18) : mix(bg, "#000000", 0.32);
-  const graphGrid = mix(bg, surface, 0.5);
+  const graphBg = isLight ? mix(bg, text, 0.06) : mix(bg, "#000000", 0.32);
+  const graphGrid = isLight ? mix(bg, text, 0.18) : mix(bg, surface, 0.5);
   const graphNode = surface;
-  const graphEdge = mix(surface, text, 0.32);
+  const graphEdge = mix(surface, text, isLight ? 0.44 : 0.32);
   const graphEdgeUp = accent;
 
-  // Pick a text color that contrasts with accent for "on accent" surfaces
-  // (e.g. primary buttons that fill with accent).
-  const accentLum = luminance(accent);
-  const textOnAccent = accentLum > 0.55 ? bg : text;
+  // Choose whichever anchor contrasts more strongly on accent-filled surfaces.
+  const textOnAccent = contrastRatio(accent, text) >= contrastRatio(accent, bg)
+    ? text
+    : bg;
 
-  // Chrome stroke/fill orientation. On dark themes, strokes are light overlays
-  // and fills are dark overlays (using #ffffff and #000000). On light themes
-  // we flip both.
-  const strokeColor = isLight ? "#000000" : "#ffffff";
-  const fillColor = isLight ? "#ffffff" : "#000000";
+  // Chrome tokens. Light themes lean on inked overlays and real shadows
+  // instead of whitening everything into haze.
+  const strokeColor = text;
+  const fillColor = isLight ? mix(surface, text, 0.16) : mix(bg, "#000000", 0.72);
+  const highlightColor = isLight ? text : "#ffffff";
+  const shadowColor = isLight ? text : "#000000";
+  const overlayColor = isLight ? text : abyss;
+
+  const panelTop = isLight ? mix(surface, "#ffffff", 0.14) : surface;
+  const panelBottom = isLight ? mix(bg, text, 0.04) : bg;
+  const panelLightTop = isLight ? mix(surface, "#ffffff", 0.24) : surface;
+  const panelLightBottom = isLight ? mix(bg, text, 0.02) : bg;
+
+  const activeStart = isLight ? 0.18 : 0.16;
+  const activeEnd = isLight ? 0.09 : 0.10;
+  const activeStrongStart = isLight ? 0.26 : 0.22;
+  const activeStrongEnd = isLight ? 0.15 : 0.14;
+  const glowTopAlpha = isLight ? 0.12 : 0.18;
+  const bodyGlowPrimary = isLight ? 0.10 : 0.18;
+  const bodyGlowSecondary = isLight ? 0.06 : 0.10;
 
   return {
-    // ─── Mode flag ──────────────────────────────────────────
     "--theme-mode": isLight ? "light" : "dark",
 
-    // ─── RGB tuples (used with `rgb(var(--x-rgb) / alpha)`) ─
     "--bg-rgb": rgbTuple(bg),
     "--surface-rgb": rgbTuple(surface),
     "--text-rgb": rgbTuple(text),
@@ -203,8 +222,10 @@ export function themeToVars(theme: ThemePalette): Record<string, string> {
     "--abyss-rgb": rgbTuple(abyss),
     "--stroke-rgb": rgbTuple(strokeColor),
     "--fill-rgb": rgbTuple(fillColor),
+    "--highlight-rgb": rgbTuple(highlightColor),
+    "--shadow-rgb": rgbTuple(shadowColor),
+    "--overlay-rgb": rgbTuple(overlayColor),
 
-    // ─── Backgrounds ─────────────────────────────────────
     "--color-bg-abyss": abyss,
     "--color-bg-primary": bgPrimary,
     "--color-bg-secondary": bgSecondary,
@@ -212,13 +233,11 @@ export function themeToVars(theme: ThemePalette): Record<string, string> {
     "--color-bg-elevated": bgElevated,
     "--color-bg-hover": bgHover,
 
-    // ─── Borders ─────────────────────────────────────────
     "--color-border-default": borderDefault,
     "--color-border-muted": borderMuted,
     "--color-border-focus": borderFocus,
     "--color-border-active": rgba(accent, 0.35),
 
-    // ─── Text ────────────────────────────────────────────
     "--color-text-primary": textPrimary,
     "--color-text-secondary": textSecondary,
     "--color-text-muted": textMuted,
@@ -226,66 +245,62 @@ export function themeToVars(theme: ThemePalette): Record<string, string> {
     "--color-text-dirty": mix(accent, text, 0.3),
     "--color-text-on-accent": textOnAccent,
 
-    // ─── Accent ──────────────────────────────────────────
     "--color-accent": accent,
     "--color-accent-muted": accentMuted,
     "--color-accent-emphasis": accentEmphasis,
 
-    // ─── Warm (decorative, tracks accent) ────────────────
     "--color-warm": warm,
     "--color-warm-pale": warmPale,
     "--color-warm-deep": warmDeep,
 
-    // ─── Surfaces ────────────────────────────────────────
     "--color-surface-scrim": scrim,
     "--color-surface-scrim-light": scrimLight,
     "--color-surface-card": rgba(mix(surface, text, 0.05), 0.6),
 
-    // ─── Chrome (mode-aware overlays) ────────────────────
-    // Borders / strokes
-    "--chrome-stroke": `rgb(var(--stroke-rgb) / 0.10)`,
-    "--chrome-stroke-strong": `rgb(var(--stroke-rgb) / 0.16)`,
-    "--chrome-stroke-emphasis": `rgb(var(--stroke-rgb) / 0.22)`,
-    // Fills
-    "--chrome-fill": `rgb(var(--fill-rgb) / 0.16)`,
-    "--chrome-fill-soft": `rgb(var(--fill-rgb) / 0.08)`,
-    "--chrome-fill-strong": `rgb(var(--fill-rgb) / 0.32)`,
-    // Highlights (top edges, hover lifts) — always biased to the strong side
-    "--chrome-highlight": `rgb(var(--stroke-rgb) / 0.06)`,
-    "--chrome-highlight-strong": `rgb(var(--stroke-rgb) / 0.12)`,
+    "--chrome-stroke": "rgb(var(--stroke-rgb) / 0.10)",
+    "--chrome-stroke-strong": "rgb(var(--stroke-rgb) / 0.16)",
+    "--chrome-stroke-emphasis": "rgb(var(--stroke-rgb) / 0.22)",
+    "--chrome-fill": "rgb(var(--fill-rgb) / 0.16)",
+    "--chrome-fill-soft": "rgb(var(--fill-rgb) / 0.08)",
+    "--chrome-fill-strong": "rgb(var(--fill-rgb) / 0.32)",
+    "--chrome-highlight": "rgb(var(--highlight-rgb) / 0.06)",
+    "--chrome-highlight-strong": "rgb(var(--highlight-rgb) / 0.12)",
 
-    // ─── Graph (zone map) ────────────────────────────────
     "--color-graph-bg": graphBg,
     "--color-graph-grid": graphGrid,
     "--color-graph-node": graphNode,
     "--color-graph-edge": graphEdge,
     "--color-graph-edge-up": graphEdgeUp,
 
-    // ─── Derived rgba tokens (the :root block) ───────────
-    "--glow-accent": `0 0 32px rgb(var(--accent-rgb) / 0.28)`,
-    "--glow-accent-strong": `0 0 48px rgb(var(--text-rgb) / 0.32)`,
-    "--glow-warm": `0 0 32px rgb(var(--accent-rgb) / 0.32)`,
+    "--glow-accent": "0 0 32px rgb(var(--accent-rgb) / 0.28)",
+    "--glow-accent-strong": isLight
+      ? "0 0 40px rgb(var(--accent-rgb) / 0.18)"
+      : "0 0 48px rgb(var(--text-rgb) / 0.32)",
+    "--glow-warm": "0 0 32px rgb(var(--accent-rgb) / 0.32)",
     "--glow-warm-strong": `0 0 48px ${rgba(warmPale, 0.42)}`,
-    "--glow-violet": `0 0 28px rgb(var(--accent-rgb) / 0.24)`,
-    "--glow-blue": `0 0 24px rgb(var(--accent-rgb) / 0.22)`,
+    "--glow-violet": "0 0 28px rgb(var(--accent-rgb) / 0.24)",
+    "--glow-blue": "0 0 24px rgb(var(--accent-rgb) / 0.22)",
 
-    "--border-accent-ring": `rgb(var(--accent-rgb) / 0.45)`,
-    "--border-accent-subtle": `rgb(var(--accent-rgb) / 0.35)`,
-    "--border-glow": `rgb(var(--text-rgb) / 0.25)`,
-    "--border-glow-strong": `rgb(var(--text-rgb) / 0.48)`,
+    "--border-accent-ring": "rgb(var(--accent-rgb) / 0.45)",
+    "--border-accent-subtle": "rgb(var(--accent-rgb) / 0.35)",
+    "--border-glow": isLight
+      ? "rgb(var(--accent-rgb) / 0.22)"
+      : "rgb(var(--text-rgb) / 0.25)",
+    "--border-glow-strong": isLight
+      ? "rgb(var(--accent-rgb) / 0.36)"
+      : "rgb(var(--text-rgb) / 0.48)",
 
-    "--bg-accent-subtle": `rgb(var(--accent-rgb) / 0.14)`,
-    "--bg-accent-hover": `rgb(var(--accent-rgb) / 0.20)`,
+    "--bg-accent-subtle": "rgb(var(--accent-rgb) / 0.14)",
+    "--bg-accent-hover": "rgb(var(--accent-rgb) / 0.20)",
 
-    "--bg-active": `linear-gradient(135deg, rgb(var(--accent-rgb) / 0.16), rgb(var(--accent-rgb) / 0.10))`,
-    "--bg-active-strong": `linear-gradient(135deg, rgb(var(--accent-rgb) / 0.22), rgb(var(--accent-rgb) / 0.14))`,
-    "--bg-panel": `linear-gradient(160deg, rgb(var(--surface-rgb) / 0.95), rgb(var(--bg-rgb) / 0.92))`,
-    "--bg-panel-light": `linear-gradient(160deg, rgb(var(--surface-rgb) / 0.85), rgb(var(--bg-rgb) / 0.85))`,
-    "--bg-glow-top": `linear-gradient(180deg, rgb(var(--accent-rgb) / 0.18), transparent)`,
+    "--bg-active": `linear-gradient(135deg, rgb(var(--accent-rgb) / ${activeStart}), rgb(var(--accent-rgb) / ${activeEnd}))`,
+    "--bg-active-strong": `linear-gradient(135deg, rgb(var(--accent-rgb) / ${activeStrongStart}), rgb(var(--accent-rgb) / ${activeStrongEnd}))`,
+    "--bg-panel": `linear-gradient(160deg, ${rgba(panelTop, 0.96)}, ${rgba(panelBottom, 0.92)})`,
+    "--bg-panel-light": `linear-gradient(160deg, ${rgba(panelLightTop, 0.88)}, ${rgba(panelLightBottom, 0.88)})`,
+    "--bg-glow-top": `linear-gradient(180deg, rgb(var(--accent-rgb) / ${glowTopAlpha}), transparent)`,
     "--graph-minimap-mask": rgba(graphBg, 0.8),
 
-    // ─── Body background gradients ───────────────────────
-    "--body-bg": `radial-gradient(circle at 14% 12%, rgb(var(--accent-rgb) / 0.18), transparent 36%), radial-gradient(circle at 84% 14%, rgb(var(--accent-rgb) / 0.10), transparent 34%), linear-gradient(180deg, ${bgPrimary} 0%, ${abyss} 100%)`,
+    "--body-bg": `radial-gradient(circle at 14% 12%, rgb(var(--accent-rgb) / ${bodyGlowPrimary}), transparent 36%), radial-gradient(circle at 84% 14%, rgb(var(--accent-rgb) / ${bodyGlowSecondary}), transparent 34%), linear-gradient(180deg, ${bgPrimary} 0%, ${abyss} 100%)`,
   };
 }
 
@@ -306,7 +321,7 @@ export function clearTheme(): void {
   }
 }
 
-// ─── Persistence ────────────────────────────────────────────────────
+// Persistence
 
 const STORAGE_KEY = "arcanum.theme.v1";
 


### PR DESCRIPTION
## Summary
- rebalance derived theme tokens so light palettes keep readable contrast, stronger panel separation, and darker overlays/shadows
- update global CSS chrome to use the new highlight, shadow, and overlay tokens
- make the Appearance panel aware of light vs dark palette interpretation and add contrast warnings
- add theme regression tests for dark and light palettes

## Testing
- bunx tsc --noEmit
- bun run test