### PR TITLE
Add publish-only tier for hub users

### DIFF
--- a/creator/src-tauri/src/hub_ai.rs
+++ b/creator/src-tauri/src/hub_ai.rs
@@ -346,6 +346,15 @@ async fn format_hub_error(response: reqwest::Response, status: reqwest::StatusCo
     // Try to parse the structured error body for a friendlier message.
     if let Ok(body) = serde_json::from_str::<HubErrorBody>(&text) {
         let err = body.error.as_deref().unwrap_or("");
+        // Publish-only tier trying to hit /ai/* — distinct from a bad
+        // key so the toast can tell the user exactly what to do.
+        if err == "tier_forbidden" {
+            return "Your hub API key is publish-only and cannot use hub AI features. \
+                    Either ask the hub admin for a full-tier key, or disable \
+                    \"Use Arcanum Hub for AI generation\" in Settings → Arcanum Hub \
+                    and configure a direct provider key instead."
+                .to_string();
+        }
         if err.starts_with("hub_quota_exceeded:") {
             let kind = err.trim_start_matches("hub_quota_exceeded:");
             if let (Some(used), Some(quota)) = (body.used, body.quota) {
@@ -360,6 +369,7 @@ async fn format_hub_error(response: reqwest::Response, status: reqwest::StatusCo
     }
     match status.as_u16() {
         401 => "Hub rejected your API key. Check Settings → Arcanum Hub.".to_string(),
+        403 => "Hub refused the request. Your key may not have permission for this endpoint.".to_string(),
         429 => "Hub quota exceeded. Ask the admin to rotate your key.".to_string(),
         _ => format!("Hub error ({status}): {}", text.chars().take(500).collect::<String>()),
     }

--- a/creator/src/components/config/panels/HubSettingsPanel.tsx
+++ b/creator/src/components/config/panels/HubSettingsPanel.tsx
@@ -60,6 +60,22 @@ export function HubSettingsPanel() {
     return <div className="text-xs text-text-muted">Loading settings...</div>;
   }
 
+  // Tier auto-detection from the key prefix. The hub issues
+  // `hubk_full_…` for full-tier keys and `hubk_pub_…` for publish-only
+  // keys; legacy `hub_…` keys from before the tier feature are
+  // grandfathered as full. The prefix is a UX hint only — the hub
+  // enforces the authoritative tier on every /ai/* call.
+  const keyIsPublishOnly = account.hub_api_key.startsWith("hubk_pub_");
+
+  // If a publish-only key is entered, force the "use hub AI" flag off
+  // in the draft so saving doesn't persist an impossible combination.
+  useEffect(() => {
+    if (keyIsPublishOnly && account.use_hub_ai) {
+      setAccount({ ...account, use_hub_ai: false });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keyIsPublishOnly]);
+
   const accountDirty =
     !settings || HUB_ACCOUNT_KEYS.some((k) => account[k] !== settings[k]);
   const worldDirty =
@@ -126,14 +142,25 @@ export function HubSettingsPanel() {
               type="password"
               value={account.hub_api_key}
               onChange={(e) => setAccount({ ...account, hub_api_key: e.target.value })}
-              placeholder="hub_..."
+              placeholder="hubk_full_..."
               className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
             />
+            {keyIsPublishOnly && (
+              <p className="mt-1 text-2xs text-warm-pale">
+                Publish-only key detected. AI routing is unavailable for this tier —
+                the hub will reject `/ai/*` calls. Publish still works normally.
+              </p>
+            )}
           </div>
-          <label className="mt-2 flex cursor-pointer items-start gap-2 rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-2 text-xs text-text-secondary">
+          <label
+            className={`mt-2 flex items-start gap-2 rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-2 text-xs text-text-secondary ${
+              keyIsPublishOnly ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+            }`}
+          >
             <input
               type="checkbox"
-              checked={account.use_hub_ai}
+              checked={account.use_hub_ai && !keyIsPublishOnly}
+              disabled={keyIsPublishOnly}
               onChange={(e) => setAccount({ ...account, use_hub_ai: e.target.checked })}
               className="mt-0.5 accent-accent"
             />

--- a/hub-admin/src/lib/api.ts
+++ b/hub-admin/src/lib/api.ts
@@ -37,12 +37,15 @@ export interface HubUsage {
   promptsQuota: number;
 }
 
+export type HubUserTier = "full" | "publish";
+
 export interface HubUser {
   id: string;
   displayName: string;
   email: string | null;
   createdAt: number;
   lastPublishAt: number | null;
+  tier: HubUserTier;
   usage: HubUsage;
   worlds: HubWorldSummary[];
 }
@@ -106,13 +109,34 @@ export async function listUsers(adminKey: string): Promise<HubUser[]> {
 
 export async function createUser(
   adminKey: string,
-  payload: { displayName: string; email: string | null },
+  payload: { displayName: string; email: string | null; tier: HubUserTier },
 ): Promise<{ user: HubUser; apiKey: string }> {
   return await request<{ user: HubUser; apiKey: string }>("/admin/users", {
     method: "POST",
     adminKey,
     body: JSON.stringify(payload),
   });
+}
+
+/**
+ * Change a user's tier. The worker auto-rotates their API key when
+ * the tier actually changes, so `apiKey` will be non-null in that
+ * case and must be shown to the operator (the old key is dead).
+ * `apiKey` is null when the requested tier already matches.
+ */
+export async function setUserTier(
+  adminKey: string,
+  userId: string,
+  tier: HubUserTier,
+): Promise<{ user: HubUser; apiKey: string | null; unchanged?: boolean }> {
+  return await request<{ user: HubUser; apiKey: string | null; unchanged?: boolean }>(
+    `/admin/users/${encodeURIComponent(userId)}/tier`,
+    {
+      method: "POST",
+      adminKey,
+      body: JSON.stringify({ tier }),
+    },
+  );
 }
 
 export async function deleteUser(adminKey: string, userId: string): Promise<void> {

--- a/hub-admin/src/pages/UsersPage.tsx
+++ b/hub-admin/src/pages/UsersPage.tsx
@@ -6,8 +6,10 @@ import {
   deleteWorld,
   listUsers,
   regenerateKey,
+  setUserTier,
   updateQuotas,
   type HubUser,
+  type HubUserTier,
 } from "../lib/api";
 
 interface UsersPageProps {
@@ -79,6 +81,7 @@ export function UsersPage({ adminKey, onLogout }: UsersPageProps) {
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
   const [newEmail, setNewEmail] = useState("");
+  const [newTier, setNewTier] = useState<HubUserTier>("full");
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -105,15 +108,39 @@ export function UsersPage({ adminKey, onLogout }: UsersPageProps) {
       const res = await createUser(adminKey, {
         displayName: newName.trim(),
         email: newEmail.trim() || null,
+        tier: newTier,
       });
       setRevealedKey({ apiKey: res.apiKey, label: `Key for ${res.user.displayName}` });
       setNewName("");
       setNewEmail("");
+      setNewTier("full");
       await refresh();
     } catch (e) {
       setError(e instanceof ApiError ? e.message : String(e));
     } finally {
       setCreating(false);
+    }
+  };
+
+  const handleSetTier = async (user: HubUser, tier: HubUserTier) => {
+    if (user.tier === tier) return;
+    const label =
+      tier === "publish"
+        ? `Downgrade ${user.displayName} to publish-only? Their current key will be rotated and they will lose access to all /ai/* features.`
+        : `Upgrade ${user.displayName} to full (publish + AI)? Their current key will be rotated.`;
+    const ok = window.confirm(label);
+    if (!ok) return;
+    try {
+      const res = await setUserTier(adminKey, user.id, tier);
+      if (res.apiKey) {
+        setRevealedKey({
+          apiKey: res.apiKey,
+          label: `New ${tier === "publish" ? "publish-only" : "full"} key for ${user.displayName}`,
+        });
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof ApiError ? e.message : String(e));
     }
   };
 
@@ -218,6 +245,45 @@ export function UsersPage({ adminKey, onLogout }: UsersPageProps) {
             disabled={creating}
           />
         </div>
+        <div className="field">
+          <label>Tier</label>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+            <label style={{ display: "flex", gap: "0.5rem", alignItems: "flex-start", cursor: "pointer" }}>
+              <input
+                type="radio"
+                name="new-tier"
+                value="full"
+                checked={newTier === "full"}
+                onChange={() => setNewTier("full")}
+                disabled={creating}
+                style={{ marginTop: "0.2rem" }}
+              />
+              <span>
+                <strong>Full</strong> — showcase publish + hub AI (image, LLM, vision).
+                <span className="muted" style={{ display: "block", fontSize: "0.8rem" }}>
+                  Key prefix: <code>hubk_full_…</code>
+                </span>
+              </span>
+            </label>
+            <label style={{ display: "flex", gap: "0.5rem", alignItems: "flex-start", cursor: "pointer" }}>
+              <input
+                type="radio"
+                name="new-tier"
+                value="publish"
+                checked={newTier === "publish"}
+                onChange={() => setNewTier("publish")}
+                disabled={creating}
+                style={{ marginTop: "0.2rem" }}
+              />
+              <span>
+                <strong>Publish-only</strong> — showcase publish, no AI budget.
+                <span className="muted" style={{ display: "block", fontSize: "0.8rem" }}>
+                  Key prefix: <code>hubk_pub_…</code> — creator auto-disables hub AI toggle.
+                </span>
+              </span>
+            </label>
+          </div>
+        </div>
         <button className="primary" onClick={() => void handleCreate()} disabled={creating || !newName.trim()}>
           {creating ? "Creating…" : "Create user + mint key"}
         </button>
@@ -235,6 +301,7 @@ export function UsersPage({ adminKey, onLogout }: UsersPageProps) {
               <tr>
                 <th>Name</th>
                 <th>Email</th>
+                <th>Tier</th>
                 <th>AI Usage</th>
                 <th>Worlds</th>
                 <th>Last publish</th>
@@ -247,18 +314,40 @@ export function UsersPage({ adminKey, onLogout }: UsersPageProps) {
                   <td>{user.displayName}</td>
                   <td className="muted">{user.email ?? "—"}</td>
                   <td>
-                    <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
-                      <UsageBar
-                        used={user.usage.imagesUsed}
-                        quota={user.usage.imagesQuota}
-                        label="Images"
-                      />
-                      <UsageBar
-                        used={user.usage.promptsUsed}
-                        quota={user.usage.promptsQuota}
-                        label="Prompts"
-                      />
-                    </div>
+                    <span
+                      style={{
+                        fontSize: "0.75rem",
+                        color: user.tier === "full" ? "var(--accent)" : "var(--muted)",
+                        border: `1px solid ${user.tier === "full" ? "var(--accent)" : "var(--muted)"}`,
+                        borderRadius: 3,
+                        padding: "0.1rem 0.4rem",
+                        textTransform: "uppercase",
+                        letterSpacing: "0.05em",
+                        fontVariant: "all-small-caps",
+                      }}
+                    >
+                      {user.tier === "full" ? "full" : "publish-only"}
+                    </span>
+                  </td>
+                  <td>
+                    {user.tier === "full" ? (
+                      <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
+                        <UsageBar
+                          used={user.usage.imagesUsed}
+                          quota={user.usage.imagesQuota}
+                          label="Images"
+                        />
+                        <UsageBar
+                          used={user.usage.promptsUsed}
+                          quota={user.usage.promptsQuota}
+                          label="Prompts"
+                        />
+                      </div>
+                    ) : (
+                      <span className="muted" style={{ fontSize: "0.8rem" }}>
+                        n/a (publish-only)
+                      </span>
+                    )}
                   </td>
                   <td>
                     {user.worlds.length === 0 ? (
@@ -302,7 +391,18 @@ export function UsersPage({ adminKey, onLogout }: UsersPageProps) {
                   <td className="muted">{formatDate(user.lastPublishAt)}</td>
                   <td>
                     <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
-                      <button onClick={() => void handleEditQuotas(user)}>Edit quotas</button>
+                      {user.tier === "full" ? (
+                        <>
+                          <button onClick={() => void handleEditQuotas(user)}>Edit quotas</button>
+                          <button onClick={() => void handleSetTier(user, "publish")}>
+                            Downgrade to publish-only
+                          </button>
+                        </>
+                      ) : (
+                        <button onClick={() => void handleSetTier(user, "full")}>
+                          Upgrade to full
+                        </button>
+                      )}
                       <button onClick={() => void handleRegenerate(user)}>Rotate key</button>
                       <button className="danger" onClick={() => void handleDeleteUser(user)}>
                         Delete

--- a/hub-worker/src/db.ts
+++ b/hub-worker/src/db.ts
@@ -1,5 +1,7 @@
 import type { Env } from "./env";
 
+export type UserTier = "full" | "publish";
+
 export interface UserRow {
   id: string;
   display_name: string;
@@ -11,6 +13,7 @@ export interface UserRow {
   images_quota: number;
   prompts_used: number;
   prompts_quota: number;
+  tier: UserTier;
 }
 
 export interface WorldRow {
@@ -43,13 +46,19 @@ export async function listUsers(env: Env): Promise<UserRow[]> {
 
 export async function createUser(
   env: Env,
-  user: { id: string; display_name: string; email: string | null; api_key_hash: string },
+  user: {
+    id: string;
+    display_name: string;
+    email: string | null;
+    api_key_hash: string;
+    tier: UserTier;
+  },
 ): Promise<void> {
   const now = Date.now();
   await env.DB.prepare(
-    "INSERT INTO users (id, display_name, email, api_key_hash, created_at) VALUES (?, ?, ?, ?, ?)",
+    "INSERT INTO users (id, display_name, email, api_key_hash, created_at, tier) VALUES (?, ?, ?, ?, ?, ?)",
   )
-    .bind(user.id, user.display_name, user.email, user.api_key_hash, now)
+    .bind(user.id, user.display_name, user.email, user.api_key_hash, now, user.tier)
     .run();
 }
 
@@ -65,6 +74,23 @@ export async function updateUserApiKeyHash(
     "UPDATE users SET api_key_hash = ?, images_used = 0, prompts_used = 0 WHERE id = ?",
   )
     .bind(apiKeyHash, userId)
+    .run();
+}
+
+// Tier changes always auto-rotate the key — the prefix encodes the
+// tier as a UX hint for the creator, so changing tier without
+// rotating would leave a stale prefix that misleads the client.
+// Counters reset alongside the rotation, same as updateUserApiKeyHash.
+export async function updateUserTierAndKey(
+  env: Env,
+  userId: string,
+  tier: UserTier,
+  apiKeyHash: string,
+): Promise<void> {
+  await env.DB.prepare(
+    "UPDATE users SET tier = ?, api_key_hash = ?, images_used = 0, prompts_used = 0 WHERE id = ?",
+  )
+    .bind(tier, apiKeyHash, userId)
     .run();
 }
 

--- a/hub-worker/src/handlers/admin.ts
+++ b/hub-worker/src/handlers/admin.ts
@@ -10,7 +10,9 @@ import {
   listWorldsForUser,
   setUserQuotas,
   updateUserApiKeyHash,
+  updateUserTierAndKey,
   type UserRow,
+  type UserTier,
   type WorldRow,
 } from "../db";
 import { corsHeaders, error, generateApiKey, json, newId, preflight } from "../util";
@@ -23,6 +25,7 @@ interface AdminUserView {
   email: string | null;
   createdAt: number;
   lastPublishAt: number | null;
+  tier: UserTier;
   usage: {
     imagesUsed: number;
     imagesQuota: number;
@@ -30,6 +33,11 @@ interface AdminUserView {
     promptsQuota: number;
   };
   worlds: { slug: string; listed: boolean; lastPublishAt: number | null; bytesUsed: number }[];
+}
+
+function parseTier(raw: unknown): UserTier | null {
+  if (raw === "full" || raw === "publish") return raw;
+  return null;
 }
 
 /**
@@ -57,6 +65,7 @@ function toUserView(user: UserRow, worlds: WorldRow[]): AdminUserView {
     email: user.email,
     createdAt: user.created_at,
     lastPublishAt: user.last_publish_at,
+    tier: user.tier,
     usage: {
       imagesUsed: user.images_used,
       imagesQuota: user.images_quota,
@@ -101,6 +110,14 @@ export async function handleAdmin(req: Request, env: Env, pathname: string): Pro
     return error(405, "Method not allowed", c);
   }
 
+  // /admin/users/<id>/tier
+  const tierMatch = /^\/admin\/users\/([^/]+)\/tier$/.exec(pathname);
+  if (tierMatch && tierMatch[1]) {
+    const id = tierMatch[1];
+    if (req.method === "POST") return await adminSetTier(req, env, id, c);
+    return error(405, "Method not allowed", c);
+  }
+
   // /admin/users/<id>/quotas
   const quotaMatch = /^\/admin\/users\/([^/]+)\/quotas$/.exec(pathname);
   if (quotaMatch && quotaMatch[1]) {
@@ -141,7 +158,7 @@ async function adminListUsers(env: Env, c: Cors): Promise<Response> {
 }
 
 async function adminCreateUser(req: Request, env: Env, c: Cors): Promise<Response> {
-  let body: { displayName?: string; email?: string };
+  let body: { displayName?: string; email?: string; tier?: string };
   try {
     body = (await req.json()) as typeof body;
   } catch {
@@ -150,11 +167,14 @@ async function adminCreateUser(req: Request, env: Env, c: Cors): Promise<Respons
   const displayName = (body.displayName ?? "").trim();
   if (!displayName) return error(400, "displayName is required", c);
   const email = (body.email ?? "").trim() || null;
+  // Tier defaults to "full" for back-compat with existing admin UIs
+  // that don't send the field yet.
+  const tier: UserTier = parseTier(body.tier) ?? "full";
 
-  const { plain, hash } = await generateApiKey();
+  const { plain, hash } = await generateApiKey(tier);
   const id = newId();
   try {
-    await createUser(env, { id, display_name: displayName, email, api_key_hash: hash });
+    await createUser(env, { id, display_name: displayName, email, api_key_hash: hash, tier });
   } catch (e) {
     return error(500, `Failed to create user: ${String(e)}`, c);
   }
@@ -188,11 +208,44 @@ async function adminDeleteUser(env: Env, id: string, c: Cors): Promise<Response>
 async function adminRegenerateKey(env: Env, id: string, c: Cors): Promise<Response> {
   const user = await getUserById(env, id);
   if (!user) return error(404, "User not found", c);
-  const { plain, hash } = await generateApiKey();
+  // Mint the new key with a prefix that matches the user's current
+  // tier so the creator's auto-detection stays consistent with D1.
+  const { plain, hash } = await generateApiKey(user.tier);
   // updateUserApiKeyHash also zeros out images_used and prompts_used —
   // rotation gives the legit user a fresh quota and kills any leaked key.
   await updateUserApiKeyHash(env, id, hash);
   return json({ apiKey: plain }, {}, c);
+}
+
+async function adminSetTier(req: Request, env: Env, id: string, c: Cors): Promise<Response> {
+  const user = await getUserById(env, id);
+  if (!user) return error(404, "User not found", c);
+
+  let body: { tier?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return error(400, "Invalid JSON body", c);
+  }
+  const tier = parseTier(body.tier);
+  if (!tier) return error(400, "tier must be \"full\" or \"publish\"", c);
+
+  // No-op if the requested tier matches. We still return the user
+  // view so the admin UI can refresh, but skip rotation — rotating
+  // on a no-op would needlessly kill a working key.
+  if (tier === user.tier) {
+    return json({ user: toUserView(user, []), apiKey: null, unchanged: true }, {}, c);
+  }
+
+  // Tier change always auto-rotates the key so the prefix stays in
+  // sync with the stored tier and any key that leaked under the old
+  // tier is immediately invalidated.
+  const { plain, hash } = await generateApiKey(tier);
+  await updateUserTierAndKey(env, id, tier, hash);
+
+  const fresh = await getUserById(env, id);
+  if (!fresh) return error(500, "User disappeared after update", c);
+  return json({ user: toUserView(fresh, []), apiKey: plain }, {}, c);
 }
 
 async function adminUpdateQuotas(

--- a/hub-worker/src/handlers/ai.ts
+++ b/hub-worker/src/handlers/ai.ts
@@ -65,6 +65,23 @@ export async function handleAi(
 ): Promise<Response> {
   if (req.method === "OPTIONS") return preflight(CORS);
 
+  // Tier gate. Publish-only users have valid credentials for /publish/*
+  // but cannot spend AI budget. D1 is the authoritative tier — the
+  // `hubk_pub_` prefix on their key is just a UX hint the creator
+  // reads to disable the toggle. Never trust the prefix; check here.
+  if (user.tier !== "full") {
+    return json(
+      {
+        error: "tier_forbidden",
+        message:
+          "This API key is publish-only and cannot use hub AI features. Ask the hub admin for a full-tier key.",
+        tier: user.tier,
+      },
+      { status: 403 },
+      CORS,
+    );
+  }
+
   if (pathname === "/ai/image/generate" && req.method === "POST") {
     return await imageGenerate(req, env, user);
   }

--- a/hub-worker/src/migrations/0002_user_tier.sql
+++ b/hub-worker/src/migrations/0002_user_tier.sql
@@ -1,0 +1,11 @@
+-- 0002_user_tier
+-- Adds a tier column to users so we can issue publish-only keys that
+-- can upload showcase content but are rejected from every /ai/*
+-- endpoint. Existing rows default to 'full' — the hub gave out
+-- full-access keys before this migration, so that's the only safe
+-- choice. New rows are inserted with whichever tier the admin picks.
+--
+-- Apply with:
+--   wrangler d1 execute arcanum-hub --remote --file=./src/migrations/0002_user_tier.sql
+
+ALTER TABLE users ADD COLUMN tier TEXT NOT NULL DEFAULT 'full';

--- a/hub-worker/src/util.ts
+++ b/hub-worker/src/util.ts
@@ -79,14 +79,28 @@ export async function sha256Hex(input: string | ArrayBuffer): Promise<string> {
     .join("");
 }
 
-/** Generate a new API key. Returns both the plain text (shown once) and its SHA-256 hash (stored). */
-export async function generateApiKey(): Promise<{ plain: string; hash: string }> {
+/**
+ * Generate a new API key. Returns both the plain text (shown once)
+ * and its SHA-256 hash (stored).
+ *
+ * The tier is encoded in the prefix (`hubk_full_...` / `hubk_pub_...`)
+ * so the creator can auto-detect publish-only keys and disable its
+ * "Use Hub AI" toggle. The prefix is purely a UX hint — the worker
+ * still looks up the authoritative tier in D1 on every `/ai/*` call.
+ * Legacy `hub_<random>` keys (no tier segment) from before this
+ * feature keep working; they're all tagged `tier='full'` by the
+ * 0002 migration.
+ */
+export async function generateApiKey(
+  tier: "full" | "publish",
+): Promise<{ plain: string; hash: string }> {
   const bytes = new Uint8Array(24);
   crypto.getRandomValues(bytes);
   const tail = Array.from(bytes)
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
-  const plain = `hub_${tail}`;
+  const segment = tier === "publish" ? "pub" : "full";
+  const plain = `hubk_${segment}_${tail}`;
   const hash = await sha256Hex(plain);
   return { plain, hash };
 }


### PR DESCRIPTION
## Summary
- New `tier` column on D1 users (`full` | `publish`); tier encoded in API key prefix (`hubk_full_…` / `hubk_pub_…`) as a UX hint, enforced server-side on every `/ai/*` call.
- Admin UI gets a tier radio on user create, a tier column on the list, and per-row "Upgrade to full" / "Downgrade to publish-only" buttons that auto-rotate the key and surface the new value in the reveal modal.
- Creator `HubSettingsPanel` auto-detects `hubk_pub_` prefix and force-disables the "Use Hub AI" toggle; `hub_ai.rs` maps the `tier_forbidden` 403 to an actionable toast.

## Design notes
- D1 is the authoritative tier. The prefix is only for creator-side UX; the worker looks up `user.tier` on every request and returns `403 { error: "tier_forbidden" }` before touching any provider.
- Tier changes always auto-rotate the key so the prefix can never drift from the stored tier and any leaked key is immediately invalidated. Rotation also resets usage counters (same semantics as the existing `/regenerate-key` endpoint).
- `regenerate-key` now preserves the caller's current tier when minting the new key.
- Legacy `hub_<random>` keys from before this feature grandfather as `full` via the 0002 migration default, so nothing breaks for existing users.

## Before merging
1. Apply migration: `cd hub-worker && npx wrangler d1 execute arcanum-hub --remote --file=./src/migrations/0002_user_tier.sql`
2. Deploy worker: `cd hub-worker && npm run deploy`
3. Deploy admin: `cd hub-admin && VITE_HUB_API_URL=https://api.arcanum-hub.com npm run build && npx wrangler pages deploy dist --project-name=arcanum-hub-admin --branch=main`

## Test plan
- [ ] Apply migration to remote D1; verify `tier` column exists with `full` default on existing rows
- [ ] Create a new full-tier user via admin UI → key has `hubk_full_` prefix → can generate an image
- [ ] Create a new publish-only user → key has `hubk_pub_` prefix → publish works → `/ai/image/generate` returns 403 `tier_forbidden`
- [ ] Paste a `hubk_pub_` key into creator settings → "Use Hub AI" toggle auto-disables with explanation → save succeeds with `use_hub_ai: false`
- [ ] Downgrade full → publish in admin UI → old key dies, new `hubk_pub_` key appears in reveal modal, usage counters reset to 0
- [ ] Upgrade publish → full → old key dies, new `hubk_full_` key appears, user regains AI access
- [ ] Verify legacy `hub_<random>` test key (if any still exists in D1) continues to work for both publish and AI
- [ ] Rotate key on a publish-only user → new key preserves `hubk_pub_` prefix