### PR TITLE
feat: balance simulation lab for Tuning Wizard

### DIFF
--- a/creator/package.json
+++ b/creator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arcanum",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "SEE LICENSE IN ../LICENSE.md",
   "type": "module",
   "scripts": {

--- a/creator/src-tauri/Cargo.lock
+++ b/creator/src-tauri/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "arcanum"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/creator/src-tauri/Cargo.toml
+++ b/creator/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arcanum"
-version = "2.4.0"
+version = "2.5.0"
 description = "Arcanum — world building, lore, and art generation tool"
 authors = []
 edition = "2021"

--- a/creator/src-tauri/tauri.conf.json
+++ b/creator/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/schema.json",
   "productName": "Arcanum",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "identifier": "dev.arcanum.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/creator/src/components/tuning/TuningWizard.tsx
+++ b/creator/src/components/tuning/TuningWizard.tsx
@@ -22,6 +22,7 @@ import { MetricSectionCards } from "./MetricSectionCards";
 import { ApplyFooterBar } from "./ApplyFooterBar";
 import { HealthCheckBanner } from "./HealthCheckBanner";
 import { ChartRow } from "./charts/ChartRow";
+import { SimulationLab } from "./simulations/SimulationLab";
 import { ActionButton, Spinner } from "@/components/ui/FormWidgets";
 import { useToastStore } from "@/stores/toastStore";
 import { usePrefersReducedMotion } from "@/lib/usePrefersReducedMotion";
@@ -293,6 +294,12 @@ export function TuningWizard() {
           presetMetrics={activePresetMetrics}
         />
       )}
+
+      {/* Simulation Lab — always visible, uses preset-merged config if active */}
+      <SimulationLab
+        activeConfig={presetConfig ?? config}
+        hasPresetSelected={selectedPresetId !== null}
+      />
 
       {/* Health check banner (D-08) -- after metric cards, before search */}
       <HealthCheckBanner />

--- a/creator/src/components/tuning/simulations/CombatSimulator.tsx
+++ b/creator/src/components/tuning/simulations/CombatSimulator.tsx
@@ -1,0 +1,170 @@
+// ─── Combat Encounter Simulator ────────────────────────────────────
+// Expected-value duel calculator: player vs mob at chosen level/tier.
+// Uses the same formulas as the Tuning Wizard metric snapshot.
+
+import { useMemo, useState } from "react";
+import type { AppConfig } from "@/types/config";
+import {
+  simulateEncounter,
+  tierForLevel,
+  TIER_KEYS,
+  TIER_LABELS,
+  type TierKey,
+} from "@/lib/tuning/simulations";
+
+interface CombatSimulatorProps {
+  config: AppConfig;
+}
+
+const VERDICT_STYLE: Record<string, { label: string; tone: string }> = {
+  easy: { label: "Easy", tone: "text-status-success" },
+  fair: { label: "Fair", tone: "text-warm" },
+  risky: { label: "Risky", tone: "text-status-warning" },
+  lethal: { label: "Lethal", tone: "text-status-error" },
+};
+
+export function CombatSimulator({ config }: CombatSimulatorProps) {
+  const classOptions = useMemo(
+    () =>
+      Object.entries(config.classes ?? {})
+        .filter(([, c]) => c.selectable !== false)
+        .map(([id, c]) => ({ id, name: c.displayName })),
+    [config.classes],
+  );
+
+  const [playerLevel, setPlayerLevel] = useState(10);
+  const [mobLevel, setMobLevel] = useState(10);
+  const [classId, setClassId] = useState<string>(classOptions[0]?.id ?? "");
+  const [tier, setTier] = useState<TierKey>(() => tierForLevel(config.mobTiers, 10));
+
+  const outcome = useMemo(
+    () =>
+      simulateEncounter(config, {
+        playerLevel,
+        classId: classId || undefined,
+        mobTier: tier,
+        mobLevel,
+      }),
+    [config, playerLevel, classId, tier, mobLevel],
+  );
+
+  const verdict = VERDICT_STYLE[outcome.verdict]!;
+  const hpPct = outcome.playerHp > 0 ? (outcome.playerHpRemaining / outcome.playerHp) * 100 : 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Inputs */}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          Player Lv
+          <input
+            type="number"
+            min={1}
+            max={config.progression.maxLevel || 50}
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={playerLevel}
+            onChange={(e) => setPlayerLevel(Math.max(1, Number(e.target.value) || 1))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          Class
+          <select
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={classId}
+            onChange={(e) => setClassId(e.target.value)}
+          >
+            <option value="">— default —</option>
+            {classOptions.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          Mob Tier
+          <select
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={tier}
+            onChange={(e) => setTier(e.target.value as TierKey)}
+          >
+            {TIER_KEYS.map((k) => (
+              <option key={k} value={k}>
+                {TIER_LABELS[k]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          Mob Lv
+          <input
+            type="number"
+            min={1}
+            max={config.progression.maxLevel || 50}
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={mobLevel}
+            onChange={(e) => setMobLevel(Math.max(1, Number(e.target.value) || 1))}
+          />
+        </label>
+      </div>
+
+      {/* Verdict headline */}
+      <div className="flex items-baseline justify-between gap-3 rounded-lg border border-border-muted bg-bg-secondary/40 px-4 py-3">
+        <div>
+          <p className="font-display text-[12px] uppercase tracking-wider text-text-muted">
+            Encounter Verdict
+          </p>
+          <p className={`font-display text-2xl tracking-wide ${verdict.tone}`}>{verdict.label}</p>
+        </div>
+        <div className="text-right font-mono text-xs text-text-secondary">
+          <p>{outcome.turnsToKill} rounds to kill</p>
+          <p>{outcome.turnsToDie === Number.MAX_SAFE_INTEGER ? "∞" : outcome.turnsToDie} rounds to die</p>
+        </div>
+      </div>
+
+      {/* Numbers */}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <StatTile label="Player HP" value={`${outcome.playerHpRemaining} / ${outcome.playerHp}`} />
+        <StatTile label="Mob HP" value={String(outcome.mobHp)} />
+        <StatTile label="Your dmg / round" value={String(outcome.playerDmgPerRound)} />
+        <StatTile label="Mob dmg / round" value={String(outcome.mobDmgPerRound)} />
+        <StatTile label="Dodge" value={`${outcome.dodgePercent}%`} />
+        <StatTile
+          label="Survived"
+          value={outcome.playerWins ? "Yes" : "No"}
+          tone={outcome.playerWins ? "text-status-success" : "text-status-error"}
+        />
+      </div>
+
+      {/* HP bar after kill */}
+      <div>
+        <p className="mb-1 text-2xs uppercase tracking-wider text-text-muted">
+          Expected HP remaining after kill
+        </p>
+        <div className="h-2 overflow-hidden rounded-full bg-bg-secondary/60">
+          <div
+            className="h-full bg-warm transition-[width] duration-300"
+            style={{ width: `${Math.max(0, Math.min(100, hpPct))}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  tone = "text-text-primary",
+}: {
+  label: string;
+  value: string;
+  tone?: string;
+}) {
+  return (
+    <div className="rounded-md border border-border-muted bg-bg-primary/40 px-3 py-2">
+      <p className="text-2xs uppercase tracking-wider text-text-muted">{label}</p>
+      <p className={`font-mono text-sm ${tone}`}>{value}</p>
+    </div>
+  );
+}

--- a/creator/src/components/tuning/simulations/CraftingSimulator.tsx
+++ b/creator/src/components/tuning/simulations/CraftingSimulator.tsx
@@ -1,0 +1,197 @@
+// ─── Crafting Viability Analyzer ───────────────────────────────────
+// For every recipe in the loaded zones, checks whether its materials
+// have sourcing gathering nodes, estimates gather time, and compares
+// material value to output price.
+
+import { useMemo, useState } from "react";
+import type { AppConfig } from "@/types/config";
+import { useZoneStore } from "@/stores/zoneStore";
+import {
+  analyzeCraftingViability,
+  type CraftingViabilityRow,
+} from "@/lib/tuning/simulations";
+
+interface CraftingSimulatorProps {
+  config: AppConfig;
+}
+
+type SortKey = "displayName" | "estimatedGatherSeconds" | "netValue" | "xpPerMinute";
+
+export function CraftingSimulator({ config }: CraftingSimulatorProps) {
+  const zones = useZoneStore((s) => s.zones);
+  const [hideUnsourced, setHideUnsourced] = useState(false);
+  const [sortKey, setSortKey] = useState<SortKey>("netValue");
+
+  const rows = useMemo(
+    () => analyzeCraftingViability(config, zones),
+    [config, zones],
+  );
+
+  const filtered = useMemo(() => {
+    let list = rows;
+    if (hideUnsourced) list = list.filter((r) => r.materialsSourced);
+    list = [...list].sort((a, b) => compareRows(a, b, sortKey));
+    return list;
+  }, [rows, hideUnsourced, sortKey]);
+
+  const stats = useMemo(() => {
+    const total = rows.length;
+    const sourced = rows.filter((r) => r.materialsSourced).length;
+    const profitable = rows.filter((r) => r.netValue > 0).length;
+    return { total, sourced, profitable };
+  }, [rows]);
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-md border border-border-muted bg-bg-secondary/40 px-4 py-6 text-center text-sm text-text-muted">
+        No recipes found in the loaded zones.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <HeadlineTile label="Recipes" value={String(stats.total)} />
+        <HeadlineTile
+          label="Fully sourced"
+          value={`${stats.sourced} / ${stats.total}`}
+          tone={stats.sourced === stats.total ? "text-status-success" : "text-warm"}
+        />
+        <HeadlineTile
+          label="Profitable to craft & sell"
+          value={`${stats.profitable} / ${stats.total}`}
+          tone={stats.profitable > 0 ? "text-status-success" : "text-text-muted"}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <label className="flex items-center gap-2 text-xs text-text-secondary">
+          <input
+            type="checkbox"
+            checked={hideUnsourced}
+            onChange={(e) => setHideUnsourced(e.target.checked)}
+            className="accent-accent"
+          />
+          Hide recipes with missing materials
+        </label>
+        <label className="flex items-center gap-2 text-xs text-text-secondary">
+          Sort by
+          <select
+            className="ornate-input px-2 py-0.5 text-xs"
+            value={sortKey}
+            onChange={(e) => setSortKey(e.target.value as SortKey)}
+          >
+            <option value="displayName">Name</option>
+            <option value="estimatedGatherSeconds">Gather time</option>
+            <option value="netValue">Net value</option>
+            <option value="xpPerMinute">XP / minute</option>
+          </select>
+        </label>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border border-border-muted">
+        <table className="w-full min-w-[640px] text-xs">
+          <thead className="bg-bg-secondary/60 text-text-muted">
+            <tr>
+              <th className="px-3 py-2 text-left font-normal uppercase tracking-wider">
+                Recipe
+              </th>
+              <th className="px-3 py-2 text-left font-normal uppercase tracking-wider">
+                Zone
+              </th>
+              <th className="px-3 py-2 text-right font-normal uppercase tracking-wider">
+                Gather
+              </th>
+              <th className="px-3 py-2 text-right font-normal uppercase tracking-wider">
+                Mat Value
+              </th>
+              <th className="px-3 py-2 text-right font-normal uppercase tracking-wider">
+                Output
+              </th>
+              <th className="px-3 py-2 text-right font-normal uppercase tracking-wider">
+                Net
+              </th>
+              <th className="px-3 py-2 text-right font-normal uppercase tracking-wider">
+                XP/min
+              </th>
+              <th className="px-3 py-2 text-left font-normal uppercase tracking-wider">
+                Missing
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((row) => (
+              <tr
+                key={`${row.zoneId}/${row.recipeId}`}
+                className={`border-t border-border-muted ${
+                  row.materialsSourced ? "" : "bg-status-error/5"
+                }`}
+              >
+                <td className="px-3 py-2 text-text-primary">{row.displayName}</td>
+                <td className="px-3 py-2 text-text-muted">{row.zoneId}</td>
+                <td className="px-3 py-2 text-right font-mono text-text-secondary">
+                  {formatSeconds(row.estimatedGatherSeconds)}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-text-secondary">
+                  {row.materialValue}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-text-secondary">
+                  {row.outputValue}
+                </td>
+                <td
+                  className={`px-3 py-2 text-right font-mono ${
+                    row.netValue > 0
+                      ? "text-status-success"
+                      : row.netValue < 0
+                        ? "text-status-error"
+                        : "text-text-muted"
+                  }`}
+                >
+                  {row.netValue > 0 ? "+" : ""}
+                  {row.netValue}
+                </td>
+                <td className="px-3 py-2 text-right font-mono text-text-secondary">
+                  {row.xpPerMinute.toFixed(1)}
+                </td>
+                <td className="px-3 py-2 text-status-error">
+                  {row.missingMaterialIds.join(", ")}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function compareRows(a: CraftingViabilityRow, b: CraftingViabilityRow, key: SortKey): number {
+  if (key === "displayName") return a.displayName.localeCompare(b.displayName);
+  // Numeric keys — descending
+  return (b[key] as number) - (a[key] as number);
+}
+
+function formatSeconds(s: number): string {
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return rem ? `${m}m ${rem}s` : `${m}m`;
+}
+
+function HeadlineTile({
+  label,
+  value,
+  tone = "text-text-primary",
+}: {
+  label: string;
+  value: string;
+  tone?: string;
+}) {
+  return (
+    <div className="rounded-md border border-border-muted bg-bg-primary/40 px-4 py-3">
+      <p className="text-2xs uppercase tracking-wider text-text-muted">{label}</p>
+      <p className={`font-display text-xl ${tone}`}>{value}</p>
+    </div>
+  );
+}

--- a/creator/src/components/tuning/simulations/EconomySimulator.tsx
+++ b/creator/src/components/tuning/simulations/EconomySimulator.tsx
@@ -1,0 +1,207 @@
+// ─── Economy Flow Simulator ────────────────────────────────────────
+// Gold-in vs gold-out at a given level. Shows tier-weighted income,
+// shop revenue, and sink spend as an at-a-glance waterfall.
+
+import { useMemo, useState } from "react";
+import type { AppConfig } from "@/types/config";
+import {
+  simulateEconomy,
+  TIER_KEYS,
+  TIER_LABELS,
+  type TierKey,
+} from "@/lib/tuning/simulations";
+
+interface EconomySimulatorProps {
+  config: AppConfig;
+}
+
+const DEFAULT_MIX: Record<TierKey, number> = {
+  weak: 0.4,
+  standard: 0.4,
+  elite: 0.15,
+  boss: 0.05,
+};
+
+export function EconomySimulator({ config }: EconomySimulatorProps) {
+  const [level, setLevel] = useState(10);
+  const [killsPerHour, setKillsPerHour] = useState(60);
+  const [mix, setMix] = useState<Record<TierKey, number>>(DEFAULT_MIX);
+  const [sellRate, setSellRate] = useState(0.5);
+  const [consumableSpend, setConsumableSpend] = useState(50);
+  const [gamblingStake, setGamblingStake] = useState(0);
+
+  const outcome = useMemo(
+    () =>
+      simulateEconomy(config, {
+        level,
+        killsPerHour,
+        tierMix: mix,
+        sellRate,
+        consumableSpendPerHour: consumableSpend,
+        gamblingStakePerHour: gamblingStake,
+      }),
+    [config, level, killsPerHour, mix, sellRate, consumableSpend, gamblingStake],
+  );
+
+  const maxBar = Math.max(
+    ...outcome.breakdown.map((b) => b.goldPerHour),
+    Math.abs(outcome.goldPerHour) || 1,
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Primary inputs */}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          Player Lv
+          <input
+            type="number"
+            min={1}
+            max={config.progression.maxLevel || 50}
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={level}
+            onChange={(e) => setLevel(Math.max(1, Number(e.target.value) || 1))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          Kills / hour
+          <input
+            type="number"
+            min={0}
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={killsPerHour}
+            onChange={(e) => setKillsPerHour(Math.max(0, Number(e.target.value) || 0))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          Sell rate (0–1)
+          <input
+            type="number"
+            min={0}
+            max={1}
+            step={0.05}
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={sellRate}
+            onChange={(e) => setSellRate(Math.max(0, Math.min(1, Number(e.target.value) || 0)))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          Consumables / hr
+          <input
+            type="number"
+            min={0}
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={consumableSpend}
+            onChange={(e) => setConsumableSpend(Math.max(0, Number(e.target.value) || 0))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted md:col-span-1">
+          Gambling stake / hr
+          <input
+            type="number"
+            min={0}
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={gamblingStake}
+            onChange={(e) => setGamblingStake(Math.max(0, Number(e.target.value) || 0))}
+          />
+        </label>
+      </div>
+
+      {/* Tier mix sliders */}
+      <div>
+        <p className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
+          Kill mix (will be normalised)
+        </p>
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {TIER_KEYS.map((k) => (
+            <label key={k} className="flex flex-col gap-1 text-xs text-text-secondary">
+              <span className="flex justify-between">
+                <span>{TIER_LABELS[k]}</span>
+                <span className="font-mono text-text-muted">
+                  {Math.round(outcome.normalisedMix[k] * 100)}%
+                </span>
+              </span>
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={mix[k]}
+                onChange={(e) =>
+                  setMix({ ...mix, [k]: Number(e.target.value) })
+                }
+                className="accent-accent"
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Headline numbers */}
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <HeadlineTile
+          label="Gold / hour"
+          value={outcome.goldPerHour.toString()}
+          tone={outcome.goldPerHour >= 0 ? "text-status-success" : "text-status-error"}
+        />
+        <HeadlineTile label="XP / hour" value={outcome.xpPerHour.toLocaleString()} />
+        <HeadlineTile
+          label="Hours to next level"
+          value={
+            Number.isFinite(outcome.timeToNextLevelHours)
+              ? outcome.timeToNextLevelHours.toFixed(2)
+              : "∞"
+          }
+        />
+      </div>
+
+      {/* Waterfall breakdown */}
+      <div>
+        <p className="mb-2 text-2xs uppercase tracking-wider text-text-muted">Breakdown</p>
+        <div className="flex flex-col gap-2">
+          {outcome.breakdown.map((b) => {
+            const pct = (b.goldPerHour / maxBar) * 100;
+            return (
+              <div key={b.source} className="flex items-center gap-3">
+                <span className="w-44 text-xs text-text-secondary">{b.source}</span>
+                <div className="h-2 flex-1 overflow-hidden rounded-full bg-bg-secondary/60">
+                  <div
+                    className={`h-full ${
+                      b.sign === "in" ? "bg-status-success/70" : "bg-status-error/70"
+                    }`}
+                    style={{ width: `${Math.max(2, Math.min(100, pct))}%` }}
+                  />
+                </div>
+                <span
+                  className={`w-20 text-right font-mono text-xs ${
+                    b.sign === "in" ? "text-status-success" : "text-status-error"
+                  }`}
+                >
+                  {b.sign === "in" ? "+" : "-"}
+                  {b.goldPerHour}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HeadlineTile({
+  label,
+  value,
+  tone = "text-text-primary",
+}: {
+  label: string;
+  value: string;
+  tone?: string;
+}) {
+  return (
+    <div className="rounded-md border border-border-muted bg-bg-primary/40 px-4 py-3">
+      <p className="text-2xs uppercase tracking-wider text-text-muted">{label}</p>
+      <p className={`font-display text-xl ${tone}`}>{value}</p>
+    </div>
+  );
+}

--- a/creator/src/components/tuning/simulations/ProgressionSimulator.tsx
+++ b/creator/src/components/tuning/simulations/ProgressionSimulator.tsx
@@ -1,0 +1,140 @@
+// ─── Progression Pacing Simulator ──────────────────────────────────
+// Given an XP/hour rate, show cumulative hours to reach each level
+// across the chosen level range. Flags the single slowest level.
+
+import { useMemo, useState } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import type { AppConfig } from "@/types/config";
+import { simulateProgression } from "@/lib/tuning/simulations";
+import { CHART_COLORS } from "@/lib/tuning/chartColors";
+import { usePrefersReducedMotion } from "@/lib/usePrefersReducedMotion";
+
+interface ProgressionSimulatorProps {
+  config: AppConfig;
+}
+
+const TICK_STYLE = {
+  fill: CHART_COLORS.axisText,
+  fontSize: 12,
+  fontFamily: "'Crimson Pro', Georgia, serif",
+};
+
+export function ProgressionSimulator({ config }: ProgressionSimulatorProps) {
+  const maxLevel = config.progression.maxLevel || 50;
+  const [startLevel, setStartLevel] = useState(1);
+  const [endLevel, setEndLevel] = useState(Math.min(maxLevel, 30));
+  const [xpPerHour, setXpPerHour] = useState(2000);
+
+  const outcome = useMemo(
+    () => simulateProgression(config, { startLevel, endLevel, xpPerHour }),
+    [config, startLevel, endLevel, xpPerHour],
+  );
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  const chartData = outcome.points.map((p) => ({
+    level: p.level,
+    hours: p.cumulativeHours,
+    xp: p.xpForLevel,
+  }));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          Start Lv
+          <input
+            type="number"
+            min={1}
+            max={maxLevel}
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={startLevel}
+            onChange={(e) => setStartLevel(Math.max(1, Number(e.target.value) || 1))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          End Lv
+          <input
+            type="number"
+            min={1}
+            max={maxLevel}
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={endLevel}
+            onChange={(e) => setEndLevel(Math.max(1, Number(e.target.value) || 1))}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-2xs uppercase tracking-wider text-text-muted">
+          XP / hour
+          <input
+            type="number"
+            min={1}
+            className="ornate-input px-2 py-1 text-sm text-text-primary"
+            value={xpPerHour}
+            onChange={(e) => setXpPerHour(Math.max(1, Number(e.target.value) || 1))}
+          />
+        </label>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <HeadlineTile label="Total XP" value={outcome.totalXp.toLocaleString()} />
+        <HeadlineTile label="Total hours" value={outcome.totalHours.toFixed(1)} />
+        <HeadlineTile
+          label="Slowest level"
+          value={`Lv ${outcome.slowestLevel} · ${outcome.slowestLevelHours.toFixed(1)}h`}
+        />
+      </div>
+
+      <div className="panel-surface rounded-[1.5rem] p-4">
+        <h3 className="mb-2 font-display text-[14px] font-normal uppercase tracking-[0.5px] text-text-secondary">
+          Cumulative Hours to Level
+        </h3>
+        <ResponsiveContainer width="100%" height={220}>
+          <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 10 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke={CHART_COLORS.grid} />
+            <XAxis dataKey="level" tick={TICK_STYLE} stroke={CHART_COLORS.axisLine} />
+            <YAxis tick={TICK_STYLE} stroke={CHART_COLORS.axisLine} />
+            <Tooltip />
+            <Legend />
+            <Line
+              type="monotone"
+              dataKey="hours"
+              name="Cumulative Hours"
+              stroke={CHART_COLORS.presetSeries}
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={!prefersReducedMotion}
+              animationDuration={300}
+            />
+            <Line
+              type="monotone"
+              dataKey="xp"
+              name="XP This Level"
+              stroke={CHART_COLORS.currentSeries}
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={!prefersReducedMotion}
+              animationDuration={300}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+function HeadlineTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border-muted bg-bg-primary/40 px-4 py-3">
+      <p className="text-2xs uppercase tracking-wider text-text-muted">{label}</p>
+      <p className="font-display text-xl text-text-primary">{value}</p>
+    </div>
+  );
+}

--- a/creator/src/components/tuning/simulations/SimulationLab.tsx
+++ b/creator/src/components/tuning/simulations/SimulationLab.tsx
@@ -1,0 +1,89 @@
+// ─── Simulation Lab ────────────────────────────────────────────────
+// Tabbed "what-if" workspace sitting below the Tuning Wizard charts.
+// Four simulators share the active (merged) config so designers can
+// preview balance changes without applying the preset.
+
+import { useState } from "react";
+import type { AppConfig } from "@/types/config";
+import { CombatSimulator } from "./CombatSimulator";
+import { EconomySimulator } from "./EconomySimulator";
+import { ProgressionSimulator } from "./ProgressionSimulator";
+import { CraftingSimulator } from "./CraftingSimulator";
+
+type SimTab = "combat" | "economy" | "progression" | "crafting";
+
+const TABS: Array<{ id: SimTab; label: string; blurb: string }> = [
+  { id: "combat", label: "Combat", blurb: "Player vs mob expected outcome" },
+  { id: "economy", label: "Economy", blurb: "Gold in vs out per hour" },
+  { id: "progression", label: "Progression", blurb: "Hours to reach each level" },
+  { id: "crafting", label: "Crafting", blurb: "Recipe viability & gather time" },
+];
+
+interface SimulationLabProps {
+  /** Preset-merged config if a preset is selected, else current config. */
+  activeConfig: AppConfig;
+  /** Whether a preset is currently highlighted. */
+  hasPresetSelected: boolean;
+}
+
+export function SimulationLab({ activeConfig, hasPresetSelected }: SimulationLabProps) {
+  const [tab, setTab] = useState<SimTab>("combat");
+
+  return (
+    <section className="animate-unfurl-in mx-auto mb-6 w-full max-w-6xl px-6">
+      <div className="panel-surface rounded-[1.5rem] p-5">
+        <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+          <div>
+            <h3 className="font-display text-[14px] font-normal uppercase tracking-[0.5px] text-text-secondary">
+              Simulation Lab
+            </h3>
+            <p className="mt-1 text-xs text-text-muted">
+              {hasPresetSelected
+                ? "Running against the selected preset's merged configuration."
+                : "Running against your current configuration."}
+            </p>
+          </div>
+        </div>
+
+        {/* Tab bar */}
+        <div
+          role="tablist"
+          aria-label="Simulation type"
+          className="mb-4 flex flex-wrap gap-1 border-b border-border-muted"
+        >
+          {TABS.map((t) => {
+            const active = t.id === tab;
+            return (
+              <button
+                key={t.id}
+                role="tab"
+                aria-selected={active}
+                onClick={() => setTab(t.id)}
+                className={`group relative -mb-px border-b-2 px-4 py-2 text-left text-xs transition-colors ${
+                  active
+                    ? "border-accent text-accent"
+                    : "border-transparent text-text-muted hover:text-text-secondary"
+                }`}
+              >
+                <span className="block font-display text-[13px] uppercase tracking-wider">
+                  {t.label}
+                </span>
+                <span className="block text-2xs text-text-muted group-hover:text-text-secondary">
+                  {t.blurb}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Active simulator */}
+        <div role="tabpanel">
+          {tab === "combat" && <CombatSimulator config={activeConfig} />}
+          {tab === "economy" && <EconomySimulator config={activeConfig} />}
+          {tab === "progression" && <ProgressionSimulator config={activeConfig} />}
+          {tab === "crafting" && <CraftingSimulator config={activeConfig} />}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/creator/src/lib/tuning/__tests__/simulations.test.ts
+++ b/creator/src/lib/tuning/__tests__/simulations.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect } from "vitest";
+import {
+  simulateEncounter,
+  simulateEconomy,
+  simulateProgression,
+  analyzeCraftingViability,
+  tierForLevel,
+} from "@/lib/tuning/simulations";
+import type { AppConfig } from "@/types/config";
+import type { WorldFile } from "@/types/world";
+
+// ─── Shared mock config ────────────────────────────────────────────
+
+const MOCK_CONFIG = {
+  progression: {
+    maxLevel: 50,
+    xp: { baseXp: 100, exponent: 2.0, linearXp: 0, multiplier: 1.0, defaultKillXp: 10 },
+    rewards: {
+      hpPerLevel: 4,
+      manaPerLevel: 3,
+      fullHealOnLevelUp: true,
+      fullManaOnLevelUp: true,
+      baseHp: 30,
+      baseMana: 30,
+    },
+  },
+  combat: {
+    maxCombatsPerTick: 10,
+    tickMillis: 1000,
+    minDamage: 2,
+    maxDamage: 4,
+    feedback: { enabled: true, roomBroadcastEnabled: true },
+  },
+  mobTiers: {
+    weak: {
+      baseHp: 10, hpPerLevel: 3,
+      baseMinDamage: 1, baseMaxDamage: 2, damagePerLevel: 0,
+      baseArmor: 0, baseXpReward: 15, xpRewardPerLevel: 5,
+      baseGoldMin: 1, baseGoldMax: 3, goldPerLevel: 1,
+    },
+    standard: {
+      baseHp: 20, hpPerLevel: 5,
+      baseMinDamage: 2, baseMaxDamage: 4, damagePerLevel: 1,
+      baseArmor: 1, baseXpReward: 30, xpRewardPerLevel: 10,
+      baseGoldMin: 3, baseGoldMax: 8, goldPerLevel: 2,
+    },
+    elite: {
+      baseHp: 40, hpPerLevel: 8,
+      baseMinDamage: 3, baseMaxDamage: 6, damagePerLevel: 1,
+      baseArmor: 2, baseXpReward: 75, xpRewardPerLevel: 25,
+      baseGoldMin: 10, baseGoldMax: 25, goldPerLevel: 5,
+    },
+    boss: {
+      baseHp: 80, hpPerLevel: 15,
+      baseMinDamage: 6, baseMaxDamage: 12, damagePerLevel: 2,
+      baseArmor: 4, baseXpReward: 200, xpRewardPerLevel: 50,
+      baseGoldMin: 30, baseGoldMax: 80, goldPerLevel: 15,
+    },
+  },
+  stats: {
+    definitions: {},
+    bindings: {
+      meleeDamageStat: "str", meleeDamageDivisor: 3,
+      dodgeStat: "dex", dodgePerPoint: 0.5, maxDodgePercent: 30,
+      spellDamageStat: "int", spellDamageDivisor: 3,
+      hpScalingStat: "con", hpScalingDivisor: 5,
+      manaScalingStat: "int", manaScalingDivisor: 5,
+      hpRegenStat: "con", hpRegenMsPerPoint: 200,
+      manaRegenStat: "int", manaRegenMsPerPoint: 200,
+      xpBonusStat: "wis", xpBonusPerPoint: 1,
+    },
+  },
+  regen: {
+    maxPlayersPerTick: 10,
+    baseIntervalMillis: 5000,
+    minIntervalMillis: 1000,
+    regenAmount: 1,
+    mana: { baseIntervalMillis: 5000, minIntervalMillis: 1000, regenAmount: 1 },
+  },
+  economy: { buyMultiplier: 1.2, sellMultiplier: 0.6 },
+  crafting: {
+    maxSkillLevel: 50,
+    baseXpPerLevel: 80,
+    xpExponent: 1.3,
+    gatherCooldownMs: 2000,
+    stationBonusQuantity: 1,
+  },
+  classes: {
+    warrior: {
+      displayName: "Warrior",
+      hpPerLevel: 6,
+      manaPerLevel: 2,
+      selectable: true,
+    },
+  },
+} as unknown as AppConfig;
+
+// ─── simulateEncounter ─────────────────────────────────────────────
+
+describe("simulateEncounter", () => {
+  it("produces a complete outcome", () => {
+    const r = simulateEncounter(MOCK_CONFIG, {
+      playerLevel: 10,
+      mobTier: "standard",
+      mobLevel: 10,
+    });
+    expect(r.turnsToKill).toBeGreaterThan(0);
+    expect(r.playerHp).toBeGreaterThan(0);
+    expect(r.mobHp).toBeGreaterThan(0);
+    expect(["easy", "fair", "risky", "lethal"]).toContain(r.verdict);
+  });
+
+  it("is 'lethal' when facing a much higher-level boss", () => {
+    const r = simulateEncounter(MOCK_CONFIG, {
+      playerLevel: 5,
+      mobTier: "boss",
+      mobLevel: 30,
+    });
+    expect(r.verdict).toBe("lethal");
+    expect(r.playerWins).toBe(false);
+  });
+
+  it("uses class hpPerLevel when classId is supplied", () => {
+    const r1 = simulateEncounter(MOCK_CONFIG, {
+      playerLevel: 10,
+      mobTier: "standard",
+      mobLevel: 10,
+    });
+    const r2 = simulateEncounter(MOCK_CONFIG, {
+      playerLevel: 10,
+      classId: "warrior",
+      mobTier: "standard",
+      mobLevel: 10,
+    });
+    // Warrior has 6 hpPerLevel vs default 3 → strictly more HP
+    expect(r2.playerHp).toBeGreaterThan(r1.playerHp);
+  });
+
+  it("treats empty classId the same as undefined", () => {
+    const r1 = simulateEncounter(MOCK_CONFIG, {
+      playerLevel: 10,
+      mobTier: "standard",
+      mobLevel: 10,
+    });
+    const r2 = simulateEncounter(MOCK_CONFIG, {
+      playerLevel: 10,
+      classId: "",
+      mobTier: "standard",
+      mobLevel: 10,
+    });
+    expect(r1.playerHp).toBe(r2.playerHp);
+  });
+});
+
+// ─── simulateEconomy ───────────────────────────────────────────────
+
+describe("simulateEconomy", () => {
+  it("normalises tier mix that does not sum to 1", () => {
+    const r = simulateEconomy(MOCK_CONFIG, {
+      level: 10,
+      killsPerHour: 60,
+      tierMix: { weak: 2, standard: 2, elite: 1, boss: 0 },
+      sellRate: 0.5,
+      consumableSpendPerHour: 0,
+    });
+    const sum = Object.values(r.normalisedMix).reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1, 5);
+  });
+
+  it("yields zero income when killsPerHour is 0", () => {
+    const r = simulateEconomy(MOCK_CONFIG, {
+      level: 10,
+      killsPerHour: 0,
+      tierMix: { weak: 1, standard: 0, elite: 0, boss: 0 },
+      sellRate: 0.5,
+      consumableSpendPerHour: 0,
+    });
+    expect(r.xpPerHour).toBe(0);
+    expect(r.goldPerHour).toBeLessThanOrEqual(0);
+    expect(r.timeToNextLevelHours).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("subtracts gambling stake from goldPerHour", () => {
+    const base = simulateEconomy(MOCK_CONFIG, {
+      level: 10,
+      killsPerHour: 60,
+      tierMix: { weak: 1, standard: 0, elite: 0, boss: 0 },
+      sellRate: 0.5,
+      consumableSpendPerHour: 0,
+    });
+    const withStake = simulateEconomy(MOCK_CONFIG, {
+      level: 10,
+      killsPerHour: 60,
+      tierMix: { weak: 1, standard: 0, elite: 0, boss: 0 },
+      sellRate: 0.5,
+      consumableSpendPerHour: 0,
+      gamblingStakePerHour: 50,
+    });
+    expect(withStake.goldPerHour).toBe(base.goldPerHour - 50);
+  });
+
+  it("higher sellMultiplier produces more gold from shop sales", () => {
+    const lowMult = simulateEconomy(
+      { ...MOCK_CONFIG, economy: { buyMultiplier: 1, sellMultiplier: 0.2 } } as AppConfig,
+      {
+        level: 10,
+        killsPerHour: 100,
+        tierMix: { weak: 1, standard: 0, elite: 0, boss: 0 },
+        sellRate: 1,
+        consumableSpendPerHour: 0,
+      },
+    );
+    const highMult = simulateEconomy(
+      { ...MOCK_CONFIG, economy: { buyMultiplier: 1, sellMultiplier: 0.9 } } as AppConfig,
+      {
+        level: 10,
+        killsPerHour: 100,
+        tierMix: { weak: 1, standard: 0, elite: 0, boss: 0 },
+        sellRate: 1,
+        consumableSpendPerHour: 0,
+      },
+    );
+    expect(highMult.goldPerHour).toBeGreaterThan(lowMult.goldPerHour);
+  });
+});
+
+// ─── simulateProgression ───────────────────────────────────────────
+
+describe("simulateProgression", () => {
+  it("produces one point per level in range inclusive", () => {
+    const r = simulateProgression(MOCK_CONFIG, {
+      startLevel: 1,
+      endLevel: 10,
+      xpPerHour: 1000,
+    });
+    expect(r.points).toHaveLength(10);
+    expect(r.points[0]!.level).toBe(1);
+    expect(r.points[9]!.level).toBe(10);
+  });
+
+  it("cumulative hours are monotonically non-decreasing", () => {
+    const r = simulateProgression(MOCK_CONFIG, {
+      startLevel: 1,
+      endLevel: 20,
+      xpPerHour: 1000,
+    });
+    for (let i = 1; i < r.points.length; i++) {
+      expect(r.points[i]!.cumulativeHours).toBeGreaterThanOrEqual(
+        r.points[i - 1]!.cumulativeHours,
+      );
+    }
+  });
+
+  it("identifies slowest level as the highest level in a steep curve", () => {
+    const r = simulateProgression(MOCK_CONFIG, {
+      startLevel: 1,
+      endLevel: 30,
+      xpPerHour: 1000,
+    });
+    // Quadratic curve — slowest level should be near the end
+    expect(r.slowestLevel).toBe(30);
+  });
+
+  it("handles reversed start/end by swapping", () => {
+    const r = simulateProgression(MOCK_CONFIG, {
+      startLevel: 10,
+      endLevel: 1,
+      xpPerHour: 1000,
+    });
+    expect(r.points[0]!.level).toBe(1);
+    expect(r.points[r.points.length - 1]!.level).toBe(10);
+  });
+});
+
+// ─── analyzeCraftingViability ──────────────────────────────────────
+
+describe("analyzeCraftingViability", () => {
+  const makeZone = (): Map<string, { data: WorldFile }> => {
+    const world: WorldFile = {
+      zone: "test",
+      startRoom: "r1",
+      rooms: { r1: { title: "R1", description: "desc" } },
+      items: {
+        iron_ore: { displayName: "Iron Ore", basePrice: 10 },
+        iron_sword: { displayName: "Iron Sword", basePrice: 120 },
+        pearl: { displayName: "Pearl", basePrice: 80 },
+      },
+      gatheringNodes: {
+        iron_vein: {
+          displayName: "Iron Vein",
+          skill: "mining",
+          yields: [{ itemId: "iron_ore", minQuantity: 1, maxQuantity: 3 }],
+          room: "r1",
+        },
+      },
+      recipes: {
+        craft_iron_sword: {
+          displayName: "Craft Iron Sword",
+          skill: "smithing",
+          materials: [{ itemId: "iron_ore", quantity: 4 }],
+          outputItemId: "iron_sword",
+          outputQuantity: 1,
+          xpReward: 50,
+        },
+        craft_pearl_necklace: {
+          displayName: "Craft Pearl Necklace",
+          skill: "jewelcrafting",
+          materials: [{ itemId: "pearl", quantity: 2 }],
+          outputItemId: "iron_sword",
+          outputQuantity: 1,
+        },
+      },
+    };
+    return new Map([["test", { data: world }]]);
+  };
+
+  it("marks recipes with no gathering source as unsourced", () => {
+    const rows = analyzeCraftingViability(MOCK_CONFIG, makeZone());
+    const pearl = rows.find((r) => r.recipeId === "craft_pearl_necklace")!;
+    expect(pearl.materialsSourced).toBe(false);
+    expect(pearl.missingMaterialIds).toContain("pearl");
+  });
+
+  it("flags sourced recipes and computes a positive gather time", () => {
+    const rows = analyzeCraftingViability(MOCK_CONFIG, makeZone());
+    const iron = rows.find((r) => r.recipeId === "craft_iron_sword")!;
+    expect(iron.materialsSourced).toBe(true);
+    expect(iron.estimatedGatherSeconds).toBeGreaterThan(0);
+  });
+
+  it("computes netValue as output minus materials", () => {
+    const rows = analyzeCraftingViability(MOCK_CONFIG, makeZone());
+    const iron = rows.find((r) => r.recipeId === "craft_iron_sword")!;
+    // 4 iron_ore @ 10 = 40 materials, iron_sword @ 120 = 120 output, net = 80
+    expect(iron.materialValue).toBe(40);
+    expect(iron.outputValue).toBe(120);
+    expect(iron.netValue).toBe(80);
+  });
+});
+
+// ─── tierForLevel ──────────────────────────────────────────────────
+
+describe("tierForLevel", () => {
+  it("returns one of the four tier keys", () => {
+    const tier = tierForLevel(MOCK_CONFIG.mobTiers, 15);
+    expect(["weak", "standard", "elite", "boss"]).toContain(tier);
+  });
+});

--- a/creator/src/lib/tuning/simulations.ts
+++ b/creator/src/lib/tuning/simulations.ts
@@ -1,0 +1,431 @@
+// ─── Balance Simulation Engines ────────────────────────────────────
+//
+// Pure "what-if" simulators for the Tuning Wizard. Each function takes
+// an AppConfig plus a handful of scenario inputs and returns analytic
+// outcomes so designers can tune balance without running the server.
+//
+// All models are deterministic expected-value calculations (no RNG):
+// reproducibility matters more than simulation fidelity at this stage.
+
+import type { AppConfig, MobTierConfig } from "@/types/config";
+import type { WorldFile, GatheringNodeFile, RecipeFile, ItemFile } from "@/types/world";
+import {
+  xpForLevel,
+  mobHpAtLevel,
+  mobAvgDamageAtLevel,
+  mobAvgGoldAtLevel,
+  playerHpAtLevel,
+  statBonus,
+  dodgeChance,
+} from "./formulas";
+
+// ─── Shared helpers ────────────────────────────────────────────────
+
+export type TierKey = "weak" | "standard" | "elite" | "boss";
+
+export const TIER_KEYS: readonly TierKey[] = ["weak", "standard", "elite", "boss"];
+
+/** Friendly label for a tier key. */
+export const TIER_LABELS: Record<TierKey, string> = {
+  weak: "Weak",
+  standard: "Standard",
+  elite: "Elite",
+  boss: "Boss",
+};
+
+/** Approximate player armor at a level — grows linearly as a baseline. */
+function estimatedPlayerArmor(level: number): number {
+  return Math.floor(level * 1.5);
+}
+
+/** Combat config damage band average, gently scaled with level + stat. */
+function playerBaseDamage(
+  config: AppConfig,
+  level: number,
+  meleeStatValue: number,
+): number {
+  const { minDamage, maxDamage } = config.combat;
+  const base = (minDamage + maxDamage) / 2;
+  const bonus = statBonus(meleeStatValue, config.stats.bindings.meleeDamageDivisor);
+  // Weapon scales loosely with level to reflect gear progression
+  const gearGrowth = level * 0.6;
+  return Math.max(1, base + bonus + gearGrowth);
+}
+
+// ─── 1. Combat Encounter ───────────────────────────────────────────
+
+export interface EncounterInputs {
+  playerLevel: number;
+  /** Chosen class id (e.g. "warrior"). Used for HP-per-level. */
+  classId?: string;
+  /** Primary stat baseline. Default 10 + 2 per level. */
+  baseStat?: number;
+  mobTier: TierKey;
+  mobLevel: number;
+}
+
+export interface EncounterOutcome {
+  /** Expected rounds for the player to reduce mob HP to zero. */
+  turnsToKill: number;
+  /** Expected rounds for the mob to reduce the player to zero HP. */
+  turnsToDie: number;
+  /** True if player kills first (turnsToKill <= turnsToDie). */
+  playerWins: boolean;
+  /** Player HP at start of fight. */
+  playerHp: number;
+  /** Mob HP at start of fight. */
+  mobHp: number;
+  /** Average damage player deals per round, after mob armor. */
+  playerDmgPerRound: number;
+  /** Average damage mob deals per round after dodge + player armor. */
+  mobDmgPerRound: number;
+  /** Expected HP remaining after the kill (clamped to 0). */
+  playerHpRemaining: number;
+  /** Dodge percent used in the calculation. */
+  dodgePercent: number;
+  /** Verdict string for quick scanning. */
+  verdict: "easy" | "fair" | "risky" | "lethal";
+}
+
+export function simulateEncounter(
+  config: AppConfig,
+  inputs: EncounterInputs,
+): EncounterOutcome {
+  const { playerLevel, mobTier, mobLevel } = inputs;
+  const baseStat = inputs.baseStat ?? 10 + playerLevel * 2;
+  const classDef = inputs.classId ? config.classes?.[inputs.classId] : undefined;
+  const classHpPerLevel = classDef?.hpPerLevel ?? 3;
+
+  const tier = config.mobTiers[mobTier];
+  const mobHp = mobHpAtLevel(tier, mobLevel);
+  const mobDmg = mobAvgDamageAtLevel(tier, mobLevel);
+
+  const playerHp = playerHpAtLevel(
+    playerLevel,
+    config.progression.rewards,
+    classHpPerLevel,
+    baseStat,
+    config.stats.bindings.hpScalingDivisor,
+  );
+
+  const playerDmgRaw = playerBaseDamage(config, playerLevel, baseStat);
+  const playerDmgPerRound = Math.max(1, playerDmgRaw - tier.baseArmor);
+
+  const armor = estimatedPlayerArmor(playerLevel);
+  const dodgePct = dodgeChance(baseStat, config.stats.bindings);
+  const mobDmgAfterArmor = Math.max(1, mobDmg - armor);
+  const mobDmgPerRound = mobDmgAfterArmor * (1 - dodgePct / 100);
+
+  const turnsToKill = Math.max(1, Math.ceil(mobHp / playerDmgPerRound));
+  const turnsToDie =
+    mobDmgPerRound > 0 ? Math.max(1, Math.ceil(playerHp / mobDmgPerRound)) : Infinity;
+
+  const playerHpRemaining = Math.max(0, playerHp - mobDmgPerRound * turnsToKill);
+  const playerWins = turnsToKill <= turnsToDie;
+
+  let verdict: EncounterOutcome["verdict"];
+  if (!playerWins) {
+    verdict = "lethal";
+  } else {
+    const pct = playerHp > 0 ? playerHpRemaining / playerHp : 0;
+    if (pct >= 0.7) verdict = "easy";
+    else if (pct >= 0.35) verdict = "fair";
+    else verdict = "risky";
+  }
+
+  return {
+    turnsToKill,
+    turnsToDie: Number.isFinite(turnsToDie) ? turnsToDie : Number.MAX_SAFE_INTEGER,
+    playerWins,
+    playerHp: Math.round(playerHp),
+    mobHp: Math.round(mobHp),
+    playerDmgPerRound: Math.round(playerDmgPerRound * 10) / 10,
+    mobDmgPerRound: Math.round(mobDmgPerRound * 10) / 10,
+    playerHpRemaining: Math.round(playerHpRemaining),
+    dodgePercent: Math.round(dodgePct * 10) / 10,
+    verdict,
+  };
+}
+
+// ─── 2. Economy Flow ────────────────────────────────────────────────
+
+export interface EconomyInputs {
+  level: number;
+  killsPerHour: number;
+  /** Fractions should roughly sum to 1; function re-normalises if not. */
+  tierMix: Record<TierKey, number>;
+  /** Fraction of gear sold to shops each hour (0–1). Average basePrice = 25. */
+  sellRate: number;
+  /** Gold spent per hour on consumables / repairs. */
+  consumableSpendPerHour: number;
+  /** Optional fixed gambling stake per hour. */
+  gamblingStakePerHour?: number;
+}
+
+export interface EconomyBreakdown {
+  source: string;
+  goldPerHour: number;
+  sign: "in" | "out";
+}
+
+export interface EconomyOutcome {
+  goldPerHour: number;
+  xpPerHour: number;
+  timeToNextLevelHours: number;
+  breakdown: EconomyBreakdown[];
+  /** Normalised tier mix as used. */
+  normalisedMix: Record<TierKey, number>;
+}
+
+const AVG_SHOP_BASE_PRICE = 25;
+
+export function simulateEconomy(
+  config: AppConfig,
+  inputs: EconomyInputs,
+): EconomyOutcome {
+  const { level, killsPerHour, tierMix, sellRate, consumableSpendPerHour } = inputs;
+  const total = TIER_KEYS.reduce((sum, k) => sum + Math.max(0, tierMix[k] ?? 0), 0);
+  const normalised: Record<TierKey, number> = { weak: 0, standard: 0, elite: 0, boss: 0 };
+  for (const k of TIER_KEYS) {
+    normalised[k] = total > 0 ? Math.max(0, tierMix[k] ?? 0) / total : 0;
+  }
+
+  let goldFromMobs = 0;
+  let xpFromMobs = 0;
+  for (const k of TIER_KEYS) {
+    const tier = config.mobTiers[k];
+    const killsOfTier = killsPerHour * normalised[k];
+    goldFromMobs += killsOfTier * mobAvgGoldAtLevel(tier, level);
+    xpFromMobs += killsOfTier * (tier.baseXpReward + tier.xpRewardPerLevel * level);
+  }
+
+  // Shop revenue — sellRate is the fraction of acquired drops sold per hour.
+  // Assume one sellable drop per 3 kills at average basePrice, multiplied by
+  // the economy sellMultiplier.
+  const dropsPerHour = killsPerHour / 3;
+  const goldFromSelling =
+    dropsPerHour * sellRate * AVG_SHOP_BASE_PRICE * config.economy.sellMultiplier;
+
+  const gamblingOut = inputs.gamblingStakePerHour ?? 0;
+
+  const goldPerHour =
+    goldFromMobs + goldFromSelling - consumableSpendPerHour - gamblingOut;
+
+  const xpCurve = config.progression.xp;
+  const xpToNext = xpForLevel(level + 1, xpCurve) - xpForLevel(level, xpCurve);
+  const timeToNextLevelHours = xpFromMobs > 0 ? xpToNext / xpFromMobs : Infinity;
+
+  const breakdown: EconomyBreakdown[] = [
+    { source: "Mob drops", goldPerHour: goldFromMobs, sign: "in" },
+    { source: "Shop sales", goldPerHour: goldFromSelling, sign: "in" },
+    { source: "Consumables / repairs", goldPerHour: consumableSpendPerHour, sign: "out" },
+  ];
+  if (gamblingOut > 0) {
+    breakdown.push({ source: "Gambling stake", goldPerHour: gamblingOut, sign: "out" });
+  }
+
+  return {
+    goldPerHour: Math.round(goldPerHour),
+    xpPerHour: Math.round(xpFromMobs),
+    timeToNextLevelHours: Number.isFinite(timeToNextLevelHours)
+      ? Math.round(timeToNextLevelHours * 100) / 100
+      : Number.POSITIVE_INFINITY,
+    breakdown: breakdown.map((b) => ({ ...b, goldPerHour: Math.round(b.goldPerHour) })),
+    normalisedMix: normalised,
+  };
+}
+
+// ─── 3. Progression Pacing ─────────────────────────────────────────
+
+export interface PacingInputs {
+  startLevel: number;
+  endLevel: number;
+  xpPerHour: number;
+}
+
+export interface PacingPoint {
+  level: number;
+  xpForLevel: number;
+  cumulativeXp: number;
+  cumulativeHours: number;
+}
+
+export interface PacingOutcome {
+  points: PacingPoint[];
+  totalXp: number;
+  totalHours: number;
+  /** Hours spent on the single slowest level. */
+  slowestLevelHours: number;
+  /** Which level was slowest (peaked XP). */
+  slowestLevel: number;
+}
+
+export function simulateProgression(
+  config: AppConfig,
+  inputs: PacingInputs,
+): PacingOutcome {
+  const { startLevel, endLevel, xpPerHour } = inputs;
+  const lo = Math.max(1, Math.min(startLevel, endLevel));
+  const hi = Math.min(config.progression.maxLevel || 50, Math.max(startLevel, endLevel));
+  const xpCurve = config.progression.xp;
+
+  const points: PacingPoint[] = [];
+  let cumulativeXp = 0;
+  let cumulativeHours = 0;
+  let slowestLevelHours = 0;
+  let slowestLevel = lo;
+
+  for (let lv = lo; lv <= hi; lv++) {
+    const xpThis = xpForLevel(lv + 1, xpCurve) - xpForLevel(lv, xpCurve);
+    cumulativeXp += xpThis;
+    const hoursThis = xpPerHour > 0 ? xpThis / xpPerHour : 0;
+    cumulativeHours += hoursThis;
+    if (hoursThis > slowestLevelHours) {
+      slowestLevelHours = hoursThis;
+      slowestLevel = lv;
+    }
+    points.push({
+      level: lv,
+      xpForLevel: xpThis,
+      cumulativeXp,
+      cumulativeHours: Math.round(cumulativeHours * 100) / 100,
+    });
+  }
+
+  return {
+    points,
+    totalXp: cumulativeXp,
+    totalHours: Math.round(cumulativeHours * 100) / 100,
+    slowestLevelHours: Math.round(slowestLevelHours * 100) / 100,
+    slowestLevel,
+  };
+}
+
+// ─── 4. Crafting Viability ─────────────────────────────────────────
+
+export interface CraftingViabilityRow {
+  recipeId: string;
+  zoneId: string;
+  displayName: string;
+  /** All materials can be produced by at least one gathering node in the loaded zones. */
+  materialsSourced: boolean;
+  missingMaterialIds: string[];
+  /** Seconds of gathering time (ignoring travel) assuming cooldown per yield. */
+  estimatedGatherSeconds: number;
+  /** Sum of material basePrice (if known) used as shorthand input value. */
+  materialValue: number;
+  /** Output item basePrice × outputQuantity, if known. */
+  outputValue: number;
+  /** outputValue − materialValue; positive = profitable to craft + sell. */
+  netValue: number;
+  /** xpReward / estimatedGatherSeconds, if both known. */
+  xpPerMinute: number;
+}
+
+/** Gather every recipe and gathering node from the project's loaded zones. */
+export function collectCraftingData(zones: Map<string, { data: WorldFile }>) {
+  const recipes: Array<{ zoneId: string; recipeId: string; recipe: RecipeFile }> = [];
+  const nodesByItem = new Map<string, GatheringNodeFile[]>();
+  const items = new Map<string, ItemFile>();
+
+  for (const [zoneId, state] of zones) {
+    const world = state.data;
+    if (world.recipes) {
+      for (const [rid, r] of Object.entries(world.recipes)) {
+        recipes.push({ zoneId, recipeId: rid, recipe: r });
+      }
+    }
+    if (world.gatheringNodes) {
+      for (const node of Object.values(world.gatheringNodes)) {
+        for (const yield_ of node.yields ?? []) {
+          const bucket = nodesByItem.get(yield_.itemId) ?? [];
+          bucket.push(node);
+          nodesByItem.set(yield_.itemId, bucket);
+        }
+        for (const rare of node.rareYields ?? []) {
+          const bucket = nodesByItem.get(rare.itemId) ?? [];
+          bucket.push(node);
+          nodesByItem.set(rare.itemId, bucket);
+        }
+      }
+    }
+    if (world.items) {
+      for (const [iid, item] of Object.entries(world.items)) {
+        items.set(iid, item);
+      }
+    }
+  }
+
+  return { recipes, nodesByItem, items };
+}
+
+export function analyzeCraftingViability(
+  config: AppConfig,
+  zones: Map<string, { data: WorldFile }>,
+): CraftingViabilityRow[] {
+  const { recipes, nodesByItem, items } = collectCraftingData(zones);
+  const gatherCooldownSec = config.crafting.gatherCooldownMs / 1000;
+
+  return recipes.map(({ zoneId, recipeId, recipe }) => {
+    const missing: string[] = [];
+    let materialValue = 0;
+    let totalGatherAttempts = 0;
+
+    for (const mat of recipe.materials ?? []) {
+      const nodes = nodesByItem.get(mat.itemId) ?? [];
+      if (nodes.length === 0) missing.push(mat.itemId);
+      const item = items.get(mat.itemId);
+      materialValue += (item?.basePrice ?? 0) * mat.quantity;
+
+      // Average yield per node — pick the first match; assume mid of min/max.
+      const primaryNode = nodes[0];
+      let avgYield = 1;
+      if (primaryNode) {
+        const yieldDef = primaryNode.yields?.find((y) => y.itemId === mat.itemId);
+        if (yieldDef) {
+          const minQ = yieldDef.minQuantity ?? 1;
+          const maxQ = yieldDef.maxQuantity ?? minQ;
+          avgYield = Math.max(1, (minQ + maxQ) / 2);
+        }
+      }
+      totalGatherAttempts += Math.ceil(mat.quantity / avgYield);
+    }
+
+    const outputItem = items.get(recipe.outputItemId);
+    const outputQty = recipe.outputQuantity ?? 1;
+    const outputValue = (outputItem?.basePrice ?? 0) * outputQty;
+    const estimatedGatherSeconds = totalGatherAttempts * gatherCooldownSec;
+    const xp = recipe.xpReward ?? 0;
+    const xpPerMinute =
+      estimatedGatherSeconds > 0 ? (xp * 60) / estimatedGatherSeconds : 0;
+
+    return {
+      recipeId,
+      zoneId,
+      displayName: recipe.displayName,
+      materialsSourced: missing.length === 0,
+      missingMaterialIds: missing,
+      estimatedGatherSeconds: Math.round(estimatedGatherSeconds),
+      materialValue: Math.round(materialValue),
+      outputValue: Math.round(outputValue),
+      netValue: Math.round(outputValue - materialValue),
+      xpPerMinute: Math.round(xpPerMinute * 10) / 10,
+    };
+  });
+}
+
+/** Helper to pick a sensible default tier for a given level. */
+export function tierForLevel(tiers: Record<TierKey, MobTierConfig>, level: number): TierKey {
+  // Pick tier whose HP at the given level is in a fightable range
+  const targetHp = 40 + level * 8;
+  let best: TierKey = "standard";
+  let bestDiff = Infinity;
+  for (const k of TIER_KEYS) {
+    const diff = Math.abs(mobHpAtLevel(tiers[k], level) - targetHp);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      best = k;
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## Summary
- Adds a **Simulation Lab** to the Tuning Wizard with four analytic "what-if" simulators: combat encounter, economy flow, progression pacing, and crafting viability
- Simulators run against the preset-merged config when a preset is highlighted, otherwise against the live config — so you can preview a preset without applying it
- Bumps version from 2.4.0 → 2.5.0

## What's new
- **Combat** — expected rounds-to-kill / rounds-to-die, dodge %, HP remaining, and an easy/fair/risky/lethal verdict for any player-level + class + mob-tier + mob-level combination
- **Economy** — tier-weighted gold and XP per hour, hours to next level, and a signed waterfall breakdown (mob drops, shop sales, consumables, gambling)
- **Progression** — cumulative hours to level across a chosen range at a given XP/hour, with the single slowest level called out and plotted on a line chart
- **Crafting** — scans every recipe in the loaded zones, flags unsourced materials, estimates gather time from `gatherCooldownMs`, and computes material-vs-output net value + XP/minute

## Files
- `creator/src/lib/tuning/simulations.ts` — pure-function engine
- `creator/src/components/tuning/simulations/` — tab container + 4 simulators
- `creator/src/lib/tuning/__tests__/simulations.test.ts` — 16 new tests
- `creator/src/components/tuning/TuningWizard.tsx` — wires the lab in below the chart row

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 1615/1615 pass (16 new simulation tests)
- [ ] Open Tuning Wizard, confirm Simulation Lab renders with all four tabs
- [ ] Select a preset and confirm the lab re-computes against the merged config
- [ ] Verify combat verdict flips to "lethal" at extreme mob/player level gaps
- [ ] Verify crafting tab surfaces missing-material warnings for recipes with no gathering node