### PR TITLE
feat: hub discovery — richer cards, OG meta, search

### DIFF
--- a/hub-worker/src/db.ts
+++ b/hub-worker/src/db.ts
@@ -25,6 +25,16 @@ export interface WorldRow {
   last_publish_at: number | null;
   bytes_used: number;
   created_at: number;
+  // Discovery metadata (migration 0003). All derived from the uploaded
+  // showcase.json on each publish; never authored by the creator directly.
+  article_count: number;
+  map_count: number;
+  image_count: number;
+  cover_image_hash: string | null;
+  /** JSON-encoded string[] of aggregated article tags, or null. */
+  tags: string | null;
+  author_display_name: string | null;
+  description: string | null;
 }
 
 // ─── Users ───────────────────────────────────────────────────────────
@@ -178,12 +188,27 @@ export async function createWorld(
 export async function updateWorldPublish(
   env: Env,
   slug: string,
-  opts: { listed: boolean; tagline: string | null; display_name: string | null; bytes_used: number },
+  opts: {
+    listed: boolean;
+    tagline: string | null;
+    display_name: string | null;
+    bytes_used: number;
+    article_count: number;
+    map_count: number;
+    image_count: number;
+    cover_image_hash: string | null;
+    tags: string | null;
+    author_display_name: string | null;
+    description: string | null;
+  },
 ): Promise<void> {
   await env.DB.prepare(
     `UPDATE worlds
      SET listed = ?, tagline = ?, display_name = COALESCE(?, display_name),
-         bytes_used = ?, last_publish_at = ?
+         bytes_used = ?, last_publish_at = ?,
+         article_count = ?, map_count = ?, image_count = ?,
+         cover_image_hash = ?, tags = ?,
+         author_display_name = ?, description = ?
      WHERE slug = ?`,
   )
     .bind(
@@ -192,6 +217,13 @@ export async function updateWorldPublish(
       opts.display_name,
       opts.bytes_used,
       Date.now(),
+      opts.article_count,
+      opts.map_count,
+      opts.image_count,
+      opts.cover_image_hash,
+      opts.tags,
+      opts.author_display_name,
+      opts.description,
       slug,
     )
     .run();

--- a/hub-worker/src/handlers/publish.ts
+++ b/hub-worker/src/handlers/publish.ts
@@ -8,6 +8,7 @@ import {
   updateWorldPublish,
 } from "../db";
 import { corsHeaders, error, isValidSlug, json, sha256Hex } from "../util";
+import { extractMetadata } from "../metadata";
 
 // ─── POST /publish/check-existing ────────────────────────────────────
 // Body: { slug, hashes: ["<sha256hex>.webp", ...] }
@@ -130,6 +131,10 @@ export async function uploadManifest(req: Request, env: Env, user: UserRow): Pro
     httpMetadata: { contentType: "application/json" },
   });
 
+  // Discovery metadata is derived from the manifest we just stored,
+  // so it can never drift from the actual published content.
+  const metadata = extractMetadata(body.showcase);
+
   // bytes_used is a coarse estimate — just the manifest size for now.
   // A follow-up could sum R2 listing for worlds/<slug>/ but listing is pricey.
   await updateWorldPublish(env, slug, {
@@ -137,6 +142,13 @@ export async function uploadManifest(req: Request, env: Env, user: UserRow): Pro
     tagline: body.tagline ?? null,
     display_name: body.displayName ?? null,
     bytes_used: bytes.byteLength,
+    article_count: metadata.article_count,
+    map_count: metadata.map_count,
+    image_count: metadata.image_count,
+    cover_image_hash: metadata.cover_image_hash,
+    tags: metadata.tags,
+    author_display_name: user.display_name,
+    description: metadata.description,
   });
   await touchUserPublish(env, user.id);
 

--- a/hub-worker/src/handlers/showcase.ts
+++ b/hub-worker/src/handlers/showcase.ts
@@ -42,13 +42,38 @@ export async function serveHubIndex(env: Env): Promise<Response> {
   const worlds = await listListedWorlds(env);
   return json(
     {
-      worlds: worlds.map((w) => ({
-        slug: w.slug,
-        displayName: w.display_name ?? w.slug,
-        tagline: w.tagline,
-        lastPublishAt: w.last_publish_at,
-        url: `https://${w.slug}.${env.HUB_ROOT_DOMAIN}/`,
-      })),
+      worlds: worlds.map((w) => {
+        // Tags are stored as a JSON string; parse defensively so a
+        // malformed row can't crash the whole directory fetch.
+        let tags: string[] = [];
+        if (w.tags) {
+          try {
+            const parsed = JSON.parse(w.tags);
+            if (Array.isArray(parsed)) {
+              tags = parsed.filter((t): t is string => typeof t === "string");
+            }
+          } catch {
+            tags = [];
+          }
+        }
+        const coverImageUrl = w.cover_image_hash
+          ? `https://${w.slug}.${env.HUB_ROOT_DOMAIN}/images/${w.cover_image_hash}.webp`
+          : null;
+        return {
+          slug: w.slug,
+          displayName: w.display_name ?? w.slug,
+          tagline: w.tagline,
+          lastPublishAt: w.last_publish_at,
+          url: `https://${w.slug}.${env.HUB_ROOT_DOMAIN}/`,
+          articleCount: w.article_count,
+          mapCount: w.map_count,
+          imageCount: w.image_count,
+          coverImageUrl,
+          tags,
+          authorDisplayName: w.author_display_name,
+          description: w.description,
+        };
+      }),
     },
     {},
     { origin: "*" },

--- a/hub-worker/src/index.ts
+++ b/hub-worker/src/index.ts
@@ -1,9 +1,11 @@
 import type { Env } from "./env";
 import { authenticateUser, isAdmin } from "./auth";
+import { getWorldBySlug } from "./db";
 import { handleAdmin, adminCorsHeaders } from "./handlers/admin";
 import { handleAi } from "./handlers/ai";
 import { checkExisting, uploadImage, uploadManifest } from "./handlers/publish";
 import { serveHubIndex, serveImage, serveShowcaseJson } from "./handlers/showcase";
+import { injectOgForWorld } from "./og";
 import { corsHeaders, error, parseHost, preflight, RESERVED_SUBDOMAINS } from "./util";
 
 export default {
@@ -61,7 +63,13 @@ export default {
       }
       // Everything else on <slug>.arcanum-hub.com is an SPA route —
       // the bundled index.html boots the showcase app, which then
-      // fetches /showcase.json from this same origin.
+      // fetches /showcase.json from this same origin. For HTML
+      // requests we rewrite OG/Twitter meta tags so crawler previews
+      // reflect the actual world (and article, where applicable).
+      const world = await getWorldBySlug(env, host.slug);
+      if (world) {
+        return await injectOgForWorld(req, env, world);
+      }
       return await env.ASSETS.fetch(req);
     }
 

--- a/hub-worker/src/metadata.ts
+++ b/hub-worker/src/metadata.ts
@@ -1,0 +1,194 @@
+// ─── Showcase metadata extractor ────────────────────────────────────
+//
+// On each publish the hub re-reads the uploaded showcase.json and
+// derives discovery metadata — article/map/image counts, tags, a
+// representative cover image hash, and a short description. The
+// results are written to the `worlds` row so the landing page and
+// OG-tag injector can read them without re-parsing every manifest.
+//
+// Runs on the worker after the manifest is uploaded to R2. The input
+// is the same payload the creator sent in `POST /publish/manifest`,
+// loosely typed because we validate fields defensively before use.
+
+const MAX_TAGS = 20;
+const MAX_DESCRIPTION_LEN = 280;
+
+export interface ExtractedMetadata {
+  article_count: number;
+  map_count: number;
+  image_count: number;
+  cover_image_hash: string | null;
+  tags: string | null;
+  description: string | null;
+}
+
+/**
+ * Pull the `<hash>` from any URL of the form
+ * `.../images/<64-hex>.webp`. Returns null for anything else so that
+ * legacy absolute URLs (e.g. from self-hosted builds re-published to
+ * the hub) don't poison the metadata.
+ */
+function extractImageHash(url: unknown): string | null {
+  if (typeof url !== "string") return null;
+  const m = /\/images\/([a-f0-9]{64})\.webp(?:[?#].*)?$/i.exec(url);
+  return m && m[1] ? m[1].toLowerCase() : null;
+}
+
+function asString(v: unknown): string | null {
+  return typeof v === "string" && v.trim().length > 0 ? v : null;
+}
+
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+/**
+ * Strip HTML tags and collapse whitespace to produce a plain-text
+ * snippet for card descriptions / OG meta. We do the bare minimum —
+ * removing tags and decoding a handful of common entities — because
+ * the source is already sanitized HTML from TipTap.
+ */
+function htmlToPlain(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const slice = text.slice(0, max);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut = lastSpace > max - 40 ? slice.slice(0, lastSpace) : slice;
+  return `${cut.trimEnd()}…`;
+}
+
+export function extractMetadata(showcase: unknown): ExtractedMetadata {
+  const root = asRecord(showcase) ?? {};
+  const articles = asArray(root.articles);
+  const maps = asArray(root.maps);
+  const meta = asRecord(root.meta) ?? {};
+  const branding = asRecord(meta.showcase) ?? {};
+
+  // ─── Counts ──────────────────────────────────────────────────────
+  const article_count = articles.length;
+  const map_count = maps.length;
+
+  // ─── Image set ───────────────────────────────────────────────────
+  // Collect every content-addressed hash referenced by the manifest.
+  // `image_count` is the unique-hash count, not the number of URLs,
+  // so articles that share an image don't inflate the number.
+  const imageHashes = new Set<string>();
+  for (const art of articles) {
+    const a = asRecord(art);
+    if (!a) continue;
+    const primary = extractImageHash(a.imageUrl);
+    if (primary) imageHashes.add(primary);
+    for (const g of asArray(a.galleryUrls)) {
+      const h = extractImageHash(g);
+      if (h) imageHashes.add(h);
+    }
+  }
+  for (const m of maps) {
+    const mr = asRecord(m);
+    if (!mr) continue;
+    const h = extractImageHash(mr.imageUrl);
+    if (h) imageHashes.add(h);
+  }
+  const bannerHash = extractImageHash(branding.bannerImage);
+  if (bannerHash) imageHashes.add(bannerHash);
+  const image_count = imageHashes.size;
+
+  // ─── Cover image ─────────────────────────────────────────────────
+  // Priority: explicit banner > first article image > first map image.
+  // Null when the world has no usable image — the landing page falls
+  // back to a placeholder card in that case.
+  let cover_image_hash: string | null = bannerHash;
+  if (!cover_image_hash) {
+    for (const art of articles) {
+      const a = asRecord(art);
+      if (!a) continue;
+      const h = extractImageHash(a.imageUrl);
+      if (h) {
+        cover_image_hash = h;
+        break;
+      }
+    }
+  }
+  if (!cover_image_hash) {
+    for (const m of maps) {
+      const mr = asRecord(m);
+      if (!mr) continue;
+      const h = extractImageHash(mr.imageUrl);
+      if (h) {
+        cover_image_hash = h;
+        break;
+      }
+    }
+  }
+
+  // ─── Tags ────────────────────────────────────────────────────────
+  // Aggregate article tags (case-insensitive dedupe, cap at MAX_TAGS).
+  // Order is first-seen — common tags from world_setting / character
+  // articles tend to appear first, which is the ordering we want.
+  const seen = new Set<string>();
+  const tagList: string[] = [];
+  for (const art of articles) {
+    const a = asRecord(art);
+    if (!a) continue;
+    for (const t of asArray(a.tags)) {
+      if (typeof t !== "string") continue;
+      const trimmed = t.trim();
+      if (!trimmed) continue;
+      const key = trimmed.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      tagList.push(trimmed);
+      if (tagList.length >= MAX_TAGS) break;
+    }
+    if (tagList.length >= MAX_TAGS) break;
+  }
+  const tags = tagList.length > 0 ? JSON.stringify(tagList) : null;
+
+  // ─── Description ─────────────────────────────────────────────────
+  // Prefer meta.tagline (the creator's intentional one-liner). Fall
+  // back to the first world_setting article's rendered content, then
+  // any article with content. Always truncated.
+  let description: string | null = asString(meta.tagline);
+  if (!description) {
+    const pickFrom = (predicate: (a: Record<string, unknown>) => boolean): string | null => {
+      for (const art of articles) {
+        const a = asRecord(art);
+        if (!a || !predicate(a)) continue;
+        const html = asString(a.contentHtml);
+        if (!html) continue;
+        const plain = htmlToPlain(html);
+        if (plain) return truncate(plain, MAX_DESCRIPTION_LEN);
+      }
+      return null;
+    };
+    description =
+      pickFrom((a) => a.template === "world_setting") ?? pickFrom(() => true);
+  } else {
+    description = truncate(description, MAX_DESCRIPTION_LEN);
+  }
+
+  return {
+    article_count,
+    map_count,
+    image_count,
+    cover_image_hash,
+    tags,
+    description,
+  };
+}

--- a/hub-worker/src/migrations/0003_world_metadata.sql
+++ b/hub-worker/src/migrations/0003_world_metadata.sql
@@ -1,0 +1,29 @@
+-- 0003_world_metadata
+-- Adds discovery metadata to the worlds table so the hub landing page
+-- can render richer cards, support search/filter, and power per-world
+-- OpenGraph tags without re-parsing every showcase.json on demand.
+--
+-- All values are derived server-side from the uploaded manifest on
+-- each publish — the creator never sends them directly. Existing rows
+-- get populated on their next publish; until then the columns stay at
+-- their defaults (zero / null) which the landing page tolerates.
+--
+-- Apply with:
+--   wrangler d1 execute arcanum-hub --remote --file=./src/migrations/0003_world_metadata.sql
+
+ALTER TABLE worlds ADD COLUMN article_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE worlds ADD COLUMN map_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE worlds ADD COLUMN image_count INTEGER NOT NULL DEFAULT 0;
+-- SHA-256 hash (no extension) of the representative cover image, or
+-- NULL if the world has no usable image. The full URL is reconstructed
+-- on read as https://<slug>.<root>/images/<hash>.webp.
+ALTER TABLE worlds ADD COLUMN cover_image_hash TEXT;
+-- JSON array of unique article tags (lowercase, deduped, capped).
+ALTER TABLE worlds ADD COLUMN tags TEXT;
+-- Denormalized from users.display_name at publish time so the landing
+-- page can show "by <author>" without a join on every card.
+ALTER TABLE worlds ADD COLUMN author_display_name TEXT;
+-- A short description pulled from showcase.meta.tagline or derived
+-- from the world_setting article's first paragraph — used on cards
+-- and in OG meta.
+ALTER TABLE worlds ADD COLUMN description TEXT;

--- a/hub-worker/src/og.ts
+++ b/hub-worker/src/og.ts
@@ -1,0 +1,238 @@
+// ─── OpenGraph / Twitter meta injection ─────────────────────────────
+//
+// Crawlers (Discord, Slack, Twitter, etc.) render the link preview
+// from the `<meta property="og:*">` tags they find in the first HTTP
+// response. They don't execute JavaScript, so whatever the SPA puts
+// in the DOM later is invisible to them. This module intercepts the
+// showcase SPA's HTML response and rewrites the static meta tags
+// with world-specific (or article-specific) values using Workers'
+// HTMLRewriter streaming API.
+//
+// Runs only on world-mode hosts (`<slug>.<root>`). The landing page
+// at the apex keeps its static meta tags — the hub directory itself
+// doesn't need per-URL previews.
+//
+// Two tiers of detail:
+//   - World root (`/`) and unrecognised SPA paths: data from D1.
+//     Fast, no R2 read.
+//   - Article routes (`/articles/<id>`): fetch showcase.json once
+//     to resolve the article's title and image. Crawlers hit these
+//     at low QPS and Cloudflare caches the manifest anyway, so the
+//     added latency is acceptable.
+
+import type { Env } from "./env";
+import type { WorldRow } from "./db";
+
+interface OgMeta {
+  title: string;
+  description: string;
+  imageUrl: string | null;
+  url: string;
+  type: "website" | "article";
+  siteName: string;
+}
+
+/**
+ * Escape a string for safe embedding inside an HTML attribute value.
+ * Only the characters that can break out of a double-quoted attribute
+ * need handling — the output is always placed in `content="..."`.
+ */
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  const slice = s.slice(0, max);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut = lastSpace > max - 40 ? slice.slice(0, lastSpace) : slice;
+  return `${cut.trimEnd()}…`;
+}
+
+function htmlToPlain(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// ─── Meta builders ──────────────────────────────────────────────────
+
+function buildWorldMeta(env: Env, world: WorldRow): OgMeta {
+  const name = world.display_name ?? world.slug;
+  const description =
+    world.description ??
+    world.tagline ??
+    `Explore ${name} — a world built in Arcanum.`;
+  const imageUrl = world.cover_image_hash
+    ? `https://${world.slug}.${env.HUB_ROOT_DOMAIN}/images/${world.cover_image_hash}.webp`
+    : null;
+  return {
+    title: name,
+    description: truncate(description, 280),
+    imageUrl,
+    url: `https://${world.slug}.${env.HUB_ROOT_DOMAIN}/`,
+    type: "website",
+    siteName: "Arcanum Hub",
+  };
+}
+
+interface ShowcaseArticleShape {
+  id?: unknown;
+  title?: unknown;
+  contentHtml?: unknown;
+  imageUrl?: unknown;
+  fields?: unknown;
+}
+
+async function buildArticleMeta(
+  env: Env,
+  world: WorldRow,
+  articleId: string,
+): Promise<OgMeta> {
+  const fallback = buildWorldMeta(env, world);
+  try {
+    const obj = await env.BUCKET.get(`worlds/${world.slug}/showcase.json`);
+    if (!obj) return fallback;
+    const data = (await obj.json()) as { articles?: unknown };
+    const articles = Array.isArray(data.articles) ? data.articles : [];
+    const article = articles.find(
+      (a): a is ShowcaseArticleShape =>
+        a != null && typeof a === "object" && (a as ShowcaseArticleShape).id === articleId,
+    );
+    if (!article) return fallback;
+
+    const title = typeof article.title === "string" ? article.title : fallback.title;
+    const contentHtml = typeof article.contentHtml === "string" ? article.contentHtml : "";
+    const plain = htmlToPlain(contentHtml);
+    const description = plain
+      ? truncate(plain, 280)
+      : `An article from ${fallback.title}.`;
+    const articleImage =
+      typeof article.imageUrl === "string" && article.imageUrl.length > 0
+        ? article.imageUrl
+        : fallback.imageUrl;
+
+    return {
+      title: `${title} — ${fallback.title}`,
+      description,
+      imageUrl: articleImage,
+      url: `https://${world.slug}.${env.HUB_ROOT_DOMAIN}/articles/${articleId}`,
+      type: "article",
+      siteName: "Arcanum Hub",
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+// ─── Rewriter ───────────────────────────────────────────────────────
+
+/**
+ * Entry point used by the Worker for every world-mode request that
+ * isn't `/showcase.json` or `/images/*`. Returns the original
+ * response unchanged when it isn't HTML or when the world isn't
+ * known (so SPA routes for unpublished slugs still render).
+ */
+export async function injectOgForWorld(
+  req: Request,
+  env: Env,
+  world: WorldRow,
+): Promise<Response> {
+  const response = await env.ASSETS.fetch(req);
+  const contentType = response.headers.get("Content-Type") ?? "";
+  if (!contentType.toLowerCase().includes("text/html")) return response;
+
+  const url = new URL(req.url);
+  const articleMatch = /^\/articles\/([a-zA-Z0-9_-]+)\/?$/.exec(url.pathname);
+  const meta = articleMatch && articleMatch[1]
+    ? await buildArticleMeta(env, world, articleMatch[1])
+    : buildWorldMeta(env, world);
+
+  return rewriteMeta(response, meta);
+}
+
+function rewriteMeta(response: Response, meta: OgMeta): Response {
+  const injected = buildMetaBlock(meta);
+
+  const rewriter = new HTMLRewriter()
+    // Replace <title> contents directly so tab titles and crawler
+    // fallbacks both pick up the world/article name.
+    .on("title", {
+      element(el) {
+        el.setInnerContent(escapeText(meta.title));
+      },
+    })
+    // Strip any pre-existing og:*, twitter:*, and description meta
+    // tags from the shipped index.html. The appended block below is
+    // authoritative so we don't end up with conflicting values.
+    .on('meta[name="description"]', {
+      element(el) {
+        el.remove();
+      },
+    })
+    .on('meta[property^="og:"]', {
+      element(el) {
+        el.remove();
+      },
+    })
+    .on('meta[name^="twitter:"]', {
+      element(el) {
+        el.remove();
+      },
+    })
+    .on("head", {
+      element(el) {
+        el.append(injected, { html: true });
+      },
+    });
+
+  // Build fresh headers — HTMLRewriter streams the body, and we want
+  // to bust any cache that might have stored the pre-rewrite bytes.
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", "public, max-age=60, s-maxage=300");
+  headers.delete("ETag");
+  headers.delete("Last-Modified");
+
+  return rewriter.transform(
+    new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    }),
+  );
+}
+
+function buildMetaBlock(meta: OgMeta): string {
+  const cardType = meta.imageUrl ? "summary_large_image" : "summary";
+  const parts: string[] = [
+    `<meta name="description" content="${escapeAttr(meta.description)}" />`,
+    `<meta property="og:site_name" content="${escapeAttr(meta.siteName)}" />`,
+    `<meta property="og:title" content="${escapeAttr(meta.title)}" />`,
+    `<meta property="og:description" content="${escapeAttr(meta.description)}" />`,
+    `<meta property="og:url" content="${escapeAttr(meta.url)}" />`,
+    `<meta property="og:type" content="${meta.type}" />`,
+    `<meta name="twitter:card" content="${cardType}" />`,
+    `<meta name="twitter:title" content="${escapeAttr(meta.title)}" />`,
+    `<meta name="twitter:description" content="${escapeAttr(meta.description)}" />`,
+  ];
+  if (meta.imageUrl) {
+    parts.push(`<meta property="og:image" content="${escapeAttr(meta.imageUrl)}" />`);
+    parts.push(`<meta name="twitter:image" content="${escapeAttr(meta.imageUrl)}" />`);
+  }
+  return parts.join("\n");
+}

--- a/hub-worker/src/schema.sql
+++ b/hub-worker/src/schema.sql
@@ -32,6 +32,15 @@ CREATE TABLE IF NOT EXISTS worlds (
   last_publish_at INTEGER,
   bytes_used INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL,
+  -- Discovery metadata (migration 0003). Populated server-side on
+  -- publish from the uploaded showcase.json.
+  article_count INTEGER NOT NULL DEFAULT 0,
+  map_count INTEGER NOT NULL DEFAULT 0,
+  image_count INTEGER NOT NULL DEFAULT 0,
+  cover_image_hash TEXT,
+  tags TEXT,
+  author_display_name TEXT,
+  description TEXT,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 

--- a/showcase/src/lib/hubMode.ts
+++ b/showcase/src/lib/hubMode.ts
@@ -43,6 +43,16 @@ export interface HubIndexWorld {
   tagline: string | null;
   lastPublishAt: number | null;
   url: string;
+  // Discovery metadata. Older rows that haven't been re-published
+  // since migration 0003 will have zeros / null / empty here — the
+  // landing page renders gracefully in that case.
+  articleCount: number;
+  mapCount: number;
+  imageCount: number;
+  coverImageUrl: string | null;
+  tags: string[];
+  authorDisplayName: string | null;
+  description: string | null;
 }
 
 export interface HubIndexResponse {

--- a/showcase/src/pages/HubIndexPage.tsx
+++ b/showcase/src/pages/HubIndexPage.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { fetchHubIndex, type HubIndexWorld } from "@/lib/hubMode";
 import { ShowcaseEmptyState } from "@/components/ShowcasePrimitives";
+
+type SortKey = "recent" | "alphabetical" | "content";
 
 function formatDate(ms: number | null): string {
   if (!ms) return "";
@@ -8,9 +10,19 @@ function formatDate(ms: number | null): string {
   return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 }
 
+function contentScore(w: HubIndexWorld): number {
+  // A loose "how much is in here" signal: articles count more than
+  // maps because a world with one illustrated article can be
+  // meaningful, while a world with nothing but maps usually isn't.
+  return w.articleCount * 2 + w.mapCount + Math.min(w.imageCount, 30) / 10;
+}
+
 export function HubIndexPage() {
   const [worlds, setWorlds] = useState<HubIndexWorld[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+  const [sort, setSort] = useState<SortKey>("recent");
 
   useEffect(() => {
     const controller = new AbortController();
@@ -22,6 +34,54 @@ export function HubIndexPage() {
       });
     return () => controller.abort();
   }, []);
+
+  // Aggregate tag universe for the filter chip bar. Sorted by
+  // frequency so the most broadly useful filters surface first,
+  // capped so we don't render a wall of chips on large hubs.
+  const topTags = useMemo(() => {
+    if (!worlds) return [] as { tag: string; count: number }[];
+    const counts = new Map<string, number>();
+    for (const w of worlds) {
+      for (const t of w.tags) {
+        const key = t.toLowerCase();
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+      }
+    }
+    return Array.from(counts.entries())
+      .map(([tag, count]) => ({ tag, count }))
+      .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+      .slice(0, 16);
+  }, [worlds]);
+
+  const filtered = useMemo(() => {
+    if (!worlds) return null;
+    const q = query.trim().toLowerCase();
+    const tagLower = activeTag?.toLowerCase() ?? null;
+    const out = worlds.filter((w) => {
+      if (tagLower && !w.tags.some((t) => t.toLowerCase() === tagLower)) return false;
+      if (!q) return true;
+      const haystack = [
+        w.displayName,
+        w.tagline ?? "",
+        w.description ?? "",
+        w.authorDisplayName ?? "",
+        w.slug,
+        w.tags.join(" "),
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+    const sorted = [...out];
+    if (sort === "alphabetical") {
+      sorted.sort((a, b) => a.displayName.localeCompare(b.displayName));
+    } else if (sort === "content") {
+      sorted.sort((a, b) => contentScore(b) - contentScore(a));
+    } else {
+      sorted.sort((a, b) => (b.lastPublishAt ?? 0) - (a.lastPublishAt ?? 0));
+    }
+    return sorted;
+  }, [worlds, query, activeTag, sort]);
 
   if (error) {
     return (
@@ -35,7 +95,7 @@ export function HubIndexPage() {
     );
   }
 
-  if (!worlds) {
+  if (!worlds || !filtered) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center px-6">
         <ShowcaseEmptyState
@@ -47,8 +107,11 @@ export function HubIndexPage() {
     );
   }
 
+  const totalWorlds = worlds.length;
+  const filterActive = query.trim().length > 0 || activeTag !== null;
+
   return (
-    <div className="mx-auto w-full max-w-5xl px-5 sm:px-8 py-12 sm:py-16">
+    <div className="mx-auto w-full max-w-6xl px-5 sm:px-8 py-12 sm:py-16">
       <header className="mb-10 text-center">
         <div className="text-[9px] uppercase tracking-[0.34em] text-text-muted/80">
           Arcanum
@@ -62,38 +125,196 @@ export function HubIndexPage() {
         </p>
       </header>
 
-      {worlds.length === 0 ? (
+      {totalWorlds > 0 && (
+        <div className="mb-8 space-y-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <div className="relative flex-1">
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search worlds, authors, tags…"
+                aria-label="Search worlds"
+                className="w-full rounded-xl border border-border-muted/50 bg-bg-elevated/40 px-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted/70 focus:border-accent/60 focus:outline-none focus:ring-1 focus:ring-accent/40"
+              />
+            </div>
+            <label className="flex items-center gap-2 text-2xs uppercase tracking-[0.24em] text-text-muted">
+              <span>Sort</span>
+              <select
+                value={sort}
+                onChange={(e) => setSort(e.target.value as SortKey)}
+                className="rounded-lg border border-border-muted/50 bg-bg-elevated/40 px-2.5 py-1.5 text-xs text-text-primary focus:border-accent/60 focus:outline-none"
+              >
+                <option value="recent">Recently published</option>
+                <option value="alphabetical">Alphabetical</option>
+                <option value="content">Most content</option>
+              </select>
+            </label>
+          </div>
+
+          {topTags.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-2xs uppercase tracking-[0.24em] text-text-muted/80 mr-1">
+                Tags
+              </span>
+              {topTags.map(({ tag, count }) => {
+                const active = activeTag?.toLowerCase() === tag;
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => setActiveTag(active ? null : tag)}
+                    className={
+                      active
+                        ? "rounded-full border border-accent/60 bg-accent/15 px-2.5 py-0.5 text-2xs text-accent"
+                        : "rounded-full border border-border-muted/40 bg-bg-elevated/30 px-2.5 py-0.5 text-2xs text-text-secondary hover:border-accent/40 hover:text-accent"
+                    }
+                  >
+                    {tag}
+                    <span className="ml-1 text-text-muted/70">{count}</span>
+                  </button>
+                );
+              })}
+              {activeTag && (
+                <button
+                  type="button"
+                  onClick={() => setActiveTag(null)}
+                  className="ml-1 text-2xs uppercase tracking-[0.24em] text-text-muted hover:text-accent"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+          )}
+
+          {filterActive && (
+            <div className="text-2xs uppercase tracking-[0.22em] text-text-muted">
+              {filtered.length} of {totalWorlds} worlds
+            </div>
+          )}
+        </div>
+      )}
+
+      {totalWorlds === 0 ? (
         <ShowcaseEmptyState
           className="mx-auto max-w-md"
           title="No worlds yet"
           description="Be the first to publish — run Arcanum and click 'Publish to Hub' in the toolbar."
         />
+      ) : filtered.length === 0 ? (
+        <ShowcaseEmptyState
+          className="mx-auto max-w-md"
+          title="Nothing matches"
+          description="Try a different search or clear the active tag."
+        />
       ) : (
-        <ul className="grid gap-5 sm:grid-cols-2">
-          {worlds.map((w) => (
-            <li
-              key={w.slug}
-              className="rounded-2xl border border-border-muted/50 bg-bg-elevated/40 p-6 transition hover:border-accent/40 hover:bg-bg-elevated/60"
-            >
-              <a href={w.url} className="block">
-                <div className="mb-2 text-[9px] uppercase tracking-[0.28em] text-text-muted">
-                  {formatDate(w.lastPublishAt)}
-                </div>
-                <h2 className="font-display text-xl tracking-[0.14em] uppercase text-[var(--color-aurum-pale)]">
-                  {w.displayName}
-                </h2>
-                {w.tagline && (
-                  <p className="mt-3 text-sm text-text-secondary leading-relaxed">
-                    {w.tagline}
-                  </p>
-                )}
-                <div className="mt-4 text-2xs text-text-muted">
-                  <code className="font-mono text-accent/70">{w.slug}.hub.arcanum.app</code>
-                </div>
-              </a>
+        <ul className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((w) => (
+            <li key={w.slug}>
+              <WorldCard world={w} onTagClick={setActiveTag} activeTag={activeTag} />
             </li>
           ))}
         </ul>
+      )}
+    </div>
+  );
+}
+
+// ─── Card ────────────────────────────────────────────────────────────
+
+interface WorldCardProps {
+  world: HubIndexWorld;
+  activeTag: string | null;
+  onTagClick: (tag: string) => void;
+}
+
+function WorldCard({ world: w, activeTag, onTagClick }: WorldCardProps) {
+  const displayTags = w.tags.slice(0, 4);
+  const remainingTagCount = Math.max(0, w.tags.length - displayTags.length);
+
+  return (
+    <div className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-border-muted/50 bg-bg-elevated/40 transition hover:border-accent/40 hover:bg-bg-elevated/60">
+      <a href={w.url} className="block" aria-label={`Open ${w.displayName}`}>
+        <div className="relative aspect-[16/9] overflow-hidden border-b border-border-muted/40 bg-bg-deep/60">
+          {w.coverImageUrl ? (
+            <img
+              src={w.coverImageUrl}
+              alt=""
+              loading="lazy"
+              className="h-full w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-bg-deep/60 to-bg-elevated/30">
+              <span className="font-display text-4xl tracking-[0.22em] uppercase text-[var(--color-aurum-pale)]/30">
+                {w.displayName.slice(0, 1)}
+              </span>
+            </div>
+          )}
+          {w.lastPublishAt && (
+            <div className="absolute left-3 top-3 rounded-full bg-bg-deep/70 px-2.5 py-0.5 text-[9px] uppercase tracking-[0.22em] text-text-muted backdrop-blur">
+              {formatDate(w.lastPublishAt)}
+            </div>
+          )}
+        </div>
+        <div className="p-5">
+          <h2 className="font-display text-lg tracking-[0.12em] uppercase text-[var(--color-aurum-pale)] leading-snug">
+            {w.displayName}
+          </h2>
+          {w.authorDisplayName && (
+            <div className="mt-1 text-2xs uppercase tracking-[0.22em] text-text-muted">
+              by {w.authorDisplayName}
+            </div>
+          )}
+          {(w.description || w.tagline) && (
+            <p className="mt-3 line-clamp-3 text-sm text-text-secondary leading-relaxed">
+              {w.description ?? w.tagline}
+            </p>
+          )}
+          <div className="mt-4 flex items-center gap-3 text-2xs uppercase tracking-[0.18em] text-text-muted">
+            {w.articleCount > 0 && (
+              <span>
+                <span className="text-text-primary">{w.articleCount}</span>{" "}
+                {w.articleCount === 1 ? "article" : "articles"}
+              </span>
+            )}
+            {w.mapCount > 0 && (
+              <span>
+                <span className="text-text-primary">{w.mapCount}</span>{" "}
+                {w.mapCount === 1 ? "map" : "maps"}
+              </span>
+            )}
+            {w.articleCount === 0 && w.mapCount === 0 && <span>published</span>}
+          </div>
+        </div>
+      </a>
+      {displayTags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 px-5 pb-5">
+          {displayTags.map((t) => {
+            const active = activeTag?.toLowerCase() === t.toLowerCase();
+            return (
+              <button
+                key={t}
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  onTagClick(t);
+                }}
+                className={
+                  active
+                    ? "rounded-full border border-accent/60 bg-accent/15 px-2 py-0.5 text-[10px] text-accent"
+                    : "rounded-full border border-border-muted/40 bg-bg-elevated/20 px-2 py-0.5 text-[10px] text-text-secondary hover:border-accent/40 hover:text-accent"
+                }
+              >
+                {t}
+              </button>
+            );
+          })}
+          {remainingTagCount > 0 && (
+            <span className="rounded-full border border-border-muted/30 bg-bg-elevated/20 px-2 py-0.5 text-[10px] text-text-muted">
+              +{remainingTagCount}
+            </span>
+          )}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Phases 1–3 of the Hub Discovery & Social Features plan. Turns the bare `arcanum-hub.com/` landing into a browsable directory and makes world URLs render proper link previews when shared.

### Phase 1 — Richer world metadata
- D1 migration **`0003_world_metadata.sql`** adds `article_count`, `map_count`, `image_count`, `cover_image_hash`, `tags`, `author_display_name`, and `description` to `worlds`.
- `hub-worker/src/metadata.ts` derives all of these from the uploaded `showcase.json` on every publish — the creator never sends them directly, so they can't drift from the actual content.
- `/api/index` returns the new fields plus a reconstructed `coverImageUrl`.

### Phase 2 — OpenGraph / Twitter meta injection
- `hub-worker/src/og.ts` streams `<slug>.arcanum-hub.com` HTML responses through `HTMLRewriter`, stripping stock meta and injecting per-world OG + Twitter tags.
- World root uses D1 metadata (fast). `/articles/<id>` fetches `showcase.json` once to resolve the article's title and primary image.
- `summary_large_image` when a cover exists, `summary` otherwise.

### Phase 3 — Search, filter, sort
- `HubIndexPage` redesigned: cover-art cards, article/map counts, author line, tag chips.
- Full-text search across title, tagline, description, author, slug, and tags.
- Frequency-ranked tag filter bar (top 16) with clickable chips on every card.
- Sort: recently published / alphabetical / most content.

### Out of scope (deferred)
Featured/trending flags, creator profiles, view analytics, and versioning — follow-up PRs.

## Deploy notes

1. **Apply the migration before deploying the worker:**
   ```
   cd hub-worker
   npx wrangler d1 execute arcanum-hub --remote --file=./src/migrations/0003_world_metadata.sql
   ```
2. **Deploy with `npm run deploy`** (not bare `wrangler deploy`) so the showcase bundle is rebuilt with `VITE_HUB_ROOT_DOMAIN`.
3. Worlds published before the migration show zero counts / null cover until their next publish — graceful fallback on both the landing cards and OG meta.

## Test plan
- [ ] Apply migration 0003 to remote D1; verify columns exist with expected defaults.
- [ ] Publish a world from the creator; confirm D1 row has non-zero counts, a `cover_image_hash`, tags JSON, and a description.
- [ ] Hit `api.arcanum-hub.com/index` and verify the new fields are present on each world.
- [ ] Load `arcanum-hub.com`; confirm cover-art cards, tag chips, search, and sort all work.
- [ ] Clear search + tag filter; confirm card count matches total worlds.
- [ ] `curl -A 'Discordbot' https://<slug>.arcanum-hub.com/` — inspect HTML for world-specific `og:title`, `og:description`, `og:image`.
- [ ] `curl -A 'Discordbot' https://<slug>.arcanum-hub.com/articles/<id>` — OG tags reflect the article, not the world root.
- [ ] Paste a world URL into Discord / Slack; confirm the preview renders with the cover image and description.
- [ ] `/showcase.json` and `/images/<hash>.webp` still respond correctly (HTMLRewriter only kicks in for `text/html`).