### PR TITLE
Add Runware Bria RMBG as bg-removal backend

### DIFF
--- a/creator/src-tauri/src/hub_ai.rs
+++ b/creator/src-tauri/src/hub_ai.rs
@@ -72,6 +72,20 @@ struct HubImageResponse {
 }
 
 #[derive(Debug, Serialize)]
+struct HubRemoveBgRequest<'a> {
+    #[serde(rename = "imageDataUrl")]
+    image_data_url: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct HubRemoveBgResponse {
+    #[serde(rename = "imageBase64Data")]
+    image_base64_data: Option<String>,
+    #[serde(rename = "imageURL")]
+    image_url: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
 struct HubLlmRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     system: Option<&'a str>,
@@ -216,6 +230,46 @@ pub async fn generate_image(
         behavior.output_format,
     )
     .await
+}
+
+/// Hub-proxied background removal (Bria RMBG v2.0 via Runware).
+/// Returns the processed PNG bytes as base64.
+pub async fn remove_background(s: &Settings, image_data_url: &str) -> Result<String, String> {
+    let body = HubRemoveBgRequest { image_data_url };
+    let url = format!("{}/ai/image/remove-background", base_url(s));
+    let client = crate::http::shared_client();
+    let response = client
+        .post(&url)
+        .bearer_auth(&s.hub_api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Hub request failed: {e}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format_hub_error(response, status).await);
+    }
+    let parsed: HubRemoveBgResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse hub bg-removal response: {e}"))?;
+
+    if let Some(b64) = parsed.image_base64_data {
+        return Ok(b64);
+    }
+    if let Some(u) = parsed.image_url {
+        let bytes = client
+            .get(&u)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to download hub bg-removed image: {e}"))?
+            .bytes()
+            .await
+            .map_err(|e| format!("Failed to read hub bg-removed image bytes: {e}"))?;
+        return Ok(base64::engine::general_purpose::STANDARD.encode(&bytes));
+    }
+    Err("Hub bg-removal response contained no image data".to_string())
 }
 
 /// Hub-proxied text LLM completion (DeepSeek V3.2).

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -64,6 +64,7 @@ pub fn run() {
             llm::llm_complete,
             llm::llm_complete_with_vision,
             runware::runware_generate_image,
+            runware::runware_remove_background,
             ffmpeg::check_ffmpeg_status,
             ffmpeg::ensure_ffmpeg_ready,
             video_export::save_video_frame,

--- a/creator/src-tauri/src/project_settings.rs
+++ b/creator/src-tauri/src/project_settings.rs
@@ -5,6 +5,10 @@ use tokio::sync::RwLock;
 
 const PROJECT_SETTINGS_FILE: &str = ".arcanum/settings.json";
 
+fn default_bg_removal_provider() -> String {
+    "local".to_string()
+}
+
 /// Cached project settings — keyed by project_dir to avoid re-reading from disk.
 static PROJECT_SETTINGS_CACHE: LazyLock<RwLock<Option<(String, ProjectSettings)>>> =
     LazyLock::new(|| RwLock::new(None));
@@ -29,6 +33,8 @@ pub struct ProjectSettings {
     pub auto_enhance_prompts: bool,
     #[serde(default)]
     pub auto_remove_bg: bool,
+    #[serde(default = "default_bg_removal_provider")]
+    pub bg_removal_provider: String,
     #[serde(default)]
     pub r2_account_id: String,
     #[serde(default)]
@@ -118,6 +124,11 @@ pub async fn seed_project_settings(
         batch_concurrency: user_settings.batch_concurrency,
         auto_enhance_prompts: user_settings.auto_enhance_prompts,
         auto_remove_bg: user_settings.auto_remove_bg,
+        bg_removal_provider: if user_settings.bg_removal_provider.is_empty() {
+            "local".to_string()
+        } else {
+            user_settings.bg_removal_provider
+        },
         r2_account_id: user_settings.r2_account_id,
         r2_access_key_id: user_settings.r2_access_key_id,
         r2_secret_access_key: user_settings.r2_secret_access_key,

--- a/creator/src-tauri/src/runware.rs
+++ b/creator/src-tauri/src/runware.rs
@@ -286,6 +286,157 @@ pub async fn runware_generate_image(
     .await
 }
 
+// ─── Background Removal (Bria RMBG v2.0) ─────────────────────────────
+//
+// Server-side background removal via Runware's Bria model. An
+// alternative to the local @imgly/background-removal WASM pipeline for
+// users whose machines can't run onnxruntime reliably, or who prefer
+// the quality of the Bria model. In hub mode this short-circuits to
+// the hub proxy; otherwise it calls Runware directly with the user's
+// runware_api_key.
+//
+// The command takes a data URL (what the frontend has on hand after
+// image generation) and returns the PNG bytes as base64, matching the
+// shape the existing `removeBackground()` helper expects so all the
+// current call sites keep working unchanged.
+
+const BG_REMOVAL_MODEL: &str = "bria:2@1";
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BriaProviderSettings {
+    preserve_alpha: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RemoveBgProviderSettings {
+    bria: BriaProviderSettings,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RemoveBgInputs {
+    image: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RunwareRemoveBgTask {
+    task_type: String,
+    #[serde(rename = "taskUUID")]
+    task_uuid: String,
+    model: String,
+    output_type: String,
+    output_format: String,
+    inputs: RemoveBgInputs,
+    provider_settings: RemoveBgProviderSettings,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RunwareRemoveBgResponse {
+    data: Option<Vec<RunwareRemoveBgResult>>,
+    errors: Option<Vec<RunwareRemoveBgError>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RunwareRemoveBgResult {
+    #[serde(alias = "imageURL", alias = "imageUrl")]
+    image_url: Option<String>,
+    image_base64_data: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RunwareRemoveBgError {
+    message: Option<String>,
+}
+
+/// Server-side background removal via Runware Bria RMBG v2.0.
+/// Takes a data URL and returns the processed PNG as base64.
+#[tauri::command]
+pub async fn runware_remove_background(
+    app: AppHandle,
+    image_data_url: String,
+) -> Result<String, String> {
+    let s = settings::get_settings(app).await?;
+
+    // Hub mode: proxy the request so the user's Runware key doesn't
+    // need to be configured locally. The hub enforces quota and bills
+    // this against the lifetime image counter.
+    if crate::hub_ai::is_enabled(&s) {
+        return crate::hub_ai::remove_background(&s, &image_data_url).await;
+    }
+
+    if s.runware_api_key.is_empty() {
+        return Err("Runware API key not configured. Set it in Settings.".to_string());
+    }
+
+    let task = RunwareRemoveBgTask {
+        task_type: "removeBackground".to_string(),
+        task_uuid: uuid::Uuid::new_v4().to_string(),
+        model: BG_REMOVAL_MODEL.to_string(),
+        output_type: "base64Data".to_string(),
+        output_format: "PNG".to_string(),
+        inputs: RemoveBgInputs { image: image_data_url },
+        provider_settings: RemoveBgProviderSettings {
+            bria: BriaProviderSettings { preserve_alpha: false },
+        },
+    };
+
+    let client = crate::http::shared_client();
+    let response = client
+        .post(API_URL)
+        .header("Authorization", crate::http::bearer_header(&s.runware_api_key))
+        .json(&vec![task])
+        .send()
+        .await
+        .map_err(|e| format!("Runware bg-removal request failed: {e}"))?;
+
+    let response = crate::http::check_response(response).await?;
+
+    let text = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read Runware bg-removal response: {e}"))?;
+
+    let parsed: RunwareRemoveBgResponse = serde_json::from_str(&text)
+        .map_err(|e| format!("Failed to parse Runware bg-removal response: {e}\nBody: {text}"))?;
+
+    if let Some(errs) = parsed.errors {
+        let msg = errs
+            .into_iter()
+            .find_map(|e| e.message)
+            .unwrap_or_else(|| "unknown Runware error".to_string());
+        return Err(format!("Runware bg-removal: {msg}"));
+    }
+
+    let first = parsed
+        .data
+        .and_then(|mut d| d.drain(..).next())
+        .ok_or_else(|| format!("No result in Runware bg-removal response. Body: {text}"))?;
+
+    // Prefer inline base64; fall back to downloading from URL if the
+    // API returned one instead (shouldn't happen with outputType =
+    // base64Data but defensive).
+    if let Some(b64) = first.image_base64_data {
+        return Ok(b64);
+    }
+    if let Some(url) = first.image_url {
+        let bytes = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| format!("Failed to download bg-removed image: {e}"))?
+            .bytes()
+            .await
+            .map_err(|e| format!("Failed to read bg-removed image bytes: {e}"))?;
+        return Ok(base64::engine::general_purpose::STANDARD.encode(&bytes));
+    }
+    Err("Runware bg-removal returned no image data".to_string())
+}
+
 // ─── Audio Generation ────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]

--- a/creator/src-tauri/src/settings.rs
+++ b/creator/src-tauri/src/settings.rs
@@ -54,6 +54,8 @@ pub struct Settings {
     pub auto_enhance_prompts: bool,
     #[serde(default)]
     pub auto_remove_bg: bool,
+    #[serde(default = "default_bg_removal_provider")]
+    pub bg_removal_provider: String,
     #[serde(default)]
     pub r2_account_id: String,
     #[serde(default)]
@@ -105,6 +107,10 @@ fn default_auto_enhance_prompts() -> bool {
     true
 }
 
+fn default_bg_removal_provider() -> String {
+    "local".to_string()
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {
@@ -121,6 +127,7 @@ impl Default for Settings {
             batch_concurrency: default_batch_concurrency(),
             auto_enhance_prompts: default_auto_enhance_prompts(),
             auto_remove_bg: false,
+            bg_removal_provider: default_bg_removal_provider(),
             r2_account_id: String::new(),
             r2_access_key_id: String::new(),
             r2_secret_access_key: String::new(),
@@ -195,6 +202,7 @@ pub async fn get_settings(app: AppHandle) -> Result<Settings, String> {
                 batch_concurrency: ps.batch_concurrency,
                 auto_enhance_prompts: ps.auto_enhance_prompts,
                 auto_remove_bg: ps.auto_remove_bg,
+                bg_removal_provider: ps.bg_removal_provider,
                 r2_account_id: ps.r2_account_id,
                 r2_access_key_id: ps.r2_access_key_id,
                 r2_secret_access_key: ps.r2_secret_access_key,
@@ -257,6 +265,7 @@ pub async fn get_merged_settings(
             batch_concurrency: ps.batch_concurrency,
             auto_enhance_prompts: ps.auto_enhance_prompts,
             auto_remove_bg: ps.auto_remove_bg,
+            bg_removal_provider: ps.bg_removal_provider,
             r2_account_id: ps.r2_account_id,
             r2_access_key_id: ps.r2_access_key_id,
             r2_secret_access_key: ps.r2_secret_access_key,

--- a/creator/src/components/config/panels/ApiSettingsPanel.tsx
+++ b/creator/src/components/config/panels/ApiSettingsPanel.tsx
@@ -88,7 +88,21 @@ const PROJECT_FIELDS = [
   "batch_concurrency",
   "auto_enhance_prompts",
   "auto_remove_bg",
+  "bg_removal_provider",
 ] as const satisfies readonly (keyof ProjectSettings)[];
+
+const BG_REMOVAL_PROVIDERS = [
+  {
+    id: "local" as const,
+    label: "Local (on-device)",
+    description: "Runs the @imgly / ONNX model in a Web Worker. Free, but uses CPU/RAM.",
+  },
+  {
+    id: "runware" as const,
+    label: "Runware (Bria RMBG v2.0)",
+    description: "Server-side, high quality. ~$0.018/image when using direct Runware; billed against your hub image quota in hub mode.",
+  },
+];
 
 export function ApiSettingsPanel() {
   const settings = useAssetStore((s) => s.settings);
@@ -415,11 +429,48 @@ export function ApiSettingsPanel() {
                 <span>
                   <span className="text-text-primary">Auto-remove background for sprite assets</span>
                   <span className="mt-0.5 block text-3xs text-text-muted/70">
-                    Client-side AI background removal on mobs, items, abilities, and portraits. Saved
-                    as a transparent variant alongside the original.
+                    AI background removal on mobs, items, abilities, and portraits. Saved as a
+                    transparent variant alongside the original.
                   </span>
                 </span>
               </label>
+
+              <div className="ml-6">
+                <h5 className="mb-1 text-2xs uppercase tracking-wider text-text-muted">
+                  Background removal backend
+                </h5>
+                <div className="flex flex-col gap-1">
+                  {BG_REMOVAL_PROVIDERS.map((p) => {
+                    const selected =
+                      (projectDraft.bg_removal_provider || "local") === p.id;
+                    return (
+                      <label
+                        key={p.id}
+                        className={`flex cursor-pointer items-start gap-2 rounded px-3 py-2 text-xs transition-colors ${
+                          selected
+                            ? "bg-accent/10 text-text-primary"
+                            : "text-text-secondary hover:bg-bg-elevated"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="bg_removal_provider"
+                          value={p.id}
+                          checked={selected}
+                          onChange={() =>
+                            setProjectDraft({ ...projectDraft, bg_removal_provider: p.id })
+                          }
+                          className="mt-0.5 accent-accent"
+                        />
+                        <div className="min-w-0">
+                          <div className="font-medium">{p.label}</div>
+                          <div className="text-3xs text-text-muted/80">{p.description}</div>
+                        </div>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
             </div>
           </div>
         </section>

--- a/creator/src/lib/useBackgroundRemoval.ts
+++ b/creator/src/lib/useBackgroundRemoval.ts
@@ -1,7 +1,19 @@
 import { useState, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import type { AssetContext, AssetEntry } from "@/types/assets";
+import type { AssetContext, AssetEntry, BgRemovalProvider } from "@/types/assets";
+import { useAssetStore } from "@/stores/assetStore";
 import { BG_REMOVAL_ASSET_TYPES } from "./arcanumPrompts";
+
+// ─── Provider resolution ─────────────────────────────────────────────
+// The background-removal backend is a project-level setting
+// (projectSettings.bg_removal_provider). We read from the asset store
+// at call time so each invocation picks up the live value — users can
+// switch between local and Runware without reloading.
+
+function currentBgProvider(): BgRemovalProvider {
+  const ps = useAssetStore.getState().projectSettings;
+  return ps?.bg_removal_provider === "runware" ? "runware" : "local";
+}
 
 // ─── Worker-based background removal ─────────────────────────────────
 // WASM/ONNX inference runs in a dedicated Web Worker so the UI stays responsive.
@@ -37,8 +49,18 @@ function getWorker(): Worker {
   return worker;
 }
 
-/** Remove background from an image data URL. Runs in a Web Worker. */
+/** Remove background from an image data URL.
+ *  Dispatches based on the project's bg_removal_provider setting:
+ *  - "local": runs the Imgly/ONNX model in a Web Worker.
+ *  - "runware": calls Runware Bria RMBG v2.0 (direct or via hub). */
 export async function removeBackground(imageDataUrl: string): Promise<Blob> {
+  if (currentBgProvider() === "runware") {
+    return removeBackgroundRunware(imageDataUrl);
+  }
+  return removeBackgroundLocal(imageDataUrl);
+}
+
+function removeBackgroundLocal(imageDataUrl: string): Promise<Blob> {
   const id = nextId++;
   const w = getWorker();
   return new Promise<Blob>((resolve, reject) => {
@@ -48,6 +70,16 @@ export async function removeBackground(imageDataUrl: string): Promise<Blob> {
     });
     w.postMessage({ id, imageDataUrl });
   });
+}
+
+async function removeBackgroundRunware(imageDataUrl: string): Promise<Blob> {
+  // The Rust side handles hub-mode short-circuiting, so this one
+  // command name works in both direct and hub configurations.
+  const b64 = await invoke<string>("runware_remove_background", { imageDataUrl });
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new Blob([bytes], { type: "image/png" });
 }
 
 // ─── Sequential queue ─────────────────────────────────────────────

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -69,6 +69,10 @@ export type AssetType =
 
 export type SyncScope = "approved" | "all";
 
+/** Background removal backend. "local" runs Imgly/ONNX in a Web Worker;
+ *  "runware" calls Bria RMBG v2.0 via Runware (or the hub proxy). */
+export type BgRemovalProvider = "local" | "runware";
+
 /** Mirrors the Rust Settings struct */
 export interface Settings {
   deepinfra_api_key: string;
@@ -84,6 +88,7 @@ export interface Settings {
   batch_concurrency: number;
   auto_enhance_prompts: boolean;
   auto_remove_bg: boolean;
+  bg_removal_provider: BgRemovalProvider;
   r2_account_id: string;
   r2_access_key_id: string;
   r2_secret_access_key: string;
@@ -105,6 +110,7 @@ export interface ProjectSettings {
   batch_concurrency: number;
   auto_enhance_prompts: boolean;
   auto_remove_bg: boolean;
+  bg_removal_provider: BgRemovalProvider;
   r2_account_id: string;
   r2_access_key_id: string;
   r2_secret_access_key: string;

--- a/hub-worker/src/handlers/ai.ts
+++ b/hub-worker/src/handlers/ai.ts
@@ -5,9 +5,10 @@
 // clamp potentially-expensive parameters (dimensions, step counts,
 // GPT quality tier) so a single request can't blow through the budget.
 //
-//   POST /ai/image/generate   → Runware (FLUX.2 or GPT Image 1.5)
-//   POST /ai/llm/complete     → OpenRouter → DeepSeek V3.2
-//   POST /ai/llm/vision       → Anthropic Claude Sonnet 4.6
+//   POST /ai/image/generate            → Runware (FLUX.2 or GPT Image 1.5)
+//   POST /ai/image/remove-background   → Runware Bria RMBG v2.0
+//   POST /ai/llm/complete              → OpenRouter → DeepSeek V3.2
+//   POST /ai/llm/vision                → Anthropic Claude Sonnet 4.6
 //
 // Vision calls bill against the same `prompts_used` counter as
 // completions — they're bucketed together as "LLM calls" per the
@@ -31,6 +32,11 @@ const IMAGE_MODELS = new Set([
   "runware:400@2", // FLUX.2 (commercial)
   "openai:4@1", // GPT Image 1.5
 ]);
+
+// Background removal is locked to a single model — no caller choice.
+// Bria RMBG v2.0 is fast, high quality, and priced at ~$0.018/image
+// which fits comfortably inside the same image quota.
+const BG_REMOVAL_MODEL = "bria:2@1";
 
 // Default Runware FLUX model matches creator/src-tauri/src/runware.rs.
 const DEFAULT_IMAGE_MODEL = "runware:400@2";
@@ -61,6 +67,9 @@ export async function handleAi(
 
   if (pathname === "/ai/image/generate" && req.method === "POST") {
     return await imageGenerate(req, env, user);
+  }
+  if (pathname === "/ai/image/remove-background" && req.method === "POST") {
+    return await imageRemoveBackground(req, env, user);
   }
   if (pathname === "/ai/llm/complete" && req.method === "POST") {
     return await llmComplete(req, env, user);
@@ -256,6 +265,117 @@ async function imageGenerate(req: Request, env: Env, user: UserRow): Promise<Res
       width,
       height,
       model,
+      cost: item.cost,
+      usage: {
+        images_used: user.images_used + 1,
+        images_quota: user.images_quota,
+      },
+    },
+    {},
+    CORS,
+  );
+}
+
+// ─── Background removal (Bria RMBG v2.0) ─────────────────────────────
+//
+// Server-side background removal via Runware's Bria model. Bills
+// against the same `images_used` counter as image generation — it's
+// one upstream image API call — so quota-exhausted users can't farm
+// free bg-removal by switching modes.
+
+interface RemoveBgBody {
+  imageDataUrl?: string;
+}
+
+interface RunwareRemoveBgTask {
+  taskType: "removeBackground";
+  taskUUID: string;
+  model: string;
+  outputType: "base64Data";
+  outputFormat: "PNG";
+  inputs: { image: string };
+  providerSettings: { bria: { preserveAlpha: boolean } };
+  includeCost: boolean;
+}
+
+async function imageRemoveBackground(req: Request, env: Env, user: UserRow): Promise<Response> {
+  if (user.images_used >= user.images_quota) {
+    return quotaExceeded("images", user.images_used, user.images_quota);
+  }
+
+  let body: RemoveBgBody;
+  try {
+    body = (await req.json()) as RemoveBgBody;
+  } catch {
+    return error(400, "Invalid JSON body", CORS);
+  }
+
+  const image = (body.imageDataUrl ?? "").trim();
+  if (!image) return error(400, "Missing imageDataUrl", CORS);
+  // Accept either a data URL or a plain URL. Anything that is neither
+  // (e.g. raw base64 with no prefix) gets a helpful error instead of
+  // being forwarded and failing upstream with a Runware 400.
+  if (!/^data:image\/[a-z+]+;base64,/.test(image) && !/^https?:\/\//.test(image)) {
+    return error(
+      400,
+      "imageDataUrl must be a base64 data URL (data:image/...;base64,...) or an https URL",
+      CORS,
+    );
+  }
+  // Rough size guard for data URLs: a 10 MB decoded ceiling mirrors the
+  // vision handler.
+  if (image.startsWith("data:")) {
+    const commaIdx = image.indexOf(",");
+    const b64Len = commaIdx >= 0 ? image.length - commaIdx - 1 : image.length;
+    if (b64Len * 0.75 > MAX_VISION_IMAGE_BYTES) {
+      return error(413, "Image exceeds 10 MB", CORS);
+    }
+  }
+
+  const task: RunwareRemoveBgTask = {
+    taskType: "removeBackground",
+    taskUUID: crypto.randomUUID(),
+    model: BG_REMOVAL_MODEL,
+    outputType: "base64Data",
+    outputFormat: "PNG",
+    inputs: { image },
+    providerSettings: { bria: { preserveAlpha: false } },
+    includeCost: true,
+  };
+
+  const upstream = await fetch("https://api.runware.ai/v1", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${env.RUNWARE_API_KEY}`,
+    },
+    body: JSON.stringify([task]),
+  });
+
+  if (!upstream.ok) {
+    const text = await upstream.text().catch(() => "");
+    return error(upstream.status, `Runware error (${upstream.status}): ${text.slice(0, 500)}`, CORS);
+  }
+
+  const raw = (await upstream.json()) as {
+    data?: RunwareSuccessItem[];
+    errors?: { message?: string; code?: string }[];
+  };
+  if (raw.errors?.length) {
+    const msg = raw.errors[0]?.message ?? "unknown Runware error";
+    return error(502, `Runware: ${msg}`, CORS);
+  }
+  const item = raw.data?.find((d) => d.taskUUID === task.taskUUID);
+  if (!item) return error(502, "Runware returned no image", CORS);
+
+  await incrementImageUsage(env, user.id);
+
+  return json(
+    {
+      imageURL: item.imageURL,
+      imageBase64Data: item.imageBase64Data,
+      imageDataURI: item.imageDataURI,
+      model: BG_REMOVAL_MODEL,
       cost: item.cost,
       usage: {
         images_used: user.images_used + 1,


### PR DESCRIPTION
## Summary
- New project-level setting `bg_removal_provider: "local" | "runware"`. "local" keeps the current @imgly Web Worker; "runware" calls Bria RMBG v2.0.
- New `runware_remove_background` Tauri command. Direct-mode calls Runware with the user's key; hub-mode short-circuits through the new `hub_ai::remove_background` proxy (same pattern as image/LLM/vision dispatch).
- New hub endpoint `POST /ai/image/remove-background`. Gated on the existing `images_used` quota, allowlisted to `bria:2@1`, increments the counter only on success.
- Frontend dispatches transparently: `removeBackground(dataUrl)` in `useBackgroundRemoval.ts` now checks `projectSettings.bg_removal_provider` and either runs the Web Worker (default) or invokes the Rust command and wraps the returned base64 into a Blob. All existing callers (`removeBgAndSave`, `BulkBgRemoval`, `batchArt`) are unchanged.
- Provider radio added in `ApiSettingsPanel` under the existing auto-remove-bg checkbox.

## Test plan
- [ ] Settings panel: switch between Local and Runware, save, reopen project — value persists.
- [ ] Direct mode, Runware selected: generate an image, click "Remove background" — new transparent variant appears and is marked active.
- [ ] Direct mode, Runware selected, empty runware API key: clear error message surfaces in the toast.
- [ ] Hub mode (`use_hub_ai = true`), Runware selected: same flow routes through the hub; `images_used` increments by 1 per removal.
- [ ] Hub quota exhausted: request returns the hub's `hub_quota_exceeded:images` error and the error surfaces to the user.
- [ ] Local provider still works end-to-end (regression check).
- [ ] `BulkBgRemoval` dialog processes a mix of targets with Runware provider selected.
- [ ] Auto-remove-bg during batch art generation runs through Runware when selected.

## Notes
- Runware Bria RMBG is ~$0.018/image. In direct mode that's the user's own Runware bill; in hub mode it bills against the lifetime `images_used` counter (same bucket as generation), so a user who mass-removes backgrounds from 500 existing assets would exhaust the default image quota.
- The hub endpoint accepts either a `data:image/...;base64,...` URL or an `https://` URL; raw base64 without a prefix is rejected with a 400.