### PR TITLE
Type, parse, save, and edit 10 missing config sections + 6 ServerConfig fields

### DIFF
--- a/creator/src/components/config/ConfigPanelHost.tsx
+++ b/creator/src/components/config/ConfigPanelHost.tsx
@@ -45,6 +45,7 @@ import { ApiSettingsPanel } from "./panels/ApiSettingsPanel";
 import { RuntimeHandoffStudio } from "./RuntimeHandoffStudio";
 import { RawYamlPanel } from "./panels/RawYamlPanel";
 import { VersionControlPanel } from "./panels/VersionControlPanel";
+import { InfrastructurePanel } from "./panels/InfrastructurePanel";
 
 function Section({
   kicker,
@@ -121,6 +122,8 @@ function renderPanel(panelId: string, props: ConfigPanelProps): ReactNode {
           </Section>
         </>
       );
+    case "infrastructure":
+      return <InfrastructurePanel config={config} onChange={onChange} />;
     case "commands":
       return <CommandDesigner config={config} onChange={onChange} />;
     case "crafting":

--- a/creator/src/components/config/panels/InfrastructurePanel.tsx
+++ b/creator/src/components/config/panels/InfrastructurePanel.tsx
@@ -1,0 +1,720 @@
+import type { ConfigPanelProps, AppConfig } from "./types";
+import { Section, FieldRow, NumberInput, TextInput, SelectInput, CheckboxInput } from "@/components/ui/FormWidgets";
+
+// ─── Deployment mode ───────────────────────────────────────────────
+
+function ModeSection({ config, onChange }: ConfigPanelProps) {
+  return (
+    <Section
+      title="Deployment mode"
+      description="How the server process is deployed. Standalone runs everything in one process. Engine and Gateway are for sharded multi-process setups."
+    >
+      <FieldRow label="Mode" hint="STANDALONE = single process (default). ENGINE = game engine only (no transports). GATEWAY = transport layer only (no local engine).">
+        <SelectInput
+          value={config.mode}
+          options={[
+            { value: "STANDALONE", label: "Standalone" },
+            { value: "ENGINE", label: "Engine" },
+            { value: "GATEWAY", label: "Gateway" },
+          ]}
+          onCommit={(v) => onChange({ mode: v as AppConfig["mode"] })}
+        />
+      </FieldRow>
+    </Section>
+  );
+}
+
+// ─── Persistence ───────────────────────────────────────────────────
+
+function PersistenceSection({ config, onChange }: ConfigPanelProps) {
+  const p = config.persistence;
+  const patch = (v: Partial<AppConfig["persistence"]>) =>
+    onChange({ persistence: { ...p, ...v } });
+
+  return (
+    <Section
+      title="Persistence"
+      description="How player data is stored. YAML writes flat files to disk; POSTGRES uses a database connection from the Database section below."
+    >
+      <div className="flex flex-col gap-1.5">
+        <FieldRow label="Backend" hint="YAML = flat files (simple, no database required). POSTGRES = relational database (requires database config below).">
+          <SelectInput
+            value={p.backend}
+            options={[
+              { value: "YAML", label: "YAML (flat files)" },
+              { value: "POSTGRES", label: "PostgreSQL" },
+            ]}
+            onCommit={(v) => patch({ backend: v as AppConfig["persistence"]["backend"] })}
+          />
+        </FieldRow>
+        <FieldRow label="Root directory" hint="Where YAML player files are stored on disk. Relative to the server working directory.">
+          <TextInput
+            value={p.rootDir}
+            onCommit={(v) => patch({ rootDir: v || "data/players" })}
+          />
+        </FieldRow>
+        <FieldRow label="Worker enabled" hint="Background worker that periodically flushes dirty player data to disk/database.">
+          <CheckboxInput
+            checked={p.worker.enabled}
+            onCommit={(v) => patch({ worker: { ...p.worker, enabled: v } })}
+            label="Flush worker active"
+          />
+        </FieldRow>
+        <FieldRow label="Flush interval (ms)" hint="How often the persistence worker writes dirty player data. Lower = more durable but more I/O.">
+          <NumberInput
+            value={p.worker.flushIntervalMs}
+            onCommit={(v) => patch({ worker: { ...p.worker, flushIntervalMs: v ?? 5000 } })}
+            min={500}
+            max={60000}
+          />
+        </FieldRow>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Login ─────────────────────────────────────────────────────────
+
+function LoginSection({ config, onChange }: ConfigPanelProps) {
+  const l = config.login;
+  const patch = (v: Partial<AppConfig["login"]>) =>
+    onChange({ login: { ...l, ...v } });
+
+  return (
+    <Section
+      title="Login"
+      description="Controls for player authentication, rate limiting, and concurrent session handling."
+    >
+      <div className="flex flex-col gap-1.5">
+        <FieldRow label="Max wrong passwords" hint="Wrong password attempts before the account is temporarily locked for that session.">
+          <NumberInput
+            value={l.maxWrongPasswordRetries}
+            onCommit={(v) => patch({ maxWrongPasswordRetries: v ?? 3 })}
+            min={1}
+            max={100}
+          />
+        </FieldRow>
+        <FieldRow label="Max failed attempts" hint="Total failed login attempts (wrong user + wrong password) before the connection is dropped.">
+          <NumberInput
+            value={l.maxFailedAttemptsBeforeDisconnect}
+            onCommit={(v) => patch({ maxFailedAttemptsBeforeDisconnect: v ?? 3 })}
+            min={1}
+            max={100}
+          />
+        </FieldRow>
+        <FieldRow label="Max concurrent logins" hint="How many players can be logging in simultaneously. Protects against login-flood attacks.">
+          <NumberInput
+            value={l.maxConcurrentLogins}
+            onCommit={(v) => patch({ maxConcurrentLogins: v ?? 50 })}
+            min={1}
+            max={10000}
+          />
+        </FieldRow>
+        <FieldRow label="Auth threads" hint="Thread pool size for password hashing. More threads = faster login throughput but more CPU. Match to your server's core count.">
+          <NumberInput
+            value={l.authThreads}
+            onCommit={(v) => patch({ authThreads: v ?? 8 })}
+            min={1}
+            max={64}
+          />
+        </FieldRow>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Transport ─────────────────────────────────────────────────────
+
+function TransportSection({ config, onChange }: ConfigPanelProps) {
+  const t = config.transport;
+  const patchTelnet = (v: Partial<AppConfig["transport"]["telnet"]>) =>
+    onChange({ transport: { ...t, telnet: { ...t.telnet, ...v } } });
+  const patchWs = (v: Partial<AppConfig["transport"]["websocket"]>) =>
+    onChange({ transport: { ...t, websocket: { ...t.websocket, ...v } } });
+
+  return (
+    <Section
+      title="Transport"
+      description="Low-level settings for the telnet and WebSocket connection layers."
+    >
+      <div className="flex flex-col gap-1.5">
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1">Telnet</p>
+        <FieldRow label="Max line length" hint="Maximum characters per line from a telnet client. Lines exceeding this are truncated.">
+          <NumberInput
+            value={t.telnet.maxLineLen}
+            onCommit={(v) => patchTelnet({ maxLineLen: v ?? 1024 })}
+            min={128}
+            max={65535}
+          />
+        </FieldRow>
+        <FieldRow label="Max non-printable/line" hint="Maximum non-printable characters per line (telnet negotiation bytes, escape sequences). Excess triggers disconnect.">
+          <NumberInput
+            value={t.telnet.maxNonPrintablePerLine}
+            onCommit={(v) => patchTelnet({ maxNonPrintablePerLine: v ?? 32 })}
+            min={0}
+            max={1024}
+          />
+        </FieldRow>
+        <FieldRow label="Socket backlog" hint="TCP listen backlog. Increase for high-traffic servers where many connections arrive simultaneously.">
+          <NumberInput
+            value={t.telnet.socketBacklog}
+            onCommit={(v) => patchTelnet({ socketBacklog: v ?? 256 })}
+            min={1}
+            max={65535}
+          />
+        </FieldRow>
+        <FieldRow label="Max connections" hint="Hard cap on simultaneous telnet connections.">
+          <NumberInput
+            value={t.telnet.maxConnections}
+            onCommit={(v) => patchTelnet({ maxConnections: v ?? 5000 })}
+            min={1}
+            max={100000}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">WebSocket</p>
+        <FieldRow label="Host" hint="Bind address for the WebSocket server. 0.0.0.0 listens on all interfaces.">
+          <TextInput
+            value={t.websocket.host}
+            onCommit={(v) => patchWs({ host: v || "0.0.0.0" })}
+          />
+        </FieldRow>
+        <FieldRow label="Stop grace (ms)" hint="Grace period before forcefully closing WebSocket connections during shutdown.">
+          <NumberInput
+            value={t.websocket.stopGraceMillis}
+            onCommit={(v) => patchWs({ stopGraceMillis: v ?? 1000 })}
+            min={0}
+            max={30000}
+          />
+        </FieldRow>
+        <FieldRow label="Stop timeout (ms)" hint="Hard timeout for WebSocket shutdown. Connections still open after this are forcefully dropped.">
+          <NumberInput
+            value={t.websocket.stopTimeoutMillis}
+            onCommit={(v) => patchWs({ stopTimeoutMillis: v ?? 2000 })}
+            min={0}
+            max={60000}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">Backpressure</p>
+        <FieldRow label="Max backpressure failures" hint="How many times a session's outbound buffer can overflow before the connection is dropped.">
+          <NumberInput
+            value={t.maxInboundBackpressureFailures}
+            onCommit={(v) => onChange({ transport: { ...t, maxInboundBackpressureFailures: v ?? 3 } })}
+            min={1}
+            max={100}
+          />
+        </FieldRow>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Demo ──────────────────────────────────────────────────────────
+
+function DemoSection({ config, onChange }: ConfigPanelProps) {
+  const d = config.demo;
+  const patch = (v: Partial<AppConfig["demo"]>) =>
+    onChange({ demo: { ...d, ...v } });
+
+  return (
+    <Section
+      title="Demo"
+      description="Demo-mode settings for launching a browser-based client automatically on server start."
+    >
+      <div className="flex flex-col gap-1.5">
+        <FieldRow label="Auto-launch browser" hint="Open the web client in the default browser when the server starts.">
+          <CheckboxInput
+            checked={d.autoLaunchBrowser}
+            onCommit={(v) => patch({ autoLaunchBrowser: v })}
+            label="Open browser on start"
+          />
+        </FieldRow>
+        <FieldRow label="Web client host" hint="Hostname for the auto-launched browser URL.">
+          <TextInput
+            value={d.webClientHost}
+            onCommit={(v) => patch({ webClientHost: v || "localhost" })}
+          />
+        </FieldRow>
+        <FieldRow label="Web client URL" hint="Full URL override. When set, this is opened instead of constructing one from host + port. Leave blank to auto-derive.">
+          <TextInput
+            value={d.webClientUrl ?? ""}
+            onCommit={(v) => patch({ webClientUrl: v || null })}
+          />
+        </FieldRow>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Database ──────────────────────────────────────────────────────
+
+function DatabaseSection({ config, onChange }: ConfigPanelProps) {
+  const db = config.database;
+  const patch = (v: Partial<AppConfig["database"]>) =>
+    onChange({ database: { ...db, ...v } });
+
+  return (
+    <Section
+      title="Database"
+      description="PostgreSQL connection settings. Only used when persistence backend is set to POSTGRES."
+    >
+      <div className="flex flex-col gap-1.5">
+        <FieldRow label="JDBC URL" hint="PostgreSQL connection string. Include host, port, and database name.">
+          <TextInput
+            value={db.jdbcUrl}
+            onCommit={(v) => patch({ jdbcUrl: v || "jdbc:postgresql://localhost:5432/ambonmud" })}
+          />
+        </FieldRow>
+        <FieldRow label="Username" hint="Database user.">
+          <TextInput
+            value={db.username}
+            onCommit={(v) => patch({ username: v || "ambon" })}
+          />
+        </FieldRow>
+        <FieldRow label="Password" hint="Database password. Stored in the config file in plain text — use environment variable injection in production.">
+          <TextInput
+            value={db.password}
+            onCommit={(v) => patch({ password: v || "ambon" })}
+          />
+        </FieldRow>
+        <FieldRow label="Max pool size" hint="Maximum simultaneous database connections. Increase for high-write loads.">
+          <NumberInput
+            value={db.maxPoolSize}
+            onCommit={(v) => patch({ maxPoolSize: v ?? 5 })}
+            min={1}
+            max={100}
+          />
+        </FieldRow>
+        <FieldRow label="Minimum idle" hint="Minimum idle connections kept alive in the pool. Avoids cold-start latency on first queries.">
+          <NumberInput
+            value={db.minimumIdle}
+            onCommit={(v) => patch({ minimumIdle: v ?? 1 })}
+            min={0}
+            max={100}
+          />
+        </FieldRow>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Redis ─────────────────────────────────────────────────────────
+
+function RedisSection({ config, onChange }: ConfigPanelProps) {
+  const r = config.redis;
+  const patch = (v: Partial<AppConfig["redis"]>) =>
+    onChange({ redis: { ...r, ...v } });
+  const patchBus = (v: Partial<AppConfig["redis"]["bus"]>) =>
+    onChange({ redis: { ...r, bus: { ...r.bus, ...v } } });
+
+  return (
+    <Section
+      title="Redis"
+      description="Optional Redis integration for caching and cross-instance message bus (required for sharded deployments)."
+    >
+      <div className="flex flex-col gap-1.5">
+        <FieldRow label="Enabled" hint="Enable Redis connection. Required for sharding and cross-instance communication.">
+          <CheckboxInput
+            checked={r.enabled}
+            onCommit={(v) => patch({ enabled: v })}
+            label="Redis enabled"
+          />
+        </FieldRow>
+        <FieldRow label="URI" hint="Redis connection string (e.g. redis://localhost:6379).">
+          <TextInput
+            value={r.uri}
+            onCommit={(v) => patch({ uri: v || "redis://localhost:6379" })}
+          />
+        </FieldRow>
+        <FieldRow label="Cache TTL (seconds)" hint="How long cached values are kept before they expire.">
+          <NumberInput
+            value={r.cacheTtlSeconds}
+            onCommit={(v) => patch({ cacheTtlSeconds: v ?? 3600 })}
+            min={1}
+            max={86400}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">Message bus</p>
+        <FieldRow label="Bus enabled" hint="Enable the Redis pub/sub message bus for cross-instance communication.">
+          <CheckboxInput
+            checked={r.bus.enabled}
+            onCommit={(v) => patchBus({ enabled: v })}
+            label="Message bus active"
+          />
+        </FieldRow>
+        <FieldRow label="Inbound channel" hint="Redis channel name for commands sent to this instance.">
+          <TextInput
+            value={r.bus.inboundChannel}
+            onCommit={(v) => patchBus({ inboundChannel: v || "ambon:inbound" })}
+          />
+        </FieldRow>
+        <FieldRow label="Outbound channel" hint="Redis channel name for events broadcast from this instance.">
+          <TextInput
+            value={r.bus.outboundChannel}
+            onCommit={(v) => patchBus({ outboundChannel: v || "ambon:outbound" })}
+          />
+        </FieldRow>
+        <FieldRow label="Instance ID" hint="Unique identifier for this server instance on the bus. Used to avoid echoing messages back to the sender.">
+          <TextInput
+            value={r.bus.instanceId}
+            onCommit={(v) => patchBus({ instanceId: v })}
+          />
+        </FieldRow>
+        <FieldRow label="Shared secret" hint="HMAC secret for authenticating bus messages between instances.">
+          <TextInput
+            value={r.bus.sharedSecret}
+            onCommit={(v) => patchBus({ sharedSecret: v })}
+          />
+        </FieldRow>
+      </div>
+    </Section>
+  );
+}
+
+// ─── gRPC ──────────────────────────────────────────────────────────
+
+function GrpcSection({ config, onChange }: ConfigPanelProps) {
+  const g = config.grpc;
+  const patchServer = (v: Partial<AppConfig["grpc"]["server"]>) =>
+    onChange({ grpc: { ...g, server: { ...g.server, ...v } } });
+  const patchClient = (v: Partial<AppConfig["grpc"]["client"]>) =>
+    onChange({ grpc: { ...g, client: { ...g.client, ...v } } });
+  const patch = (v: Partial<AppConfig["grpc"]>) =>
+    onChange({ grpc: { ...g, ...v } });
+
+  return (
+    <Section
+      title="gRPC"
+      description="Settings for the gRPC control plane used in sharded (Engine + Gateway) deployments."
+    >
+      <div className="flex flex-col gap-1.5">
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1">Server</p>
+        <FieldRow label="Port" hint="Port the gRPC server listens on (Engine mode).">
+          <NumberInput
+            value={g.server.port}
+            onCommit={(v) => patchServer({ port: v ?? 9090 })}
+            min={1}
+            max={65535}
+          />
+        </FieldRow>
+        <FieldRow label="Send timeout (ms)" hint="Timeout for control-plane messages sent from the engine to gateways.">
+          <NumberInput
+            value={g.server.controlPlaneSendTimeoutMs}
+            onCommit={(v) => patchServer({ controlPlaneSendTimeoutMs: v ?? 2000 })}
+            min={100}
+            max={60000}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">Client</p>
+        <FieldRow label="Engine host" hint="Hostname of the engine to connect to (Gateway mode).">
+          <TextInput
+            value={g.client.engineHost}
+            onCommit={(v) => patchClient({ engineHost: v || "localhost" })}
+          />
+        </FieldRow>
+        <FieldRow label="Engine port" hint="gRPC port of the engine to connect to (Gateway mode).">
+          <NumberInput
+            value={g.client.enginePort}
+            onCommit={(v) => patchClient({ enginePort: v ?? 9090 })}
+            min={1}
+            max={65535}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">Security</p>
+        <FieldRow label="Shared secret" hint="HMAC secret for authenticating gRPC calls between engine and gateway.">
+          <TextInput
+            value={g.sharedSecret}
+            onCommit={(v) => patch({ sharedSecret: v })}
+          />
+        </FieldRow>
+        <FieldRow label="Allow plaintext" hint="Accept unencrypted gRPC connections. Disable in production to require TLS.">
+          <CheckboxInput
+            checked={g.allowPlaintext}
+            onCommit={(v) => patch({ allowPlaintext: v })}
+            label="Allow unencrypted"
+          />
+        </FieldRow>
+        <FieldRow label="Timestamp tolerance (ms)" hint="Maximum clock skew allowed between engine and gateway for request authentication.">
+          <NumberInput
+            value={g.timestampToleranceMs}
+            onCommit={(v) => patch({ timestampToleranceMs: v ?? 30000 })}
+            min={1000}
+            max={300000}
+          />
+        </FieldRow>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Gateway ───────────────────────────────────────────────────────
+
+function GatewaySection({ config, onChange }: ConfigPanelProps) {
+  const gw = config.gateway;
+  const patch = (v: Partial<AppConfig["gateway"]>) =>
+    onChange({ gateway: { ...gw, ...v } });
+  const patchReconnect = (v: Partial<AppConfig["gateway"]["reconnect"]>) =>
+    onChange({ gateway: { ...gw, reconnect: { ...gw.reconnect, ...v } } });
+
+  return (
+    <Section
+      title="Gateway"
+      description="Settings for the Gateway process in a sharded deployment. Controls how the gateway identifies itself, reconnects to engines, and routes players."
+    >
+      <div className="flex flex-col gap-1.5">
+        <FieldRow label="Gateway ID" hint="Unique numeric ID for this gateway instance.">
+          <NumberInput
+            value={gw.id}
+            onCommit={(v) => patch({ id: v ?? 0 })}
+            min={0}
+            max={1023}
+          />
+        </FieldRow>
+        <FieldRow label="Start zone" hint="Zone new players are placed into when connecting through this gateway. Leave blank to use the global start room.">
+          <TextInput
+            value={gw.startZone}
+            onCommit={(v) => patch({ startZone: v })}
+          />
+        </FieldRow>
+        <FieldRow label="Snowflake lease TTL (s)" hint="How long a snowflake ID lease is valid before it must be renewed.">
+          <NumberInput
+            value={gw.snowflake.idLeaseTtlSeconds}
+            onCommit={(v) => patch({ snowflake: { idLeaseTtlSeconds: v ?? 300 } })}
+            min={10}
+            max={3600}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">Reconnect</p>
+        <FieldRow label="Max attempts" hint="How many times the gateway will try to reconnect to a lost engine before giving up.">
+          <NumberInput
+            value={gw.reconnect.maxAttempts}
+            onCommit={(v) => patchReconnect({ maxAttempts: v ?? 10 })}
+            min={0}
+            max={100}
+          />
+        </FieldRow>
+        <FieldRow label="Initial delay (ms)" hint="First reconnect attempt delay. Subsequent attempts use exponential backoff.">
+          <NumberInput
+            value={gw.reconnect.initialDelayMs}
+            onCommit={(v) => patchReconnect({ initialDelayMs: v ?? 1000 })}
+            min={100}
+            max={60000}
+          />
+        </FieldRow>
+        <FieldRow label="Max delay (ms)" hint="Cap on exponential backoff delay between reconnect attempts.">
+          <NumberInput
+            value={gw.reconnect.maxDelayMs}
+            onCommit={(v) => patchReconnect({ maxDelayMs: v ?? 30000 })}
+            min={1000}
+            max={300000}
+          />
+        </FieldRow>
+        <FieldRow label="Jitter factor" hint="Random jitter multiplier (0-1) added to backoff delay to avoid thundering herd.">
+          <NumberInput
+            value={gw.reconnect.jitterFactor}
+            onCommit={(v) => patchReconnect({ jitterFactor: v ?? 0.2 })}
+            min={0}
+            max={1}
+            step={0.05}
+          />
+        </FieldRow>
+        <FieldRow label="Stream verify (ms)" hint="Time to wait for the gRPC stream to prove healthy after reconnect before declaring success.">
+          <NumberInput
+            value={gw.reconnect.streamVerifyMs}
+            onCommit={(v) => patchReconnect({ streamVerifyMs: v ?? 2000 })}
+            min={100}
+            max={30000}
+          />
+        </FieldRow>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Sharding ──────────────────────────────────────────────────────
+
+function ShardingSection({ config, onChange }: ConfigPanelProps) {
+  const s = config.sharding;
+  const patch = (v: Partial<AppConfig["sharding"]>) =>
+    onChange({ sharding: { ...s, ...v } });
+  const patchRegistry = (v: Partial<AppConfig["sharding"]["registry"]>) =>
+    onChange({ sharding: { ...s, registry: { ...s.registry, ...v } } });
+  const patchPlayerIndex = (v: Partial<AppConfig["sharding"]["playerIndex"]>) =>
+    onChange({ sharding: { ...s, playerIndex: { ...s.playerIndex, ...v } } });
+  const patchInstancing = (v: Partial<AppConfig["sharding"]["instancing"]>) =>
+    onChange({ sharding: { ...s, instancing: { ...s.instancing, ...v } } });
+  const patchAutoScale = (v: Partial<AppConfig["sharding"]["instancing"]["autoScale"]>) =>
+    onChange({ sharding: { ...s, instancing: { ...s.instancing, autoScale: { ...s.instancing.autoScale, ...v } } } });
+
+  return (
+    <Section
+      title="Sharding"
+      description="Distribute zones across multiple engine processes. Enable sharding, assign zones, and configure instance auto-scaling."
+    >
+      <div className="flex flex-col gap-1.5">
+        <FieldRow label="Enabled" hint="Enable zone sharding. When off, all zones run in a single process.">
+          <CheckboxInput
+            checked={s.enabled}
+            onCommit={(v) => patch({ enabled: v })}
+            label="Sharding enabled"
+          />
+        </FieldRow>
+        <FieldRow label="Engine ID" hint="Unique string identifier for this engine instance (e.g. engine-1).">
+          <TextInput
+            value={s.engineId}
+            onCommit={(v) => patch({ engineId: v || "engine-1" })}
+          />
+        </FieldRow>
+        <FieldRow label="Advertise host" hint="Hostname this engine advertises to gateways and other engines.">
+          <TextInput
+            value={s.advertiseHost}
+            onCommit={(v) => patch({ advertiseHost: v || "localhost" })}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">Registry</p>
+        <FieldRow label="Type" hint="How zone-to-engine assignments are resolved. STATIC = config-driven. Future: CONSUL, ETCD.">
+          <TextInput
+            value={s.registry.type}
+            onCommit={(v) => patchRegistry({ type: v || "STATIC" })}
+          />
+        </FieldRow>
+        <FieldRow label="Lease TTL (s)" hint="How long a shard lease is valid before the engine must renew it.">
+          <NumberInput
+            value={s.registry.leaseTtlSeconds}
+            onCommit={(v) => patchRegistry({ leaseTtlSeconds: v ?? 30 })}
+            min={5}
+            max={3600}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">Handoff</p>
+        <FieldRow label="Ack timeout (ms)" hint="How long to wait for a zone handoff acknowledgment before considering it failed.">
+          <NumberInput
+            value={s.handoff.ackTimeoutMs}
+            onCommit={(v) => patch({ handoff: { ackTimeoutMs: v ?? 2000 } })}
+            min={500}
+            max={60000}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">Player index</p>
+        <FieldRow label="Enabled" hint="Track which engine each player is on for cross-shard communication.">
+          <CheckboxInput
+            checked={s.playerIndex.enabled}
+            onCommit={(v) => patchPlayerIndex({ enabled: v })}
+            label="Player index active"
+          />
+        </FieldRow>
+        <FieldRow label="Heartbeat (ms)" hint="How often the player index is refreshed.">
+          <NumberInput
+            value={s.playerIndex.heartbeatMs}
+            onCommit={(v) => patchPlayerIndex({ heartbeatMs: v ?? 10000 })}
+            min={1000}
+            max={120000}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">Instancing</p>
+        <FieldRow label="Enabled" hint="Allow multiple instances of the same zone to run concurrently (for overflow).">
+          <CheckboxInput
+            checked={s.instancing.enabled}
+            onCommit={(v) => patchInstancing({ enabled: v })}
+            label="Instancing enabled"
+          />
+        </FieldRow>
+        <FieldRow label="Default capacity" hint="Max players per zone instance before a new instance is created.">
+          <NumberInput
+            value={s.instancing.defaultCapacity}
+            onCommit={(v) => patchInstancing({ defaultCapacity: v ?? 200 })}
+            min={1}
+            max={10000}
+          />
+        </FieldRow>
+        <FieldRow label="Load report interval (ms)" hint="How often each engine reports its zone load metrics.">
+          <NumberInput
+            value={s.instancing.loadReportIntervalMs}
+            onCommit={(v) => patchInstancing({ loadReportIntervalMs: v ?? 5000 })}
+            min={1000}
+            max={120000}
+          />
+        </FieldRow>
+        <FieldRow label="Start zone min instances" hint="Minimum instances always running for the starting zone. Prevents new players from hitting a cold start.">
+          <NumberInput
+            value={s.instancing.startZoneMinInstances}
+            onCommit={(v) => patchInstancing({ startZoneMinInstances: v ?? 1 })}
+            min={1}
+            max={100}
+          />
+        </FieldRow>
+
+        <p className="text-xs font-display uppercase tracking-wide-ui text-text-muted mb-1 mt-3">Auto-scale</p>
+        <FieldRow label="Enabled" hint="Automatically create/destroy zone instances based on load thresholds.">
+          <CheckboxInput
+            checked={s.instancing.autoScale.enabled}
+            onCommit={(v) => patchAutoScale({ enabled: v })}
+            label="Auto-scale enabled"
+          />
+        </FieldRow>
+        <FieldRow label="Evaluation interval (ms)" hint="How often the auto-scaler checks load metrics.">
+          <NumberInput
+            value={s.instancing.autoScale.evaluationIntervalMs}
+            onCommit={(v) => patchAutoScale({ evaluationIntervalMs: v ?? 30000 })}
+            min={5000}
+            max={300000}
+          />
+        </FieldRow>
+        <FieldRow label="Scale-up threshold" hint="Load fraction (0-1) above which a new instance is created. E.g. 0.8 = at 80% capacity.">
+          <NumberInput
+            value={s.instancing.autoScale.scaleUpThreshold}
+            onCommit={(v) => patchAutoScale({ scaleUpThreshold: v ?? 0.8 })}
+            min={0.1}
+            max={1}
+            step={0.05}
+          />
+        </FieldRow>
+        <FieldRow label="Scale-down threshold" hint="Load fraction (0-1) below which an instance is removed. E.g. 0.2 = below 20% capacity.">
+          <NumberInput
+            value={s.instancing.autoScale.scaleDownThreshold}
+            onCommit={(v) => patchAutoScale({ scaleDownThreshold: v ?? 0.2 })}
+            min={0}
+            max={1}
+            step={0.05}
+          />
+        </FieldRow>
+        <FieldRow label="Cooldown (ms)" hint="Minimum time between scale events to prevent thrashing.">
+          <NumberInput
+            value={s.instancing.autoScale.cooldownMs}
+            onCommit={(v) => patchAutoScale({ cooldownMs: v ?? 60000 })}
+            min={1000}
+            max={600000}
+          />
+        </FieldRow>
+      </div>
+    </Section>
+  );
+}
+
+// ─── Main panel ────────────────────────────────────────────────────
+
+export function InfrastructurePanel({ config, onChange }: ConfigPanelProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <ModeSection config={config} onChange={onChange} />
+      <PersistenceSection config={config} onChange={onChange} />
+      <LoginSection config={config} onChange={onChange} />
+      <TransportSection config={config} onChange={onChange} />
+      <DemoSection config={config} onChange={onChange} />
+      <DatabaseSection config={config} onChange={onChange} />
+      <RedisSection config={config} onChange={onChange} />
+      <GrpcSection config={config} onChange={onChange} />
+      <GatewaySection config={config} onChange={onChange} />
+      <ShardingSection config={config} onChange={onChange} />
+    </div>
+  );
+}

--- a/creator/src/components/config/panels/ServerPanel.tsx
+++ b/creator/src/components/config/panels/ServerPanel.tsx
@@ -10,7 +10,7 @@ export function ServerPanel({ config, onChange }: ConfigPanelProps) {
     <>
       <Section
         title="Network"
-        description="Ports the AmbonMUD server listens on. Telnet is for traditional MUD clients; the web port serves the browser-based client and REST API. Avoid conflicts with other services on the host machine."
+        description="Ports the AmbonMUD server listens on. Telnet is for traditional MUD clients; the web port serves the browser-based client and REST API."
       >
         <div className="flex flex-col gap-1.5">
           <FieldRow label="Telnet Port" hint="Classic MUD client connections. Standard MUD port is 4000. Use 23 for the well-known telnet port, though it may require elevated privileges.">
@@ -27,6 +27,61 @@ export function ServerPanel({ config, onChange }: ConfigPanelProps) {
               onCommit={(v) => patch({ webPort: v ?? 8080 })}
               min={1}
               max={65535}
+            />
+          </FieldRow>
+        </div>
+      </Section>
+      <Section
+        title="Event loop"
+        description="Internal channel sizes, tick rate, and inbound budget. These control how the server processes player commands and game events each tick."
+      >
+        <div className="flex flex-col gap-1.5">
+          <FieldRow label="Tick (ms)" hint="Game loop interval in milliseconds. Lower values make the world feel more responsive but cost more CPU. Default 100 ms = 10 ticks/sec.">
+            <NumberInput
+              value={s.tickMillis}
+              onCommit={(v) => patch({ tickMillis: v ?? 100 })}
+              min={10}
+              max={5000}
+            />
+          </FieldRow>
+          <FieldRow label="Inbound budget (ms)" hint="Max time per tick spent processing player commands before yielding to game logic. Prevents command floods from starving NPC AI and combat.">
+            <NumberInput
+              value={s.inboundBudgetMs}
+              onCommit={(v) => patch({ inboundBudgetMs: v ?? 30 })}
+              min={1}
+              max={5000}
+            />
+          </FieldRow>
+          <FieldRow label="Max inbound/tick" hint="Hard cap on how many player commands are processed per tick. Excess commands wait for the next tick.">
+            <NumberInput
+              value={s.maxInboundEventsPerTick}
+              onCommit={(v) => patch({ maxInboundEventsPerTick: v ?? 1000 })}
+              min={1}
+              max={100000}
+            />
+          </FieldRow>
+          <FieldRow label="Inbound channel" hint="Buffer size for incoming player commands. Increase for high-population servers.">
+            <NumberInput
+              value={s.inboundChannelCapacity}
+              onCommit={(v) => patch({ inboundChannelCapacity: v ?? 10000 })}
+              min={100}
+              max={1000000}
+            />
+          </FieldRow>
+          <FieldRow label="Outbound channel" hint="Buffer size for outgoing messages (room descriptions, combat output, etc.).">
+            <NumberInput
+              value={s.outboundChannelCapacity}
+              onCommit={(v) => patch({ outboundChannelCapacity: v ?? 10000 })}
+              min={100}
+              max={1000000}
+            />
+          </FieldRow>
+          <FieldRow label="Session queue" hint="Per-session outbound queue depth. If a single player's connection can't keep up, messages beyond this limit are dropped.">
+            <NumberInput
+              value={s.sessionOutboundQueueCapacity}
+              onCommit={(v) => patch({ sessionOutboundQueueCapacity: v ?? 200 })}
+              min={10}
+              max={10000}
             />
           </FieldRow>
         </div>

--- a/creator/src/lib/__tests__/exportMud.test.ts
+++ b/creator/src/lib/__tests__/exportMud.test.ts
@@ -5,7 +5,8 @@ import { parseAppConfigYaml } from "../loader";
 import type { AppConfig } from "@/types/config";
 
 const BASE_CONFIG: AppConfig = {
-  server: { telnetPort: 4000, webPort: 8080 },
+  mode: "STANDALONE",
+  server: { telnetPort: 4000, webPort: 8080, inboundChannelCapacity: 10000, outboundChannelCapacity: 10000, sessionOutboundQueueCapacity: 200, maxInboundEventsPerTick: 1000, tickMillis: 100, inboundBudgetMs: 30 },
   world: { startRoom: "ambon_hub:hall_of_portals", resources: ["world/tutorial_glade.yaml"] },
   classStartRooms: {},
   stats: {
@@ -135,6 +136,15 @@ const BASE_CONFIG: AppConfig = {
   },
   achievementDefs: {},
   emotePresets: { presets: [] },
+  persistence: { backend: "YAML", rootDir: "data/players", worker: { enabled: true, flushIntervalMs: 5000 } },
+  login: { maxWrongPasswordRetries: 3, maxFailedAttemptsBeforeDisconnect: 3, maxConcurrentLogins: 50, authThreads: 8 },
+  transport: { telnet: { maxLineLen: 1024, maxNonPrintablePerLine: 32, socketBacklog: 256, maxConnections: 5000 }, websocket: { host: "0.0.0.0", stopGraceMillis: 1000, stopTimeoutMillis: 2000 }, maxInboundBackpressureFailures: 3 },
+  demo: { autoLaunchBrowser: false, webClientHost: "localhost", webClientUrl: null },
+  database: { jdbcUrl: "jdbc:postgresql://localhost:5432/ambonmud", username: "ambon", password: "ambon", maxPoolSize: 5, minimumIdle: 1 },
+  redis: { enabled: false, uri: "redis://localhost:6379", cacheTtlSeconds: 3600, bus: { enabled: false, inboundChannel: "ambon:inbound", outboundChannel: "ambon:outbound", instanceId: "", sharedSecret: "" } },
+  grpc: { server: { port: 9090, controlPlaneSendTimeoutMs: 2000 }, client: { engineHost: "localhost", enginePort: 9090 }, sharedSecret: "", allowPlaintext: true, timestampToleranceMs: 30000 },
+  gateway: { id: 0, snowflake: { idLeaseTtlSeconds: 300 }, reconnect: { maxAttempts: 10, initialDelayMs: 1000, maxDelayMs: 30000, jitterFactor: 0.2, streamVerifyMs: 2000 }, engines: [], startZone: "" },
+  sharding: { enabled: false, engineId: "engine-1", zones: [], registry: { type: "STATIC", leaseTtlSeconds: 30, assignments: [] }, handoff: { ackTimeoutMs: 2000 }, advertiseHost: "localhost", advertisePort: null, playerIndex: { enabled: false, heartbeatMs: 10000 }, instancing: { enabled: false, defaultCapacity: 200, loadReportIntervalMs: 5000, startZoneMinInstances: 1, autoScale: { enabled: false, evaluationIntervalMs: 30000, scaleUpThreshold: 0.8, scaleDownThreshold: 0.2, cooldownMs: 60000 } } },
   rawSections: {},
 };
 

--- a/creator/src/lib/__tests__/validateConfig.test.ts
+++ b/creator/src/lib/__tests__/validateConfig.test.ts
@@ -4,7 +4,8 @@ import type { AppConfig } from "@/types/config";
 
 /** Minimal valid config for tests to spread over */
 const BASE_CONFIG: AppConfig = {
-  server: { telnetPort: 4000, webPort: 8080 },
+  mode: "STANDALONE",
+  server: { telnetPort: 4000, webPort: 8080, inboundChannelCapacity: 10000, outboundChannelCapacity: 10000, sessionOutboundQueueCapacity: 200, maxInboundEventsPerTick: 1000, tickMillis: 100, inboundBudgetMs: 30 },
   admin: { enabled: false, port: 9091, token: "", basePath: "/", grafanaUrl: "", corsOrigins: [] },
   observability: { metricsEnabled: true, metricsEndpoint: "/metrics", metricsHttpPort: 9099, metricsHttpHost: "0.0.0.0", staticTags: {} },
   logging: { level: "INFO", packageLevels: {} },
@@ -135,6 +136,15 @@ const BASE_CONFIG: AppConfig = {
     minimap_unexplored: "minimap-unexplored.png",
     map_background: "map_background.png",
   },
+  persistence: { backend: "YAML", rootDir: "data/players", worker: { enabled: true, flushIntervalMs: 5000 } },
+  login: { maxWrongPasswordRetries: 3, maxFailedAttemptsBeforeDisconnect: 3, maxConcurrentLogins: 50, authThreads: 8 },
+  transport: { telnet: { maxLineLen: 1024, maxNonPrintablePerLine: 32, socketBacklog: 256, maxConnections: 5000 }, websocket: { host: "0.0.0.0", stopGraceMillis: 1000, stopTimeoutMillis: 2000 }, maxInboundBackpressureFailures: 3 },
+  demo: { autoLaunchBrowser: false, webClientHost: "localhost", webClientUrl: null },
+  database: { jdbcUrl: "jdbc:postgresql://localhost:5432/ambonmud", username: "ambon", password: "ambon", maxPoolSize: 5, minimumIdle: 1 },
+  redis: { enabled: false, uri: "redis://localhost:6379", cacheTtlSeconds: 3600, bus: { enabled: false, inboundChannel: "ambon:inbound", outboundChannel: "ambon:outbound", instanceId: "", sharedSecret: "" } },
+  grpc: { server: { port: 9090, controlPlaneSendTimeoutMs: 2000 }, client: { engineHost: "localhost", enginePort: 9090 }, sharedSecret: "", allowPlaintext: true, timestampToleranceMs: 30000 },
+  gateway: { id: 0, snowflake: { idLeaseTtlSeconds: 300 }, reconnect: { maxAttempts: 10, initialDelayMs: 1000, maxDelayMs: 30000, jitterFactor: 0.2, streamVerifyMs: 2000 }, engines: [], startZone: "" },
+  sharding: { enabled: false, engineId: "engine-1", zones: [], registry: { type: "STATIC", leaseTtlSeconds: 30, assignments: [] }, handoff: { ackTimeoutMs: 2000 }, advertiseHost: "localhost", advertisePort: null, playerIndex: { enabled: false, heartbeatMs: 10000 }, instancing: { enabled: false, defaultCapacity: 200, loadReportIntervalMs: 5000, startZoneMinInstances: 1, autoScale: { enabled: false, evaluationIntervalMs: 30000, scaleUpThreshold: 0.8, scaleDownThreshold: 0.2, cooldownMs: 60000 } } },
   rawSections: {},
 };
 
@@ -145,7 +155,7 @@ describe("validateConfig", () => {
 
   // ─── Server ─────────────────────────────────────────────────
   it("flags telnet port out of range", () => {
-    const cfg = { ...BASE_CONFIG, server: { telnetPort: 0, webPort: 8080 } };
+    const cfg = { ...BASE_CONFIG, server: { ...BASE_CONFIG.server, telnetPort: 0, webPort: 8080 } };
     const issues = validateConfig(cfg);
     expect(issues).toContainEqual(
       expect.objectContaining({ entity: "server", severity: "error", message: expect.stringContaining("Telnet port") }),
@@ -153,7 +163,7 @@ describe("validateConfig", () => {
   });
 
   it("flags web port out of range", () => {
-    const cfg = { ...BASE_CONFIG, server: { telnetPort: 4000, webPort: 70000 } };
+    const cfg = { ...BASE_CONFIG, server: { ...BASE_CONFIG.server, telnetPort: 4000, webPort: 70000 } };
     const issues = validateConfig(cfg);
     expect(issues).toContainEqual(
       expect.objectContaining({ entity: "server", severity: "error", message: expect.stringContaining("Web port") }),
@@ -161,7 +171,7 @@ describe("validateConfig", () => {
   });
 
   it("flags duplicate ports", () => {
-    const cfg = { ...BASE_CONFIG, server: { telnetPort: 4000, webPort: 4000 } };
+    const cfg = { ...BASE_CONFIG, server: { ...BASE_CONFIG.server, telnetPort: 4000, webPort: 4000 } };
     const issues = validateConfig(cfg);
     expect(issues).toContainEqual(
       expect.objectContaining({ entity: "server", message: expect.stringContaining("different") }),

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -57,9 +57,6 @@ function sanitizeAdminConfigForRuntime(admin: AppConfig["admin"] | undefined): A
 
 function applyRawSections(target: Record<string, unknown>, rawSections: AppConfig["rawSections"]): void {
   for (const [key, value] of Object.entries(rawSections)) {
-    if (key === "root.mode") {
-      continue;
-    }
     if (key.startsWith("root.")) {
       target[key.slice(5)] = value;
     } else if (key.startsWith("engine.")) {
@@ -445,101 +442,57 @@ export function buildMonolithicConfigObject(
   engine.questCompletionTypes = { types: withFallbackMap(c.questCompletionTypes, DEFAULT_QUEST_COMPLETION_TYPES) };
 
   const ambonmud: Record<string, unknown> = {
-    mode: "STANDALONE",
+    mode: c.mode ?? "STANDALONE",
     sharding: {
-      enabled: false,
-      engineId: "engine-1",
-      zones: [],
-      advertiseHost: "localhost",
-      registry: { type: "STATIC", leaseTtlSeconds: 30, assignments: [] },
-      handoff: { ackTimeoutMs: 2000 },
-      playerIndex: { enabled: false, heartbeatMs: 10000 },
-      instancing: {
-        enabled: false,
-        defaultCapacity: 200,
-        loadReportIntervalMs: 5000,
-        startZoneMinInstances: 1,
-        autoScale: {
-          enabled: false,
-          evaluationIntervalMs: 30000,
-          scaleUpThreshold: 0.8,
-          scaleDownThreshold: 0.2,
-          cooldownMs: 60000,
-        },
-      },
+      enabled: c.sharding.enabled,
+      engineId: c.sharding.engineId,
+      zones: c.sharding.zones,
+      advertiseHost: c.sharding.advertiseHost,
+      ...(c.sharding.advertisePort != null ? { advertisePort: c.sharding.advertisePort } : {}),
+      registry: c.sharding.registry,
+      handoff: c.sharding.handoff,
+      playerIndex: c.sharding.playerIndex,
+      instancing: c.sharding.instancing,
     },
     grpc: {
-      server: { port: 9090 },
-      client: { engineHost: "localhost", enginePort: 9090 },
+      server: c.grpc.server,
+      client: c.grpc.client,
+      sharedSecret: c.grpc.sharedSecret || undefined,
+      allowPlaintext: c.grpc.allowPlaintext,
+      timestampToleranceMs: c.grpc.timestampToleranceMs,
     },
     gateway: {
-      id: 0,
-      snowflake: { idLeaseTtlSeconds: 300 },
-      reconnect: {
-        maxAttempts: 10,
-        initialDelayMs: 1000,
-        maxDelayMs: 30000,
-        jitterFactor: 0.2,
-        streamVerifyMs: 2000,
-      },
-      startZone: "",
-      engines: [],
+      id: c.gateway.id,
+      snowflake: c.gateway.snowflake,
+      reconnect: c.gateway.reconnect,
+      startZone: c.gateway.startZone || undefined,
+      engines: c.gateway.engines.length > 0 ? c.gateway.engines : [],
     },
     server: {
       telnetPort: c.server.telnetPort,
       webPort: c.server.webPort,
       productionMode: c.server.productionMode ?? false,
-      inboundChannelCapacity: 10000,
-      outboundChannelCapacity: 10000,
-      sessionOutboundQueueCapacity: 200,
-      maxInboundEventsPerTick: 1000,
-      tickMillis: 100,
-      inboundBudgetMs: 30,
+      inboundChannelCapacity: c.server.inboundChannelCapacity,
+      outboundChannelCapacity: c.server.outboundChannelCapacity,
+      sessionOutboundQueueCapacity: c.server.sessionOutboundQueueCapacity,
+      maxInboundEventsPerTick: c.server.maxInboundEventsPerTick,
+      tickMillis: c.server.tickMillis,
+      inboundBudgetMs: c.server.inboundBudgetMs,
     },
     world: {
       startRoom: c.world.startRoom,
       resources: c.world.resources,
     },
-    persistence: {
-      backend: "YAML",
-      rootDir: "data/players",
-      worker: {
-        enabled: true,
-        flushIntervalMs: 5000,
-      },
-    },
-    database: {
-      jdbcUrl: "jdbc:postgresql://localhost:5432/ambonmud",
-      username: "ambon",
-      password: "ambon",
-      maxPoolSize: 5,
-      minimumIdle: 1,
-    },
-    login: {
-      maxWrongPasswordRetries: 3,
-      maxFailedAttemptsBeforeDisconnect: 3,
-      maxConcurrentLogins: 150,
-      authThreads: 8,
-    },
+    persistence: c.persistence,
+    database: c.database,
+    login: c.login,
     engine,
     progression: c.progression,
-    transport: {
-      telnet: {
-        maxLineLen: 1024,
-        maxNonPrintablePerLine: 32,
-        socketBacklog: 256,
-      },
-      websocket: {
-        host: "0.0.0.0",
-        stopGraceMillis: 1000,
-        stopTimeoutMillis: 2000,
-      },
-      maxInboundBackpressureFailures: 3,
-    },
+    transport: c.transport,
     demo: {
-      autoLaunchBrowser: false,
-      webClientHost: "localhost",
-      webClientUrl: null,
+      autoLaunchBrowser: c.demo.autoLaunchBrowser,
+      webClientHost: c.demo.webClientHost,
+      webClientUrl: c.demo.webClientUrl,
     },
     observability: {
       metricsEnabled: c.observability?.metricsEnabled ?? true,
@@ -564,16 +517,10 @@ export function buildMonolithicConfigObject(
       },
     },
     redis: {
-      enabled: false,
-      uri: "redis://localhost:6379",
-      cacheTtlSeconds: 3600,
-      bus: {
-        enabled: false,
-        inboundChannel: "ambon:inbound",
-        outboundChannel: "ambon:outbound",
-        instanceId: "",
-        sharedSecret: "CHANGE_ME",
-      },
+      enabled: c.redis.enabled,
+      uri: c.redis.uri,
+      cacheTtlSeconds: c.redis.cacheTtlSeconds,
+      bus: c.redis.bus,
     },
     images: {
       baseUrl: imageBaseUrl,

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -72,6 +72,7 @@ export function parseAppConfigYaml(content: string): AppConfig {
   const progression = (root.progression ?? {}) as Record<string, unknown>;
 
   return {
+    mode: parseDeploymentMode(root.mode),
     server: parseServerConfig(root.server),
     admin: parseAdminConfig(root.admin),
     observability: parseObservabilityConfig(root.observability),
@@ -134,6 +135,15 @@ export function parseAppConfigYaml(content: string): AppConfig {
     factions: engine.factions as AppConfig["factions"],
     leaderboard: engine.leaderboard as AppConfig["leaderboard"],
     currencies: parseCurrenciesConfig(engine.currencies),
+    persistence: parsePersistenceConfig(root.persistence),
+    login: parseLoginConfig(root.login),
+    transport: parseTransportConfig(root.transport),
+    demo: parseDemoConfig(root.demo),
+    database: parseDatabaseConfig(root.database),
+    redis: parseRedisConfig(root.redis),
+    grpc: parseGrpcConfig(root.grpc),
+    gateway: parseGatewayConfig(root.gateway),
+    sharding: parseShardingConfig(root.sharding),
     rawSections: collectRawSections(root, engine),
   };
 }
@@ -180,12 +190,185 @@ export async function loadAppConfig(
 
 // ─── Parsing helpers ────────────────────────────────────────────────
 
+function parseDeploymentMode(raw: unknown): AppConfig["mode"] {
+  const val = typeof raw === "string" ? raw.toUpperCase() : "";
+  if (val === "ENGINE" || val === "GATEWAY") return val;
+  return "STANDALONE";
+}
+
 function parseServerConfig(raw: unknown): AppConfig["server"] {
   const s = (raw ?? {}) as Record<string, unknown>;
   return {
     telnetPort: asNumber(s.telnetPort, 4000),
     webPort: asNumber(s.webPort, 8080),
     productionMode: asBool(s.productionMode, false),
+    inboundChannelCapacity: asNumber(s.inboundChannelCapacity, 10000),
+    outboundChannelCapacity: asNumber(s.outboundChannelCapacity, 10000),
+    sessionOutboundQueueCapacity: asNumber(s.sessionOutboundQueueCapacity, 200),
+    maxInboundEventsPerTick: asNumber(s.maxInboundEventsPerTick, 1000),
+    tickMillis: asNumber(s.tickMillis, 100),
+    inboundBudgetMs: asNumber(s.inboundBudgetMs, 30),
+  };
+}
+
+function parsePersistenceConfig(raw: unknown): AppConfig["persistence"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  const worker = (s.worker ?? {}) as Record<string, unknown>;
+  return {
+    backend: s.backend === "POSTGRES" ? "POSTGRES" : "YAML",
+    rootDir: asString(s.rootDir, "data/players"),
+    worker: {
+      enabled: asBool(worker.enabled, true),
+      flushIntervalMs: asNumber(worker.flushIntervalMs, 5000),
+    },
+  };
+}
+
+function parseLoginConfig(raw: unknown): AppConfig["login"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  return {
+    maxWrongPasswordRetries: asNumber(s.maxWrongPasswordRetries, 3),
+    maxFailedAttemptsBeforeDisconnect: asNumber(s.maxFailedAttemptsBeforeDisconnect, 3),
+    maxConcurrentLogins: asNumber(s.maxConcurrentLogins, 50),
+    authThreads: asNumber(s.authThreads, 8),
+  };
+}
+
+function parseTransportConfig(raw: unknown): AppConfig["transport"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  const telnet = (s.telnet ?? {}) as Record<string, unknown>;
+  const ws = (s.websocket ?? {}) as Record<string, unknown>;
+  return {
+    telnet: {
+      maxLineLen: asNumber(telnet.maxLineLen, 1024),
+      maxNonPrintablePerLine: asNumber(telnet.maxNonPrintablePerLine, 32),
+      socketBacklog: asNumber(telnet.socketBacklog, 256),
+      maxConnections: asNumber(telnet.maxConnections, 5000),
+    },
+    websocket: {
+      host: asString(ws.host, "0.0.0.0"),
+      stopGraceMillis: asNumber(ws.stopGraceMillis, 1000),
+      stopTimeoutMillis: asNumber(ws.stopTimeoutMillis, 2000),
+    },
+    maxInboundBackpressureFailures: asNumber(s.maxInboundBackpressureFailures, 3),
+  };
+}
+
+function parseDemoConfig(raw: unknown): AppConfig["demo"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  return {
+    autoLaunchBrowser: asBool(s.autoLaunchBrowser, false),
+    webClientHost: asString(s.webClientHost, "localhost"),
+    webClientUrl: typeof s.webClientUrl === "string" ? s.webClientUrl : null,
+  };
+}
+
+function parseDatabaseConfig(raw: unknown): AppConfig["database"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  return {
+    jdbcUrl: asString(s.jdbcUrl, "jdbc:postgresql://localhost:5432/ambonmud"),
+    username: asString(s.username, "ambon"),
+    password: asString(s.password, "ambon"),
+    maxPoolSize: asNumber(s.maxPoolSize, 5),
+    minimumIdle: asNumber(s.minimumIdle, 1),
+  };
+}
+
+function parseRedisConfig(raw: unknown): AppConfig["redis"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  const bus = (s.bus ?? {}) as Record<string, unknown>;
+  return {
+    enabled: asBool(s.enabled, false),
+    uri: asString(s.uri, "redis://localhost:6379"),
+    cacheTtlSeconds: asNumber(s.cacheTtlSeconds, 3600),
+    bus: {
+      enabled: asBool(bus.enabled, false),
+      inboundChannel: asString(bus.inboundChannel, "ambon:inbound"),
+      outboundChannel: asString(bus.outboundChannel, "ambon:outbound"),
+      instanceId: asString(bus.instanceId, ""),
+      sharedSecret: asString(bus.sharedSecret, ""),
+    },
+  };
+}
+
+function parseGrpcConfig(raw: unknown): AppConfig["grpc"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  const server = (s.server ?? {}) as Record<string, unknown>;
+  const client = (s.client ?? {}) as Record<string, unknown>;
+  return {
+    server: {
+      port: asNumber(server.port, 9090),
+      controlPlaneSendTimeoutMs: asNumber(server.controlPlaneSendTimeoutMs, 2000),
+    },
+    client: {
+      engineHost: asString(client.engineHost, "localhost"),
+      enginePort: asNumber(client.enginePort, 9090),
+    },
+    sharedSecret: asString(s.sharedSecret, ""),
+    allowPlaintext: asBool(s.allowPlaintext, true),
+    timestampToleranceMs: asNumber(s.timestampToleranceMs, 30000),
+  };
+}
+
+function parseGatewayConfig(raw: unknown): AppConfig["gateway"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  const snowflake = (s.snowflake ?? {}) as Record<string, unknown>;
+  const reconnect = (s.reconnect ?? {}) as Record<string, unknown>;
+  return {
+    id: asNumber(s.id, 0),
+    snowflake: {
+      idLeaseTtlSeconds: asNumber(snowflake.idLeaseTtlSeconds, 300),
+    },
+    reconnect: {
+      maxAttempts: asNumber(reconnect.maxAttempts, 10),
+      initialDelayMs: asNumber(reconnect.initialDelayMs, 1000),
+      maxDelayMs: asNumber(reconnect.maxDelayMs, 30000),
+      jitterFactor: asNumber(reconnect.jitterFactor, 0.2),
+      streamVerifyMs: asNumber(reconnect.streamVerifyMs, 2000),
+    },
+    engines: Array.isArray(s.engines) ? s.engines as AppConfig["gateway"]["engines"] : [],
+    startZone: asString(s.startZone, ""),
+  };
+}
+
+function parseShardingConfig(raw: unknown): AppConfig["sharding"] {
+  const s = (raw ?? {}) as Record<string, unknown>;
+  const registry = (s.registry ?? {}) as Record<string, unknown>;
+  const handoff = (s.handoff ?? {}) as Record<string, unknown>;
+  const playerIndex = (s.playerIndex ?? {}) as Record<string, unknown>;
+  const instancing = (s.instancing ?? {}) as Record<string, unknown>;
+  const autoScale = (instancing.autoScale ?? {}) as Record<string, unknown>;
+  return {
+    enabled: asBool(s.enabled, false),
+    engineId: asString(s.engineId, "engine-1"),
+    zones: Array.isArray(s.zones) ? s.zones as string[] : [],
+    registry: {
+      type: asString(registry.type, "STATIC"),
+      leaseTtlSeconds: asNumber(registry.leaseTtlSeconds, 30),
+      assignments: Array.isArray(registry.assignments) ? registry.assignments as string[] : [],
+    },
+    handoff: {
+      ackTimeoutMs: asNumber(handoff.ackTimeoutMs, 2000),
+    },
+    advertiseHost: asString(s.advertiseHost, "localhost"),
+    advertisePort: typeof s.advertisePort === "number" ? s.advertisePort : null,
+    playerIndex: {
+      enabled: asBool(playerIndex.enabled, false),
+      heartbeatMs: asNumber(playerIndex.heartbeatMs, 10000),
+    },
+    instancing: {
+      enabled: asBool(instancing.enabled, false),
+      defaultCapacity: asNumber(instancing.defaultCapacity, 200),
+      loadReportIntervalMs: asNumber(instancing.loadReportIntervalMs, 5000),
+      startZoneMinInstances: asNumber(instancing.startZoneMinInstances, 1),
+      autoScale: {
+        enabled: asBool(autoScale.enabled, false),
+        evaluationIntervalMs: asNumber(autoScale.evaluationIntervalMs, 30000),
+        scaleUpThreshold: asNumber(autoScale.scaleUpThreshold, 0.8),
+        scaleDownThreshold: asNumber(autoScale.scaleDownThreshold, 0.2),
+        cooldownMs: asNumber(autoScale.cooldownMs, 60000),
+      },
+    },
   };
 }
 
@@ -669,8 +852,8 @@ function collectRawSections(
   engine: Record<string, unknown>,
 ): Record<string, unknown> {
   const knownRoot = new Set([
-    "mode", "server", "engine", "progression", "images", "globalAssets", "playerTiers", "world", "persistence",
-    "login", "transport", "demo", "observability", "admin",
+    "mode", "server", "engine", "progression", "images", "globalAssets", "playerTiers", "world",
+    "persistence", "login", "transport", "demo", "observability", "admin",
     "logging", "database", "redis", "grpc", "gateway", "sharding",
     "videos", "audio",
   ]);
@@ -1125,6 +1308,7 @@ async function loadSplitConfig(projectDir: string): Promise<AppConfig | null> {
 
     const config: AppConfig = {
       // world.yaml
+      mode: parseDeploymentMode(worldRaw.mode),
       server: parseServerConfig(worldRaw.server),
       admin: parseAdminConfig(worldRaw.admin),
       observability: parseObservabilityConfig(worldRaw.observability),
@@ -1210,6 +1394,16 @@ async function loadSplitConfig(projectDir: string): Promise<AppConfig | null> {
       factions: worldRaw.factions as AppConfig["factions"],
       leaderboard: worldRaw.leaderboard as AppConfig["leaderboard"],
       currencies: parseCurrenciesConfig(worldRaw.currencies),
+
+      persistence: parsePersistenceConfig(worldRaw.persistence),
+      login: parseLoginConfig(worldRaw.login),
+      transport: parseTransportConfig(worldRaw.transport),
+      demo: parseDemoConfig(worldRaw.demo),
+      database: parseDatabaseConfig(worldRaw.database),
+      redis: parseRedisConfig(worldRaw.redis),
+      grpc: parseGrpcConfig(worldRaw.grpc),
+      gateway: parseGatewayConfig(worldRaw.gateway),
+      sharding: parseShardingConfig(worldRaw.sharding),
 
       rawSections: {},
     };

--- a/creator/src/lib/panelRegistry.ts
+++ b/creator/src/lib/panelRegistry.ts
@@ -90,6 +90,7 @@ const CHARACTER_PANELS: PanelDef[] = [
 const WORLD_PANELS: PanelDef[] = [
   { id: "tuningWizard", label: "Tuning Wizard", group: "world", host: "command", kicker: "World", title: "Tuning Wizard", description: "Configure all game balance — presets, inline editing, and before/after comparison.", maxWidth: "max-w-7xl", island: "orrery", glyph: "\u2699\uFE0F" },
   { id: "worldServer", label: "World & Server", group: "world", host: "config", kicker: "Infrastructure", title: "World & server", description: "Start room, server ports, admin API, observability, and logging.", maxWidth: "max-w-5xl", island: "orrery", glyph: "\u{1F30D}" },
+  { id: "infrastructure", label: "Infrastructure", group: "world", host: "config", kicker: "Deployment", title: "Infrastructure", description: "Deployment mode, persistence, login, transport, database, Redis, gRPC, gateway, and sharding.", maxWidth: "max-w-5xl", island: "orrery", glyph: "\u{1F3D7}\uFE0F" },
   { id: "commands", label: "Commands", group: "world", host: "config", kicker: "Commands", title: "Command designer", description: "Custom commands, usage strings, and categories.", maxWidth: "max-w-5xl", island: "loom", glyph: "\u{1F58B}\uFE0F" },
 ];
 

--- a/creator/src/lib/saveConfig.ts
+++ b/creator/src/lib/saveConfig.ts
@@ -167,6 +167,7 @@ async function saveSplitConfig(projectDir: string): Promise<void> {
     }),
 
     write("world", cleanObj({
+      mode: config.mode,
       server: config.server,
       admin: sanitizeAdminConfigForSave(config.admin),
       observability: config.observability,
@@ -218,6 +219,15 @@ async function saveSplitConfig(projectDir: string): Promise<void> {
       factions: config.factions,
       leaderboard: config.leaderboard,
       currencies: normalizeCurrenciesConfig(config.currencies),
+      persistence: config.persistence,
+      login: config.login,
+      transport: config.transport,
+      demo: config.demo,
+      database: config.database,
+      redis: config.redis,
+      grpc: config.grpc,
+      gateway: config.gateway,
+      sharding: config.sharding,
     })),
 
     write("assets", cleanObj({

--- a/creator/src/lib/tuning/__tests__/presets.test.ts
+++ b/creator/src/lib/tuning/__tests__/presets.test.ts
@@ -13,7 +13,8 @@ import type { AppConfig } from "@/types/config";
 // Used as the base for merging preset overlays.
 
 const FULL_MOCK_CONFIG: AppConfig = {
-  server: { telnetPort: 4000, webPort: 8080 },
+  mode: "STANDALONE",
+  server: { telnetPort: 4000, webPort: 8080, inboundChannelCapacity: 10000, outboundChannelCapacity: 10000, sessionOutboundQueueCapacity: 200, maxInboundEventsPerTick: 1000, tickMillis: 100, inboundBudgetMs: 30 },
   admin: { enabled: false, port: 9090, token: "test", basePath: "/admin", grafanaUrl: "" },
   observability: { metricsEnabled: false, metricsEndpoint: "/metrics", metricsHttpPort: 9100 },
   logging: { level: "INFO", packageLevels: {} },
@@ -125,6 +126,15 @@ const FULL_MOCK_CONFIG: AppConfig = {
   guildHalls: { enabled: true, baseCost: 10000, roomTemplates: {} },
   leaderboard: { refreshIntervalMs: 120000, topN: 10 },
   globalAssets: {},
+  persistence: { backend: "YAML", rootDir: "data/players", worker: { enabled: true, flushIntervalMs: 5000 } },
+  login: { maxWrongPasswordRetries: 3, maxFailedAttemptsBeforeDisconnect: 3, maxConcurrentLogins: 50, authThreads: 8 },
+  transport: { telnet: { maxLineLen: 1024, maxNonPrintablePerLine: 32, socketBacklog: 256, maxConnections: 5000 }, websocket: { host: "0.0.0.0", stopGraceMillis: 1000, stopTimeoutMillis: 2000 }, maxInboundBackpressureFailures: 3 },
+  demo: { autoLaunchBrowser: false, webClientHost: "localhost", webClientUrl: null },
+  database: { jdbcUrl: "jdbc:postgresql://localhost:5432/ambonmud", username: "ambon", password: "ambon", maxPoolSize: 5, minimumIdle: 1 },
+  redis: { enabled: false, uri: "redis://localhost:6379", cacheTtlSeconds: 3600, bus: { enabled: false, inboundChannel: "ambon:inbound", outboundChannel: "ambon:outbound", instanceId: "", sharedSecret: "" } },
+  grpc: { server: { port: 9090, controlPlaneSendTimeoutMs: 2000 }, client: { engineHost: "localhost", enginePort: 9090 }, sharedSecret: "", allowPlaintext: true, timestampToleranceMs: 30000 },
+  gateway: { id: 0, snowflake: { idLeaseTtlSeconds: 300 }, reconnect: { maxAttempts: 10, initialDelayMs: 1000, maxDelayMs: 30000, jitterFactor: 0.2, streamVerifyMs: 2000 }, engines: [], startZone: "" },
+  sharding: { enabled: false, engineId: "engine-1", zones: [], registry: { type: "STATIC", leaseTtlSeconds: 30, assignments: [] }, handoff: { ackTimeoutMs: 2000 }, advertiseHost: "localhost", advertisePort: null, playerIndex: { enabled: false, heartbeatMs: 10000 }, instancing: { enabled: false, defaultCapacity: 200, loadReportIntervalMs: 5000, startZoneMinInstances: 1, autoScale: { enabled: false, evaluationIntervalMs: 30000, scaleUpThreshold: 0.8, scaleDownThreshold: 0.2, cooldownMs: 60000 } } },
   rawSections: {},
 };
 

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -583,6 +583,188 @@ export interface ServerConfig {
   telnetPort: number;
   webPort: number;
   productionMode?: boolean;
+  inboundChannelCapacity: number;
+  outboundChannelCapacity: number;
+  sessionOutboundQueueCapacity: number;
+  maxInboundEventsPerTick: number;
+  tickMillis: number;
+  inboundBudgetMs: number;
+}
+
+// ─── Deployment mode ───────────────────────────────────────────────
+
+export type DeploymentMode = "STANDALONE" | "ENGINE" | "GATEWAY";
+
+// ─── Persistence ───────────────────────────────────────────────────
+
+export type PersistenceBackend = "YAML" | "POSTGRES";
+
+export interface PersistenceWorkerConfig {
+  enabled: boolean;
+  flushIntervalMs: number;
+}
+
+export interface PersistenceConfig {
+  backend: PersistenceBackend;
+  rootDir: string;
+  worker: PersistenceWorkerConfig;
+}
+
+// ─── Login ─────────────────────────────────────────────────────────
+
+export interface LoginConfig {
+  maxWrongPasswordRetries: number;
+  maxFailedAttemptsBeforeDisconnect: number;
+  maxConcurrentLogins: number;
+  authThreads: number;
+}
+
+// ─── Transport ─────────────────────────────────────────────────────
+
+export interface TelnetTransportConfig {
+  maxLineLen: number;
+  maxNonPrintablePerLine: number;
+  socketBacklog: number;
+  maxConnections: number;
+}
+
+export interface WebSocketTransportConfig {
+  host: string;
+  stopGraceMillis: number;
+  stopTimeoutMillis: number;
+}
+
+export interface TransportConfig {
+  telnet: TelnetTransportConfig;
+  websocket: WebSocketTransportConfig;
+  maxInboundBackpressureFailures: number;
+}
+
+// ─── Demo ──────────────────────────────────────────────────────────
+
+export interface DemoConfig {
+  autoLaunchBrowser: boolean;
+  webClientHost: string;
+  webClientUrl: string | null;
+}
+
+// ─── Database ──────────────────────────────────────────────────────
+
+export interface DatabaseConfig {
+  jdbcUrl: string;
+  username: string;
+  password: string;
+  maxPoolSize: number;
+  minimumIdle: number;
+}
+
+// ─── Redis ─────────────────────────────────────────────────────────
+
+export interface RedisBusConfig {
+  enabled: boolean;
+  inboundChannel: string;
+  outboundChannel: string;
+  instanceId: string;
+  sharedSecret: string;
+}
+
+export interface RedisConfig {
+  enabled: boolean;
+  uri: string;
+  cacheTtlSeconds: number;
+  bus: RedisBusConfig;
+}
+
+// ─── gRPC ──────────────────────────────────────────────────────────
+
+export interface GrpcServerConfig {
+  port: number;
+  controlPlaneSendTimeoutMs: number;
+}
+
+export interface GrpcClientConfig {
+  engineHost: string;
+  enginePort: number;
+}
+
+export interface GrpcConfig {
+  server: GrpcServerConfig;
+  client: GrpcClientConfig;
+  sharedSecret: string;
+  allowPlaintext: boolean;
+  timestampToleranceMs: number;
+}
+
+// ─── Gateway ───────────────────────────────────────────────────────
+
+export interface SnowflakeConfig {
+  idLeaseTtlSeconds: number;
+}
+
+export interface GatewayReconnectConfig {
+  maxAttempts: number;
+  initialDelayMs: number;
+  maxDelayMs: number;
+  jitterFactor: number;
+  streamVerifyMs: number;
+}
+
+export interface GatewayEngineEntry {
+  host: string;
+  port: number;
+}
+
+export interface GatewayConfig {
+  id: number;
+  snowflake: SnowflakeConfig;
+  reconnect: GatewayReconnectConfig;
+  engines: GatewayEngineEntry[];
+  startZone: string;
+}
+
+// ─── Sharding ──────────────────────────────────────────────────────
+
+export interface ShardingRegistryConfig {
+  type: string;
+  leaseTtlSeconds: number;
+  assignments: string[];
+}
+
+export interface ShardingHandoffConfig {
+  ackTimeoutMs: number;
+}
+
+export interface PlayerIndexConfig {
+  enabled: boolean;
+  heartbeatMs: number;
+}
+
+export interface AutoScaleConfig {
+  enabled: boolean;
+  evaluationIntervalMs: number;
+  scaleUpThreshold: number;
+  scaleDownThreshold: number;
+  cooldownMs: number;
+}
+
+export interface InstanceConfig {
+  enabled: boolean;
+  defaultCapacity: number;
+  loadReportIntervalMs: number;
+  startZoneMinInstances: number;
+  autoScale: AutoScaleConfig;
+}
+
+export interface ShardingConfig {
+  enabled: boolean;
+  engineId: string;
+  zones: string[];
+  registry: ShardingRegistryConfig;
+  handoff: ShardingHandoffConfig;
+  advertiseHost: string;
+  advertisePort: number | null;
+  playerIndex: PlayerIndexConfig;
+  instancing: InstanceConfig;
 }
 
 // ─── Admin ──────────────────────────────────────────────────────────
@@ -771,6 +953,7 @@ export interface LeaderboardConfig {
 // ─── Top-level config state ─────────────────────────────────────────
 
 export interface AppConfig {
+  mode: DeploymentMode;
   server: ServerConfig;
   admin: AdminServerConfig;
   observability: ObservabilityConfig;
@@ -836,6 +1019,15 @@ export interface AppConfig {
   leaderboard?: LeaderboardConfig;
   globalAssets: Record<string, string>;
   playerTiers?: Record<string, TierDefinitionConfig>;
+  persistence: PersistenceConfig;
+  login: LoginConfig;
+  transport: TransportConfig;
+  demo: DemoConfig;
+  database: DatabaseConfig;
+  redis: RedisConfig;
+  grpc: GrpcConfig;
+  gateway: GatewayConfig;
+  sharding: ShardingConfig;
   /** Raw YAML content for unrecognized sections */
   rawSections: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

Closes the last gap from the parity audit: 10 config sections and 6 ServerConfig fields that were recognized by the loader but never typed, parsed into structured state, or editable — they survived only as `rawSections` and were silently overwritten with hardcoded defaults on every save.

- **Types**: Added full TypeScript interfaces for `PersistenceConfig`, `LoginConfig`, `TransportConfig`, `DemoConfig`, `DatabaseConfig`, `RedisConfig`, `GrpcConfig`, `GatewayConfig`, `ShardingConfig` (with all nested sub-types), `DeploymentMode` enum, and 6 new `ServerConfig` fields (channel capacities, tick rate, inbound budget)
- **Loader**: Parse functions for all 10 sections in both monolithic and split config paths
- **Saver**: Replaced all hardcoded defaults in `buildMonolithicConfigObject()` with actual config values; fixed `applyRawSections()` silently dropping `root.mode`; added 3 missing gRPC fields
- **UI**: New `InfrastructurePanel` with 10 section editors (mode, persistence, login, transport, demo, database, redis, gRPC, gateway, sharding); extended `ServerPanel` with event-loop tuning fields
- **Tests**: Updated 3 test files with new required `AppConfig` fields; all 1593 tests pass

## Test plan

- [ ] Open the Infrastructure panel from the World sidebar group
- [ ] Edit fields in each section (mode, persistence, login, transport, demo, database, redis, gRPC, gateway, sharding) and verify auto-save writes them to YAML
- [ ] Open World & Server panel — verify new event-loop fields (tick, budget, channels) appear and are editable
- [ ] Load a project with existing infrastructure config values in YAML — verify they round-trip correctly (not overwritten with defaults)
- [ ] Change deployment mode to ENGINE or GATEWAY, save, reload — verify mode persists
- [ ] `bunx tsc --noEmit` passes
- [ ] `bun run test` — all 1593 tests pass