### PR TITLE
Unify undo/redo across zones, lore, stories, and config

### DIFF
--- a/creator/src/components/config/ConfigPanelHost.tsx
+++ b/creator/src/components/config/ConfigPanelHost.tsx
@@ -5,6 +5,8 @@ import { saveProjectConfig } from "@/lib/saveConfig";
 import { PANEL_MAP } from "@/lib/panelRegistry";
 import type { AppConfig } from "@/types/config";
 import { Spinner } from "@/components/ui/FormWidgets";
+import { UndoRedoButtons } from "@/components/ui/UndoRedoButtons";
+import { useToastStore } from "@/stores/toastStore";
 import configBg from "@/assets/config-bg.png";
 
 import { ClassDesigner } from "./ClassDesigner";
@@ -171,6 +173,10 @@ export function ConfigPanelHost({ panelId }: { panelId: string }) {
   const config = useConfigStore((s) => s.config);
   const dirty = useConfigStore((s) => s.dirty);
   const updateConfig = useConfigStore((s) => s.updateConfig);
+  const undoConfig = useConfigStore((s) => s.undoConfig);
+  const redoConfig = useConfigStore((s) => s.redoConfig);
+  const undoDepth = useConfigStore((s) => s.configPast.length);
+  const redoDepth = useConfigStore((s) => s.configFuture.length);
   const project = useProjectStore((s) => s.project);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -248,19 +254,39 @@ export function ConfigPanelHost({ panelId }: { panelId: string }) {
         </div>
 
         <div className={`relative z-10 mx-auto flex flex-col gap-6 px-6 py-5 ${def?.maxWidth ?? "max-w-5xl"}`}>
-          {(dirty || saving || saveError) && (
-            <div className="pointer-events-auto sticky top-3 z-20 flex items-center justify-end gap-2">
-              {saveError && <span role="alert" className="text-2xs text-status-error">Save failed</span>}
-              <button
-                onClick={handleSave}
-                disabled={!dirty || saving}
-                aria-label={saving ? "Saving configuration" : "Save configuration"}
-                className="focus-ring rounded-full border border-[var(--chrome-stroke)] bg-bg-primary/80 px-3 py-1 text-2xs font-medium text-accent shadow-md transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                {saving ? <span className="flex items-center gap-1.5"><Spinner />Saving</span> : "Save Config"}
-              </button>
-            </div>
-          )}
+          <div className="pointer-events-auto sticky top-3 z-20 flex items-center justify-end gap-2">
+            <UndoRedoButtons
+              canUndo={undoDepth > 0}
+              canRedo={redoDepth > 0}
+              undoDepth={undoDepth}
+              redoDepth={redoDepth}
+              onUndo={() => {
+                if (undoDepth > 0) {
+                  undoConfig();
+                  useToastStore.getState().show("Change undone");
+                }
+              }}
+              onRedo={() => {
+                if (redoDepth > 0) {
+                  redoConfig();
+                  useToastStore.getState().show("Change restored");
+                }
+              }}
+            />
+            {(dirty || saving || saveError) && (
+              <>
+                {saveError && <span role="alert" className="text-2xs text-status-error">Save failed</span>}
+                <button
+                  onClick={handleSave}
+                  disabled={!dirty || saving}
+                  aria-label={saving ? "Saving configuration" : "Save configuration"}
+                  className="focus-ring rounded-full border border-[var(--chrome-stroke)] bg-bg-primary/80 px-3 py-1 text-2xs font-medium text-accent shadow-md transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {saving ? <span className="flex items-center gap-1.5"><Spinner />Saving</span> : "Save Config"}
+                </button>
+              </>
+            )}
+          </div>
           {renderPanel(panelId, { config, onChange: handleChange })}
         </div>
       </div>

--- a/creator/src/components/lore/LorePanelHost.tsx
+++ b/creator/src/components/lore/LorePanelHost.tsx
@@ -1,9 +1,12 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useLoreStore } from "@/stores/loreStore";
+import { useStoryStore } from "@/stores/storyStore";
 import { useProjectStore } from "@/stores/projectStore";
+import { useToastStore } from "@/stores/toastStore";
 import { saveLore } from "@/lib/lorePersistence";
 import { PANEL_MAP } from "@/lib/panelRegistry";
 import { Spinner } from "@/components/ui/FormWidgets";
+import { UndoRedoButtons } from "@/components/ui/UndoRedoButtons";
 import configBg from "@/assets/config-bg.png";
 
 import { WorldSettingPanel } from "./WorldSettingPanel";
@@ -64,6 +67,16 @@ export function LorePanelHost({ panelId }: { panelId: string }) {
   const project = useProjectStore((s) => s.project);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Story editor is a `lore` host panel but edits the story store, so the
+  // host-level undo buttons must route to the right store based on panelId.
+  const isStoryPanel = panelId === "storyEditor";
+  const loreUndoDepth = useLoreStore((s) => s.lorePast.length);
+  const loreRedoDepth = useLoreStore((s) => s.loreFuture.length);
+  const storyUndoDepth = useStoryStore((s) => s.storyPast.length);
+  const storyRedoDepth = useStoryStore((s) => s.storyFuture.length);
+  const undoDepth = isStoryPanel ? storyUndoDepth : loreUndoDepth;
+  const redoDepth = isStoryPanel ? storyRedoDepth : loreRedoDepth;
 
   const autoSaveTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   useEffect(() => {
@@ -129,19 +142,39 @@ export function LorePanelHost({ panelId }: { panelId: string }) {
         </div>
 
         <div className={`relative z-10 mx-auto flex flex-col gap-6 px-6 py-5 ${def?.maxWidth ?? "max-w-5xl"}`}>
-          {(dirty || saving || saveError) && (
-            <div className="pointer-events-auto sticky top-3 z-20 flex items-center justify-end gap-2">
-              {saveError && <span role="alert" className="text-2xs text-status-error">Save failed</span>}
-              <button
-                onClick={handleSave}
-                disabled={!dirty || saving}
-                aria-label={saving ? "Saving lore" : "Save lore"}
-                className="focus-ring rounded-full border border-[var(--chrome-stroke)] bg-bg-primary/80 px-3 py-1 text-2xs font-medium text-accent shadow-md transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                {saving ? <span className="flex items-center gap-1.5"><Spinner />Saving</span> : "Save Lore"}
-              </button>
-            </div>
-          )}
+          <div className="pointer-events-auto sticky top-3 z-20 flex items-center justify-end gap-2">
+            <UndoRedoButtons
+              canUndo={undoDepth > 0}
+              canRedo={redoDepth > 0}
+              undoDepth={undoDepth}
+              redoDepth={redoDepth}
+              onUndo={() => {
+                if (undoDepth === 0) return;
+                if (isStoryPanel) useStoryStore.getState().undoStory();
+                else useLoreStore.getState().undoLore();
+                useToastStore.getState().show("Change undone");
+              }}
+              onRedo={() => {
+                if (redoDepth === 0) return;
+                if (isStoryPanel) useStoryStore.getState().redoStory();
+                else useLoreStore.getState().redoLore();
+                useToastStore.getState().show("Change restored");
+              }}
+            />
+            {(dirty || saving || saveError) && (
+              <>
+                {saveError && <span role="alert" className="text-2xs text-status-error">Save failed</span>}
+                <button
+                  onClick={handleSave}
+                  disabled={!dirty || saving}
+                  aria-label={saving ? "Saving lore" : "Save lore"}
+                  className="focus-ring rounded-full border border-[var(--chrome-stroke)] bg-bg-primary/80 px-3 py-1 text-2xs font-medium text-accent shadow-md transition hover:bg-bg-primary disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {saving ? <span className="flex items-center gap-1.5"><Spinner />Saving</span> : "Save Lore"}
+                </button>
+              </>
+            )}
+          </div>
           {renderPanel(panelId)}
         </div>
       </div>

--- a/creator/src/components/lore/StoryEditorPanel.tsx
+++ b/creator/src/components/lore/StoryEditorPanel.tsx
@@ -23,11 +23,7 @@ export function StoryEditorPanel({ storyId, onDelete }: StoryEditorPanelProps) {
   const project = useProjectStore((s) => s.project);
   const story = useStoryStore((s) => s.stories[storyId]);
   const dirty = useStoryStore((s) => s.dirty[storyId] ?? false);
-  const canUndo = useStoryStore((s) => s.storyPast.length > 0);
-  const canRedo = useStoryStore((s) => s.storyFuture.length > 0);
   const updateStory = useStoryStore((s) => s.updateStory);
-  const undoStory = useStoryStore((s) => s.undoStory);
-  const redoStory = useStoryStore((s) => s.redoStory);
   const markClean = useStoryStore((s) => s.markClean);
   const activeSceneId = useStoryStore((s) => s.activeSceneId);
   const setActiveScene = useStoryStore((s) => s.setActiveScene);
@@ -224,7 +220,8 @@ export function StoryEditorPanel({ storyId, onDelete }: StoryEditorPanelProps) {
           </span>
         </div>
 
-        {/* Present + Export + Undo / Redo */}
+        {/* Present + Export + Delete. Undo/Redo now live in the LorePanelHost
+            toolbar so all lore panels surface them consistently. */}
         <div className="flex shrink-0 items-center gap-2">
           <button
             type="button"
@@ -261,35 +258,6 @@ export function StoryEditorPanel({ storyId, onDelete }: StoryEditorPanelProps) {
             </svg>
             Export
           </button>
-
-          <div className="mx-0.5 h-5 w-px bg-border-muted" />
-
-          <ActionButton
-            variant="ghost"
-            size="icon"
-            onClick={undoStory}
-            disabled={!canUndo}
-            aria-label="Undo"
-            className={!canUndo ? "opacity-45" : ""}
-          >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path d="M4 7h8a3 3 0 0 1 0 6H9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              <path d="M7 4L4 7l3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-          </ActionButton>
-          <ActionButton
-            variant="ghost"
-            size="icon"
-            onClick={redoStory}
-            disabled={!canRedo}
-            aria-label="Redo"
-            className={!canRedo ? "opacity-45" : ""}
-          >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path d="M12 7H4a3 3 0 0 0 0 6h3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              <path d="M9 4l3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-          </ActionButton>
 
           {onDelete && (
             <>

--- a/creator/src/components/ui/ShortcutsHelp.tsx
+++ b/creator/src/components/ui/ShortcutsHelp.tsx
@@ -6,8 +6,8 @@ interface ShortcutsHelpProps {
 
 const shortcuts = [
   { keys: "Ctrl+S", desc: "Save all zones and config" },
-  { keys: "Ctrl+Z", desc: "Undo (active zone or lore)" },
-  { keys: "Ctrl+Shift+Z / Ctrl+Y", desc: "Redo (active zone or lore)" },
+  { keys: "Ctrl+Z", desc: "Undo (active zone, lore, story, or config)" },
+  { keys: "Ctrl+Shift+Z / Ctrl+Y", desc: "Redo (active zone, lore, story, or config)" },
   { keys: "Ctrl+W", desc: "Close active tab" },
   { keys: "Ctrl+Tab", desc: "Next tab" },
   { keys: "Ctrl+Shift+Tab", desc: "Previous tab" },

--- a/creator/src/components/ui/UndoRedoButtons.tsx
+++ b/creator/src/components/ui/UndoRedoButtons.tsx
@@ -1,0 +1,64 @@
+import { ActionButton } from "./FormWidgets";
+
+interface UndoRedoButtonsProps {
+  canUndo: boolean;
+  canRedo: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  /** Past-stack depth, surfaced in the tooltip. */
+  undoDepth?: number;
+  redoDepth?: number;
+}
+
+/**
+ * Shared undo/redo button pair used by panel hosts and editor toolbars.
+ * Consistent styling, icons, and tooltips across the app.
+ */
+export function UndoRedoButtons({
+  canUndo,
+  canRedo,
+  onUndo,
+  onRedo,
+  undoDepth,
+  redoDepth,
+}: UndoRedoButtonsProps) {
+  const undoTitle = canUndo
+    ? `Undo (Ctrl+Z)${undoDepth ? ` — ${undoDepth} step${undoDepth === 1 ? "" : "s"}` : ""}`
+    : "Nothing to undo";
+  const redoTitle = canRedo
+    ? `Redo (Ctrl+Shift+Z)${redoDepth ? ` — ${redoDepth} step${redoDepth === 1 ? "" : "s"}` : ""}`
+    : "Nothing to redo";
+
+  return (
+    <div className="flex items-center gap-0.5">
+      <ActionButton
+        variant="ghost"
+        size="icon"
+        onClick={onUndo}
+        disabled={!canUndo}
+        aria-label="Undo"
+        title={undoTitle}
+        className={!canUndo ? "opacity-45" : ""}
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path d="M4 7h8a3 3 0 0 1 0 6H9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M7 4L4 7l3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </ActionButton>
+      <ActionButton
+        variant="ghost"
+        size="icon"
+        onClick={onRedo}
+        disabled={!canRedo}
+        aria-label="Redo"
+        title={redoTitle}
+        className={!canRedo ? "opacity-45" : ""}
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path d="M12 7H4a3 3 0 0 0 0 6h3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          <path d="M9 4l3 3-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </ActionButton>
+    </div>
+  );
+}

--- a/creator/src/lib/historyDepths.ts
+++ b/creator/src/lib/historyDepths.ts
@@ -1,0 +1,11 @@
+/**
+ * Central constants for undo/redo history depths across stores.
+ * Keep these aligned so users see consistent undo behavior regardless
+ * of which editor they're in.
+ */
+export const HISTORY_DEPTHS = {
+  ZONE: 100,
+  LORE: 100,
+  STORY: 100,
+  CONFIG: 100,
+} as const;

--- a/creator/src/lib/useKeyboardShortcuts.ts
+++ b/creator/src/lib/useKeyboardShortcuts.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { useProjectStore } from "@/stores/projectStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useLoreStore } from "@/stores/loreStore";
+import { useStoryStore } from "@/stores/storyStore";
+import { useConfigStore } from "@/stores/configStore";
 import { saveEverything } from "@/lib/saveAll";
 import { PANEL_MAP, panelTab } from "@/lib/panelRegistry";
 import { useToastStore } from "@/stores/toastStore";
@@ -42,29 +44,19 @@ export function useKeyboardShortcuts() {
       // Skip remaining shortcuts when typing in inputs
       if (inInput) return;
 
-      // ─── Ctrl+Z → undo (zone or lore, depending on context) ─
+      // ─── Ctrl+Z → undo (routed by active panel) ───────────
       if (e.key === "z" && !e.shiftKey) {
         e.preventDefault();
-        const activeZoneId = getActiveZoneId();
-        if (activeZoneId) {
-          useZoneStore.getState().undo(activeZoneId);
-          useToastStore.getState().show("Change undone");
-        } else if (isActiveLorePanel()) {
-          useLoreStore.getState().undoLore();
+        if (dispatchUndo()) {
           useToastStore.getState().show("Change undone");
         }
         return;
       }
 
-      // ─── Ctrl+Shift+Z / Ctrl+Y → redo (zone or lore) ───────
+      // ─── Ctrl+Shift+Z / Ctrl+Y → redo (routed by active panel) ───
       if ((e.key === "z" && e.shiftKey) || e.key === "y") {
         e.preventDefault();
-        const activeZoneId = getActiveZoneId();
-        if (activeZoneId) {
-          useZoneStore.getState().redo(activeZoneId);
-          useToastStore.getState().show("Change restored");
-        } else if (isActiveLorePanel()) {
-          useLoreStore.getState().redoLore();
+        if (dispatchRedo()) {
           useToastStore.getState().show("Change restored");
         }
         return;
@@ -123,9 +115,66 @@ function getActiveZoneId(): string | null {
   return activeTabId.replace(/^zone:/, "");
 }
 
-function isActiveLorePanel(): boolean {
+/** Active panel ID, or null if the active tab isn't a panel. */
+function getActivePanelId(): string | null {
   const { activeTabId } = useProjectStore.getState();
-  if (!activeTabId?.startsWith("panel:")) return false;
-  const panelId = activeTabId.replace(/^panel:/, "");
-  return PANEL_MAP[panelId]?.host === "lore";
+  if (!activeTabId?.startsWith("panel:")) return null;
+  return activeTabId.replace(/^panel:/, "");
+}
+
+/**
+ * Route Ctrl+Z to the correct store based on the active tab.
+ * Returns true if something was dispatched (so the caller can show a toast).
+ *
+ * Dispatch order matters: the Story Editor is a `lore` host panel, so it
+ * must be checked before the generic lore branch — otherwise Ctrl+Z in the
+ * story editor would wipe unrelated lore changes instead of undoing the
+ * user's story edit.
+ */
+function dispatchUndo(): boolean {
+  const activeZoneId = getActiveZoneId();
+  if (activeZoneId) {
+    useZoneStore.getState().undo(activeZoneId);
+    return true;
+  }
+  const panelId = getActivePanelId();
+  if (!panelId) return false;
+  if (panelId === "storyEditor") {
+    useStoryStore.getState().undoStory();
+    return true;
+  }
+  const host = PANEL_MAP[panelId]?.host;
+  if (host === "lore") {
+    useLoreStore.getState().undoLore();
+    return true;
+  }
+  if (host === "config") {
+    useConfigStore.getState().undoConfig();
+    return true;
+  }
+  return false;
+}
+
+function dispatchRedo(): boolean {
+  const activeZoneId = getActiveZoneId();
+  if (activeZoneId) {
+    useZoneStore.getState().redo(activeZoneId);
+    return true;
+  }
+  const panelId = getActivePanelId();
+  if (!panelId) return false;
+  if (panelId === "storyEditor") {
+    useStoryStore.getState().redoStory();
+    return true;
+  }
+  const host = PANEL_MAP[panelId]?.host;
+  if (host === "lore") {
+    useLoreStore.getState().redoLore();
+    return true;
+  }
+  if (host === "config") {
+    useConfigStore.getState().redoConfig();
+    return true;
+  }
+  return false;
 }

--- a/creator/src/stores/__tests__/storyStore.test.ts
+++ b/creator/src/stores/__tests__/storyStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useStoryStore, selectActiveScene } from "../storyStore";
+import { HISTORY_DEPTHS } from "@/lib/historyDepths";
 import type { Story, Scene } from "@/types/story";
 
 function makeScene(overrides: Partial<Scene> = {}): Scene {
@@ -96,13 +97,15 @@ describe("storyStore", () => {
   });
 
   describe("undo stack cap", () => {
-    it("caps at 50 entries", () => {
+    it("caps at HISTORY_DEPTHS.STORY entries", () => {
       useStoryStore.getState().setStory(makeStory());
-      for (let i = 0; i < 52; i++) {
+      // Make enough edits to exceed the cap regardless of the exact value,
+      // then assert the stack was trimmed to the configured depth.
+      const overflow = HISTORY_DEPTHS.STORY + 3;
+      for (let i = 0; i < overflow; i++) {
         useStoryStore.getState().updateStory("story_test_abc1", { title: `Title ${i}` });
       }
-      // 1 from setStory + 52 from updateStory = 53 snapshots, capped at 50
-      expect(useStoryStore.getState().storyPast.length).toBe(50);
+      expect(useStoryStore.getState().storyPast.length).toBe(HISTORY_DEPTHS.STORY);
     });
   });
 

--- a/creator/src/stores/configStore.ts
+++ b/creator/src/stores/configStore.ts
@@ -1,22 +1,62 @@
 import { create } from "zustand";
 import type { AppConfig } from "@/types/config";
+import { snapshot as histSnapshot, undo as histUndo, redo as histRedo } from "@/lib/historyStack";
+import { HISTORY_DEPTHS } from "@/lib/historyDepths";
+
+const MAX_CONFIG_HISTORY = HISTORY_DEPTHS.CONFIG;
 
 interface ConfigStore {
   config: AppConfig | null;
   dirty: boolean;
+  configPast: AppConfig[];
+  configFuture: AppConfig[];
 
   setConfig: (config: AppConfig) => void;
   updateConfig: (config: AppConfig) => void;
   markClean: () => void;
   clearConfig: () => void;
+  undoConfig: () => void;
+  redoConfig: () => void;
+  canUndoConfig: () => boolean;
+  canRedoConfig: () => boolean;
 }
 
-export const useConfigStore = create<ConfigStore>((set) => ({
+export const useConfigStore = create<ConfigStore>((set, get) => ({
   config: null,
   dirty: false,
+  configPast: [],
+  configFuture: [],
 
-  setConfig: (config) => set({ config, dirty: false }),
-  updateConfig: (config) => set({ config, dirty: true }),
+  // Replace config without recording history — used when loading from disk.
+  setConfig: (config) => set({ config, dirty: false, configPast: [], configFuture: [] }),
+
+  updateConfig: (config) =>
+    set((s) => {
+      if (!s.config) return { config, dirty: true };
+      const { past, future } = histSnapshot(s.configPast, s.config, MAX_CONFIG_HISTORY);
+      return { config, dirty: true, configPast: past, configFuture: future };
+    }),
+
   markClean: () => set({ dirty: false }),
-  clearConfig: () => set({ config: null, dirty: false }),
+
+  clearConfig: () => set({ config: null, dirty: false, configPast: [], configFuture: [] }),
+
+  undoConfig: () =>
+    set((s) => {
+      if (!s.config) return s;
+      const result = histUndo(s.configPast, s.config, s.configFuture);
+      if (!result) return s;
+      return { config: result.data, dirty: true, configPast: result.past, configFuture: result.future };
+    }),
+
+  redoConfig: () =>
+    set((s) => {
+      if (!s.config) return s;
+      const result = histRedo(s.configPast, s.config, s.configFuture);
+      if (!result) return s;
+      return { config: result.data, dirty: true, configPast: result.past, configFuture: result.future };
+    }),
+
+  canUndoConfig: () => get().configPast.length > 0,
+  canRedoConfig: () => get().configFuture.length > 0,
 }));

--- a/creator/src/stores/loreStore.ts
+++ b/creator/src/stores/loreStore.ts
@@ -1,8 +1,9 @@
 import { create } from "zustand";
 import type { WorldLore, Article, ArticleTemplate, ColorLabel, LoreMap, MapPin, CalendarSystem, TimelineEvent, LoreDocument, TemplateOverrides, ShowcaseSettings, CustomTemplateDefinition, CustomSceneTemplate, ArtStyle, ZonePlan } from "@/types/lore";
 import { snapshot as histSnapshot, undo as histUndo, redo as histRedo } from "@/lib/historyStack";
+import { HISTORY_DEPTHS } from "@/lib/historyDepths";
 
-const MAX_LORE_HISTORY = 50;
+const MAX_LORE_HISTORY = HISTORY_DEPTHS.LORE;
 
 // Stable empty references for selectors (prevents infinite re-render loops)
 const EMPTY_ARTICLES: Record<string, Article> = {};

--- a/creator/src/stores/storyStore.ts
+++ b/creator/src/stores/storyStore.ts
@@ -1,8 +1,9 @@
 import { create } from "zustand";
 import type { Story, Scene } from "@/types/story";
 import { snapshot as histSnapshot, undo as histUndo, redo as histRedo } from "@/lib/historyStack";
+import { HISTORY_DEPTHS } from "@/lib/historyDepths";
 
-const MAX_STORY_HISTORY = 50;
+const MAX_STORY_HISTORY = HISTORY_DEPTHS.STORY;
 
 // Stable empty reference for selectors (prevents infinite re-render loops)
 const EMPTY_STORIES: Record<string, Story> = {};

--- a/creator/src/stores/zoneStore.ts
+++ b/creator/src/stores/zoneStore.ts
@@ -1,7 +1,8 @@
 import { create } from "zustand";
 import type { WorldFile } from "@/types/world";
+import { HISTORY_DEPTHS } from "@/lib/historyDepths";
 
-const MAX_HISTORY = 100;
+const MAX_HISTORY = HISTORY_DEPTHS.ZONE;
 
 export interface ZoneState {
   filePath: string;


### PR DESCRIPTION
## Summary

Audit found four different undo architectures with one genuine bug, missing coverage, and inconsistent UX. This PR collapses everything into a single consistent system.

**The bug:** Ctrl+Z inside the Story Editor was dispatching to `loreStore.undoLore()` — silently wiping the last article/map/timeline edit instead of undoing the story change. Root cause: the Story Editor is registered as a `host: "lore"` panel, and the keyboard dispatcher matched on host without a story-specific check.

**Before → after matrix:**

| Store  | Depth before | Depth after | Ctrl+Z before | Ctrl+Z after | UI buttons before | UI buttons after |
|--------|--------------|-------------|---------------|--------------|-------------------|------------------|
| Zone   | 100          | 100         | ✓             | ✓            | ZoneEditor toolbar | unchanged |
| Lore   | 50           | 100         | ✓             | ✓            | Story Editor only | all lore panels (host toolbar) |
| Story  | 50           | 100         | **✗ bug**     | ✓            | Story Editor only | host toolbar (deduplicated) |
| Config | 0            | 100         | ✗             | ✓            | Tuning Wizard only | all config panels (host toolbar) |

## What changed

- **`historyDepths.ts`** — central `HISTORY_DEPTHS` constant; all four stores import it.
- **`useKeyboardShortcuts.ts`** — new `dispatchUndo` / `dispatchRedo` routers. Story-editor check runs before the generic lore branch.
- **`configStore.ts`** — adds `configPast`/`configFuture` with `undoConfig`/`redoConfig`/`canUndoConfig`/`canRedoConfig`. Every existing `updateConfig()` call site (35+) becomes undoable automatically — no per-panel changes needed.
- **`UndoRedoButtons.tsx` (new)** — shared component with depth-aware tooltips (e.g. "Undo (Ctrl+Z) — 3 steps").
- **`ConfigPanelHost` / `LorePanelHost`** — persistent sticky toolbar with undo/redo always visible; save button continues to fade in only when dirty. Lore host routes to `storyStore` when `panelId === 'storyEditor'`.
- **`StoryEditorPanel`** — its local undo/redo removed to avoid duplication; the host-level buttons route to storyStore when active.
- **`ShortcutsHelp`** — help text now covers all four stores.

Tuning Wizard's single-level preset snapshot is left in place; its explicit \"Undo\" button complements the new multi-level Ctrl+Z.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run test` — 1599/1599 pass (updated one story-store test that hardcoded the old 50-entry cap)
- [ ] Ctrl+Z in Story Editor undoes the last story edit, not lore
- [ ] Ctrl+Z in any lore panel (Articles, Maps, Timeline, Documents) undoes lore
- [ ] Ctrl+Z in any config panel (Factions, Abilities, Classes, etc.) undoes the last config change
- [ ] Undo/redo icon buttons visible and tooltip shows stack depth (\"— N steps\") in Config + Lore panel hosts
- [ ] Tuning Wizard's own Undo button still works after applying a preset, and Ctrl+Z also reverts preset applies
- [ ] Redo works from all four stores