### PR TITLE
Harden and adapt the tuning wizard

### DIFF
--- a/creator/src/components/tuning/ApplyFooterBar.tsx
+++ b/creator/src/components/tuning/ApplyFooterBar.tsx
@@ -17,10 +17,12 @@ export function ApplyFooterBar() {
   const acceptedSections = useTuningWizardStore((s) => s.acceptedSections);
   const undoAvailable = useTuningWizardStore((s) => s.undoAvailable);
   const applySuccess = useTuningWizardStore((s) => s.applySuccess);
+  const actionError = useTuningWizardStore((s) => s.actionError);
   const applyPreset = useTuningWizardStore((s) => s.applyPreset);
   const undoApply = useTuningWizardStore((s) => s.undoApply);
   const resetWizard = useTuningWizardStore((s) => s.resetWizard);
   const clearApplySuccess = useTuningWizardStore((s) => s.clearApplySuccess);
+  const clearActionError = useTuningWizardStore((s) => s.clearActionError);
 
   const [applying, setApplying] = useState(false);
   const acceptedCount = acceptedSections.size;
@@ -43,34 +45,42 @@ export function ApplyFooterBar() {
   }
 
   return (
-    <div className="sticky bottom-0 z-10 border-t border-border-muted bg-bg-primary px-6 py-3 shadow-[0_-4px_16px_rgba(8,10,18,0.3)] animate-unfurl-in">
-      <div className="flex items-center justify-between">
+    <div className="sticky bottom-0 z-10 border-t border-border-muted bg-bg-primary/95 px-6 py-3 shadow-section backdrop-blur-sm animate-unfurl-in">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         {/* Left: section count summary + success flash */}
-        <div className="flex items-center">
+        <div className="flex min-w-0 flex-col gap-1 sm:flex-row sm:items-center">
           <span className="font-sans text-sm text-text-secondary">
             {acceptedCount} of {totalSections} sections selected
           </span>
           {applySuccess && (
-            <span className="ml-3 font-sans text-sm font-semibold text-status-success animate-saved-flash">
+            <span className="font-sans text-sm font-semibold text-status-success animate-saved-flash sm:ml-3">
               Applied!
+            </span>
+          )}
+          {actionError && (
+            <span role="alert" className="font-sans text-sm text-status-error sm:ml-3">
+              {actionError}
             </span>
           )}
         </div>
 
         {/* Right: action buttons */}
-        <div className="flex items-center gap-3">
-          <ActionButton variant="ghost" onClick={resetWizard}>
+        <div className="flex flex-wrap items-center gap-3">
+          <ActionButton variant="ghost" onClick={() => { clearActionError(); resetWizard(); }}>
             Reset
           </ActionButton>
           {undoAvailable && (
-            <ActionButton variant="secondary" onClick={undoApply}>
+            <ActionButton variant="secondary" onClick={() => { clearActionError(); void undoApply(); }}>
               Undo
             </ActionButton>
           )}
           <ActionButton
             variant="primary"
             disabled={acceptedCount === 0 || applying}
-            onClick={handleApply}
+            onClick={() => {
+              clearActionError();
+              void handleApply();
+            }}
           >
             {applying ? (
               <>

--- a/creator/src/components/tuning/HealthCheckBanner.tsx
+++ b/creator/src/components/tuning/HealthCheckBanner.tsx
@@ -11,10 +11,14 @@ export function HealthCheckBanner() {
   if (healthWarnings.length === 0) return null;
 
   return (
-    <div className="mx-6 mt-4 rounded-lg border border-status-warning/30 bg-status-warning/[0.08] px-4 py-3 animate-unfurl-in">
+    <div
+      role="status"
+      aria-live="polite"
+      className="mx-6 mt-4 rounded-[1.25rem] border border-status-warning/30 bg-status-warning/[0.08] px-4 py-3 animate-unfurl-in"
+    >
       <div className="flex items-start gap-3">
         {/* Warning icon */}
-        <span className="text-status-warning">&#9888;</span>
+        <span aria-hidden="true" className="text-status-warning">&#9888;</span>
         {/* Warning content */}
         <div className="min-w-0 flex-1">
           <h4 className="font-sans text-sm font-semibold text-status-warning">
@@ -30,6 +34,7 @@ export function HealthCheckBanner() {
         <button
           type="button"
           onClick={() => setHealthWarnings([])}
+          aria-label="Dismiss balance warnings"
           className="ml-auto shrink-0 text-text-muted hover:text-text-primary"
         >
           &#10005;

--- a/creator/src/components/tuning/MetricCard.tsx
+++ b/creator/src/components/tuning/MetricCard.tsx
@@ -2,8 +2,7 @@
 // Single KPI card for one TuningSection. Shows 2-3 curated derived
 // metrics with current vs preset values and delta badges.
 
-import { useRef, useEffect, useMemo } from "react";
-import tippy from "tippy.js";
+import { useMemo } from "react";
 import { TuningSection } from "@/lib/tuning/types";
 import type { MetricSnapshot } from "@/lib/tuning/types";
 import { pctDelta, deltaDirection, deltaColor } from "@/lib/tuning/deltaUtils";
@@ -53,20 +52,6 @@ function MetricRow({
   formulaTooltip,
   showHeader,
 }: MetricRowData & { showHeader?: boolean }) {
-  const labelRef = useRef<HTMLSpanElement>(null);
-
-  useEffect(() => {
-    if (!labelRef.current || !formulaTooltip) return;
-    const t = tippy(labelRef.current, {
-      content: formulaTooltip,
-      theme: "arcanum",
-      placement: "top-start",
-      delay: [200, 100],
-      maxWidth: 260,
-    });
-    return () => t.destroy();
-  }, [formulaTooltip]);
-
   const dir = deltaDirection(current, preset);
   const color = deltaColor(dir);
   const delta = pctDelta(current, preset);
@@ -74,27 +59,29 @@ function MetricRow({
   return (
     <div>
       {showHeader && (
-        <div className="mb-1 flex items-baseline justify-between gap-2">
+        <div className="mb-1 grid grid-cols-[minmax(0,1fr)_auto_auto] items-baseline gap-2">
           <span className="flex-1" />
-          <span className="w-[72px] text-right font-sans text-[12px] uppercase tracking-wide text-text-muted">
+          <span className="text-right font-sans text-[12px] uppercase tracking-wide text-text-muted">
             Current
           </span>
-          <span className="w-[110px] text-right font-sans text-[12px] uppercase tracking-wide text-text-muted">
+          <span className="text-right font-sans text-[12px] uppercase tracking-wide text-text-muted">
             Preset
           </span>
         </div>
       )}
-      <div className="flex items-baseline justify-between gap-2 py-1">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-baseline gap-2 py-1">
         <span
-          ref={labelRef}
-          className="flex-1 cursor-default font-sans text-[14px] text-text-secondary"
+          tabIndex={0}
+          title={formulaTooltip}
+          aria-label={`${label}. ${formulaTooltip}`}
+          className="focus-ring rounded-sm font-sans text-[14px] text-text-secondary"
         >
           {label}
         </span>
-        <span className="w-[72px] text-right font-mono text-[13px] text-text-muted">
+        <span className="text-right font-mono text-[13px] text-text-muted">
           {format(current)}
         </span>
-        <span className={`w-[110px] text-right font-mono text-[13px] ${color}`}>
+        <span className={`text-right font-mono text-[13px] ${color}`}>
           {format(preset)}{" "}
           {dir !== "same" ? delta : "\u2014"}
         </span>
@@ -201,7 +188,7 @@ export function MetricCard({ section, currentMetrics, presetMetrics, diffCount }
   );
 
   return (
-    <div className="rounded-xl border border-border-muted bg-bg-secondary p-4">
+    <div className="panel-surface rounded-[1.5rem] p-4">
       <h3 className="mb-2 font-display text-[14px] font-normal uppercase tracking-[0.5px] text-text-secondary">
         {section}
       </h3>

--- a/creator/src/components/tuning/MetricSectionCards.tsx
+++ b/creator/src/components/tuning/MetricSectionCards.tsx
@@ -25,7 +25,7 @@ export function MetricSectionCards({
   diffCounts,
 }: MetricSectionCardsProps) {
   return (
-    <div className="animate-unfurl-in mt-6 mb-6 grid grid-cols-2 gap-4 px-6">
+    <div className="animate-unfurl-in mb-6 mt-6 grid grid-cols-1 gap-4 px-6 xl:grid-cols-2">
       {CARD_ORDER.map((section) => (
         <MetricCard
           key={section}

--- a/creator/src/components/tuning/ParameterRow.tsx
+++ b/creator/src/components/tuning/ParameterRow.tsx
@@ -2,10 +2,9 @@
 // Single parameter row showing label with tooltip, current value (editable),
 // optional preset value with diff highlighting and percentage delta.
 
-import { useRef, useEffect, useState } from "react";
-import tippy from "tippy.js";
+import { useState } from "react";
 import type { FieldMeta } from "@/lib/tuning/types";
-import { pctDelta, deltaDirection, deltaColor, buildTooltipContent } from "@/lib/tuning/deltaUtils";
+import { pctDelta, deltaDirection, deltaColor, buildTooltipText } from "@/lib/tuning/deltaUtils";
 
 interface ParameterRowProps {
   path: string;
@@ -38,27 +37,12 @@ export function ParameterRow({
   even,
   onValueChange,
 }: ParameterRowProps) {
-  const labelRef = useRef<HTMLSpanElement>(null);
   const [editingValue, setEditingValue] = useState<string | null>(null);
-
-  // Tooltip on field label (D-10, D-11, UI-04)
-  useEffect(() => {
-    if (!labelRef.current) return;
-    const content = buildTooltipContent(meta);
-    const instance = tippy(labelRef.current, {
-      content,
-      allowHTML: true,
-      theme: "arcanum",
-      placement: "top-start",
-      delay: [250, 100],
-      maxWidth: 280,
-    });
-    return () => instance.destroy();
-  }, [meta.description, meta.interactionNote, meta.impact]);
+  const tooltipText = buildTooltipText(meta);
 
   const gridCols = hasPreset
-    ? "grid-cols-[1.2fr_100px_140px_1.5fr]"
-    : "grid-cols-[1.2fr_120px_1.5fr]";
+    ? "md:grid-cols-[minmax(0,1.35fr)_minmax(120px,auto)] xl:grid-cols-[minmax(0,1.15fr)_100px_140px_minmax(0,1.5fr)]"
+    : "md:grid-cols-[minmax(0,1.35fr)_minmax(120px,auto)] xl:grid-cols-[minmax(0,1.2fr)_120px_minmax(0,1.5fr)]";
 
   const rowHighlight =
     isChanged && presetAccentBorder ? `border-l-2 ${presetAccentBorder}` : "";
@@ -121,7 +105,8 @@ export function ParameterRow({
           type="checkbox"
           checked={currentValue as boolean}
           onChange={handleToggleBoolean}
-          className="h-3.5 w-3.5 cursor-pointer accent-accent"
+          aria-label={`Toggle ${meta.label}`}
+          className="h-4 w-4 cursor-pointer accent-accent"
         />
       </label>
     );
@@ -139,7 +124,8 @@ export function ParameterRow({
           if (e.key === "Escape") setEditingValue(null);
         }}
         onFocus={() => setEditingValue(String(currentValue))}
-        className="w-full rounded bg-transparent text-right font-mono text-sm text-text-secondary outline-none ring-1 ring-transparent transition-colors focus:ring-accent/50 hover:ring-white/20 px-1.5 py-0.5"
+        aria-label={`Edit ${meta.label}`}
+        className="min-h-11 w-full rounded bg-transparent px-1.5 py-0.5 text-right font-mono text-sm text-text-secondary outline-none ring-1 ring-transparent transition-colors hover:ring-white/20 focus:ring-accent/50"
       />
     );
   } else {
@@ -152,12 +138,14 @@ export function ParameterRow({
 
   return (
     <div
-      className={`grid min-h-[40px] items-center gap-x-4 py-2 px-2 transition-colors duration-200 hover:bg-bg-hover ${gridCols} ${rowHighlight} ${stripe}`}
+      className={`grid min-h-[40px] grid-cols-1 gap-x-4 gap-y-2 px-2 py-3 transition-colors duration-200 hover:bg-bg-hover ${gridCols} ${rowHighlight} ${stripe}`}
     >
       {/* Label with tooltip */}
       <span
-        ref={labelRef}
-        className="cursor-default font-sans text-[15px] font-semibold text-text-primary"
+        tabIndex={0}
+        title={tooltipText}
+        aria-label={`${meta.label}. ${tooltipText}`}
+        className="focus-ring rounded-sm font-sans text-[15px] font-semibold text-text-primary"
       >
         {meta.label}
       </span>
@@ -173,7 +161,7 @@ export function ParameterRow({
       )}
 
       {/* Description */}
-      <span className="truncate font-sans text-sm text-text-muted">
+      <span className="font-sans text-sm leading-5 text-text-muted md:col-span-2 xl:col-auto">
         {meta.description}
       </span>
     </div>

--- a/creator/src/components/tuning/ParameterSection.tsx
+++ b/creator/src/components/tuning/ParameterSection.tsx
@@ -41,6 +41,9 @@ export function ParameterSection({
   presetAccentBorder,
   onValueChange,
 }: ParameterSectionProps) {
+  const sectionSlug = section.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const regionId = `tuning-section-${sectionSlug}`;
+  const titleId = `${regionId}-title`;
   const changedCount = useMemo(
     () => fields.filter(([path]) => diffMap.has(path)).length,
     [fields, diffMap],
@@ -52,6 +55,8 @@ export function ParameterSection({
       <button
         type="button"
         onClick={onToggleCollapsed}
+        aria-expanded={!isCollapsed}
+        aria-controls={regionId}
         className="flex w-full cursor-pointer items-center gap-3 border-t border-border-muted py-3"
       >
         {/* Section acceptance checkbox (D-01) */}
@@ -61,12 +66,15 @@ export function ParameterSection({
             checked={isAccepted}
             onClick={(e) => e.stopPropagation()}
             onChange={onToggleAccepted}
-            className="h-4 w-4 cursor-pointer accent-accent"
+            aria-labelledby={titleId}
+            aria-label={`Include ${section} when applying the preset`}
+            className="h-5 w-5 cursor-pointer accent-accent"
           />
         )}
 
         {/* Chevron */}
         <span
+          aria-hidden="true"
           className={`inline-block text-text-muted transition-transform duration-200 ${
             isCollapsed ? "rotate-0" : "rotate-90"
           }`}
@@ -75,7 +83,7 @@ export function ParameterSection({
         </span>
 
         {/* Section name */}
-        <span className="font-display text-sm uppercase tracking-[0.5px] text-text-secondary">
+        <span id={titleId} className="font-display text-sm uppercase tracking-[0.5px] text-text-secondary">
           {section}
         </span>
 
@@ -94,7 +102,7 @@ export function ParameterSection({
 
       {/* Parameter rows */}
       {!isCollapsed && (
-        <div>
+        <div id={regionId} role="region" aria-labelledby={titleId}>
           {fields.map(([path, meta], idx) => {
             const diff = diffMap.get(path);
             const currentValue = getNestedValue(currentConfig, path);

--- a/creator/src/components/tuning/PresetCard.tsx
+++ b/creator/src/components/tuning/PresetCard.tsx
@@ -113,9 +113,11 @@ export function PresetCard({ preset, metrics, isSelected, isDimmed, onSelect }: 
     <button
       type="button"
       onClick={onSelect}
+      aria-pressed={isSelected}
+      aria-label={`${preset.name} preset${isSelected ? ", selected" : ""}`}
       className={[
-        "max-w-[320px] w-full rounded-xl border p-6 text-left",
-        "bg-bg-tertiary cursor-pointer",
+        "focus-ring panel-surface relative w-full overflow-hidden rounded-[1.75rem] p-6 text-left",
+        "min-h-[16rem] cursor-pointer",
         "transition-[color,background-color,border-color,box-shadow,opacity] duration-200 hover:bg-bg-hover",
         borderClass,
         glowClass,
@@ -124,7 +126,11 @@ export function PresetCard({ preset, metrics, isSelected, isDimmed, onSelect }: 
         .filter(Boolean)
         .join(" ")}
     >
+      <div className="pointer-events-none absolute inset-x-5 top-0 h-px bg-gradient-to-r from-transparent via-accent/45 to-transparent opacity-70" />
       <div className="flex flex-col gap-4">
+        <p className={`font-display text-2xs uppercase tracking-wide-ui ${accent.text}`}>
+          Tuning preset
+        </p>
         {/* Preset name */}
         <h3 className="font-display text-lg font-semibold leading-[1.2] tracking-[0.5px] text-text-primary">
           {preset.name}

--- a/creator/src/components/tuning/SearchFilterBar.tsx
+++ b/creator/src/components/tuning/SearchFilterBar.tsx
@@ -32,18 +32,19 @@ export function SearchFilterBar() {
   }, [searchQuery]);
 
   return (
-    <div className="sticky top-0 z-10 mt-12 mb-6 flex items-center gap-4 border-b border-border-muted bg-bg-primary px-6 pb-4">
+    <div className="sticky top-0 z-10 mt-12 mb-6 flex flex-wrap items-center gap-3 border-b border-border-muted bg-bg-primary/95 px-6 pb-4 pt-2 backdrop-blur-sm">
       {/* Search input */}
       <input
         type="text"
         value={localQuery}
         onChange={(e) => setLocalQuery(e.target.value)}
         placeholder="Search parameters..."
-        className="ornate-input flex-1 rounded px-3 py-2 font-sans text-[15px] text-text-primary"
+        aria-label="Search tuning parameters"
+        className="ornate-input min-h-11 min-w-[16rem] flex-1 rounded px-3 py-2 font-sans text-[15px] text-text-primary"
       />
 
       {/* Section filter chips */}
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2" aria-label="Section filters">
         {ALL_SECTIONS.map((section) => {
           const isActive = activeSections.has(section);
           return (
@@ -51,7 +52,8 @@ export function SearchFilterBar() {
               key={section}
               type="button"
               onClick={() => toggleSection(section)}
-              className={`cursor-pointer rounded-full border px-2 py-1 font-sans text-sm font-semibold uppercase tracking-[0.18em] transition-colors duration-150 ${
+              aria-pressed={isActive}
+              className={`focus-ring min-h-11 cursor-pointer rounded-full border px-3 py-1.5 font-sans text-sm font-semibold uppercase tracking-[0.18em] transition-colors duration-150 ${
                 isActive
                   ? "border-accent/[0.35] bg-accent/[0.14] text-accent"
                   : "border-border-muted bg-bg-secondary text-text-muted"

--- a/creator/src/components/tuning/TuningWizard.tsx
+++ b/creator/src/components/tuning/TuningWizard.tsx
@@ -22,7 +22,9 @@ import { MetricSectionCards } from "./MetricSectionCards";
 import { ApplyFooterBar } from "./ApplyFooterBar";
 import { HealthCheckBanner } from "./HealthCheckBanner";
 import { ChartRow } from "./charts/ChartRow";
-import { Spinner } from "@/components/ui/FormWidgets";
+import { ActionButton, Spinner } from "@/components/ui/FormWidgets";
+import { useToastStore } from "@/stores/toastStore";
+import { usePrefersReducedMotion } from "@/lib/usePrefersReducedMotion";
 
 const ALL_SECTIONS_ORDERED = [
   TuningSection.CombatStats,
@@ -57,6 +59,9 @@ export function TuningWizard() {
 
   const browserRef = useRef<HTMLDivElement>(null);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const showToast = useToastStore((s) => s.show);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   /** Inline edit: update a single field by dot-path in the config. */
   const handleValueChange = useCallback(
@@ -73,16 +78,29 @@ export function TuningWizard() {
   const handleSave = useCallback(async () => {
     if (!project || saving) return;
     setSaving(true);
+    setSaveError(null);
     try {
       const { saveProjectConfig } = await import("@/lib/saveConfig");
       await saveProjectConfig(project);
       useConfigStore.getState().markClean();
+      showToast({
+        kicker: "Tuning Wizard",
+        message: "Configuration saved.",
+        variant: "astral",
+      });
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setSaveError(message);
+      showToast({
+        kicker: "Tuning Wizard",
+        message: `Save failed: ${message}`,
+        variant: "ember",
+      }, 4000);
       console.error("Tuning save failed:", err);
     } finally {
       setSaving(false);
     }
-  }, [project, saving]);
+  }, [project, saving, showToast]);
 
   /** Compute metrics for each preset by merging onto current config. */
   const presetMetrics = useMemo(() => {
@@ -182,9 +200,12 @@ export function TuningWizard() {
   /** Scroll parameter browser into view when a preset is selected. */
   useEffect(() => {
     if (selectedPresetId && browserRef.current) {
-      browserRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      browserRef.current.scrollIntoView({
+        behavior: prefersReducedMotion ? "auto" : "smooth",
+        block: "nearest",
+      });
     }
-  }, [selectedPresetId]);
+  }, [prefersReducedMotion, selectedPresetId]);
 
   function handleSelect(preset: TuningPreset) {
     if (selectedPresetId === preset.id) {
@@ -213,23 +234,35 @@ export function TuningWizard() {
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
       {/* Title section + save button */}
-      <div className="flex items-center justify-between px-6 pt-16">
-        <h1 className="font-display text-[22px] leading-[1.2] tracking-[1px] text-text-primary">
-          Tuning Wizard
-        </h1>
-        {(dirty || saving) && (
-          <button
+      <div className="flex flex-col gap-4 px-6 pt-12 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <h1 className="font-display text-[22px] leading-[1.2] tracking-[1px] text-text-primary">
+            Tuning Wizard
+          </h1>
+          <p className="mt-2 max-w-3xl text-sm text-text-secondary">
+            Compare curated balance presets, accept the sections you want, and keep the final save explicit.
+          </p>
+          {saveError && (
+            <p role="alert" className="mt-2 text-2xs text-status-error">
+              Save failed: {saveError}
+            </p>
+          )}
+        </div>
+        {(dirty || saving || saveError) && (
+          <ActionButton
+            variant="secondary"
             onClick={handleSave}
             disabled={!dirty || saving}
-            className="focus-ring rounded-full border border-[var(--chrome-stroke)] bg-bg-primary/80 px-4 py-1.5 text-sm font-medium text-accent shadow-md backdrop-blur-sm transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
+            aria-label={saving ? "Saving tuning changes" : "Save tuning changes"}
+            className="self-start"
           >
-            {saving ? <span className="flex items-center gap-1.5"><Spinner />Saving</span> : "Save Changes"}
-          </button>
+            {saving ? <><Spinner />Saving</> : "Save Changes"}
+          </ActionButton>
         )}
       </div>
 
       {/* Preset card grid */}
-      <div className="grid grid-cols-3 justify-items-center gap-4 px-6 mt-8 max-w-[1020px] mx-auto">
+      <div className="mx-auto mt-8 grid w-full max-w-6xl grid-cols-1 gap-4 px-6 lg:grid-cols-2 2xl:grid-cols-3">
         {TUNING_PRESETS.map((preset) => (
           <PresetCard
             key={preset.id}

--- a/creator/src/components/tuning/charts/ChartRow.tsx
+++ b/creator/src/components/tuning/charts/ChartRow.tsx
@@ -33,7 +33,7 @@ export function ChartRow({
   );
 
   return (
-    <div className="animate-unfurl-in mb-4 mt-4 grid grid-cols-3 gap-4 px-6">
+    <div className="animate-unfurl-in mb-4 mt-4 grid grid-cols-1 gap-4 px-6 lg:grid-cols-2 2xl:grid-cols-3">
       <XpCurveChart data={xpCurveData} />
       <MobTierChart currentConfig={presetConfig} />
       <StatRadarChart data={statRadarData} />

--- a/creator/src/components/tuning/charts/MobTierChart.tsx
+++ b/creator/src/components/tuning/charts/MobTierChart.tsx
@@ -16,6 +16,7 @@ import {
 import type { AppConfig } from "@/types/config";
 import { buildMobTierData, type MobTierPoint } from "@/lib/tuning/chartData";
 import { CHART_COLORS } from "@/lib/tuning/chartColors";
+import { usePrefersReducedMotion } from "@/lib/usePrefersReducedMotion";
 
 interface MobTierChartProps {
   currentConfig: AppConfig;
@@ -64,6 +65,7 @@ function MobTierTooltip({ active, payload, label }: {
 
 export function MobTierChart({ currentConfig }: MobTierChartProps) {
   const [selectedLevel, setSelectedLevel] = useState(30);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   const data = useMemo(
     () => buildMobTierData(currentConfig, selectedLevel),
@@ -71,12 +73,13 @@ export function MobTierChart({ currentConfig }: MobTierChartProps) {
   );
 
   return (
-    <div className="rounded-lg border border-border-muted bg-bg-tertiary p-4">
+    <div className="panel-surface rounded-[1.5rem] p-4">
       <div className="mb-2 flex items-center justify-between">
         <h3 className="font-display text-[14px] font-normal uppercase tracking-[0.5px] text-text-secondary">
           MOB POWER
         </h3>
         <select
+          aria-label="Select mob power preview level"
           className="ornate-input px-2 py-0.5 text-[13px]"
           value={selectedLevel}
           onChange={(e) => setSelectedLevel(Number(e.target.value))}
@@ -112,7 +115,7 @@ export function MobTierChart({ currentConfig }: MobTierChartProps) {
             dataKey="hp"
             name="HP"
             fill={CHART_COLORS.barHp}
-            isAnimationActive={true}
+            isAnimationActive={!prefersReducedMotion}
             animationDuration={300}
             animationEasing="ease-out"
           />
@@ -120,7 +123,7 @@ export function MobTierChart({ currentConfig }: MobTierChartProps) {
             dataKey="damage"
             name="Damage"
             fill={CHART_COLORS.barDamage}
-            isAnimationActive={true}
+            isAnimationActive={!prefersReducedMotion}
             animationDuration={300}
             animationEasing="ease-out"
           />
@@ -128,7 +131,7 @@ export function MobTierChart({ currentConfig }: MobTierChartProps) {
             dataKey="armor"
             name="Armor"
             fill={CHART_COLORS.barArmor}
-            isAnimationActive={true}
+            isAnimationActive={!prefersReducedMotion}
             animationDuration={300}
             animationEasing="ease-out"
           />
@@ -136,7 +139,7 @@ export function MobTierChart({ currentConfig }: MobTierChartProps) {
             dataKey="xp"
             name="XP"
             fill={CHART_COLORS.barXp}
-            isAnimationActive={true}
+            isAnimationActive={!prefersReducedMotion}
             animationDuration={300}
             animationEasing="ease-out"
           />

--- a/creator/src/components/tuning/charts/StatRadarChart.tsx
+++ b/creator/src/components/tuning/charts/StatRadarChart.tsx
@@ -15,14 +15,17 @@ import {
 } from "recharts";
 import type { StatRadarPoint } from "@/lib/tuning/chartData";
 import { CHART_COLORS } from "@/lib/tuning/chartColors";
+import { usePrefersReducedMotion } from "@/lib/usePrefersReducedMotion";
 
 interface StatRadarChartProps {
   data: StatRadarPoint[];
 }
 
 export function StatRadarChart({ data }: StatRadarChartProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
   return (
-    <div className="rounded-lg border border-border-muted bg-bg-tertiary p-4">
+    <div className="panel-surface rounded-[1.5rem] p-4">
       <h3 className="mb-2 font-display text-[14px] font-normal uppercase tracking-[0.5px] text-text-secondary">
         STAT PROFILE
       </h3>
@@ -45,7 +48,7 @@ export function StatRadarChart({ data }: StatRadarChartProps) {
             fill={CHART_COLORS.currentSeries}
             fillOpacity={0.15}
             strokeWidth={1.5}
-            isAnimationActive={true}
+            isAnimationActive={!prefersReducedMotion}
             animationDuration={300}
           />
           <Radar
@@ -55,7 +58,7 @@ export function StatRadarChart({ data }: StatRadarChartProps) {
             fill={CHART_COLORS.presetSeries}
             fillOpacity={0.25}
             strokeWidth={1.5}
-            isAnimationActive={true}
+            isAnimationActive={!prefersReducedMotion}
             animationDuration={300}
           />
           <Tooltip />

--- a/creator/src/components/tuning/charts/XpCurveChart.tsx
+++ b/creator/src/components/tuning/charts/XpCurveChart.tsx
@@ -15,6 +15,7 @@ import {
 } from "recharts";
 import type { XpCurvePoint } from "@/lib/tuning/chartData";
 import { CHART_COLORS } from "@/lib/tuning/chartColors";
+import { usePrefersReducedMotion } from "@/lib/usePrefersReducedMotion";
 
 interface XpCurveChartProps {
   data: XpCurvePoint[];
@@ -31,8 +32,10 @@ function formatLargeNumber(v: number): string {
 }
 
 export function XpCurveChart({ data }: XpCurveChartProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
   return (
-    <div className="rounded-lg border border-border-muted bg-bg-tertiary p-4">
+    <div className="panel-surface rounded-[1.5rem] p-4">
       <h3 className="mb-2 font-display text-[14px] font-normal uppercase tracking-[0.5px] text-text-secondary">
         XP CURVE
       </h3>
@@ -58,7 +61,7 @@ export function XpCurveChart({ data }: XpCurveChartProps) {
             stroke={CHART_COLORS.currentSeries}
             strokeWidth={2}
             dot={false}
-            isAnimationActive={true}
+            isAnimationActive={!prefersReducedMotion}
             animationDuration={300}
             animationEasing="ease-out"
           />
@@ -69,7 +72,7 @@ export function XpCurveChart({ data }: XpCurveChartProps) {
             stroke={CHART_COLORS.presetSeries}
             strokeWidth={2}
             dot={false}
-            isAnimationActive={true}
+            isAnimationActive={!prefersReducedMotion}
             animationDuration={300}
             animationEasing="ease-out"
           />

--- a/creator/src/lib/tuning/__tests__/chartData.test.ts
+++ b/creator/src/lib/tuning/__tests__/chartData.test.ts
@@ -224,12 +224,12 @@ describe("buildStatRadarData", () => {
 // ─── CHART_COLORS ─────────────────────────────────────────────────
 
 describe("CHART_COLORS", () => {
-  it("currentSeries is #dccbb3", () => {
-    expect(CHART_COLORS.currentSeries).toBe("#dccbb3");
+  it("currentSeries uses the semantic text token", () => {
+    expect(CHART_COLORS.currentSeries).toBe("var(--color-text-secondary)");
   });
 
-  it("presetSeries is #ff7d00", () => {
-    expect(CHART_COLORS.presetSeries).toBe("#ff7d00");
+  it("presetSeries uses the semantic accent token", () => {
+    expect(CHART_COLORS.presetSeries).toBe("var(--color-accent)");
   });
 
   it("has all 9 color keys", () => {

--- a/creator/src/lib/tuning/__tests__/tooltipContent.test.ts
+++ b/creator/src/lib/tuning/__tests__/tooltipContent.test.ts
@@ -24,19 +24,19 @@ describe("buildTooltipContent", () => {
   it("includes HIGH IMPACT badge with correct color for high impact", () => {
     const html = buildTooltipContent(makeMeta({ impact: "high" }));
     expect(html).toContain("HIGH IMPACT");
-    expect(html).toContain("#d9756b");
+    expect(html).toContain("var(--color-status-error)");
   });
 
   it("includes MEDIUM IMPACT badge with correct color", () => {
     const html = buildTooltipContent(makeMeta({ impact: "medium" }));
     expect(html).toContain("MEDIUM IMPACT");
-    expect(html).toContain("#ff9d3d");
+    expect(html).toContain("var(--color-status-warning)");
   });
 
   it("includes LOW IMPACT badge with correct color", () => {
     const html = buildTooltipContent(makeMeta({ impact: "low" }));
     expect(html).toContain("LOW IMPACT");
-    expect(html).toContain("#ad9d88");
+    expect(html).toContain("var(--color-text-muted)");
   });
 
   it("includes interaction note when present", () => {

--- a/creator/src/lib/tuning/chartColors.ts
+++ b/creator/src/lib/tuning/chartColors.ts
@@ -4,13 +4,13 @@
 // Used by Recharts SVG rendering in visualization components.
 
 export const CHART_COLORS = {
-  currentSeries: "#dccbb3",   // text-text-secondary -- muted current config
-  presetSeries: "#ff7d00",    // ember orange -- preset visually dominates
-  grid: "#174852",            // border-muted
-  axisText: "#ad9d88",        // text-muted
-  axisLine: "#2e7680",        // border-default
-  barHp: "#d9756b",           // chart-hp
-  barDamage: "#e08a73",       // status-error warm red
-  barArmor: "#2f93a1",        // stellar-blue
-  barXp: "#7cb66d",           // status-success green
+  currentSeries: "var(--color-text-secondary)",
+  presetSeries: "var(--color-accent)",
+  grid: "var(--color-border-muted)",
+  axisText: "var(--color-text-muted)",
+  axisLine: "var(--color-border-default)",
+  barHp: "var(--color-chart-hp)",
+  barDamage: "var(--color-diff-del-text)",
+  barArmor: "var(--color-stellar-blue)",
+  barXp: "var(--color-status-success)",
 } as const;

--- a/creator/src/lib/tuning/deltaUtils.ts
+++ b/creator/src/lib/tuning/deltaUtils.ts
@@ -39,9 +39,9 @@ export function pctDelta(oldVal: number, newVal: number): string {
 
 /** Impact badge colors matching Arcanum design system (D-11, UI-SPEC). */
 const IMPACT_COLORS: Record<string, string> = {
-  high: "#d9756b",   // status-error
-  medium: "#ff9d3d", // status-warning
-  low: "#ad9d88",    // text-muted
+  high: "var(--color-status-error)",
+  medium: "var(--color-status-warning)",
+  low: "var(--color-text-muted)",
 };
 
 const IMPACT_LABELS: Record<string, string> = {
@@ -62,9 +62,20 @@ export function buildTooltipContent(meta: FieldMeta): string {
   if (meta.interactionNote) {
     parts.push(`<div style="margin-bottom:6px;opacity:0.8">Interacts with: ${meta.interactionNote}</div>`);
   }
-  const color = IMPACT_COLORS[meta.impact] ?? "#ad9d88";
+  const color = IMPACT_COLORS[meta.impact] ?? "var(--color-text-muted)";
   const label = IMPACT_LABELS[meta.impact] ?? "LOW IMPACT";
   parts.push(`<span style="color:${color};font-size:11px;font-weight:600;letter-spacing:0.5px">${label}</span>`);
   parts.push(`</div>`);
   return parts.join("");
+}
+
+/** Lightweight plain-text tooltip for dense tables where DOM tooltips are too expensive. */
+export function buildTooltipText(meta: FieldMeta): string {
+  const parts = [meta.description];
+  if (meta.interactionNote) {
+    parts.push(`Interacts with: ${meta.interactionNote}`);
+  }
+  const label = IMPACT_LABELS[meta.impact] ?? "LOW IMPACT";
+  parts.push(`Impact: ${label}`);
+  return parts.join("\n");
 }

--- a/creator/src/lib/usePrefersReducedMotion.ts
+++ b/creator/src/lib/usePrefersReducedMotion.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+/** Track the user's reduced-motion preference for motion-heavy UI surfaces. */
+export function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return false;
+    }
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(QUERY);
+    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches);
+    handleChange();
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/creator/src/stores/tuningWizardStore.ts
+++ b/creator/src/stores/tuningWizardStore.ts
@@ -13,6 +13,7 @@ import { deepMerge, buildPartialFromDiffs } from "@/lib/tuning/merge";
 import { checkTuningHealth } from "@/lib/tuning/healthCheck";
 import type { HealthWarning } from "@/lib/tuning/healthCheck";
 import type { AppConfig } from "@/types/config";
+import { useToastStore } from "@/stores/toastStore";
 
 const ALL_SECTIONS = new Set([
   TuningSection.CombatStats,
@@ -31,6 +32,7 @@ interface TuningWizardStore {
   undoAvailable: boolean;
   healthWarnings: HealthWarning[];
   applySuccess: boolean;
+  actionError: string | null;
   selectPreset: (id: string | null) => void;
   setSearchQuery: (q: string) => void;
   toggleSection: (s: TuningSection) => void;
@@ -42,6 +44,7 @@ interface TuningWizardStore {
   resetWizard: () => void;
   setHealthWarnings: (w: HealthWarning[]) => void;
   clearApplySuccess: () => void;
+  clearActionError: () => void;
 }
 
 export const useTuningWizardStore = create<TuningWizardStore>((set, get) => ({
@@ -54,6 +57,7 @@ export const useTuningWizardStore = create<TuningWizardStore>((set, get) => ({
   undoAvailable: false,
   healthWarnings: [],
   applySuccess: false,
+  actionError: null,
 
   selectPreset: (id) =>
     set({
@@ -61,6 +65,7 @@ export const useTuningWizardStore = create<TuningWizardStore>((set, get) => ({
       acceptedSections: new Set(ALL_SECTIONS),
       healthWarnings: [],
       applySuccess: false,
+      actionError: null,
     }),
 
   setSearchQuery: (q) => set({ searchQuery: q }),
@@ -104,6 +109,7 @@ export const useTuningWizardStore = create<TuningWizardStore>((set, get) => ({
     if (!selectedPresetId || acceptedSections.size === 0) return;
 
     const config = useConfigStore.getState().config;
+    const wasDirty = useConfigStore.getState().dirty;
     const project = useProjectStore.getState().project;
     if (!config || !project) return;
 
@@ -127,42 +133,90 @@ export const useTuningWizardStore = create<TuningWizardStore>((set, get) => ({
       partial,
     ) as unknown as AppConfig;
 
-    // Apply to configStore and persist (D-11)
-    useConfigStore.getState().updateConfig(merged);
-    const { saveProjectConfig } = await import("@/lib/saveConfig");
-    await saveProjectConfig(project);
-    useConfigStore.getState().markClean();
+    try {
+      // Apply to configStore and persist (D-11)
+      useConfigStore.getState().updateConfig(merged);
+      const { saveProjectConfig } = await import("@/lib/saveConfig");
+      await saveProjectConfig(project);
+      useConfigStore.getState().markClean();
 
-    // Health check (D-09): only when mixed sections
-    const postMetrics = computeMetrics(merged);
-    const warnings = checkTuningHealth(preMetrics, postMetrics, acceptedSections);
+      // Health check (D-09): only when mixed sections
+      const postMetrics = computeMetrics(merged);
+      const warnings = checkTuningHealth(preMetrics, postMetrics, acceptedSections);
 
-    set({
-      configSnapshot: snapshot,
-      undoAvailable: true,
-      applySuccess: true,
-      healthWarnings: warnings,
-    });
+      set({
+        configSnapshot: snapshot,
+        undoAvailable: true,
+        applySuccess: true,
+        healthWarnings: warnings,
+        actionError: null,
+      });
+      useToastStore.getState().show({
+        kicker: "Tuning Wizard",
+        message: "Preset sections applied and saved.",
+        variant: "astral",
+      });
+    } catch (err) {
+      useConfigStore.getState().updateConfig(snapshot);
+      if (!wasDirty) {
+        useConfigStore.getState().markClean();
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      set({
+        configSnapshot: null,
+        undoAvailable: false,
+        applySuccess: false,
+        healthWarnings: [],
+        actionError: message,
+      });
+      useToastStore.getState().show({
+        kicker: "Tuning Wizard",
+        message: `Apply failed: ${message}`,
+        variant: "ember",
+      }, 4000);
+    }
   },
 
   undoApply: async () => {
     const { configSnapshot } = get();
     if (!configSnapshot) return;
 
+    const wasDirty = useConfigStore.getState().dirty;
     const project = useProjectStore.getState().project;
     if (!project) return;
 
-    useConfigStore.getState().updateConfig(configSnapshot);
-    const { saveProjectConfig } = await import("@/lib/saveConfig");
-    await saveProjectConfig(project);
-    useConfigStore.getState().markClean();
+    try {
+      useConfigStore.getState().updateConfig(configSnapshot);
+      const { saveProjectConfig } = await import("@/lib/saveConfig");
+      await saveProjectConfig(project);
+      useConfigStore.getState().markClean();
 
-    set({
-      configSnapshot: null,
-      undoAvailable: false,
-      healthWarnings: [],
-      applySuccess: false,
-    });
+      set({
+        configSnapshot: null,
+        undoAvailable: false,
+        healthWarnings: [],
+        applySuccess: false,
+        actionError: null,
+      });
+      useToastStore.getState().show({
+        kicker: "Tuning Wizard",
+        message: "Last preset apply was undone.",
+      });
+    } catch (err) {
+      if (!wasDirty) {
+        useConfigStore.getState().markClean();
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      set({
+        applySuccess: false,
+        actionError: message,
+      });
+      useToastStore.getState().show({
+        kicker: "Tuning Wizard",
+        message: `Undo failed: ${message}`,
+        variant: "ember",
+      }, 4000);
+    }
   },
 
   resetWizard: () =>
@@ -176,8 +230,10 @@ export const useTuningWizardStore = create<TuningWizardStore>((set, get) => ({
       undoAvailable: false,
       healthWarnings: [],
       applySuccess: false,
+      actionError: null,
     }),
 
   setHealthWarnings: (w) => set({ healthWarnings: w }),
   clearApplySuccess: () => set({ applySuccess: false }),
+  clearActionError: () => set({ actionError: null }),
 }));


### PR DESCRIPTION
## Summary
- harden the tuning wizard with explicit labels, ARIA state, reduced-motion handling, and user-facing apply/save failure feedback
- adapt the wizard layout for narrower workspaces and shift tuning surfaces toward the shared Arcanum panel/token language
- lighten the parameter and metric browsers by replacing dense per-row Tippy setup with lightweight native tooltip text and update affected tuning tests

## Verification
- `bunx tsc --noEmit`
- `bun run test -- chartData tooltipContent metricDelta`
- `bun run test -- tuning`