### PR TITLE
Add Community Edition (AI-free) build mode, bump version to 2.0.0-rc1

### DIFF
--- a/creator/bun.lock
+++ b/creator/bun.lock
@@ -47,6 +47,7 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
         "autoprefixer": "^10.4.0",
+        "cross-env": "^10.1.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.8.0",
@@ -109,6 +110,8 @@
     "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
 
     "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
+
+    "@epic-web/invariant": ["@epic-web/invariant@1.0.0", "", {}, "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -508,6 +511,10 @@
 
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
+    "cross-env": ["cross-env@10.1.0", "", { "dependencies": { "@epic-web/invariant": "^1.0.0", "cross-spawn": "^7.0.6" }, "bin": { "cross-env": "dist/bin/cross-env.js", "cross-env-shell": "dist/bin/cross-env-shell.js" } }, "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
@@ -604,6 +611,8 @@
 
     "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -677,6 +686,8 @@
     "onnxruntime-web": ["onnxruntime-web@1.21.0", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.21.0", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-adzOe+7uI7lKz6pQNbAsLMQd2Fq5Jhmoxd8LZjJr8m3KvbFyiYyRxRiC57/XXD+jb18voppjeGAjoZmskXG+7A=="],
 
     "orderedmap": ["orderedmap@2.1.1", "", {}, "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -768,6 +779,10 @@
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -819,6 +834,8 @@
     "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 

--- a/creator/package.json
+++ b/creator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arcanum",
   "private": true,
-  "version": "1.6.0",
+  "version": "2.0.0-rc1",
   "license": "SEE LICENSE IN ../LICENSE.md",
   "type": "module",
   "scripts": {
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "build:community": "cross-env VITE_AI=false tauri build -- --no-default-features"
   },
   "dependencies": {
     "@dagrejs/dagre": "^2.0.4",
@@ -55,6 +56,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "^10.4.0",
+    "cross-env": "^10.1.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.8.0",

--- a/creator/src-tauri/Cargo.lock
+++ b/creator/src-tauri/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "arcanum"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/creator/src-tauri/Cargo.toml
+++ b/creator/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcanum"
-version = "1.6.0"
+version = "2.0.0-rc1"
 description = "Arcanum — world building, lore, and art generation tool"
 authors = []
 edition = "2021"
@@ -8,6 +8,10 @@ edition = "2021"
 [lib]
 name = "arcanum_lib"
 crate-type = ["lib", "cdylib", "staticlib"]
+
+[features]
+default = ["ai"]
+ai = []
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/creator/src-tauri/src/deepinfra.rs
+++ b/creator/src-tauri/src/deepinfra.rs
@@ -287,39 +287,6 @@ pub async fn img2img_generate(
     .await
 }
 
-fn detect_extension(bytes: &[u8]) -> &'static str {
-    if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
-        "png"
-    } else if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
-        "jpg"
-    } else if bytes.starts_with(b"RIFF") && bytes.len() > 12 && &bytes[8..12] == b"WEBP" {
-        "webp"
-    } else {
-        "png" // default
-    }
-}
-
-fn detect_mime(ext: &str) -> &'static str {
-    match ext {
-        "jpg" => "image/jpeg",
-        "webp" => "image/webp",
-        _ => "image/png",
-    }
-}
-
-/// Read a saved image from disk and return it as a data URL.
-#[tauri::command]
-pub async fn read_image_data_url(path: String) -> Result<String, String> {
-    let bytes = tokio::fs::read(&path)
-        .await
-        .map_err(|e| format!("Failed to read image: {e}"))?;
-
-    let ext = detect_extension(&bytes);
-    let mime = detect_mime(ext);
-    let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
-    Ok(format!("data:{mime};base64,{b64}"))
-}
-
 // ─── Prompt Enhancement ──────────────────────────────────────────────
 
 #[tauri::command]

--- a/creator/src-tauri/src/fs_utils.rs
+++ b/creator/src-tauri/src/fs_utils.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use serde::Serialize;
 use std::path::Path;
 
@@ -13,4 +14,36 @@ pub async fn write_json_file<T: Serialize>(
     tokio::fs::write(path, json)
         .await
         .map_err(|e| format!("Failed to write {label}: {e}"))
+}
+
+pub fn detect_extension(bytes: &[u8]) -> &'static str {
+    if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
+        "png"
+    } else if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        "jpg"
+    } else if bytes.starts_with(b"RIFF") && bytes.len() > 12 && &bytes[8..12] == b"WEBP" {
+        "webp"
+    } else {
+        "png"
+    }
+}
+
+pub fn detect_mime(ext: &str) -> &'static str {
+    match ext {
+        "jpg" => "image/jpeg",
+        "webp" => "image/webp",
+        _ => "image/png",
+    }
+}
+
+#[tauri::command]
+pub async fn read_image_data_url(path: String) -> Result<String, String> {
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|e| format!("Failed to read image: {e}"))?;
+
+    let ext = detect_extension(&bytes);
+    let mime = detect_mime(ext);
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Ok(format!("data:{mime};base64,{b64}"))
 }

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -1,41 +1,46 @@
 mod admin;
+#[cfg(feature = "ai")]
 mod anthropic;
 mod arcanum_meta;
 mod assets;
 mod audio_mix;
 mod cancellation;
 mod captions;
+#[cfg(feature = "ai")]
 mod deepinfra;
 mod ffmpeg;
 mod ffmpeg_progress;
 mod fs_utils;
 mod git;
+#[cfg(feature = "ai")]
 mod generation;
 mod http;
 mod hub;
+#[cfg(feature = "ai")]
 mod hub_ai;
+#[cfg(feature = "ai")]
 mod llm;
+#[cfg(feature = "ai")]
 mod openai_images;
+#[cfg(feature = "ai")]
 mod openai_tts;
+#[cfg(feature = "ai")]
 mod openrouter;
 mod project;
 mod r2;
+#[cfg(feature = "ai")]
 mod runware;
 mod project_settings;
 mod settings;
+#[cfg(feature = "ai")]
 mod sketch;
 mod video_encode;
 mod video_export;
 mod vibes;
 
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
-    tauri::Builder::default()
-        .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_fs::init())
-        .plugin(tauri_plugin_shell::init())
-        .plugin(tauri_plugin_window_state::Builder::new().build())
-        .invoke_handler(tauri::generate_handler![
+macro_rules! base_handler {
+    ($($extra:path),* $(,)?) => {
+        tauri::generate_handler![
             project::validate_mud_dir,
             project::validate_project,
             project::create_standalone_project,
@@ -57,14 +62,7 @@ pub fn run() {
             project_settings::get_project_settings,
             project_settings::save_project_settings,
             project_settings::seed_project_settings,
-            deepinfra::generate_image,
-            deepinfra::img2img_generate,
-            deepinfra::enhance_prompt,
-            deepinfra::read_image_data_url,
-            llm::llm_complete,
-            llm::llm_complete_with_vision,
-            runware::runware_generate_image,
-            runware::runware_remove_background,
+            fs_utils::read_image_data_url,
             ffmpeg::check_ffmpeg_status,
             ffmpeg::ensure_ffmpeg_ready,
             video_export::save_video_frame,
@@ -72,10 +70,6 @@ pub fn run() {
             video_export::resolve_first_existing_path,
             video_export::export_story_video,
             video_export::cancel_story_video_export,
-            openai_images::openai_generate_image,
-            openai_tts::openai_tts_generate,
-            runware::runware_generate_audio,
-            runware::runware_generate_video,
             assets::accept_asset,
             assets::list_assets,
             assets::delete_asset,
@@ -109,7 +103,6 @@ pub fn run() {
             vibes::load_zone_vibe,
             arcanum_meta::load_arcanum_meta,
             arcanum_meta::save_arcanum_meta,
-            sketch::analyze_sketch,
             admin::load_admin_config,
             admin::save_admin_config,
             admin::admin_overview,
@@ -145,7 +138,41 @@ pub fn run() {
             git::git_abort_merge,
             git::git_log,
             git::git_create_pr,
-        ])
+            $($extra,)*
+        ]
+    }
+}
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_window_state::Builder::new().build())
+        .invoke_handler({
+            #[cfg(feature = "ai")]
+            {
+                base_handler![
+                    deepinfra::generate_image,
+                    deepinfra::img2img_generate,
+                    deepinfra::enhance_prompt,
+                    llm::llm_complete,
+                    llm::llm_complete_with_vision,
+                    runware::runware_generate_image,
+                    runware::runware_remove_background,
+                    runware::runware_generate_audio,
+                    runware::runware_generate_video,
+                    openai_images::openai_generate_image,
+                    openai_tts::openai_tts_generate,
+                    sketch::analyze_sketch,
+                ]
+            }
+            #[cfg(not(feature = "ai"))]
+            {
+                base_handler![]
+            }
+        })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|_app, _event| {});

--- a/creator/src-tauri/tauri.conf.json
+++ b/creator/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/schema.json",
   "productName": "Arcanum",
-  "version": "1.6.0",
+  "version": "2.0.0-rc1",
   "identifier": "dev.arcanum.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/creator/src/components/AbilityStudio.tsx
+++ b/creator/src/components/AbilityStudio.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useAssetStore } from "@/stores/assetStore";
@@ -570,6 +571,8 @@ export function AbilityStudio() {
   if (!config) {
     return null;
   }
+
+  if (!AI_ENABLED) return null;
 
   const anyBusy = generatingPrompt || generatingImage || batchGenerating || importing || generatingTemplate;
   const batchCompleted = batchProgress.done + batchProgress.failed;

--- a/creator/src/components/AssetGenerator.tsx
+++ b/creator/src/components/AssetGenerator.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { invoke } from "@tauri-apps/api/core";
 import { useAssetStore } from "@/stores/assetStore";
 import { useConfigStore } from "@/stores/configStore";
@@ -189,6 +190,8 @@ export function AssetGenerator() {
     setResult(null);
     setStage("compose");
   };
+
+  if (!AI_ENABLED) return null;
 
   if (!hasApiKey) {
     return (

--- a/creator/src/components/CustomAssetStudio.tsx
+++ b/creator/src/components/CustomAssetStudio.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useAssetStore } from "@/stores/assetStore";
@@ -340,6 +341,8 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
       setError(String(e));
     }
   };
+
+  if (!AI_ENABLED) return null;
 
   return (
     <section className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel p-5 shadow-section">

--- a/creator/src/components/GettingStartedPanel.tsx
+++ b/creator/src/components/GettingStartedPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useProjectStore } from "@/stores/projectStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { panelTab } from "@/lib/panelRegistry";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import {
   loadGettingStarted,
   markStepCompleted,
@@ -81,22 +82,22 @@ export function GettingStartedPanel({ onClose }: GettingStartedPanelProps) {
           }
         },
       },
-      {
+      ...(AI_ENABLED ? [{
         id: "characters",
         glyph: "\u2694\uFE0F",
         title: "Discover Characters",
         description:
           "See the portraits for every class and race that inhabits your world.",
         action: () => openTab(panelTab("portraits")),
-      },
-      {
+      }] : []),
+      ...(AI_ENABLED ? [{
         id: "art",
         glyph: "\u{1F3A8}",
         title: "Generate Art",
         description:
           "Every creature, item, and place can have AI artwork. Try rendering your first image.",
         action: () => openTab(panelTab("art")),
-      },
+      }] : []),
       {
         id: "lore",
         glyph: "\u{1F4DC}",

--- a/creator/src/components/NewZoneDialogSteps.tsx
+++ b/creator/src/components/NewZoneDialogSteps.tsx
@@ -4,6 +4,7 @@ import { buildToneDirective } from "@/lib/loreGeneration";
 import { sanitizeLabel, inferDirection } from "@/lib/sketchToZone";
 import { LoreEditor } from "./lore/LoreEditor";
 import { SketchCanvas } from "./SketchCanvas";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import type { WorldFile } from "@/types/world";
 import type { SketchParseResult } from "@/types/sketch";
 import type { FixedLayout, FixedLayoutRoom } from "@/lib/generateZoneContent";
@@ -490,103 +491,105 @@ export function LayoutStep({
         )}
       </div>
 
-      {/* Sketch */}
-      <div>
-        <label className="mb-1 block text-2xs uppercase tracking-wider text-text-muted">
-          Sketch
-          <span className="ml-2 font-normal normal-case text-text-muted">
-            (optional — defines the room layout)
-          </span>
-        </label>
+      {/* Sketch (requires AI vision) */}
+      {AI_ENABLED && (
+        <div>
+          <label className="mb-1 block text-2xs uppercase tracking-wider text-text-muted">
+            Sketch
+            <span className="ml-2 font-normal normal-case text-text-muted">
+              (optional — defines the room layout)
+            </span>
+          </label>
 
-        {/* Summary when we have a parsed sketch */}
-        {hasSketch && sketchParse && (
-          <div className="rounded border border-border-default bg-bg-primary p-3">
-            <div className="flex items-center justify-between">
-              <div className="text-xs text-text-secondary">
-                <span className="text-text-primary">
-                  {sketchParse.rooms.length}
-                </span>{" "}
-                rooms parsed,{" "}
-                <span className="text-text-primary">
-                  {sketchParse.connections.length}
-                </span>{" "}
-                connections
+          {/* Summary when we have a parsed sketch */}
+          {hasSketch && sketchParse && (
+            <div className="rounded border border-border-default bg-bg-primary p-3">
+              <div className="flex items-center justify-between">
+                <div className="text-xs text-text-secondary">
+                  <span className="text-text-primary">
+                    {sketchParse.rooms.length}
+                  </span>{" "}
+                  rooms parsed,{" "}
+                  <span className="text-text-primary">
+                    {sketchParse.connections.length}
+                  </span>{" "}
+                  connections
+                </div>
+                <button
+                  onClick={clearSketch}
+                  className="rounded bg-bg-elevated px-2 py-1 text-2xs font-medium text-text-primary hover:bg-bg-hover"
+                >
+                  Clear
+                </button>
               </div>
+              {sketchParse.rooms.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1 text-2xs text-text-muted">
+                  {sketchParse.rooms.slice(0, 12).map((r) => (
+                    <span
+                      key={r.id}
+                      className="rounded bg-bg-elevated px-1.5 py-0.5"
+                    >
+                      {r.label || r.id}
+                    </span>
+                  ))}
+                  {sketchParse.rooms.length > 12 && (
+                    <span className="text-text-muted">
+                      +{sketchParse.rooms.length - 12} more
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Picker when no sketch yet */}
+          {!hasSketch && sketchMode === "none" && !analyzingSketch && (
+            <div className="flex gap-2">
               <button
-                onClick={clearSketch}
-                className="rounded bg-bg-elevated px-2 py-1 text-2xs font-medium text-text-primary hover:bg-bg-hover"
+                onClick={onPickPhoto}
+                className="flex flex-1 flex-col items-center gap-1 rounded border border-border-default bg-bg-primary p-4 text-xs font-medium text-text-primary transition-colors hover:border-accent/50 hover:bg-bg-elevated"
               >
-                Clear
+                <span className="text-lg">&#128247;</span>
+                Import photo
+                <span className="text-2xs font-normal text-text-muted">
+                  Hand-drawn on paper
+                </span>
+              </button>
+              <button
+                onClick={() => setSketchMode("draw")}
+                className="flex flex-1 flex-col items-center gap-1 rounded border border-border-default bg-bg-primary p-4 text-xs font-medium text-text-primary transition-colors hover:border-accent/50 hover:bg-bg-elevated"
+              >
+                <span className="text-lg">&#9998;</span>
+                Draw here
+                <span className="text-2xs font-normal text-text-muted">
+                  In-app canvas
+                </span>
               </button>
             </div>
-            {sketchParse.rooms.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-1 text-2xs text-text-muted">
-                {sketchParse.rooms.slice(0, 12).map((r) => (
-                  <span
-                    key={r.id}
-                    className="rounded bg-bg-elevated px-1.5 py-0.5"
-                  >
-                    {r.label || r.id}
-                  </span>
-                ))}
-                {sketchParse.rooms.length > 12 && (
-                  <span className="text-text-muted">
-                    +{sketchParse.rooms.length - 12} more
-                  </span>
-                )}
-              </div>
-            )}
-          </div>
-        )}
+          )}
 
-        {/* Picker when no sketch yet */}
-        {!hasSketch && sketchMode === "none" && !analyzingSketch && (
-          <div className="flex gap-2">
-            <button
-              onClick={onPickPhoto}
-              className="flex flex-1 flex-col items-center gap-1 rounded border border-border-default bg-bg-primary p-4 text-xs font-medium text-text-primary transition-colors hover:border-accent/50 hover:bg-bg-elevated"
-            >
-              <span className="text-lg">&#128247;</span>
-              Import photo
-              <span className="text-2xs font-normal text-text-muted">
-                Hand-drawn on paper
-              </span>
-            </button>
-            <button
-              onClick={() => setSketchMode("draw")}
-              className="flex flex-1 flex-col items-center gap-1 rounded border border-border-default bg-bg-primary p-4 text-xs font-medium text-text-primary transition-colors hover:border-accent/50 hover:bg-bg-elevated"
-            >
-              <span className="text-lg">&#9998;</span>
-              Draw here
-              <span className="text-2xs font-normal text-text-muted">
-                In-app canvas
-              </span>
-            </button>
-          </div>
-        )}
+          {/* Canvas */}
+          {sketchMode === "draw" && !hasSketch && !analyzingSketch && (
+            <div>
+              <SketchCanvas onExport={onCanvasExport} />
+              <button
+                onClick={() => setSketchMode("none")}
+                className="mt-2 rounded bg-bg-elevated px-3 py-1 text-2xs text-text-primary hover:bg-bg-hover"
+              >
+                Back
+              </button>
+            </div>
+          )}
 
-        {/* Canvas */}
-        {sketchMode === "draw" && !hasSketch && !analyzingSketch && (
-          <div>
-            <SketchCanvas onExport={onCanvasExport} />
-            <button
-              onClick={() => setSketchMode("none")}
-              className="mt-2 rounded bg-bg-elevated px-3 py-1 text-2xs text-text-primary hover:bg-bg-hover"
-            >
-              Back
-            </button>
-          </div>
-        )}
-
-        {/* Analyzing */}
-        {analyzingSketch && (
-          <div className="flex flex-col items-center gap-2 rounded border border-border-default bg-bg-primary py-6">
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-accent border-t-transparent" />
-            <p className="text-2xs text-text-muted">Analyzing sketch...</p>
-          </div>
-        )}
-      </div>
+          {/* Analyzing */}
+          {analyzingSketch && (
+            <div className="flex flex-col items-center gap-2 rounded border border-border-default bg-bg-primary py-6">
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+              <p className="text-2xs text-text-muted">Analyzing sketch...</p>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/creator/src/components/PlayerSpriteHelpers.tsx
+++ b/creator/src/components/PlayerSpriteHelpers.tsx
@@ -4,6 +4,7 @@ import { useImageSrc, isR2HashPath } from "@/lib/useImageSrc";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 import { removeBgAndSave } from "@/lib/useBackgroundRemoval";
 import { generateArtDirection } from "@/lib/spritePromptGen";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import type { BulkBgTarget } from "@/components/ui/BulkBgRemoval";
 import type {
   SpriteDefinition,
@@ -239,14 +240,16 @@ export function ArtDirectionField({
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between">
         <span className="text-xs text-text-secondary">Art Direction</span>
-        <button
-          onClick={handleAiSuggest}
-          disabled={generating || !hasLlmKey}
-          className="shrink-0 rounded px-1.5 py-0.5 text-2xs text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
-          title={hasLlmKey ? "Use AI to suggest visual art direction" : "No LLM API key configured"}
-        >
-          {generating ? "Generating..." : "AI Suggest"}
-        </button>
+        {AI_ENABLED && (
+          <button
+            onClick={handleAiSuggest}
+            disabled={generating || !hasLlmKey}
+            className="shrink-0 rounded px-1.5 py-0.5 text-2xs text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
+            title={hasLlmKey ? "Use AI to suggest visual art direction" : "No LLM API key configured"}
+          >
+            {generating ? "Generating..." : "AI Suggest"}
+          </button>
+        )}
       </div>
       <textarea
         className="ornate-input min-h-[5rem] resize-y rounded-3xl px-4 py-3 text-sm text-text-primary"
@@ -539,22 +542,26 @@ export function VariantRow({
       </div>
 
       <div className="flex shrink-0 flex-col gap-1">
-        <ActionButton
-          onClick={() => onGenerate(variant)}
-          disabled={!hasApiKey || generating}
-          variant="secondary"
-          size="sm"
-        >
-          {generating ? "..." : "Render"}
-        </ActionButton>
-        <ActionButton
-          onClick={() => onPreview(variant)}
-          disabled={!hasApiKey || generating}
-          variant="ghost"
-          size="sm"
-        >
-          Preview
-        </ActionButton>
+        {AI_ENABLED && (
+          <>
+            <ActionButton
+              onClick={() => onGenerate(variant)}
+              disabled={!hasApiKey || generating}
+              variant="secondary"
+              size="sm"
+            >
+              {generating ? "..." : "Render"}
+            </ActionButton>
+            <ActionButton
+              onClick={() => onPreview(variant)}
+              disabled={!hasApiKey || generating}
+              variant="ghost"
+              size="sm"
+            >
+              Preview
+            </ActionButton>
+          </>
+        )}
         <ActionButton
           onClick={() => onRemove(index)}
           variant="danger"
@@ -839,24 +846,26 @@ export function SpriteDetailEditor({
                 />
               </label>
             </div>
-            <div className="flex shrink-0 flex-col gap-1">
-              <ActionButton
-                onClick={() => onGenerateImage(id)}
-                disabled={!hasApiKey || generating === id}
-                variant="primary"
-                size="sm"
-              >
-                {generating === id ? "Generating..." : "Generate"}
-              </ActionButton>
-              <ActionButton
-                onClick={() => onPreviewGenerate(id)}
-                disabled={!hasApiKey || generating === id}
-                variant="secondary"
-                size="sm"
-              >
-                Preview
-              </ActionButton>
-            </div>
+            {AI_ENABLED && (
+              <div className="flex shrink-0 flex-col gap-1">
+                <ActionButton
+                  onClick={() => onGenerateImage(id)}
+                  disabled={!hasApiKey || generating === id}
+                  variant="primary"
+                  size="sm"
+                >
+                  {generating === id ? "Generating..." : "Generate"}
+                </ActionButton>
+                <ActionButton
+                  onClick={() => onPreviewGenerate(id)}
+                  disabled={!hasApiKey || generating === id}
+                  variant="secondary"
+                  size="sm"
+                >
+                  Preview
+                </ActionButton>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/creator/src/components/PlayerSpriteManager.tsx
+++ b/creator/src/components/PlayerSpriteManager.tsx
@@ -7,6 +7,7 @@ import { useAssetStore } from "@/stores/assetStore";
 import { UNIVERSAL_NEGATIVE } from "@/lib/arcanumPrompts";
 import { removeBgAndSave } from "@/lib/useBackgroundRemoval";
 import { BulkBgRemoval } from "@/components/ui/BulkBgRemoval";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { ENTITY_DIMENSIONS, imageGenerateCommand, resolveImageModel, requestsTransparentBackground } from "@/types/assets";
 import {
   buildSpritePrompt,
@@ -244,7 +245,7 @@ export function PlayerSpriteManager() {
 
   const handleGenerateImage = useCallback(
     async (imageId: string) => {
-      if (!hasApiKey || !settings) return;
+      if (!AI_ENABLED || !hasApiKey || !settings) return;
       setGenerating(imageId);
       setGenerationError(null);
 

--- a/creator/src/components/PortraitStudio.tsx
+++ b/creator/src/components/PortraitStudio.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { invoke } from "@tauri-apps/api/core";
 import { useAssetStore } from "@/stores/assetStore";
 import { useConfigStore } from "@/stores/configStore";
@@ -319,6 +320,8 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
       setError(String(e));
     }
   };
+
+  if (!AI_ENABLED) return null;
 
   if (!config) {
     return null;

--- a/creator/src/components/SpriteScaffold.tsx
+++ b/creator/src/components/SpriteScaffold.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, useCallback } from "react";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { invoke } from "@tauri-apps/api/core";
 import { useConfigStore } from "@/stores/configStore";
 import { useSpriteDefinitionStore } from "@/stores/spriteDefinitionStore";
@@ -255,6 +256,8 @@ export function SpriteScaffold({ onClose, onComplete }: SpriteScaffoldProps) {
     imageProvider, setDefinition, saveDefinitions,
     acceptAsset, loadAssets,
   ]);
+
+  if (!AI_ENABLED) return null;
 
   if (!config || !gaps) {
     return (

--- a/creator/src/components/Toolbar.tsx
+++ b/creator/src/components/Toolbar.tsx
@@ -7,6 +7,7 @@ import { useToastStore } from "@/stores/toastStore";
 import { ActionButton, Spinner } from "./ui/FormWidgets";
 import { exportShowcaseData } from "@/lib/exportShowcase";
 import { ProjectSwitcherMenu } from "./ui/ProjectSwitcherMenu";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 const PublishWorldModal = lazy(() =>
   import("./PublishWorldModal").then((m) => ({ default: m.PublishWorldModal })),
@@ -125,14 +126,16 @@ export function Toolbar({ onNewProject, onToggleGuide, guideOpen }: ToolbarProps
 
           {/* ── Right: actions ─────────────────────────────────────────── */}
           <div className="flex min-w-0 flex-1 shrink-0 items-center justify-end gap-2">
-            <ActionButton
-              onClick={openGenerator}
-              variant="ghost"
-              title="Generate new art"
-              aria-label="Generate new art"
-            >
-              Render Art
-            </ActionButton>
+            {AI_ENABLED && (
+              <ActionButton
+                onClick={openGenerator}
+                variant="ghost"
+                title="Generate new art"
+                aria-label="Generate new art"
+              >
+                Render Art
+              </ActionButton>
+            )}
 
             <ActionButton
               onClick={openGallery}

--- a/creator/src/components/WelcomeScreen.tsx
+++ b/creator/src/components/WelcomeScreen.tsx
@@ -7,10 +7,11 @@ import {
 } from "@/lib/uiPersistence";
 import { ErrorDialog } from "./ErrorDialog";
 import { CosmicBackdrop } from "./ui/CosmicBackdrop";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import splashHero from "@/assets/splash-hero.jpg";
 
 const ImportFromR2Dialog = lazy(() => import("./ImportFromR2Dialog").then((m) => ({ default: m.ImportFromR2Dialog })));
-const OnboardingFlow = lazy(() => import("./onboarding/OnboardingFlow").then((m) => ({ default: m.OnboardingFlow })));
+const OnboardingFlow = __BUILD_VARIANT__ === "full" ? lazy(() => import("./onboarding/OnboardingFlow").then((m) => ({ default: m.OnboardingFlow }))) : () => null;
 
 interface WelcomeScreenProps {
   onNewProject: () => void;
@@ -122,25 +123,27 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
 
           {/* ── Create paths ──────────────────────────────────────── */}
           <div className={`w-full ${mostRecent ? "mt-4" : "mt-10"} grid gap-3 sm:grid-cols-2`}>
-            <button
-              onClick={() => setShowOnboarding(true)}
-              className="group relative overflow-hidden rounded-2xl border border-[var(--border-accent-ring)]/60 px-5 py-5 text-left transition hover:border-[var(--border-accent-ring)] hover:shadow-[0_14px_36px_rgb(var(--accent-rgb)/0.18)]"
-              style={{
-                background: "linear-gradient(155deg, rgb(var(--accent-rgb) / 0.12), rgb(var(--surface-rgb) / 0.10) 50%, rgb(var(--bg-rgb) / 0.88))",
-              }}
-            >
-              <div className="flex items-center gap-2">
-                <span className="font-display text-sm text-text-primary">
-                  Start with Arcanum Hub
-                </span>
-                <span className="rounded-full border border-accent/30 bg-accent/10 px-1.5 py-px text-[10px] uppercase tracking-label text-accent">
-                  New
-                </span>
-              </div>
-              <p className="mt-2 text-2xs leading-relaxed text-text-muted">
-                Enter a hub API key and we'll generate your first zone, art and all, in about a minute.
-              </p>
-            </button>
+            {AI_ENABLED && (
+              <button
+                onClick={() => setShowOnboarding(true)}
+                className="group relative overflow-hidden rounded-2xl border border-[var(--border-accent-ring)]/60 px-5 py-5 text-left transition hover:border-[var(--border-accent-ring)] hover:shadow-[0_14px_36px_rgb(var(--accent-rgb)/0.18)]"
+                style={{
+                  background: "linear-gradient(155deg, rgb(var(--accent-rgb) / 0.12), rgb(var(--surface-rgb) / 0.10) 50%, rgb(var(--bg-rgb) / 0.88))",
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="font-display text-sm text-text-primary">
+                    Start with Arcanum Hub
+                  </span>
+                  <span className="rounded-full border border-accent/30 bg-accent/10 px-1.5 py-px text-[10px] uppercase tracking-label text-accent">
+                    New
+                  </span>
+                </div>
+                <p className="mt-2 text-2xs leading-relaxed text-text-muted">
+                  Enter a hub API key and we'll generate your first zone, art and all, in about a minute.
+                </p>
+              </button>
+            )}
 
             <button
               onClick={onNewProject}
@@ -230,7 +233,7 @@ export function WelcomeScreen({ onNewProject }: WelcomeScreenProps) {
       </Suspense>
 
       <Suspense>
-        {showOnboarding && (
+        {AI_ENABLED && showOnboarding && (
           <OnboardingFlow onClose={() => setShowOnboarding(false)} />
         )}
       </Suspense>

--- a/creator/src/components/config/panels/ApiSettingsPanel.tsx
+++ b/creator/src/components/config/panels/ApiSettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useAssetStore } from "@/stores/assetStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { IMAGE_MODELS } from "@/types/assets";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import type { ProjectSettings, Settings } from "@/types/assets";
 
 // ─── Provider catalog ──────────────────────────────────────────────
@@ -169,68 +170,70 @@ export function ApiSettingsPanel() {
   return (
     <div className="flex flex-col gap-8">
       {/* ─── Account keys ─────────────────────────────────────── */}
-      <section>
-        <h3 className="mb-1 font-display text-sm uppercase tracking-widest text-text-primary">
-          Account API keys
-        </h3>
-        <p className="mb-4 text-2xs text-text-muted">
-          Provider credentials used when you're not routing through the Arcanum Hub. Each key is
-          stored on this machine only.
-        </p>
-        <div className="grid gap-3 md:grid-cols-2">
-          {PROVIDER_CARDS.map((p) => {
-            const configured = !!draft[p.keyField];
-            return (
-              <div
-                key={p.id}
-                className={`rounded-2xl border px-4 py-3 transition ${
-                  configured
-                    ? "border-accent/20 bg-[var(--chrome-fill)]"
-                    : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)]"
-                }`}
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <label
-                    htmlFor={`apikey-${p.id}`}
-                    className="font-display text-xs uppercase tracking-wide-ui text-text-primary"
-                  >
-                    {p.label}
-                  </label>
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-3xs uppercase tracking-ui ${
-                      configured
-                        ? "bg-status-success/15 text-status-success"
-                        : "bg-[var(--chrome-highlight)] text-text-muted"
-                    }`}
-                  >
-                    {configured ? "set" : "empty"}
-                  </span>
+      {AI_ENABLED && (
+        <section>
+          <h3 className="mb-1 font-display text-sm uppercase tracking-widest text-text-primary">
+            Account API keys
+          </h3>
+          <p className="mb-4 text-2xs text-text-muted">
+            Provider credentials used when you're not routing through the Arcanum Hub. Each key is
+            stored on this machine only.
+          </p>
+          <div className="grid gap-3 md:grid-cols-2">
+            {PROVIDER_CARDS.map((p) => {
+              const configured = !!draft[p.keyField];
+              return (
+                <div
+                  key={p.id}
+                  className={`rounded-2xl border px-4 py-3 transition ${
+                    configured
+                      ? "border-accent/20 bg-[var(--chrome-fill)]"
+                      : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)]"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <label
+                      htmlFor={`apikey-${p.id}`}
+                      className="font-display text-xs uppercase tracking-wide-ui text-text-primary"
+                    >
+                      {p.label}
+                    </label>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-3xs uppercase tracking-ui ${
+                        configured
+                          ? "bg-status-success/15 text-status-success"
+                          : "bg-[var(--chrome-highlight)] text-text-muted"
+                      }`}
+                    >
+                      {configured ? "set" : "empty"}
+                    </span>
+                  </div>
+                  <input
+                    id={`apikey-${p.id}`}
+                    type="password"
+                    value={draft[p.keyField]}
+                    onChange={(e) => setDraft({ ...draft, [p.keyField]: e.target.value })}
+                    placeholder={`Enter your ${p.label} API key`}
+                    className="mt-2 w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+                  />
+                  <p className="mt-2 text-2xs text-text-muted/80">{p.uses}</p>
+                  <p className="mt-0.5 text-3xs text-text-muted/60">
+                    Get your key at <code className="font-mono text-accent/70">{p.helpUrl}</code>
+                  </p>
                 </div>
-                <input
-                  id={`apikey-${p.id}`}
-                  type="password"
-                  value={draft[p.keyField]}
-                  onChange={(e) => setDraft({ ...draft, [p.keyField]: e.target.value })}
-                  placeholder={`Enter your ${p.label} API key`}
-                  className="mt-2 w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
-                />
-                <p className="mt-2 text-2xs text-text-muted/80">{p.uses}</p>
-                <p className="mt-0.5 text-3xs text-text-muted/60">
-                  Get your key at <code className="font-mono text-accent/70">{p.helpUrl}</code>
-                </p>
-              </div>
-            );
-          })}
-        </div>
-
-        {draft.use_hub_ai && (
-          <div className="mt-4 rounded-2xl border border-accent/30 bg-accent/5 px-4 py-3 text-2xs leading-5 text-accent">
-            Hub AI mode is on. Every image, LLM, and vision call routes through the hub and uses
-            your hub quota — these keys are only used for direct-provider fallback. Change the
-            routing in Settings → Arcanum Hub.
+              );
+            })}
           </div>
-        )}
-      </section>
+
+          {draft.use_hub_ai && (
+            <div className="mt-4 rounded-2xl border border-accent/30 bg-accent/5 px-4 py-3 text-2xs leading-5 text-accent">
+              Hub AI mode is on. Every image, LLM, and vision call routes through the hub and uses
+              your hub quota — these keys are only used for direct-provider fallback. Change the
+              routing in Settings → Arcanum Hub.
+            </div>
+          )}
+        </section>
+      )}
 
       {/* ─── Pipeline ─────────────────────────────────────────── */}
       {projectDir && projectDraft ? (
@@ -242,180 +245,186 @@ export function ApiSettingsPanel() {
             Per-project choices for which provider and model power each step.
           </p>
 
-          <div className="grid gap-5 md:grid-cols-2">
-            {/* Prompt LLM */}
-            <div>
-              <h4 className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
-                Prompt LLM
-              </h4>
-              <div className="flex flex-col gap-1">
-                {LLM_PROVIDERS.map((p) => {
-                  const hasKey = !!draft[p.keyField];
-                  const selected = projectDraft.prompt_llm_provider === p.id;
-                  return (
-                    <label
-                      key={p.id}
-                      className={`flex cursor-pointer items-center gap-2 rounded px-3 py-1.5 text-xs transition-colors ${
-                        selected
-                          ? "bg-accent/10 text-text-primary"
-                          : "text-text-secondary hover:bg-bg-elevated"
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name="llm_provider"
-                        value={p.id}
-                        checked={selected}
-                        onChange={() =>
-                          setProjectDraft({ ...projectDraft, prompt_llm_provider: p.id })
-                        }
-                        className="accent-accent"
-                      />
-                      <span className="flex-1 font-medium">{p.label}</span>
-                      {!hasKey && (
-                        <span className="rounded-full bg-[var(--chrome-highlight)] px-2 py-0.5 text-3xs text-text-muted">
-                          no key
-                        </span>
-                      )}
-                    </label>
-                  );
-                })}
-              </div>
+          {AI_ENABLED && (
+            <div className="grid gap-5 md:grid-cols-2">
+              {/* Prompt LLM */}
+              <div>
+                <h4 className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
+                  Prompt LLM
+                </h4>
+                <div className="flex flex-col gap-1">
+                  {LLM_PROVIDERS.map((p) => {
+                    const hasKey = !!draft[p.keyField];
+                    const selected = projectDraft.prompt_llm_provider === p.id;
+                    return (
+                      <label
+                        key={p.id}
+                        className={`flex cursor-pointer items-center gap-2 rounded px-3 py-1.5 text-xs transition-colors ${
+                          selected
+                            ? "bg-accent/10 text-text-primary"
+                            : "text-text-secondary hover:bg-bg-elevated"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="llm_provider"
+                          value={p.id}
+                          checked={selected}
+                          onChange={() =>
+                            setProjectDraft({ ...projectDraft, prompt_llm_provider: p.id })
+                          }
+                          className="accent-accent"
+                        />
+                        <span className="flex-1 font-medium">{p.label}</span>
+                        {!hasKey && (
+                          <span className="rounded-full bg-[var(--chrome-highlight)] px-2 py-0.5 text-3xs text-text-muted">
+                            no key
+                          </span>
+                        )}
+                      </label>
+                    );
+                  })}
+                </div>
 
-              <label htmlFor="enhance-model" className="mt-3 block text-2xs uppercase tracking-wider text-text-muted">
-                Enhancement model
-              </label>
-              <input
-                id="enhance-model"
-                type="text"
-                value={projectDraft.enhance_model}
-                onChange={(e) =>
-                  setProjectDraft({ ...projectDraft, enhance_model: e.target.value })
-                }
-                className="mt-1 w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
-              />
-              <p className="mt-1 text-3xs text-text-muted/70">
-                Free-form model ID. Used by DeepInfra and OpenRouter.
-              </p>
-            </div>
-
-            {/* Image pipeline */}
-            <div>
-              <h4 className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
-                Image generation
-              </h4>
-              <div className="flex flex-col gap-1">
-                {IMAGE_PROVIDERS.map((p) => {
-                  const selected = projectDraft.image_provider === p.id;
-                  return (
-                    <label
-                      key={p.id}
-                      className={`flex cursor-pointer items-center gap-2 rounded px-3 py-1.5 text-xs transition-colors ${
-                        selected
-                          ? "bg-accent/10 text-text-primary"
-                          : "text-text-secondary hover:bg-bg-elevated"
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name="image_provider"
-                        value={p.id}
-                        checked={selected}
-                        onChange={() =>
-                          setProjectDraft({ ...projectDraft, image_provider: p.id })
-                        }
-                        className="accent-accent"
-                      />
-                      <span className="font-medium">{p.label}</span>
-                    </label>
-                  );
-                })}
-              </div>
-
-              <h4 className="mt-3 mb-1 text-2xs uppercase tracking-wider text-text-muted">
-                Default model
-              </h4>
-              <div className="flex flex-col gap-1">
-                {filteredModels.map((model) => {
-                  const selected = projectDraft.image_model === model.id;
-                  return (
-                    <label
-                      key={model.id}
-                      className={`flex cursor-pointer items-start gap-2 rounded px-3 py-2 text-xs transition-colors ${
-                        selected
-                          ? "bg-accent/10 text-text-primary"
-                          : "text-text-secondary hover:bg-bg-elevated"
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name="image_model"
-                        value={model.id}
-                        checked={selected}
-                        onChange={() =>
-                          setProjectDraft({ ...projectDraft, image_model: model.id })
-                        }
-                        className="mt-0.5 accent-accent"
-                      />
-                      <div className="min-w-0">
-                        <div className="font-medium">{model.label}</div>
-                        <div className="text-3xs text-text-muted/80">{model.description}</div>
-                      </div>
-                    </label>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-
-          {/* Generation options */}
-          <div className="mt-6 border-t border-border-muted pt-4">
-            <h4 className="mb-3 text-2xs uppercase tracking-wider text-text-muted">
-              Generation options
-            </h4>
-            <div className="flex flex-col gap-3">
-              <div className="flex items-center gap-3">
-                <label htmlFor="batch-concurrency" className="text-2xs uppercase tracking-wider text-text-muted">
-                  Batch concurrency
+                <label htmlFor="enhance-model" className="mt-3 block text-2xs uppercase tracking-wider text-text-muted">
+                  Enhancement model
                 </label>
                 <input
-                  id="batch-concurrency"
-                  type="number"
-                  min={1}
-                  max={20}
-                  value={projectDraft.batch_concurrency}
+                  id="enhance-model"
+                  type="text"
+                  value={projectDraft.enhance_model}
                   onChange={(e) =>
-                    setProjectDraft({
-                      ...projectDraft,
-                      batch_concurrency: parseInt(e.target.value) || 5,
-                    })
+                    setProjectDraft({ ...projectDraft, enhance_model: e.target.value })
                   }
-                  className="w-20 rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+                  className="mt-1 w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
                 />
-                <span className="text-3xs text-text-muted/70">
-                  Max parallel image generations during batch operations.
-                </span>
+                <p className="mt-1 text-3xs text-text-muted/70">
+                  Free-form model ID. Used by DeepInfra and OpenRouter.
+                </p>
               </div>
 
-              <label className="flex cursor-pointer items-start gap-2 text-xs text-text-secondary">
-                <input
-                  type="checkbox"
-                  checked={projectDraft.auto_enhance_prompts}
-                  onChange={(e) =>
-                    setProjectDraft({
-                      ...projectDraft,
-                      auto_enhance_prompts: e.target.checked,
-                    })
-                  }
-                  className="mt-0.5 accent-accent"
-                />
-                <span>
-                  <span className="text-text-primary">Auto-enhance prompts before generation</span>
-                  <span className="mt-0.5 block text-3xs text-text-muted/70">
-                    Runs the prompt LLM inside the generation pipeline before image models are called.
+              {/* Image pipeline */}
+              <div>
+                <h4 className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
+                  Image generation
+                </h4>
+                <div className="flex flex-col gap-1">
+                  {IMAGE_PROVIDERS.map((p) => {
+                    const selected = projectDraft.image_provider === p.id;
+                    return (
+                      <label
+                        key={p.id}
+                        className={`flex cursor-pointer items-center gap-2 rounded px-3 py-1.5 text-xs transition-colors ${
+                          selected
+                            ? "bg-accent/10 text-text-primary"
+                            : "text-text-secondary hover:bg-bg-elevated"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="image_provider"
+                          value={p.id}
+                          checked={selected}
+                          onChange={() =>
+                            setProjectDraft({ ...projectDraft, image_provider: p.id })
+                          }
+                          className="accent-accent"
+                        />
+                        <span className="font-medium">{p.label}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+
+                <h4 className="mt-3 mb-1 text-2xs uppercase tracking-wider text-text-muted">
+                  Default model
+                </h4>
+                <div className="flex flex-col gap-1">
+                  {filteredModels.map((model) => {
+                    const selected = projectDraft.image_model === model.id;
+                    return (
+                      <label
+                        key={model.id}
+                        className={`flex cursor-pointer items-start gap-2 rounded px-3 py-2 text-xs transition-colors ${
+                          selected
+                            ? "bg-accent/10 text-text-primary"
+                            : "text-text-secondary hover:bg-bg-elevated"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="image_model"
+                          value={model.id}
+                          checked={selected}
+                          onChange={() =>
+                            setProjectDraft({ ...projectDraft, image_model: model.id })
+                          }
+                          className="mt-0.5 accent-accent"
+                        />
+                        <div className="min-w-0">
+                          <div className="font-medium">{model.label}</div>
+                          <div className="text-3xs text-text-muted/80">{model.description}</div>
+                        </div>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Generation options */}
+          <div className={AI_ENABLED ? "mt-6 border-t border-border-muted pt-4" : ""}>
+            <h4 className="mb-3 text-2xs uppercase tracking-wider text-text-muted">
+              {AI_ENABLED ? "Generation options" : "Asset options"}
+            </h4>
+            <div className="flex flex-col gap-3">
+              {AI_ENABLED && (
+                <div className="flex items-center gap-3">
+                  <label htmlFor="batch-concurrency" className="text-2xs uppercase tracking-wider text-text-muted">
+                    Batch concurrency
+                  </label>
+                  <input
+                    id="batch-concurrency"
+                    type="number"
+                    min={1}
+                    max={20}
+                    value={projectDraft.batch_concurrency}
+                    onChange={(e) =>
+                      setProjectDraft({
+                        ...projectDraft,
+                        batch_concurrency: parseInt(e.target.value) || 5,
+                      })
+                    }
+                    className="w-20 rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+                  />
+                  <span className="text-3xs text-text-muted/70">
+                    Max parallel image generations during batch operations.
                   </span>
-                </span>
-              </label>
+                </div>
+              )}
+
+              {AI_ENABLED && (
+                <label className="flex cursor-pointer items-start gap-2 text-xs text-text-secondary">
+                  <input
+                    type="checkbox"
+                    checked={projectDraft.auto_enhance_prompts}
+                    onChange={(e) =>
+                      setProjectDraft({
+                        ...projectDraft,
+                        auto_enhance_prompts: e.target.checked,
+                      })
+                    }
+                    className="mt-0.5 accent-accent"
+                  />
+                  <span>
+                    <span className="text-text-primary">Auto-enhance prompts before generation</span>
+                    <span className="mt-0.5 block text-3xs text-text-muted/70">
+                      Runs the prompt LLM inside the generation pipeline before image models are called.
+                    </span>
+                  </span>
+                </label>
+              )}
 
               <label className="flex cursor-pointer items-start gap-2 text-xs text-text-secondary">
                 <input

--- a/creator/src/components/config/panels/GlobalAssetGeneratorModal.tsx
+++ b/creator/src/components/config/panels/GlobalAssetGeneratorModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { createPortal } from "react-dom";
 import { invoke } from "@tauri-apps/api/core";
 import { useAssetStore } from "@/stores/assetStore";
@@ -198,6 +199,8 @@ export function GlobalAssetGeneratorModal({ asset, onClose, onComplete }: Props)
     setError(null);
     setStage("compose");
   };
+
+  if (!AI_ENABLED) return null;
 
   if (!hasApiKey) {
     return createPortal(

--- a/creator/src/components/config/panels/HubSettingsPanel.tsx
+++ b/creator/src/components/config/panels/HubSettingsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useAssetStore } from "@/stores/assetStore";
 import { useProjectStore } from "@/stores/projectStore";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import type { ProjectSettings, Settings } from "@/types/assets";
 
 type HubAccountDraft = Pick<Settings, "hub_api_url" | "hub_api_key" | "use_hub_ai">;
@@ -152,27 +153,29 @@ export function HubSettingsPanel() {
               </p>
             )}
           </div>
-          <label
-            className={`mt-2 flex items-start gap-2 rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-2 text-xs text-text-secondary ${
-              keyIsPublishOnly ? "cursor-not-allowed opacity-50" : "cursor-pointer"
-            }`}
-          >
-            <input
-              type="checkbox"
-              checked={account.use_hub_ai && !keyIsPublishOnly}
-              disabled={keyIsPublishOnly}
-              onChange={(e) => setAccount({ ...account, use_hub_ai: e.target.checked })}
-              className="mt-0.5 accent-accent"
-            />
-            <span>
-              <span className="text-text-primary">Use Arcanum Hub for AI generation</span>
-              <span className="mt-1 block text-2xs text-text-muted/80">
-                Route image generation (FLUX.2, GPT Image), prompt enhancement (DeepSeek), and
-                vision analysis (Claude) through the hub. You won't need any other provider keys,
-                and usage counts against your playtest quota.
+          {AI_ENABLED && (
+            <label
+              className={`mt-2 flex items-start gap-2 rounded-lg border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-2 text-xs text-text-secondary ${
+                keyIsPublishOnly ? "cursor-not-allowed opacity-50" : "cursor-pointer"
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={account.use_hub_ai && !keyIsPublishOnly}
+                disabled={keyIsPublishOnly}
+                onChange={(e) => setAccount({ ...account, use_hub_ai: e.target.checked })}
+                className="mt-0.5 accent-accent"
+              />
+              <span>
+                <span className="text-text-primary">Use Arcanum Hub for AI generation</span>
+                <span className="mt-1 block text-2xs text-text-muted/80">
+                  Route image generation (FLUX.2, GPT Image), prompt enhancement (DeepSeek), and
+                  vision analysis (Claude) through the hub. You won't need any other provider keys,
+                  and usage counts against your playtest quota.
+                </span>
               </span>
-            </span>
-          </label>
+            </label>
+          )}
         </div>
       </section>
 

--- a/creator/src/components/config/panels/SharedAssetsPanel.tsx
+++ b/creator/src/components/config/panels/SharedAssetsPanel.tsx
@@ -20,6 +20,7 @@ import {
 import { BUNDLED_DEFAULT_ASSETS } from "@/assets/defaults";
 import type { SyncProgress } from "@/types/assets";
 import { GlobalAssetGeneratorModal } from "./GlobalAssetGeneratorModal";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -190,7 +191,7 @@ function AssetCard({
       </div>
 
       <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover/card:opacity-100 focus-within:opacity-100">
-        {slot.generateSpec && (
+        {AI_ENABLED && slot.generateSpec && (
           <button
             onClick={onGenerate}
             className="focus-ring rounded border border-accent/40 px-1.5 py-0.5 text-[10px] text-accent transition-colors hover:bg-accent/10"

--- a/creator/src/components/editors/EditorShared.tsx
+++ b/creator/src/components/editors/EditorShared.tsx
@@ -6,6 +6,7 @@ import { MediaPicker } from "@/components/ui/MediaPicker";
 import { MusicGenerator } from "@/components/ui/MusicGenerator";
 import { VideoGenerator } from "@/components/ui/VideoGenerator";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import type { ArtStyle } from "@/lib/arcanumPrompts";
 import type { AssetContext } from "@/types/assets";
 
@@ -139,6 +140,8 @@ export function EnhanceDescriptionButton({
       setLoading(false);
     }
   };
+
+  if (!AI_ENABLED) return null;
 
   return (
     <div className="flex items-center gap-2">

--- a/creator/src/components/lore/ArtStylePanel.tsx
+++ b/creator/src/components/lore/ArtStylePanel.tsx
@@ -5,6 +5,7 @@ import { Section, ActionButton, Spinner } from "@/components/ui/FormWidgets";
 import { ART_STYLE_PRESETS, artStyleFromPreset } from "@/lib/artStylePresets";
 import { generateArtStyle, refineArtStyle } from "@/lib/artStyleGeneration";
 import { useFocusTrap } from "@/lib/useFocusTrap";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── Helpers ───────────────────────────────────────────────────────
 
@@ -111,13 +112,15 @@ function CreateMenu({
             tabIndex={0}
           />
           <div className="absolute right-0 top-full z-20 mt-1 w-60 overflow-hidden rounded-lg border border-border-default bg-bg-secondary shadow-panel">
-            <button
-              onClick={() => { onAi(); setOpen(false); }}
-              className="block w-full border-b border-border-muted px-3 py-2 text-left text-xs text-text-primary transition hover:bg-bg-hover"
-            >
-              <span className="font-medium text-accent">✦ Generate with AI</span>
-              <span className="mt-0.5 block text-2xs text-text-muted">From a theme prompt</span>
-            </button>
+            {AI_ENABLED && (
+              <button
+                onClick={() => { onAi(); setOpen(false); }}
+                className="block w-full border-b border-border-muted px-3 py-2 text-left text-xs text-text-primary transition hover:bg-bg-hover"
+              >
+                <span className="font-medium text-accent">✦ Generate with AI</span>
+                <span className="mt-0.5 block text-2xs text-text-muted">From a theme prompt</span>
+              </button>
+            )}
             {ART_STYLE_PRESETS.map((preset) => (
               <button
                 key={preset.key}
@@ -394,9 +397,11 @@ export function ArtStylePanel() {
               lore art (character portraits, article heroes), with optional surface-specific overrides.
             </p>
             <div className="flex gap-2">
-              <ActionButton variant="primary" size="sm" onClick={() => setShowAiDialog(true)}>
-                ✦ Generate with AI
-              </ActionButton>
+              {AI_ENABLED && (
+                <ActionButton variant="primary" size="sm" onClick={() => setShowAiDialog(true)}>
+                  ✦ Generate with AI
+                </ActionButton>
+              )}
               <CreateMenu
                 onEmpty={handleCreateEmpty}
                 onPreset={handleCreatePreset}
@@ -478,9 +483,11 @@ export function ArtStylePanel() {
                     Set as active
                   </ActionButton>
                 )}
-                <ActionButton variant="ghost" size="sm" onClick={() => setShowRefineDialog(true)}>
-                  ✦ Refine with AI
-                </ActionButton>
+                {AI_ENABLED && (
+                  <ActionButton variant="ghost" size="sm" onClick={() => setShowRefineDialog(true)}>
+                    ✦ Refine with AI
+                  </ActionButton>
+                )}
                 <ActionButton variant="ghost" size="sm" onClick={() => handleDuplicate(selected.id)}>
                   Duplicate
                 </ActionButton>

--- a/creator/src/components/lore/LoreEditor.tsx
+++ b/creator/src/components/lore/LoreEditor.tsx
@@ -13,6 +13,7 @@ import { plainTextToTiptap, tiptapToPlainText } from "@/lib/loreRelations";
 import { useAssetStore } from "@/stores/assetStore";
 import { useLoreStore } from "@/stores/loreStore";
 import { MentionList, type MentionListRef } from "./MentionList";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 interface LoreEditorProps {
   value: string;
@@ -388,7 +389,7 @@ export function LoreEditor({
     <div className="rounded-lg border border-border-default bg-bg-primary">
       {editor && <EditorToolbar editor={editor} />}
       <EditorContent editor={editor} />
-      {(showGenerate || showEnhance || showContinue) && (
+      {AI_ENABLED && (showGenerate || showEnhance || showContinue) && (
         <div className="flex gap-2 border-t border-border-muted px-2 py-1">
           {showGenerate && (
             <button

--- a/creator/src/components/lore/LoreTextArea.tsx
+++ b/creator/src/components/lore/LoreTextArea.tsx
@@ -4,6 +4,7 @@ import { CommitTextarea, InlineError } from "@/components/ui/FormWidgets";
 import { getLoreEnhancePrompt } from "@/lib/lorePrompts";
 import { getPromptLlmConfigurationError } from "@/lib/promptLlm";
 import { useAssetStore } from "@/stores/assetStore";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 interface LoreTextAreaProps {
   label: string;
@@ -109,7 +110,7 @@ export function LoreTextArea({
         placeholder={placeholder}
         rows={rows}
       />
-      {(showGenerate || showEnhance) && (
+      {AI_ENABLED && (showGenerate || showEnhance) && (
         <div className="mt-1 flex gap-2">
           {showGenerate && (
             <button

--- a/creator/src/components/lore/MapEnhancer.tsx
+++ b/creator/src/components/lore/MapEnhancer.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from "react";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { createPortal } from "react-dom";
 import { invoke } from "@tauri-apps/api/core";
 import type { GeneratedImage } from "@/types/assets";
@@ -172,6 +173,8 @@ export function MapEnhancer({
       setGenerating(false);
     }
   }, [crop, prompt, strength, extractCropBase64]);
+
+  if (!AI_ENABLED) return null;
 
   return createPortal(
     <div

--- a/creator/src/components/lore/StoryAIToolbar.tsx
+++ b/creator/src/components/lore/StoryAIToolbar.tsx
@@ -5,6 +5,7 @@
 //   - Synopsis:  reverse — fill story.synopsis from current scenes
 
 import { useState, useCallback } from "react";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { invoke } from "@tauri-apps/api/core";
 import { useStoryStore, generateSceneId } from "@/stores/storyStore";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -174,6 +175,8 @@ export function StoryAIToolbar({ story }: StoryAIToolbarProps) {
       setLoading(null);
     }
   }, [story, sortedScenes, updateStory]);
+
+  if (!AI_ENABLED) return null;
 
   // ─── Render ────────────────────────────────────────────────────
 

--- a/creator/src/components/ui/CommandPalette.tsx
+++ b/creator/src/components/ui/CommandPalette.tsx
@@ -4,6 +4,7 @@ import { useLoreStore, selectArticles } from "@/stores/loreStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useAssetStore } from "@/stores/assetStore";
 import { ALL_PANELS, panelTab } from "@/lib/panelRegistry";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 
 interface PaletteItem {
@@ -48,13 +49,15 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
       subtitle: "Import AmbonMUD zone YAML files into the project",
       action: () => setShowImportZone(true),
     });
-    result.push({
-      id: "action:render-art",
-      type: "action",
-      title: "Render Art",
-      subtitle: "Open the asset generator",
-      action: () => openGenerator(),
-    });
+    if (AI_ENABLED) {
+      result.push({
+        id: "action:render-art",
+        type: "action",
+        title: "Render Art",
+        subtitle: "Open the asset generator",
+        action: () => openGenerator(),
+      });
+    }
     result.push({
       id: "action:browse-gallery",
       type: "action",

--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo } from "react";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useAssetStore } from "@/stores/assetStore";
@@ -408,8 +409,8 @@ export function EntityArtGenerator({
 
       {stage === "idle" && (
         <div className="flex flex-col gap-1.5">
-          {/* Prompt box — always visible when any AI key is configured */}
-          {(hasApiKey || hasLlmKey) && (
+          {/* Prompt box — visible when AI is enabled and any key is configured */}
+          {AI_ENABLED && (hasApiKey || hasLlmKey) && (
             <div className="flex flex-col gap-1">
               <textarea
                 value={activePrompt}
@@ -453,7 +454,7 @@ export function EntityArtGenerator({
 
           {/* Action row: Generate / Pick / Gallery + advanced toggle */}
           <div className="flex gap-1">
-            {hasApiKey && (
+            {AI_ENABLED && hasApiKey && (
               <button
                 onClick={handleGenerate}
                 disabled={removingBg}
@@ -476,7 +477,7 @@ export function EntityArtGenerator({
             >
               Gallery
             </button>
-            {hasApiKey && (
+            {AI_ENABLED && hasApiKey && (
               <button
                 onClick={() => setShowAdvanced((v) => !v)}
                 aria-expanded={showAdvanced}
@@ -493,7 +494,7 @@ export function EntityArtGenerator({
           </div>
 
           {/* Advanced: style + model + dimension overrides (hidden by default) */}
-          {showAdvanced && hasApiKey && (
+          {AI_ENABLED && showAdvanced && hasApiKey && (
             <div className="flex flex-col gap-1 rounded border border-border-default/60 bg-bg-primary/40 px-2 py-1.5">
               <div className="flex items-center gap-1">
                 <span className="w-10 shrink-0 text-2xs text-text-muted">Style</span>
@@ -560,7 +561,7 @@ export function EntityArtGenerator({
         </div>
       )}
 
-      {stage === "generating" && (
+      {AI_ENABLED && stage === "generating" && (
         <div className="flex items-center gap-2 py-2">
           <div className="h-4 w-4 rounded-full border-2 border-accent border-t-transparent animate-spin" />
           <span className="text-2xs text-text-secondary">
@@ -576,7 +577,7 @@ export function EntityArtGenerator({
         </div>
       )}
 
-      {stage === "preview" && (
+      {AI_ENABLED && stage === "preview" && (
         <div className="flex gap-1">
           <button
             onClick={handleAccept}

--- a/creator/src/components/ui/MusicGenerator.tsx
+++ b/creator/src/components/ui/MusicGenerator.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { useAssetStore } from "@/stores/assetStore";
 import { getAudioSystemPrompt, getDefaultDuration, type AudioTrackType } from "@/lib/musicPrompts";
 import { useMediaSrc } from "@/lib/useMediaSrc";
@@ -53,6 +54,8 @@ export function MusicGenerator({
   );
 
   const audioSrc = useMediaSrc(resultPath ?? currentAudio);
+
+  if (!AI_ENABLED) return null;
 
   if (!hasRunwareKey) return null;
 

--- a/creator/src/components/ui/VideoGenerator.tsx
+++ b/creator/src/components/ui/VideoGenerator.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import { useAssetStore } from "@/stores/assetStore";
 import { getVideoSystemPrompt, VIDEO_TYPE_LABELS, type VideoAssetType } from "@/lib/videoPrompts";
 import { useMediaSrc } from "@/lib/useMediaSrc";
@@ -50,6 +51,8 @@ export function VideoGenerator({
   );
 
   const videoSrc = useMediaSrc(resultPath ?? undefined);
+
+  if (!AI_ENABLED) return null;
 
   if (!hasRunwareKey || !imagePath) return null;
 

--- a/creator/src/components/zone/BatchArtGenerator.tsx
+++ b/creator/src/components/zone/BatchArtGenerator.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from "react";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import type { WorldFile } from "@/types/world";
 import { ART_STYLE_LABELS } from "@/lib/arcanumPrompts";
 import { useAssetStore } from "@/stores/assetStore";
@@ -80,6 +81,8 @@ export function BatchArtGenerator({
     setBgRemoval(null);
     setRunning(false);
   }, [targets, world, onWorldChange, artStyle, vibe, imageProvider, concurrency, zoneId, acceptAsset, settings]);
+
+  if (!AI_ENABLED) return null;
 
   if (targets.length === 0) {
     return (

--- a/creator/src/components/zone/ZoneAssetWorkbench.tsx
+++ b/creator/src/components/zone/ZoneAssetWorkbench.tsx
@@ -19,6 +19,7 @@ import {
   loadCollapsedZoneAssetSections,
   saveCollapsedZoneAssetSections,
 } from "@/lib/uiPersistence";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import type { WorldFile } from "@/types/world";
 
 type EntityKind = "room" | "mob" | "item" | "shop" | "gatheringNode";
@@ -721,19 +722,21 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                         </span>
                       )}
                     </div>
-                    <button
-                      onClick={handleGeneratePrompt}
-                      disabled={!hasLlmKey || generatingPrompt || generatingImage || removingBg}
-                      className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-3 py-1 text-2xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
-                    >
-                      {generatingPrompt ? (
-                        <span className="flex items-center gap-1.5"><Spinner />Enhancing</span>
-                      ) : promptGeneratedByLlm ? (
-                        "Re-enhance"
-                      ) : (
-                        "Enhance prompt"
-                      )}
-                    </button>
+                    {AI_ENABLED && (
+                      <button
+                        onClick={handleGeneratePrompt}
+                        disabled={!hasLlmKey || generatingPrompt || generatingImage || removingBg}
+                        className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-3 py-1 text-2xs font-medium text-text-primary transition enabled:hover:bg-[var(--chrome-highlight-strong)] disabled:opacity-50"
+                      >
+                        {generatingPrompt ? (
+                          <span className="flex items-center gap-1.5"><Spinner />Enhancing</span>
+                        ) : promptGeneratedByLlm ? (
+                          "Re-enhance"
+                        ) : (
+                          "Enhance prompt"
+                        )}
+                      </button>
+                    )}
                   </div>
                   <textarea
                     value={promptDraft}
@@ -764,38 +767,42 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
               </div>
 
               <div className="mt-4 flex flex-wrap items-center gap-2">
-                <span className="text-2xs uppercase tracking-ui text-text-muted">Step 2 · Generate</span>
-                <select
-                  value={batchCount}
-                  onChange={(event) => setBatchCount(Number(event.target.value))}
-                  disabled={!hasImageKey || generatingPrompt || generatingImage || removingBg}
-                  aria-label="Number of variants to generate"
-                  className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-3 py-2 text-xs font-medium text-text-primary outline-none transition focus-visible:ring-2 focus-visible:ring-border-active disabled:opacity-50"
-                >
-                  <option value={1} className="bg-bg-primary">×1</option>
-                  <option value={2} className="bg-bg-primary">×2</option>
-                  <option value={4} className="bg-bg-primary">×4</option>
-                  <option value={8} className="bg-bg-primary">×8</option>
-                </select>
-                <button
-                  onClick={handleGenerate}
-                  disabled={!hasImageKey || generatingPrompt || generatingImage || removingBg}
-                  className="rounded-full border border-[var(--border-accent-subtle)] bg-gradient-active-strong px-4 py-2 text-xs font-medium text-text-primary transition hover:brightness-110 disabled:opacity-50"
-                >
-                  {generatingImage ? (
-                    <span className="flex items-center gap-1.5">
-                      <Spinner />
-                      {batchCount > 1 ? `Generating ×${batchCount}` : "Generating image"}
-                    </span>
-                  ) : removingBg ? (
-                    <span className="flex items-center gap-1.5"><Spinner />Removing background</span>
-                  ) : batchCount > 1 ? (
-                    `Generate ×${batchCount}`
-                  ) : (
-                    "Generate image"
-                  )}
-                </button>
-                <span className="mx-1 h-6 w-px bg-[var(--chrome-highlight-strong)]" aria-hidden="true" />
+                {AI_ENABLED && (
+                  <>
+                    <span className="text-2xs uppercase tracking-ui text-text-muted">Step 2 · Generate</span>
+                    <select
+                      value={batchCount}
+                      onChange={(event) => setBatchCount(Number(event.target.value))}
+                      disabled={!hasImageKey || generatingPrompt || generatingImage || removingBg}
+                      aria-label="Number of variants to generate"
+                      className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-highlight)] px-3 py-2 text-xs font-medium text-text-primary outline-none transition focus-visible:ring-2 focus-visible:ring-border-active disabled:opacity-50"
+                    >
+                      <option value={1} className="bg-bg-primary">×1</option>
+                      <option value={2} className="bg-bg-primary">×2</option>
+                      <option value={4} className="bg-bg-primary">×4</option>
+                      <option value={8} className="bg-bg-primary">×8</option>
+                    </select>
+                    <button
+                      onClick={handleGenerate}
+                      disabled={!hasImageKey || generatingPrompt || generatingImage || removingBg}
+                      className="rounded-full border border-[var(--border-accent-subtle)] bg-gradient-active-strong px-4 py-2 text-xs font-medium text-text-primary transition hover:brightness-110 disabled:opacity-50"
+                    >
+                      {generatingImage ? (
+                        <span className="flex items-center gap-1.5">
+                          <Spinner />
+                          {batchCount > 1 ? `Generating ×${batchCount}` : "Generating image"}
+                        </span>
+                      ) : removingBg ? (
+                        <span className="flex items-center gap-1.5"><Spinner />Removing background</span>
+                      ) : batchCount > 1 ? (
+                        `Generate ×${batchCount}`
+                      ) : (
+                        "Generate image"
+                      )}
+                    </button>
+                    <span className="mx-1 h-6 w-px bg-[var(--chrome-highlight-strong)]" aria-hidden="true" />
+                  </>
+                )}
                 <button
                   onClick={handleImport}
                   disabled={importing || generatingPrompt || generatingImage || removingBg}

--- a/creator/src/components/zone/ZoneVibePanel.tsx
+++ b/creator/src/components/zone/ZoneVibePanel.tsx
@@ -7,6 +7,7 @@ import { defaultImageContext, defaultImagePrompt, type DefaultImageKind } from "
 import { getEnhanceSystemPrompt, getNegativePrompt } from "@/lib/arcanumPrompts";
 import { useImageSrc } from "@/lib/useImageSrc";
 import { imageGenerateCommand, resolveImageModel, requestsTransparentBackground, type GeneratedImage } from "@/types/assets";
+import { AI_ENABLED } from "@/lib/featureFlags";
 import type { WorldFile } from "@/types/world";
 
 interface ZoneVibePanelProps {
@@ -282,20 +283,24 @@ export function ZoneVibePanel({ zoneId, world, onWorldChange }: ZoneVibePanelPro
       />
 
       <div className="flex flex-wrap gap-1">
-        <button
-          onClick={handleGenerate}
-          disabled={generating || anyDefaultGenerating}
-          className="rounded bg-accent/15 px-2 py-0.5 text-2xs font-medium text-accent transition-colors hover:bg-accent/25 disabled:opacity-50"
-        >
-          {generating ? "Generating vibe..." : "Generate vibe + defaults"}
-        </button>
-        <button
-          onClick={() => generateAllDefaults(draft)}
-          disabled={!draft.trim() || anyDefaultGenerating || generating || !hasImageKey}
-          className="rounded bg-bg-elevated px-2 py-0.5 text-2xs font-medium text-text-secondary transition-colors hover:bg-bg-hover disabled:opacity-50"
-        >
-          {anyDefaultGenerating ? "Generating defaults..." : "Generate defaults"}
-        </button>
+        {AI_ENABLED && (
+          <button
+            onClick={handleGenerate}
+            disabled={generating || anyDefaultGenerating}
+            className="rounded bg-accent/15 px-2 py-0.5 text-2xs font-medium text-accent transition-colors hover:bg-accent/25 disabled:opacity-50"
+          >
+            {generating ? "Generating vibe..." : "Generate vibe + defaults"}
+          </button>
+        )}
+        {AI_ENABLED && (
+          <button
+            onClick={() => generateAllDefaults(draft)}
+            disabled={!draft.trim() || anyDefaultGenerating || generating || !hasImageKey}
+            className="rounded bg-bg-elevated px-2 py-0.5 text-2xs font-medium text-text-secondary transition-colors hover:bg-bg-hover disabled:opacity-50"
+          >
+            {anyDefaultGenerating ? "Generating defaults..." : "Generate defaults"}
+          </button>
+        )}
         {isDirty && (
           <button
             onClick={handleSave}

--- a/creator/src/lib/abilityPromptGen.ts
+++ b/creator/src/lib/abilityPromptGen.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getStyleSuffix, parseLlmJson } from "./arcanumPrompts";
 import { buildToneDirective } from "./loreGeneration";
 import type { AbilityDefinitionConfig, StatusEffectDefinitionConfig } from "@/types/config";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 const FORMAT_SPEC =
   "1:1 square ability icon centered in frame, symbolic/iconic representation, solid pale lavender (#d8d0e8) background";
@@ -75,6 +76,7 @@ export async function generateAbilityPrompt(
   ability: AbilityDefinitionConfig,
   _abilityId: string,
 ): Promise<string> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const userContent = `Format: ${FORMAT_SPEC}
 
 Ability: ${ability.displayName}
@@ -100,6 +102,7 @@ export async function generateStatusEffectPrompt(
   effect: StatusEffectDefinitionConfig,
   _effectId: string,
 ): Promise<string> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const details = [
     `Effect type: ${effect.effectType}`,
     effect.durationMs ? `Duration: ${(effect.durationMs / 1000).toFixed(0)}s` : null,
@@ -140,6 +143,7 @@ export async function generateAbilityTemplate(
   classes: string[],
   effectTypes: string[],
 ): Promise<AbilityPromptTemplate> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const classList = classes
     .map((c) => `- ${c}: ${getClassPalette(c)}`)
     .join("\n");
@@ -244,6 +248,7 @@ export function fillStatusEffectTemplate(
  * Falls back to the original prompt if the LLM call fails.
  */
 export async function enhanceAbilityPrompt(rawPrompt: string): Promise<string> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const tone = buildToneDirective();
   const toneRule = tone ? `\n- Match the world's tone: ${tone}` : "";
 

--- a/creator/src/lib/artStyleGeneration.ts
+++ b/creator/src/lib/artStyleGeneration.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { ArtStyle } from "@/types/lore";
 import { buildToneDirective } from "./loreGeneration";
 import { parseLlmJson } from "./arcanumPrompts";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── AI-assisted art style generation ───────────────────────────────
 //
@@ -39,6 +40,7 @@ Output ONLY valid JSON with this exact shape — no markdown fences, no commenta
  * Uses the world tone directive (if any) as context so the style stays on-theme.
  */
 export async function generateArtStyle(themePrompt: string): Promise<ArtStyle> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const tone = buildToneDirective();
   const toneBlock = tone ? `\n\nWorld context (stay consistent with this):\n${tone}` : "";
 
@@ -89,6 +91,7 @@ export async function refineArtStyle(
   style: ArtStyle,
   instruction: string,
 ): Promise<Partial<ArtStyle>> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const tone = buildToneDirective();
   const toneBlock = tone ? `\n\nWorld context (preserve consistency with this):\n${tone}` : "";
 

--- a/creator/src/lib/baseTemplate/reSkinPipeline.ts
+++ b/creator/src/lib/baseTemplate/reSkinPipeline.ts
@@ -17,6 +17,7 @@ import {
   BASE_RACES,
   BASE_PETS,
 } from "./baseConfig";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── Public types ─────────────────────────────────────────────────
 
@@ -406,6 +407,7 @@ export async function startReSkin(
   seedPrompt: string,
   onProgress: (progress: ReSkinProgress) => void,
 ): Promise<ReSkinResults> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const progress: ReSkinProgress = {
     classesAndAbilities: "pending",
     races: "pending",

--- a/creator/src/lib/batchArt.ts
+++ b/creator/src/lib/batchArt.ts
@@ -15,6 +15,7 @@ import {
 import type { GeneratedImage } from "@/types/assets";
 import { ENTITY_DIMENSIONS, imageGenerateCommand, resolveImageModel, requestsTransparentBackground, modelNativelyTransparent } from "@/types/assets";
 import { removeBgAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 export function assetTypeForKind(kind: string): string {
   if (kind === "room") return "background";
@@ -168,6 +169,7 @@ export async function runBatchArtGeneration(
   callbacks: ArtGenerationCallbacks,
   autoRemoveBg?: boolean,
 ): Promise<WorldFile> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   // Use a ref-like container so all workers always read/write the latest world
   const worldRef = { current: { ...world } };
 

--- a/creator/src/lib/featureFlags.ts
+++ b/creator/src/lib/featureFlags.ts
@@ -1,0 +1,2 @@
+export const BUILD_VARIANT = __BUILD_VARIANT__;
+export const AI_ENABLED = BUILD_VARIANT === "full";

--- a/creator/src/lib/generateZoneContent.ts
+++ b/creator/src/lib/generateZoneContent.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { WorldFile, RoomFile, MobFile, ItemFile } from "@/types/world";
 import { buildToneDirective } from "./loreGeneration";
 import { OPPOSITE } from "./zoneEdits";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -578,6 +579,7 @@ function scaleMaxTokens(entityCount: number): number {
 export async function generateZoneContent(
   params: ZoneGenerationParams,
 ): Promise<WorldFile> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const userPrompt = buildUserPrompt(params);
   const systemBase =
     params.roomCount > SMALL_TOPOLOGY_LIMIT
@@ -606,6 +608,7 @@ export async function generateZoneFromSketch(
   params: ZoneGenerationParams,
   layout: FixedLayout,
 ): Promise<WorldFile> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   if (layout.rooms.length === 0) {
     throw new Error("Sketch layout has no rooms");
   }
@@ -678,6 +681,7 @@ export interface ExtendZoneResult {
 export async function extendZoneContent(
   params: ExtendZoneParams,
 ): Promise<ExtendZoneResult> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const userPrompt = buildExtendUserPrompt(params);
   const systemPrompt = buildSystemPrompt(SYSTEM_PROMPT_EXTEND);
   const maxTokens = scaleMaxTokens(

--- a/creator/src/lib/loreGeneration.ts
+++ b/creator/src/lib/loreGeneration.ts
@@ -3,6 +3,7 @@ import { useLoreStore } from "@/stores/loreStore";
 import type { Article, ArticleTemplate, CalendarSystem, CalendarEra, TimelineEvent } from "@/types/lore";
 import { TEMPLATE_SCHEMAS } from "@/lib/loreTemplates";
 import { tiptapToPlainText } from "@/lib/loreRelations";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── World context builder ──────────────────────────────────────────
 
@@ -221,6 +222,7 @@ export interface GenerateArticleOptions {
 }
 
 export async function generateArticle(opts: GenerateArticleOptions): Promise<Article> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const schema = TEMPLATE_SCHEMAS[opts.template];
   const fieldDesc = schema?.fields.map((f) => `  "${f.key}": ${f.type}`).join(",\n") ?? "";
 
@@ -273,6 +275,7 @@ export interface GenerateRelatedOptions {
 }
 
 export async function generateRelatedArticles(opts: GenerateRelatedOptions): Promise<Article[]> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const userPrompt = `Given this existing article:
 Title: ${opts.sourceArticle.title}
 Type: ${opts.sourceArticle.template}
@@ -322,6 +325,7 @@ export interface WorldSeedResult {
 }
 
 export async function generateWorldSeed(concept: string): Promise<WorldSeedResult> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const result = await invoke<string>("llm_complete", {
     systemPrompt: WORLD_SEED_SYSTEM,
     userPrompt: `World concept:\n${concept}`,

--- a/creator/src/lib/loreMapAnalysis.ts
+++ b/creator/src/lib/loreMapAnalysis.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { WorldLore, LoreMap } from "@/types/lore";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 export interface MapFeatureSuggestion {
   label: string;
@@ -37,6 +38,7 @@ export async function analyzeMap(
   imageDataUrl: string,
   lore: WorldLore,
 ): Promise<MapFeatureSuggestion[]> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const articleTitles = Object.values(lore.articles)
     .filter((a) => !a.draft)
     .map((a) => ({ id: a.id, title: a.title, template: a.template }));

--- a/creator/src/lib/loreRewrite.ts
+++ b/creator/src/lib/loreRewrite.ts
@@ -4,6 +4,7 @@ import { TEMPLATE_SCHEMAS } from "@/lib/loreTemplates";
 import { buildWorldContext } from "@/lib/loreGeneration";
 import { tiptapToPlainText, plainTextToTiptap } from "@/lib/loreRelations";
 import { getRewriteSystemPrompt } from "@/lib/lorePrompts";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 export interface RewriteResult {
   content: string; // TipTap JSON string
@@ -14,6 +15,7 @@ export async function rewriteArticle(
   article: Article,
   instructions: string,
 ): Promise<RewriteResult> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const schema = TEMPLATE_SCHEMAS[article.template];
   const worldContext = buildWorldContext();
   const currentContent = tiptapToPlainText(article.content);

--- a/creator/src/lib/loreTimelineInference.ts
+++ b/creator/src/lib/loreTimelineInference.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { WorldLore, Article } from "@/types/lore";
 import { tiptapToPlainText } from "@/lib/loreRelations";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 export interface TimelineSuggestion {
   title: string;
@@ -41,6 +42,7 @@ export async function inferTimelineEvents(
   articleIds?: string[],
   onProgress?: (progress: InferenceProgress) => void,
 ): Promise<TimelineSuggestion[]> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const articles: Article[] = articleIds
     ? articleIds.reduce<Article[]>((acc, id) => {
         const a = lore.articles[id];

--- a/creator/src/lib/loreZonePlanning.ts
+++ b/creator/src/lib/loreZonePlanning.ts
@@ -6,6 +6,7 @@ import {
   renderGridOverlay,
   type GridSpec,
 } from "./gridOverlay";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── Generation contract ────────────────────────────────────────────
 
@@ -562,6 +563,7 @@ export async function generateZonePlans(
   lore: WorldLore,
   options: ZonePlanGenerationOptions = {},
 ): Promise<RepairResult> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const {
     targetCount,
     toneHint,

--- a/creator/src/lib/mudImport.ts
+++ b/creator/src/lib/mudImport.ts
@@ -14,6 +14,7 @@ import type {
   ShopFile,
   ExitValue,
 } from "@/types/world";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── Types ─────────────────────────────────────────────────────────
 
@@ -393,6 +394,7 @@ const SYSTEM_PROMPTS: Record<MudFileType, string> = {
 export async function convertChunk(
   chunk: ConversionChunk,
 ): Promise<{ data: unknown[]; warnings: string[] }> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const systemPrompt = SYSTEM_PROMPTS[chunk.fileType];
   if (!systemPrompt) {
     throw new Error(`No conversion prompt for file type: ${chunk.fileType}`);

--- a/creator/src/lib/narrationSynthesis.ts
+++ b/creator/src/lib/narrationSynthesis.ts
@@ -9,6 +9,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { extractPlainText } from "@/lib/sceneLayout";
 import type { NarrationSpeed } from "@/lib/narrationSpeed";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -90,6 +91,7 @@ export function resolveTtsSpeed(speed: NarrationSpeed | number | undefined): num
 export async function synthesizeNarration(
   options: SynthesizeNarrationOptions,
 ): Promise<NarrationAudio> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const text = options.text.trim();
   if (!text) {
     throw new Error("Cannot synthesize narration from empty text.");

--- a/creator/src/lib/panelRegistry.ts
+++ b/creator/src/lib/panelRegistry.ts
@@ -2,6 +2,8 @@
 // Central source of truth for all navigable panels. The sidebar, tab
 // bar, and main-area router all read from this registry.
 
+import { AI_ENABLED } from "@/lib/featureFlags";
+
 export type SidebarGroup =
   | "studio"
   | "characters"
@@ -44,6 +46,8 @@ export interface PanelDef {
   island?: Island;
   /** Short glyph (emoji or single char) shown beside the hotspot label. */
   glyph?: string;
+  /** Panel requires AI features and is hidden in the community build. */
+  aiOnly?: boolean;
 }
 
 // ─── Studio panels ──────────────────────────────────────────────────
@@ -66,8 +70,8 @@ const ART_STYLE_PANEL: PanelDef = {
 const STUDIO_PANELS: PanelDef[] = [
   { id: "art", label: "Art", group: "studio", host: "studio", kicker: "Studio", title: "Art", description: "Zone vibes, entity art, defaults, and free-form generation.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F3A8}" },
   { id: "media", label: "Media", group: "studio", host: "studio", kicker: "Studio", title: "Media", description: "Music, ambience, and cinematic staging.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F5BC}\uFE0F" },
-  { id: "portraits", label: "Portraits", group: "studio", host: "studio", kicker: "Studio", title: "Portraits", description: "Race and class portrait creation.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F464}" },
-  { id: "studioAbilities", label: "Icons", group: "studio", host: "studio", kicker: "Studio", title: "Icons", description: "Ability and status-effect icon generation.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F532}" },
+  { id: "portraits", label: "Portraits", group: "studio", host: "studio", kicker: "Studio", title: "Portraits", description: "Race and class portrait creation.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F464}", aiOnly: true },
+  { id: "studioAbilities", label: "Icons", group: "studio", host: "studio", kicker: "Studio", title: "Icons", description: "Ability and status-effect icon generation.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F532}", aiOnly: true },
   { id: "sprites", label: "Player Sprites", group: "studio", host: "command", kicker: "Studio", title: "Player sprites", description: "Visible identity, unlockable variants, and portrait logic.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F9CD}" },
   ART_STYLE_PANEL,
 ];
@@ -165,6 +169,7 @@ export const ALL_PANELS: PanelDef[] = (() => {
     ...COMMAND_PANELS,
   ]) {
     if (seen.has(p.id)) continue;
+    if (p.aiOnly && !AI_ENABLED) continue;
     seen.add(p.id);
     out.push(p);
   }
@@ -178,7 +183,7 @@ export const PANEL_MAP: Record<string, PanelDef> = Object.fromEntries(
 export type Workspace = "worldmaker" | "lore";
 
 export const WORLDMAKER_GROUPS: { id: SidebarGroup; label: string; panels: PanelDef[] }[] = [
-  { id: "studio", label: "Studio", panels: STUDIO_PANELS },
+  { id: "studio", label: "Studio", panels: STUDIO_PANELS.filter(p => !p.aiOnly || AI_ENABLED) },
   { id: "characters", label: "Characters", panels: CHARACTER_PANELS },
   { id: "world", label: "World", panels: WORLD_PANELS },
   { id: "systems", label: "Systems", panels: SYSTEMS_PANELS },

--- a/creator/src/lib/portraitPromptGen.ts
+++ b/creator/src/lib/portraitPromptGen.ts
@@ -4,6 +4,7 @@ import { useConfigStore } from "@/stores/configStore";
 import { buildToneDirective, buildVisualStyleDirective } from "./loreGeneration";
 import { DEFAULT_CLASS_SHOWCASE_RACES } from "./defaultSpriteData";
 import { getRaceBodyDescription, getClassOutfitDescription } from "./spritePromptGen";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -58,6 +59,7 @@ export async function generatePortraitTemplate(
   classes: string[],
   zoneVibe: string,
 ): Promise<PortraitPromptTemplate> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const raceList = races
     .map((r) => `- ${r}: ${getRaceBodyDescription(r)}`)
     .join("\n");

--- a/creator/src/lib/spritePromptGen.ts
+++ b/creator/src/lib/spritePromptGen.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_RACE_BODY_DESCRIPTIONS,
   DEFAULT_CLASS_OUTFIT_DESCRIPTIONS,
 } from "./defaultSpriteData";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // Fallback art-direction when the world has no visualStyle defined.
 // Kept lean — we never want project-specific aesthetic baked into code —
@@ -117,6 +118,7 @@ export async function generateSpriteTemplate(
   classes: string[],
   zoneVibe: string,
 ): Promise<SpritePromptTemplate> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const raceList = races
     .map((r) => `- ${r}: ${getRaceBodyDescription(r)}`)
     .join("\n");
@@ -177,6 +179,7 @@ export async function generateArtDirection(
   playerClass?: string,
   gender?: string,
 ): Promise<string> {
+  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   const toneDirective = buildToneDirective();
   const toneBlock = toneDirective
     ? `\nWorld tone: ${toneDirective}\nThe description must match this tone.`

--- a/creator/src/lib/useBackgroundRemoval.ts
+++ b/creator/src/lib/useBackgroundRemoval.ts
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { AssetContext, AssetEntry, BgRemovalProvider } from "@/types/assets";
 import { useAssetStore } from "@/stores/assetStore";
 import { BG_REMOVAL_ASSET_TYPES } from "./arcanumPrompts";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 // ─── Provider resolution ─────────────────────────────────────────────
 // The background-removal backend is a project-level setting
@@ -11,6 +12,7 @@ import { BG_REMOVAL_ASSET_TYPES } from "./arcanumPrompts";
 // switch between local and Runware without reloading.
 
 function currentBgProvider(): BgRemovalProvider {
+  if (!AI_ENABLED) return "local";
   const ps = useAssetStore.getState().projectSettings;
   return ps?.bg_removal_provider === "runware" ? "runware" : "local";
 }
@@ -54,6 +56,7 @@ function getWorker(): Worker {
  *  - "local": runs the Imgly/ONNX model in a Web Worker.
  *  - "runware": calls Runware Bria RMBG v2.0 (direct or via hub). */
 export async function removeBackground(imageDataUrl: string): Promise<Blob> {
+  if (!AI_ENABLED) return removeBackgroundLocal(imageDataUrl);
   if (currentBgProvider() === "runware") {
     return removeBackgroundRunware(imageDataUrl);
   }

--- a/creator/src/lib/useOpenProject.ts
+++ b/creator/src/lib/useOpenProject.ts
@@ -11,6 +11,7 @@ import { useSpriteDefinitionStore } from "@/stores/spriteDefinitionStore";
 import { useStoryStore } from "@/stores/storyStore";
 import { loadAllStoryIds } from "@/lib/storyPersistence";
 import { loadUIState, addRecentProject } from "@/lib/uiPersistence";
+import { PANEL_MAP } from "@/lib/panelRegistry";
 import type { Project, ProjectFormat, Tab } from "@/types/project";
 
 interface ProjectValidation {
@@ -99,6 +100,10 @@ export function useOpenProject() {
         if (tab.kind === "zone") {
           const zoneId = tab.id.replace(/^zone:/, "");
           return zoneIds.has(zoneId);
+        }
+        if (tab.kind === "panel") {
+          const panelId = tab.id.replace(/^panel:/, "");
+          return !!PANEL_MAP[panelId];
         }
         return true; // config, console tabs always valid
       });

--- a/creator/src/stores/vibeStore.ts
+++ b/creator/src/stores/vibeStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
 import { VIBE_SYSTEM_PROMPT } from "@/lib/vibePrompts";
+import { AI_ENABLED } from "@/lib/featureFlags";
 
 interface VibeState {
   vibes: Map<string, string>;
@@ -51,6 +52,7 @@ export const useVibeStore = create<VibeState>((set, get) => ({
   },
 
   generateVibe: async (zoneId, worldContext) => {
+    if (!AI_ENABLED) return "";
     const vibe = await invoke<string>("llm_complete", {
       systemPrompt: VIBE_SYSTEM_PROMPT,
       userPrompt: worldContext,

--- a/creator/src/vite-env.d.ts
+++ b/creator/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare const __BUILD_VARIANT__: "full" | "community";

--- a/creator/vite.config.ts
+++ b/creator/vite.config.ts
@@ -31,6 +31,9 @@ const crossOriginIsolation = (): Plugin => ({
 
 export default defineConfig(async () => ({
   plugins: [react(), crossOriginIsolation()],
+  define: {
+    __BUILD_VARIANT__: JSON.stringify(process.env.VITE_AI === 'false' ? 'community' : 'full'),
+  },
   worker: {
     format: "es" as const,
   },

--- a/creator/vitest.config.ts
+++ b/creator/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
+  define: {
+    __BUILD_VARIANT__: JSON.stringify("full"),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Introduce a Cargo feature flag `ai` (default on) that compiles out all AI provider code, and a Vite build-time constant `__BUILD_VARIANT__` that tree-shakes AI UI elements. The result: two downloadable builds from the same codebase — Full Edition and Community Edition.

Rust: 10 AI modules gated behind `#[cfg(feature = "ai")]`, `base_handler!` macro avoids duplicating the 90+ base command list. `read_image_data_url` moved from `deepinfra.rs` to `fs_utils.rs` (non-AI utility).

Frontend: `featureFlags.ts` exports `BUILD_VARIANT` and `AI_ENABLED`. Panel registry filters `aiOnly` panels. 12 AI-only components return null, 16 mixed components hide AI sections, 14 library files guard AI invoke calls. EntityArtGenerator keeps Pick Image / Gallery buttons visible. Background removal forced to local-only in Community Edition.

Build: `bun run build:community` (cross-env VITE_AI=false tauri build -- --no-default-features) produces the AI-free binary.