### PR TITLE
Add hub-first onboarding flow from the welcome screen

### DIFF
--- a/creator/src/components/WelcomeScreen.tsx
+++ b/creator/src/components/WelcomeScreen.tsx
@@ -10,6 +10,7 @@ import { CosmicBackdrop } from "./ui/CosmicBackdrop";
 import splashHero from "@/assets/splash-hero.jpg";
 
 const ImportFromR2Dialog = lazy(() => import("./ImportFromR2Dialog").then((m) => ({ default: m.ImportFromR2Dialog })));
+const OnboardingFlow = lazy(() => import("./onboarding/OnboardingFlow").then((m) => ({ default: m.OnboardingFlow })));
 
 interface WelcomeScreenProps {
   onNewProject: () => void;
@@ -20,6 +21,7 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
   const [errors, setErrors] = useState<string[] | null>(null);
   const [loading, setLoading] = useState<string | null>(null);
   const [showR2Import, setShowR2Import] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
   const [recentProjects, setRecentProjects] = useState<RecentProject[]>(
     () => loadUIState()?.recentProjects ?? [],
   );
@@ -78,11 +80,21 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
             <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[linear-gradient(155deg,rgb(var(--surface-rgb)/0.78),rgb(var(--bg-rgb)/0.92))] p-6 shadow-panel">
               <div className="mt-1 flex flex-col gap-4">
                 <button
-                  onClick={onNewProject}
-                  className="rounded-3xl border border-[var(--border-accent-ring)] bg-[linear-gradient(135deg,rgb(var(--accent-rgb)/0.26),rgb(var(--surface-rgb)/0.18))] px-5 py-5 text-left text-sm font-medium text-text-primary transition hover:shadow-[0_14px_34px_rgb(var(--accent-rgb)/0.2)]"
+                  onClick={() => setShowOnboarding(true)}
+                  className="rounded-3xl border border-[var(--border-accent-ring)] bg-[linear-gradient(135deg,rgb(var(--accent-rgb)/0.34),rgb(var(--surface-rgb)/0.18))] px-5 py-5 text-left text-sm font-medium text-text-primary shadow-[0_16px_40px_rgb(var(--accent-rgb)/0.18)] transition hover:shadow-[0_18px_46px_rgb(var(--accent-rgb)/0.28)]"
                 >
-                  <div className="font-display text-xl">Create new project</div>
-                  <div className="mt-2 text-xs font-normal leading-6 text-text-secondary">Lay down a fresh scaffold, then move directly into worldmaking.</div>
+                  <div className="flex items-center gap-2">
+                    <div className="font-display text-xl">Start with Arcanum Hub</div>
+                    <span className="rounded-full border border-[var(--border-accent-ring)] bg-[var(--chrome-fill)] px-2 py-0.5 text-2xs uppercase tracking-ui text-accent">New</span>
+                  </div>
+                  <div className="mt-2 text-xs font-normal leading-6 text-text-secondary">Drop in a hub API key and we'll generate your first zone, art and all, in about a minute.</div>
+                </button>
+                <button
+                  onClick={onNewProject}
+                  className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-5 py-4 text-left text-sm font-medium text-text-primary transition hover:border-[var(--border-accent-ring)] hover:bg-[var(--chrome-highlight-strong)]"
+                >
+                  <div className="font-display text-lg">Create new project</div>
+                  <div className="mt-1 text-xs font-normal leading-6 text-text-secondary">Bring your own API keys. Lay down a fresh scaffold and go.</div>
                 </button>
                 <div className="space-y-2 border-t border-[var(--chrome-stroke)] pt-4">
                   <button
@@ -194,6 +206,12 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
       <Suspense>
         {showR2Import && (
           <ImportFromR2Dialog onClose={() => setShowR2Import(false)} />
+        )}
+      </Suspense>
+
+      <Suspense>
+        {showOnboarding && (
+          <OnboardingFlow onClose={() => setShowOnboarding(false)} />
         )}
       </Suspense>
     </div>

--- a/creator/src/components/onboarding/ArtStyleStep.tsx
+++ b/creator/src/components/onboarding/ArtStyleStep.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { useAssetStore } from "@/stores/assetStore";
+
+export type OnboardingImageStyle = "flux" | "gpt";
+
+interface ArtStyleStepProps {
+  onDone: (style: OnboardingImageStyle) => void;
+}
+
+interface StyleOption {
+  id: OnboardingImageStyle;
+  label: string;
+  tagline: string;
+  description: string;
+  provider: "runware" | "openai";
+  model: string;
+  previewBackground: string;
+  previewHint: string;
+}
+
+const STYLE_OPTIONS: StyleOption[] = [
+  {
+    id: "flux",
+    label: "FLUX",
+    tagline: "Classic fantasy",
+    description:
+      "Painterly, illustrated, a little cinematic. Leans into high-contrast lighting and moody atmosphere — the look of a hand-painted fantasy cover.",
+    provider: "runware",
+    model: "runware:400@2",
+    previewBackground:
+      "linear-gradient(140deg, #2a1840 0%, #6d3a8a 45%, #c58a4a 100%)",
+    previewHint: "Moody, painterly, hand-illustrated",
+  },
+  {
+    id: "gpt",
+    label: "GPT Image",
+    tagline: "Warmer, studio-softened",
+    description:
+      "Soft edges, gentle palettes, a storybook warmth. Reads more like animation concept art — approachable, friendly, and lightly whimsical.",
+    provider: "openai",
+    model: "openai:4@1",
+    previewBackground:
+      "linear-gradient(140deg, #f6d6c0 0%, #e3a0c5 40%, #8b7ac0 100%)",
+    previewHint: "Soft, warm, storybook",
+  },
+];
+
+export function ArtStyleStep({ onDone }: ArtStyleStepProps) {
+  const settings = useAssetStore((s) => s.settings);
+  const saveSettings = useAssetStore((s) => s.saveSettings);
+  const setArtStyle = useAssetStore((s) => s.setArtStyle);
+  const [pending, setPending] = useState<OnboardingImageStyle | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePick = async (option: StyleOption) => {
+    if (!settings) {
+      setError("Settings not loaded yet — give it a moment and try again.");
+      return;
+    }
+    setPending(option.id);
+    setError(null);
+    try {
+      await saveSettings({
+        ...settings,
+        image_provider: option.provider,
+        image_model: option.model,
+      });
+      setArtStyle("gentle_magic");
+      onDone(option.id);
+    } catch (e) {
+      setError(String(e));
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-sm leading-7 text-text-secondary">
+        Both produce the same scenes from the same prompts, but they feel different. Pick whichever
+        look you'd like your world to wear. You can swap later from Settings.
+      </p>
+
+      <div className="grid gap-5 sm:grid-cols-2">
+        {STYLE_OPTIONS.map((option) => {
+          const isPending = pending === option.id;
+          return (
+            <button
+              key={option.id}
+              onClick={() => handlePick(option)}
+              disabled={pending !== null}
+              className="group flex flex-col overflow-hidden rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-left transition hover:border-[var(--border-accent-ring)] hover:shadow-[0_16px_40px_rgb(var(--accent-rgb)/0.16)] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {/* Preview: hand-committed sample images go in creator/public/onboarding/.
+                  Until those exist we render a representative gradient so the flow still reads. */}
+              <div
+                className="relative flex h-48 items-end p-4"
+                style={{ background: option.previewBackground }}
+              >
+                <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgb(255_255_255/0.12),transparent_60%)]" />
+                <div className="relative z-10">
+                  <div className="text-2xs uppercase tracking-ui text-white/70">Sample</div>
+                  <div className="mt-1 font-display text-sm text-white/90">{option.previewHint}</div>
+                </div>
+                {isPending && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-black/40">
+                    <div className="h-6 w-6 rounded-full border-2 border-white/70 border-t-transparent animate-spin" />
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-col gap-2 p-5">
+                <div className="flex items-baseline justify-between gap-3">
+                  <div className="font-display text-xl text-text-primary">{option.label}</div>
+                  <div className="text-2xs uppercase tracking-ui text-text-muted">
+                    {option.tagline}
+                  </div>
+                </div>
+                <p className="text-xs leading-6 text-text-secondary">{option.description}</p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      {error && <p className="text-2xs text-status-error">{error}</p>}
+    </div>
+  );
+}

--- a/creator/src/components/onboarding/GeneratingStep.tsx
+++ b/creator/src/components/onboarding/GeneratingStep.tsx
@@ -1,0 +1,364 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { writeTextFile } from "@tauri-apps/plugin-fs";
+import { homeDir } from "@tauri-apps/api/path";
+import { stringify } from "yaml";
+import { useOpenProject } from "@/lib/useOpenProject";
+import { useAssetStore } from "@/stores/assetStore";
+import { useConfigStore } from "@/stores/configStore";
+import { useProjectStore } from "@/stores/projectStore";
+import { useZoneStore } from "@/stores/zoneStore";
+import { useVibeStore } from "@/stores/vibeStore";
+import { applyTemplate, TEMPLATES } from "@/lib/templates";
+import { saveProjectConfig } from "@/lib/saveConfig";
+import { zoneFilePath } from "@/lib/projectPaths";
+import { addRecentProject, saveArtSubTab } from "@/lib/uiPersistence";
+import {
+  generateZoneContent,
+  createFallbackZone,
+  type ZoneGenerationParams,
+} from "@/lib/generateZoneContent";
+import { roomPrompt, mobPrompt, itemPrompt } from "@/lib/entityPrompts";
+import { getNegativePrompt } from "@/lib/arcanumPrompts";
+import {
+  imageGenerateCommand,
+  resolveImageModel,
+  requestsTransparentBackground,
+  type GeneratedImage,
+} from "@/types/assets";
+import { YAML_OPTS } from "@/lib/yamlOpts";
+import type { WorldFile } from "@/types/world";
+import type { OnboardingZoneTemplate } from "@/lib/onboardingZoneTemplates";
+import type { OnboardingImageStyle } from "./ArtStyleStep";
+
+type Phase = "project" | "zone" | "art" | "opening" | "done";
+
+interface PhaseInfo {
+  id: Phase;
+  label: string;
+}
+
+const PHASES: PhaseInfo[] = [
+  { id: "project", label: "Creating your project folder" },
+  { id: "zone", label: "Sketching the first zone" },
+  { id: "art", label: "Rendering your first art" },
+  { id: "opening", label: "Opening the workspace" },
+];
+
+interface GeneratingStepProps {
+  imageStyle: OnboardingImageStyle;
+  template: OnboardingZoneTemplate;
+  onFinished: () => void;
+}
+
+function pickRandom<T>(items: T[]): T | undefined {
+  if (items.length === 0) return undefined;
+  return items[Math.floor(Math.random() * items.length)];
+}
+
+function joinPath(parent: string, child: string): string {
+  const sep = parent.includes("\\") ? "\\" : "/";
+  return parent.endsWith("/") || parent.endsWith("\\")
+    ? `${parent}${child}`
+    : `${parent}${sep}${child}`;
+}
+
+async function createProjectWithRetry(
+  parentDir: string,
+  baseName: string,
+): Promise<{ mudDir: string; projectName: string }> {
+  for (let i = 0; i < 20; i++) {
+    const projectName = i === 0 ? baseName : `${baseName}_${i + 1}`;
+    try {
+      const mudDir = await invoke<string>("create_standalone_project", {
+        targetDir: parentDir,
+        projectName,
+      });
+      return { mudDir, projectName };
+    } catch (e) {
+      const msg = String(e);
+      if (!msg.includes("already exists")) throw e;
+    }
+  }
+  throw new Error("Could not find an unused project name under the default location.");
+}
+
+export function GeneratingStep({ imageStyle, template, onFinished }: GeneratingStepProps) {
+  const { openDir } = useOpenProject();
+  const settings = useAssetStore((s) => s.settings);
+  const acceptAsset = useAssetStore((s) => s.acceptAsset);
+  const loadAssets = useAssetStore((s) => s.loadAssets);
+  const [activePhase, setActivePhase] = useState<Phase>("project");
+  const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [finishedMessage, setFinishedMessage] = useState<string | null>(null);
+  const hasStartedRef = useRef(false);
+
+  useEffect(() => {
+    if (hasStartedRef.current) return;
+    if (!settings) return;
+    hasStartedRef.current = true;
+
+    const run = async () => {
+      let localWarning: string | null = null;
+      try {
+        // ─── Phase 1: Create project ────────────────────────────
+        setActivePhase("project");
+        const home = await homeDir();
+        const parentDir = joinPath(home, "Arcanum Worlds");
+        const baseName = template.id === "custom" ? "my_world" : template.id;
+        const { mudDir, projectName } = await createProjectWithRetry(parentDir, baseName);
+
+        const openResult = await openDir(mudDir, "standalone");
+        if (!openResult.success) {
+          throw new Error(openResult.errors?.join(", ") ?? "Failed to open project");
+        }
+
+        // Apply the classic_fantasy config silently — user is picking zone
+        // aesthetic here, not rule system.
+        const classic = TEMPLATES.find((t) => t.id === "classic_fantasy");
+        const baseConfig = useConfigStore.getState().config;
+        const project = useProjectStore.getState().project;
+        if (baseConfig && classic && project) {
+          const merged = applyTemplate(baseConfig, classic.configOverrides);
+          useConfigStore.getState().updateConfig(merged);
+          await saveProjectConfig(project);
+        }
+
+        // ─── Phase 2: Generate the zone ──────────────────────────
+        setActivePhase("zone");
+        const zoneId = template.id === "custom" ? "first_zone" : template.id;
+        const config = useConfigStore.getState().config;
+        const statNames = config?.stats?.definitions
+          ? Object.values(config.stats.definitions).map((s) => s.id)
+          : [];
+        const equipmentSlots = config?.equipmentSlots ? Object.keys(config.equipmentSlots) : [];
+        const classNames = config?.classes
+          ? Object.values(config.classes).map((c) => c.displayName).filter(Boolean)
+          : [];
+
+        const genParams: ZoneGenerationParams = {
+          zoneName: template.name,
+          zoneTheme: template.seedPrompt,
+          backgroundContext: template.backgroundContext || undefined,
+          worldTheme: template.seedPrompt,
+          roomCount: template.roomCount,
+          mobCount: template.mobCount,
+          itemCount: template.itemCount,
+          statNames,
+          equipmentSlots,
+          classNames,
+        };
+
+        let world: WorldFile;
+        try {
+          world = await generateZoneContent(genParams);
+        } catch (e) {
+          localWarning = `Hub couldn't generate a zone (${String(e)}). Starting with an empty stub you can edit.`;
+          world = createFallbackZone(template.name, template.roomCount);
+        }
+
+        // ─── Phase 3: Generate representative art in parallel ───
+        setActivePhase("art");
+        const provider = imageStyle === "flux" ? "runware" : "openai";
+        const modelId = imageStyle === "flux" ? "runware:400@2" : "openai:4@1";
+        const resolvedModel = resolveImageModel(provider, modelId);
+
+        const pickedRoomId = pickRandom(Object.keys(world.rooms));
+        const pickedMobId = pickRandom(Object.keys(world.mobs ?? {}));
+        const pickedItemId = pickRandom(Object.keys(world.items ?? {}));
+
+        interface DefaultJob {
+          kind: "room" | "mob" | "item";
+          prompt: string;
+          assetType: "background" | "mob" | "item";
+          width: number;
+          height: number;
+        }
+        const jobs: DefaultJob[] = [];
+        if (pickedRoomId && world.rooms[pickedRoomId]) {
+          jobs.push({
+            kind: "room",
+            prompt: roomPrompt(pickedRoomId, world.rooms[pickedRoomId], "gentle_magic"),
+            assetType: "background",
+            width: 1920,
+            height: 1080,
+          });
+        }
+        if (pickedMobId && world.mobs?.[pickedMobId]) {
+          jobs.push({
+            kind: "mob",
+            prompt: mobPrompt(pickedMobId, world.mobs[pickedMobId], "gentle_magic"),
+            assetType: "mob",
+            width: 512,
+            height: 512,
+          });
+        }
+        if (pickedItemId && world.items?.[pickedItemId]) {
+          jobs.push({
+            kind: "item",
+            prompt: itemPrompt(pickedItemId, world.items[pickedItemId], "gentle_magic"),
+            assetType: "item",
+            width: 256,
+            height: 256,
+          });
+        }
+
+        const results = resolvedModel
+          ? await Promise.allSettled(
+              jobs.map(async (job) => {
+                const image = await invoke<GeneratedImage>(imageGenerateCommand(provider), {
+                  prompt: job.prompt,
+                  negativePrompt: getNegativePrompt(job.assetType),
+                  model: resolvedModel.id,
+                  width: job.width,
+                  height: job.height,
+                  steps: resolvedModel.defaultSteps ?? 4,
+                  guidance:
+                    "defaultGuidance" in resolvedModel ? resolvedModel.defaultGuidance : null,
+                  assetType: job.assetType,
+                  autoEnhance: false,
+                  transparentBackground:
+                    provider === "openai" && requestsTransparentBackground(job.assetType),
+                });
+                const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
+                await acceptAsset(
+                  image,
+                  job.assetType,
+                  job.prompt,
+                  { zone: zoneId, entity_type: "default", entity_id: job.kind },
+                  `default:${zoneId}:${job.kind}`,
+                  true,
+                );
+                return { kind: job.kind, fileName };
+              }),
+            )
+          : [];
+
+        const imageMap: { room?: string; mob?: string; item?: string } = {};
+        let failedCount = 0;
+        for (const r of results) {
+          if (r.status === "fulfilled") {
+            imageMap[r.value.kind] = r.value.fileName;
+          } else {
+            failedCount++;
+          }
+        }
+        if (failedCount > 0 && !localWarning) {
+          localWarning = `${failedCount} of ${results.length} starter images didn't render. You can retry from the Zone Direction panel.`;
+        }
+        if (localWarning) setWarning(localWarning);
+
+        world = {
+          ...world,
+          image: {
+            ...(world.image ?? {}),
+            ...imageMap,
+          },
+        };
+
+        // ─── Phase 4: Write zone to disk + open workspace ───────
+        setActivePhase("opening");
+        const project2 = useProjectStore.getState().project;
+        if (!project2) throw new Error("Project state was lost during onboarding.");
+
+        await invoke("create_zone_directory", {
+          projectDir: project2.mudDir,
+          zoneId,
+        });
+        const filePath = zoneFilePath(project2, zoneId);
+        const yaml = stringify(world, YAML_OPTS);
+        await writeTextFile(filePath, yaml);
+        useZoneStore.getState().loadZone(zoneId, filePath, world);
+
+        if (template.vibeText) {
+          await useVibeStore.getState().saveVibe(zoneId, template.vibeText).catch(() => {});
+        }
+
+        await loadAssets();
+        addRecentProject(project2.mudDir, projectName);
+        saveArtSubTab("direction");
+        useProjectStore.getState().openTab({
+          id: "panel:art",
+          kind: "panel",
+          panelId: "art",
+          label: "Art",
+        });
+
+        setActivePhase("done");
+        setFinishedMessage(`"${template.name}" is ready to shape.`);
+        setTimeout(() => {
+          onFinished();
+        }, 600);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    };
+
+    void run();
+  }, [settings, template, imageStyle, acceptAsset, loadAssets, openDir, onFinished]);
+
+  const activeIndex = PHASES.findIndex((p) => p.id === activePhase);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-3">
+        <p className="text-sm leading-7 text-text-secondary">
+          Hold tight while the hub forges "{template.name}". This takes about a minute — zone layout
+          first, then three representative pieces of art.
+        </p>
+      </div>
+
+      <ol className="flex flex-col gap-3">
+        {PHASES.map((phase, i) => {
+          const isDone = activeIndex > i || activePhase === "done";
+          const isActive = activePhase === phase.id;
+          return (
+            <li
+              key={phase.id}
+              className="flex items-center gap-4 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-5 py-3"
+            >
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[var(--chrome-stroke-strong)] bg-bg-secondary">
+                {isDone ? (
+                  <span className="text-xs text-status-success">✓</span>
+                ) : isActive ? (
+                  <div className="h-4 w-4 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+                ) : (
+                  <span className="text-2xs text-text-muted">{i + 1}</span>
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div
+                  className={`text-sm ${
+                    isActive ? "text-text-primary" : isDone ? "text-text-secondary" : "text-text-muted"
+                  }`}
+                >
+                  {phase.label}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      {warning && (
+        <div className="rounded-2xl border border-status-warning/40 bg-status-warning/5 px-5 py-3 text-xs leading-6 text-text-secondary">
+          {warning}
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-2xl border border-status-error/40 bg-status-error/5 px-5 py-3">
+          <div className="text-2xs uppercase tracking-ui text-status-error">Something went wrong</div>
+          <p className="mt-1 text-xs leading-6 text-text-secondary">{error}</p>
+        </div>
+      )}
+
+      {finishedMessage && (
+        <div className="rounded-2xl border border-status-success/40 bg-status-success/5 px-5 py-3 text-xs leading-6 text-text-secondary">
+          {finishedMessage}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/onboarding/HubKeyStep.tsx
+++ b/creator/src/components/onboarding/HubKeyStep.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { useAssetStore } from "@/stores/assetStore";
+
+const DEFAULT_HUB_API_URL = "https://api.arcanum-hub.com";
+
+interface HubKeyStepProps {
+  onDone: () => void;
+}
+
+export function HubKeyStep({ onDone }: HubKeyStepProps) {
+  const settings = useAssetStore((s) => s.settings);
+  const saveSettings = useAssetStore((s) => s.saveSettings);
+  const [key, setKey] = useState(settings?.hub_api_key ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!settings) {
+      setError("Settings not loaded yet — give it a moment and try again.");
+      return;
+    }
+    const trimmed = key.trim();
+    if (!trimmed) {
+      setError("Enter your Arcanum Hub API key to continue.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await saveSettings({
+        ...settings,
+        hub_api_key: trimmed,
+        hub_api_url: settings.hub_api_url?.trim() || DEFAULT_HUB_API_URL,
+        use_hub_ai: true,
+      });
+      onDone();
+    } catch (e) {
+      setError(String(e));
+      setSaving(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !saving) {
+      void handleSubmit();
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="space-y-3">
+        <p className="text-sm leading-7 text-text-secondary">
+          Arcanum Hub handles AI generation for you — no API keys to manage, no provider accounts to
+          juggle. Drop in the key you were given and we'll have you sketching worlds in about a
+          minute.
+        </p>
+        <p className="text-xs leading-6 text-text-muted">
+          Your key is saved to this machine only. You can revoke or rotate it later from the Hub admin
+          console.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="hub-api-key" className="text-2xs uppercase tracking-ui text-text-muted">
+          Arcanum Hub API Key
+        </label>
+        <input
+          id="hub-api-key"
+          type="password"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="arch_live_..."
+          autoFocus
+          className="ornate-input w-full rounded-xl border border-border-default bg-bg-primary px-4 py-3 font-mono text-sm text-text-primary placeholder:text-text-muted focus:border-accent/60 focus-visible:ring-2 focus-visible:ring-border-active"
+        />
+        {error && <p className="text-2xs text-status-error">{error}</p>}
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-2xs text-text-muted">
+          Don't have one?{" "}
+          <a
+            href="https://arcanum-hub.com"
+            target="_blank"
+            rel="noreferrer"
+            className="text-text-link underline-offset-2 hover:underline"
+          >
+            Request access at arcanum-hub.com
+          </a>
+        </p>
+        <button
+          onClick={handleSubmit}
+          disabled={saving || !settings}
+          className="rounded-full border border-[var(--border-accent-ring)] bg-[linear-gradient(135deg,rgb(var(--accent-rgb)/0.3),rgb(var(--surface-rgb)/0.18))] px-6 py-2 text-sm font-medium text-text-primary transition hover:shadow-[0_14px_34px_rgb(var(--accent-rgb)/0.2)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {saving ? "Saving..." : "Continue"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/onboarding/OnboardingFlow.tsx
+++ b/creator/src/components/onboarding/OnboardingFlow.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { useFocusTrap } from "@/lib/useFocusTrap";
+import type { OnboardingZoneTemplate } from "@/lib/onboardingZoneTemplates";
+import { HubKeyStep } from "./HubKeyStep";
+import { ArtStyleStep, type OnboardingImageStyle } from "./ArtStyleStep";
+import { ZoneTemplateStep } from "./ZoneTemplateStep";
+import { GeneratingStep } from "./GeneratingStep";
+
+export type OnboardingStep = "hubKey" | "artStyle" | "zoneTemplate" | "generating";
+
+const STEP_ORDER: OnboardingStep[] = ["hubKey", "artStyle", "zoneTemplate", "generating"];
+
+const STEP_LABELS: Record<OnboardingStep, string> = {
+  hubKey: "Connect to Arcanum Hub",
+  artStyle: "Pick your image style",
+  zoneTemplate: "Choose a first world",
+  generating: "Forging your world",
+};
+
+interface OnboardingFlowProps {
+  onClose: () => void;
+}
+
+export function OnboardingFlow({ onClose }: OnboardingFlowProps) {
+  const trapRef = useFocusTrap<HTMLDivElement>(onClose);
+  const [step, setStep] = useState<OnboardingStep>("hubKey");
+  const [imageStyle, setImageStyle] = useState<OnboardingImageStyle | null>(null);
+  const [template, setTemplate] = useState<OnboardingZoneTemplate | null>(null);
+
+  const stepIndex = STEP_ORDER.indexOf(step);
+  const canCloseFromCurrentStep = step !== "generating";
+
+  const handleHubKeyDone = () => setStep("artStyle");
+  const handleArtStyleDone = (style: OnboardingImageStyle) => {
+    setImageStyle(style);
+    setStep("zoneTemplate");
+  };
+  const handleTemplateDone = (picked: OnboardingZoneTemplate) => {
+    setTemplate(picked);
+    setStep("generating");
+  };
+
+  return (
+    <div className="dialog-overlay">
+      <div
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-title"
+        className="dialog-shell flex max-h-[92vh] w-full max-w-4xl flex-col"
+      >
+        <div className="dialog-header block">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 flex-1">
+              <h2 id="onboarding-title" className="dialog-title">
+                Start with Arcanum Hub
+              </h2>
+              <p className="dialog-subtitle">{STEP_LABELS[step]}</p>
+            </div>
+            {canCloseFromCurrentStep && (
+              <button
+                onClick={onClose}
+                aria-label="Close"
+                className="shrink-0 rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs uppercase tracking-ui text-text-muted transition hover:text-text-primary"
+              >
+                Skip
+              </button>
+            )}
+          </div>
+          <div className="mt-4 flex gap-1.5" aria-hidden="true">
+            {STEP_ORDER.map((s, i) => (
+              <div
+                key={s}
+                className={`h-1 flex-1 rounded-full transition-colors ${
+                  i === stepIndex
+                    ? "bg-accent"
+                    : i < stepIndex
+                      ? "bg-accent/40"
+                      : "bg-bg-elevated"
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="dialog-body">
+          {step === "hubKey" && <HubKeyStep onDone={handleHubKeyDone} />}
+          {step === "artStyle" && <ArtStyleStep onDone={handleArtStyleDone} />}
+          {step === "zoneTemplate" && <ZoneTemplateStep onDone={handleTemplateDone} />}
+          {step === "generating" && imageStyle && template && (
+            <GeneratingStep
+              imageStyle={imageStyle}
+              template={template}
+              onFinished={onClose}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/onboarding/ZoneTemplateStep.tsx
+++ b/creator/src/components/onboarding/ZoneTemplateStep.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import {
+  ONBOARDING_ZONE_TEMPLATES,
+  buildCustomOnboardingTemplate,
+  type OnboardingZoneTemplate,
+} from "@/lib/onboardingZoneTemplates";
+
+interface ZoneTemplateStepProps {
+  onDone: (template: OnboardingZoneTemplate) => void;
+}
+
+export function ZoneTemplateStep({ onDone }: ZoneTemplateStepProps) {
+  const [customOpen, setCustomOpen] = useState(false);
+  const [customText, setCustomText] = useState("");
+
+  const handleCustom = () => {
+    const trimmed = customText.trim();
+    if (!trimmed) return;
+    onDone(buildCustomOnboardingTemplate(trimmed));
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-sm leading-7 text-text-secondary">
+        Pick the flavor of the first zone we'll generate. You'll keep shaping it by hand afterward —
+        this is just a starting point, not a commitment.
+      </p>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {ONBOARDING_ZONE_TEMPLATES.map((template) => (
+          <button
+            key={template.id}
+            onClick={() => onDone(template)}
+            className="group flex h-full flex-col gap-2 rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5 text-left transition hover:border-[var(--border-accent-ring)] hover:shadow-[0_16px_40px_rgb(var(--accent-rgb)/0.16)]"
+          >
+            <div className="font-display text-lg text-text-primary">{template.name}</div>
+            <p className="text-xs leading-6 text-text-secondary">{template.blurb}</p>
+          </button>
+        ))}
+
+        <button
+          onClick={() => setCustomOpen((o) => !o)}
+          className={`flex h-full flex-col gap-2 rounded-3xl border-2 border-dashed p-5 text-left transition ${
+            customOpen
+              ? "border-[var(--border-accent-ring)] bg-[var(--chrome-fill)]"
+              : "border-[var(--chrome-stroke)] hover:border-[var(--border-accent-ring)]"
+          }`}
+        >
+          <div className="font-display text-lg text-text-primary">Create your own</div>
+          <p className="text-xs leading-6 text-text-secondary">
+            Describe the world in your own words and we'll seed it from that.
+          </p>
+        </button>
+      </div>
+
+      {customOpen && (
+        <div className="flex flex-col gap-3 rounded-3xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-5">
+          <label htmlFor="custom-world" className="text-2xs uppercase tracking-ui text-text-muted">
+            Describe your world
+          </label>
+          <textarea
+            id="custom-world"
+            value={customText}
+            onChange={(e) => setCustomText(e.target.value)}
+            rows={4}
+            autoFocus
+            placeholder="A sunken city of coral spires lit by bioluminescent jellyfish..."
+            className="ornate-input w-full rounded-xl border border-border-default bg-bg-primary px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-accent/60 focus-visible:ring-2 focus-visible:ring-border-active"
+          />
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-2xs text-text-muted">
+              A sentence or two is plenty — we'll ask the hub to fill in the rest.
+            </p>
+            <button
+              onClick={handleCustom}
+              disabled={!customText.trim()}
+              className="rounded-full border border-[var(--border-accent-ring)] bg-[linear-gradient(135deg,rgb(var(--accent-rgb)/0.3),rgb(var(--surface-rgb)/0.18))] px-5 py-2 text-xs font-medium text-text-primary transition hover:shadow-[0_14px_34px_rgb(var(--accent-rgb)/0.2)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Generate this world
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/creator/src/lib/onboardingZoneTemplates.ts
+++ b/creator/src/lib/onboardingZoneTemplates.ts
@@ -1,0 +1,103 @@
+export interface OnboardingZoneTemplate {
+  id: string;
+  name: string;
+  blurb: string;
+  seedPrompt: string;
+  backgroundContext: string;
+  vibeText: string;
+  roomCount: number;
+  mobCount: number;
+  itemCount: number;
+}
+
+export const ONBOARDING_ZONE_TEMPLATES: OnboardingZoneTemplate[] = [
+  {
+    id: "western_town",
+    name: "Western Town",
+    blurb: "Dusty frontier streets, a saloon, a sheriff's office, wooden boardwalks.",
+    seedPrompt:
+      "A dusty frontier town on the edge of civilization — wooden storefronts, swinging saloon doors, a weathered sheriff's office, hitching posts and water troughs. The town sits at the meeting of several trails and sees travelers of every stripe.",
+    backgroundContext:
+      "Sunbaked, arid, and lightly lawless. The kind of place where a stranger walking in draws every eye.",
+    vibeText:
+      "A sleepy frontier town baking in slow gold sunlight. Boardwalks creak under boot heels; tumbleweeds drift past shuttered windows. There is quiet tension here — somebody always seems to be watching from a porch, and the air carries the distant toll of a wind-worn bell.",
+    roomCount: 5,
+    mobCount: 3,
+    itemCount: 3,
+  },
+  {
+    id: "cartoon_village",
+    name: "Cartoon Village",
+    blurb: "A whimsical hillside village with round doors, flower boxes, and a friendly mill.",
+    seedPrompt:
+      "A whimsical cartoon village nestled in rolling green hills — round wooden doors set into curved cottages, window boxes overflowing with flowers, a working watermill turning beside a bright stream. Everything feels drawn with a warm hand.",
+    backgroundContext:
+      "A cozy, peaceful village full of gentle life. The kind of place with soft edges where nothing too terrible ever happens — but secrets still linger in the mill cellar and the old orchard.",
+    vibeText:
+      "A warmly lit village of curved rooftops and overgrown gardens, where every cottage seems to breathe a little. Bees drone over the apple orchard, a waterwheel turns at its own patient pace, and the low hum of village life feels like a half-remembered lullaby.",
+    roomCount: 5,
+    mobCount: 3,
+    itemCount: 3,
+  },
+  {
+    id: "dark_forest",
+    name: "Dark Forest",
+    blurb: "Twisting old-growth trees, crooked paths, and things that watch from between trunks.",
+    seedPrompt:
+      "A dense, ancient forest of twisting old-growth trees and narrow mossy paths. Shafts of pale green light fall between the trunks. The deeper you go, the quieter — and the more the forest seems to notice you.",
+    backgroundContext:
+      "An untamed woodland that has seen empires come and go. Ruins of older civilizations are slowly being reclaimed by roots and lichen.",
+    vibeText:
+      "An old forest where the canopy sews the sky shut and sound carries strangely. Ferns coil around fallen stonework; a distant branch cracks when no wind is blowing. The forest is not hostile, exactly — it is simply older and patient, and it is paying attention.",
+    roomCount: 5,
+    mobCount: 3,
+    itemCount: 3,
+  },
+  {
+    id: "crystal_caves",
+    name: "Crystal Caves",
+    blurb: "Glowing crystalline caverns, underground streams, and echoes from far below.",
+    seedPrompt:
+      "A network of vast crystalline caverns lit by the soft glow of embedded gemstones. Stalactites and stalagmites of clear crystal refract distant light into slow-moving rainbows. Cold underground streams wind through narrow passages.",
+    backgroundContext:
+      "A place of natural wonder that miners once tried to exploit and then abandoned. Rusted rails and broken carts still sit where they were dropped.",
+    vibeText:
+      "A hushed cathedral of living crystal, where every footstep rings faintly against unseen facets. Veins of pale light pulse in slow patterns through the walls, as if the mountain itself is breathing. The air tastes of cold mineral water and very old silence.",
+    roomCount: 5,
+    mobCount: 3,
+    itemCount: 3,
+  },
+  {
+    id: "ancient_ruins",
+    name: "Ancient Ruins",
+    blurb: "Crumbling temples, toppled columns, and inscriptions nobody alive can read.",
+    seedPrompt:
+      "The crumbling ruins of a once-great temple complex — toppled columns draped in vines, a central plaza sunken into the earth, inscriptions in a forgotten language worn almost smooth by centuries of rain.",
+    backgroundContext:
+      "Whoever built this place worshipped something the modern world has forgotten. A few glyphs still catch firelight in an unsettling way.",
+    vibeText:
+      "Shattered stonework under a sky bruised with incoming weather. The ruins wear their centuries like a tired cloak — patient, proud, and still holding on to something they will not explain. Every carved face seems to be mid-sentence.",
+    roomCount: 5,
+    mobCount: 3,
+    itemCount: 3,
+  },
+];
+
+export function findOnboardingTemplate(id: string): OnboardingZoneTemplate | undefined {
+  return ONBOARDING_ZONE_TEMPLATES.find((t) => t.id === id);
+}
+
+export function buildCustomOnboardingTemplate(description: string): OnboardingZoneTemplate {
+  const trimmed = description.trim();
+  return {
+    id: "custom",
+    name: "Your World",
+    blurb: "A world of your own design.",
+    seedPrompt: trimmed,
+    backgroundContext: "",
+    vibeText: trimmed,
+    roomCount: 5,
+    mobCount: 3,
+    itemCount: 3,
+  };
+}


### PR DESCRIPTION
New "Start with Arcanum Hub" card launches a four-step guided flow: enter hub API key, pick FLUX vs GPT Image aesthetic, choose one of five zone templates (or write a custom prompt), then watch the hub generate the first zone and three representative images in parallel before landing on the Zone Direction panel.