### PR TITLE
feat: first-class factions & reputation

### DIFF
--- a/creator/src/components/config/panels/FactionPanel.tsx
+++ b/creator/src/components/config/panels/FactionPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState, memo } from "react";
 import { useConfigStore } from "@/stores/configStore";
-import type { FactionConfig, FactionDefinition } from "@/types/config";
+import type { FactionConfig, FactionDefinition, ReputationTier } from "@/types/config";
+import { DEFAULT_REPUTATION_TIERS } from "@/types/config";
 import {
   TextInput,
   NumberInput,
@@ -362,6 +363,18 @@ export function FactionPanel() {
           />
         )}
       </section>
+
+      <ReputationTiersSection
+        tiers={factions.tiers}
+        onChange={(tiers) => patch({ tiers })}
+      />
+
+      {factionIds.length > 1 && (
+        <RivalryGraph
+          definitions={factions.definitions}
+          factionLabelMap={factionLabelMap}
+        />
+      )}
 
       <section className="flex flex-col gap-3">
         <header className="flex items-end justify-between gap-3">
@@ -902,3 +915,262 @@ const QuestRewardRow = memo(function QuestRewardRow({
     </div>
   );
 });
+
+// ─── Reputation tiers ─────────────────────────────────────────────
+
+interface ReputationTiersSectionProps {
+  tiers: ReputationTier[] | undefined;
+  onChange: (tiers: ReputationTier[] | undefined) => void;
+}
+
+function ReputationTiersSection({ tiers, onChange }: ReputationTiersSectionProps) {
+  const effective = tiers && tiers.length > 0 ? tiers : DEFAULT_REPUTATION_TIERS;
+  const isDefault = !tiers || tiers.length === 0;
+
+  const patchTier = (index: number, p: Partial<ReputationTier>) => {
+    const next = [...effective];
+    next[index] = { ...next[index]!, ...p };
+    next.sort((a, b) => a.minReputation - b.minReputation);
+    onChange(next);
+  };
+
+  const addTier = () => {
+    const last = effective[effective.length - 1];
+    const next: ReputationTier = {
+      id: `tier_${effective.length + 1}`,
+      label: `Tier ${effective.length + 1}`,
+      minReputation: (last?.minReputation ?? 0) + 5000,
+    };
+    onChange([...effective, next]);
+  };
+
+  const deleteTier = (index: number) => {
+    if (effective.length <= 2) return;
+    const next = effective.filter((_, i) => i !== index);
+    onChange(next);
+  };
+
+  const resetToDefaults = () => {
+    onChange(undefined);
+  };
+
+  return (
+    <section className="flex flex-col gap-3">
+      <header className="flex items-end justify-between gap-3">
+        <div>
+          <h3 className="font-display font-semibold text-base text-text-primary">
+            Reputation Tiers
+          </h3>
+          <p className="mt-0.5 max-w-xl text-2xs leading-relaxed text-text-muted/70">
+            Named bands of standing. Each tier covers everything from its
+            threshold up to the next one. Referenced by reputation gates on
+            shops and quests.
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {!isDefault && (
+            <button
+              type="button"
+              onClick={resetToDefaults}
+              className="focus-ring rounded border border-border-muted/60 px-2.5 py-1 text-2xs text-text-muted hover:border-border-default hover:text-text-primary"
+            >
+              Reset to default
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={addTier}
+            className="focus-ring rounded border border-accent/40 bg-accent/10 px-2.5 py-1 text-xs font-medium text-accent transition hover:bg-accent/20"
+          >
+            + Add tier
+          </button>
+        </div>
+      </header>
+
+      <div className="flex flex-col gap-1.5 rounded-2xl border border-border-muted/50 bg-bg-primary/25 p-3">
+        {effective.map((tier, i) => {
+          const nextMin = effective[i + 1]?.minReputation;
+          return (
+            <div
+              key={i}
+              className="grid grid-cols-[1fr_1fr_1fr_auto] items-center gap-2"
+            >
+              <TextInput
+                value={tier.label}
+                onCommit={(v) => patchTier(i, { label: v })}
+                placeholder="Label"
+              />
+              <TextInput
+                value={tier.id}
+                onCommit={(v) => patchTier(i, { id: normalizeId(v) })}
+                placeholder="id"
+              />
+              <div className="flex items-center gap-1">
+                <NumberInput
+                  value={tier.minReputation}
+                  onCommit={(v) =>
+                    patchTier(i, { minReputation: v ?? 0 })
+                  }
+                />
+                {nextMin != null && (
+                  <span className="text-2xs text-text-muted/60 whitespace-nowrap">
+                    → {nextMin - 1}
+                  </span>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => deleteTier(i)}
+                disabled={effective.length <= 2}
+                aria-label={`Delete ${tier.label}`}
+                className="focus-ring rounded p-1 text-text-muted/50 transition hover:bg-status-error/15 hover:text-status-error disabled:cursor-not-allowed disabled:opacity-30"
+              >
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                  <path
+                    d="M4 4L12 12M12 4L4 12"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+      {isDefault && (
+        <p className="text-2xs italic text-text-muted/60">
+          Using built-in defaults. Edit any value to override.
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ─── Rivalry graph ────────────────────────────────────────────────
+
+interface RivalryGraphProps {
+  definitions: Record<string, FactionDefinition>;
+  factionLabelMap: Map<string, string>;
+}
+
+function RivalryGraph({ definitions, factionLabelMap }: RivalryGraphProps) {
+  const ids = Object.keys(definitions);
+
+  // Collect deduplicated rivalry edges (sorted tuple → visited set).
+  const edges = useMemo(() => {
+    const seen = new Set<string>();
+    const pairs: Array<[string, string]> = [];
+    for (const [aid, def] of Object.entries(definitions)) {
+      for (const bid of def.enemies ?? []) {
+        if (!definitions[bid]) continue;
+        const key = aid < bid ? `${aid}|${bid}` : `${bid}|${aid}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        pairs.push([aid, bid]);
+      }
+    }
+    return pairs;
+  }, [definitions]);
+
+  const layout = useMemo(() => {
+    const cx = 180;
+    const cy = 180;
+    const radius = 130;
+    const positions = new Map<string, { x: number; y: number }>();
+    const n = ids.length;
+    ids.forEach((id, i) => {
+      const angle = (2 * Math.PI * i) / n - Math.PI / 2;
+      positions.set(id, {
+        x: cx + radius * Math.cos(angle),
+        y: cy + radius * Math.sin(angle),
+      });
+    });
+    return positions;
+  }, [ids]);
+
+  if (ids.length < 2) return null;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <header>
+        <h3 className="font-display font-semibold text-base text-text-primary">
+          Rivalry Map
+        </h3>
+        <p className="mt-0.5 text-2xs leading-relaxed text-text-muted/70">
+          Lines mark hostile pairs. Killing a member of one faction earns rep
+          with the other.
+        </p>
+      </header>
+
+      <div className="rounded-2xl border border-border-muted/50 bg-bg-primary/25 p-4">
+        <svg
+          viewBox="0 0 360 360"
+          className="mx-auto block h-auto w-full max-w-md"
+          role="img"
+          aria-label="Faction rivalry graph"
+        >
+          {edges.length === 0 && (
+            <text
+              x={180}
+              y={180}
+              textAnchor="middle"
+              className="fill-text-muted"
+              fontSize="11"
+              fontFamily="system-ui"
+            >
+              No rivalries defined
+            </text>
+          )}
+
+          {edges.map(([a, b], i) => {
+            const pa = layout.get(a);
+            const pb = layout.get(b);
+            if (!pa || !pb) return null;
+            return (
+              <line
+                key={i}
+                x1={pa.x}
+                y1={pa.y}
+                x2={pb.x}
+                y2={pb.y}
+                stroke="rgb(var(--status-error-rgb))"
+                strokeOpacity="0.45"
+                strokeWidth="1.5"
+                strokeDasharray="4 3"
+              />
+            );
+          })}
+
+          {ids.map((id) => {
+            const p = layout.get(id);
+            if (!p) return null;
+            const label = factionLabelMap.get(id) ?? id;
+            return (
+              <g key={id}>
+                <circle
+                  cx={p.x}
+                  cy={p.y}
+                  r={18}
+                  fill="rgb(var(--bg-primary-rgb))"
+                  stroke="rgb(var(--accent-rgb))"
+                  strokeOpacity="0.5"
+                  strokeWidth="1.5"
+                />
+                <text
+                  x={p.x}
+                  y={p.y + 32}
+                  textAnchor="middle"
+                  className="fill-text-primary font-display"
+                  fontSize="11"
+                >
+                  {label.length > 18 ? label.slice(0, 16) + "…" : label}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+    </section>
+  );
+}

--- a/creator/src/components/editors/QuestEditor.tsx
+++ b/creator/src/components/editors/QuestEditor.tsx
@@ -21,6 +21,7 @@ import {
   ArrayRow,
 } from "@/components/ui/FormWidgets";
 import { DeleteEntityButton } from "./EditorShared";
+import { ReputationGateEditor } from "./ReputationGateEditor";
 import { useConfigStore } from "@/stores/configStore";
 import { useConfigOptions } from "@/lib/useConfigOptions";
 
@@ -264,6 +265,12 @@ export function QuestEditor({
           </FieldRow>
         </div>
       </Section>
+
+      <ReputationGateEditor
+        value={quest.requiredReputation}
+        onChange={(v) => patch({ requiredReputation: v })}
+        hint="Giver won't offer the quest to players who fail this gate."
+      />
 
       <DeleteEntityButton onClick={handleDelete} label="Delete Quest" />
     </>

--- a/creator/src/components/editors/ReputationGateEditor.tsx
+++ b/creator/src/components/editors/ReputationGateEditor.tsx
@@ -1,0 +1,120 @@
+import { useMemo, memo } from "react";
+import type { ReputationRequirement } from "@/types/world";
+import { useConfigStore } from "@/stores/configStore";
+import { getTiers } from "@/lib/reputationTiers";
+import {
+  Section,
+  FieldRow,
+  SelectInput,
+  NumberInput,
+  IconButton,
+} from "@/components/ui/FormWidgets";
+
+interface ReputationGateEditorProps {
+  value: ReputationRequirement | undefined;
+  onChange: (next: ReputationRequirement | undefined) => void;
+  /** Section label — defaults to "Reputation gate". */
+  label?: string;
+  /** Section hint — renders inside the Section. */
+  hint?: string;
+}
+
+export const ReputationGateEditor = memo(function ReputationGateEditor({
+  value,
+  onChange,
+  label = "Reputation gate",
+  hint,
+}: ReputationGateEditorProps) {
+  const factions = useConfigStore((s) => s.config?.factions);
+
+  const factionOptions = useMemo(() => {
+    const defs = factions?.definitions ?? {};
+    return Object.entries(defs).map(([id, def]) => ({
+      value: id,
+      label: def.name || id,
+    }));
+  }, [factions]);
+
+  const tierOptions = useMemo(() => {
+    const tiers = getTiers(factions);
+    return tiers.map((t) => ({
+      value: String(t.minReputation),
+      label: `${t.label} (${t.minReputation >= 0 ? "+" : ""}${t.minReputation})`,
+    }));
+  }, [factions]);
+
+  if (factionOptions.length === 0) {
+    return (
+      <Section title={label} defaultExpanded={false}>
+        <p className="text-2xs italic text-text-muted/70">
+          No factions defined. Add one in the Factions panel to enable gating.
+        </p>
+      </Section>
+    );
+  }
+
+  if (!value) {
+    return (
+      <Section title={label} defaultExpanded={false}>
+        {hint && <p className="mb-2 text-2xs text-text-muted/70">{hint}</p>}
+        <button
+          type="button"
+          onClick={() =>
+            onChange({ faction: factionOptions[0]!.value, min: 0 })
+          }
+          className="focus-ring self-start rounded border border-accent/40 bg-accent/10 px-2.5 py-1 text-2xs font-medium text-accent transition hover:bg-accent/20"
+        >
+          + Add rep gate
+        </button>
+      </Section>
+    );
+  }
+
+  const handleMinSelect = (raw: string) => {
+    const min = raw === "" ? undefined : Number(raw);
+    onChange({ ...value, min });
+  };
+
+  return (
+    <Section
+      title={label}
+      defaultExpanded={true}
+      actions={
+        <IconButton
+          onClick={() => onChange(undefined)}
+          title="Remove rep gate"
+          danger
+        >
+          &times;
+        </IconButton>
+      }
+    >
+      {hint && <p className="mb-2 text-2xs text-text-muted/70">{hint}</p>}
+      <FieldRow label="Faction">
+        <SelectInput
+          value={value.faction}
+          options={factionOptions}
+          onCommit={(v) => onChange({ ...value, faction: v })}
+        />
+      </FieldRow>
+      <FieldRow label="Min tier" hint="Lowest reputation tier the player needs.">
+        <SelectInput
+          value={value.min != null ? String(value.min) : ""}
+          options={[{ value: "", label: "— any —" }, ...tierOptions]}
+          onCommit={handleMinSelect}
+          allowEmpty
+        />
+      </FieldRow>
+      <FieldRow
+        label="Max rep"
+        hint="Optional ceiling. Use for enemies-only content (e.g. rebel quests that disappear once you're Honored with the crown)."
+      >
+        <NumberInput
+          value={value.max}
+          onCommit={(v) => onChange({ ...value, max: v })}
+          placeholder="— none —"
+        />
+      </FieldRow>
+    </Section>
+  );
+});

--- a/creator/src/components/editors/ShopEditor.tsx
+++ b/creator/src/components/editors/ShopEditor.tsx
@@ -11,6 +11,7 @@ import {
   EntityHeader,
 } from "@/components/ui/FormWidgets";
 import { DeleteEntityButton, MediaSection } from "./EditorShared";
+import { ReputationGateEditor } from "./ReputationGateEditor";
 import { shopPrompt } from "@/lib/entityPrompts";
 
 interface ShopEditorProps {
@@ -114,6 +115,12 @@ export function ShopEditor({
           </div>
         )}
       </Section>
+
+      <ReputationGateEditor
+        value={shop.requiredReputation}
+        onChange={(v) => patch({ requiredReputation: v })}
+        hint="Players who fail the gate see the shop refuse service."
+      />
 
       <MediaSection image={shop.image} onImageChange={(v) => patch({ image: v })} getPrompt={(style) => shopPrompt(shopId, shop, style)} assetType="background" context={zoneId ? { zone: zoneId, entity_type: "shop", entity_id: shopId } : undefined} />
       <DeleteEntityButton onClick={handleDelete} label="Delete Shop" />

--- a/creator/src/components/lore/TemplateFields.tsx
+++ b/creator/src/components/lore/TemplateFields.tsx
@@ -5,6 +5,7 @@ import { getTemplateSchema } from "@/lib/loreTemplates";
 import { Section, FieldRow, TextInput, NumberInput, SelectInput } from "@/components/ui/FormWidgets";
 import { LoreTextArea } from "./LoreTextArea";
 import { useLoreStore, selectArticles } from "@/stores/loreStore";
+import { useConfigStore } from "@/stores/configStore";
 
 // ─── Tag list (inline) ─────────────────────────────────────────────
 
@@ -146,6 +147,45 @@ function ArticleRefsSelect({
   );
 }
 
+// ─── Config faction picker ─────────────────────────────────────────
+
+function ConfigFactionSelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (id: string) => void;
+}) {
+  const defs = useConfigStore((s) => s.config?.factions?.definitions);
+  const options = Object.entries(defs ?? {}).map(([id, def]) => ({
+    value: id,
+    label: `${def.name || id} (${id})`,
+  }));
+
+  if (options.length === 0) {
+    return (
+      <p className="text-2xs italic text-text-muted/70">
+        No factions defined yet. Add them in the Factions config panel.
+      </p>
+    );
+  }
+
+  return (
+    <select
+      className="rounded border border-border-default bg-bg-primary px-2 py-1 text-xs text-text-secondary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">— none —</option>
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
 // ─── Field renderer ────────────────────────────────────────────────
 
 function FieldRenderer({
@@ -213,6 +253,13 @@ function FieldRenderer({
         <ArticleRefsSelect
           selected={Array.isArray(value) ? value : []}
           onChange={(v) => onChange(v.length > 0 ? v : undefined)}
+        />
+      );
+    case "config_faction_ref":
+      return (
+        <ConfigFactionSelect
+          value={typeof value === "string" ? value : ""}
+          onChange={(v) => onChange(v || undefined)}
         />
       );
     default:

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -17,6 +17,7 @@ import "@xyflow/react/dist/style.css";
 
 import { useZoneStore } from "@/stores/zoneStore";
 import { useProjectStore } from "@/stores/projectStore";
+import { useConfigStore } from "@/stores/configStore";
 import { panelTab } from "@/lib/panelRegistry";
 import { useAssetStore } from "@/stores/assetStore";
 import { useToastStore } from "@/stores/toastStore";
@@ -151,6 +152,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
   const reactFlow = useReactFlow();
   const zoneState = useZoneStore((s) => s.zones.get(zoneId));
   const updateZone = useZoneStore((s) => s.updateZone);
+  const factionDefs = useConfigStore((s) => s.config?.factions?.definitions);
   const undo = useZoneStore((s) => s.undo);
   const redo = useZoneStore((s) => s.redo);
   const canUndo = useZoneStore((s) => s.canUndo(zoneId));
@@ -201,6 +203,11 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
     if (!zoneState) return;
     const v = e.target.value;
     updateZone(zoneId, { ...zoneState.data, terrain: v || undefined });
+  }, [zoneState, updateZone, zoneId]);
+  const handleFactionChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (!zoneState) return;
+    const v = e.target.value;
+    updateZone(zoneId, { ...zoneState.data, faction: v || undefined });
   }, [zoneState, updateZone, zoneId]);
 
   // Auto-close entity panel if the selected entity was removed (e.g. by undo)
@@ -764,6 +771,28 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
                 <option value="sky">Sky</option>
               </select>
             </label>
+
+            {/* Controlling faction */}
+            {factionDefs && Object.keys(factionDefs).length > 0 && (
+              <label
+                className="flex items-center gap-1.5 text-xs text-text-secondary max-[1100px]:min-h-9"
+                title="Faction that controls this region. Mobs without their own faction inherit it; guards react to rep against it."
+              >
+                <span className="whitespace-nowrap">Faction</span>
+                <select
+                  value={zoneState.data.faction ?? ""}
+                  onChange={handleFactionChange}
+                  className="ornate-input px-1.5 py-0.5 text-xs text-text-primary"
+                >
+                  <option value="">— none —</option>
+                  {Object.entries(factionDefs).map(([id, def]) => (
+                    <option key={id} value={id}>
+                      {def.name || id}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
           </div>
 
           {/* Compact zone badge — visible only when the right column is hidden */}

--- a/creator/src/lib/__tests__/reputationTiers.test.ts
+++ b/creator/src/lib/__tests__/reputationTiers.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { getTiers, tierForRep, formatRep } from "../reputationTiers";
+import { DEFAULT_REPUTATION_TIERS, type FactionConfig } from "@/types/config";
+
+describe("reputation tiers", () => {
+  it("falls back to defaults when no config given", () => {
+    expect(getTiers()).toEqual(DEFAULT_REPUTATION_TIERS);
+    expect(getTiers(null)).toEqual(DEFAULT_REPUTATION_TIERS);
+  });
+
+  it("uses config tiers when present", () => {
+    const config: FactionConfig = {
+      defaultReputation: 0,
+      killPenalty: 5,
+      killBonus: 3,
+      definitions: {},
+      tiers: [
+        { id: "enemy", label: "Enemy", minReputation: -1000 },
+        { id: "ally", label: "Ally", minReputation: 1000 },
+      ],
+    };
+    const tiers = getTiers(config);
+    expect(tiers.map((t) => t.id)).toEqual(["enemy", "ally"]);
+  });
+
+  it("sorts tiers ascending by minReputation", () => {
+    const config: FactionConfig = {
+      defaultReputation: 0,
+      killPenalty: 5,
+      killBonus: 3,
+      definitions: {},
+      tiers: [
+        { id: "ally", label: "Ally", minReputation: 1000 },
+        { id: "enemy", label: "Enemy", minReputation: -1000 },
+      ],
+    };
+    expect(getTiers(config).map((t) => t.id)).toEqual(["enemy", "ally"]);
+  });
+
+  it("resolves tier for a given rep value", () => {
+    // Defaults: hated(-20000) hostile(-1000) unfriendly(-500) neutral(0)
+    //           friendly(250) honored(1000) revered(5000) exalted(20000)
+    expect(tierForRep(0).id).toBe("neutral");
+    expect(tierForRep(-1).id).toBe("unfriendly");
+    expect(tierForRep(-500).id).toBe("unfriendly");
+    expect(tierForRep(-501).id).toBe("hostile");
+    expect(tierForRep(249).id).toBe("neutral");
+    expect(tierForRep(250).id).toBe("friendly");
+    expect(tierForRep(999_999).id).toBe("exalted");
+    expect(tierForRep(-999_999).id).toBe("hated");
+  });
+
+  it("formats reputation with sign and tier label", () => {
+    expect(formatRep(250)).toBe("Friendly (+250)");
+    expect(formatRep(-600)).toBe("Hostile (-600)");
+    expect(formatRep(0)).toBe("Neutral (+0)");
+  });
+});

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -377,4 +377,66 @@ describe("validateZone", () => {
       true,
     );
   });
+
+  // ─── Factions & reputation ────────────────────────────────────
+  describe("faction references", () => {
+    const known = new Set(["royal_court", "rebel_cell"]);
+
+    it("warns when zone-level faction is unknown", () => {
+      const world = makeValidWorld();
+      world.faction = "mystery_cult";
+      const issues = warnings(validateZone(world, undefined, undefined, known));
+      expect(issues.some((i) => i.entity === "zone" && i.message.includes("mystery_cult"))).toBe(true);
+    });
+
+    it("warns when mob faction is unknown", () => {
+      const world = makeValidWorld();
+      world.mobs!.rat!.faction = "mystery_cult";
+      const issues = warnings(validateZone(world, undefined, undefined, known));
+      expect(issues.some((i) => i.entity === "mob:rat")).toBe(true);
+    });
+
+    it("warns when shop rep gate faction is unknown", () => {
+      const world = makeValidWorld();
+      world.shops = {
+        armorer: {
+          name: "Armorer",
+          room: "room1",
+          requiredReputation: { faction: "mystery_cult", min: 250 },
+        },
+      };
+      const issues = warnings(validateZone(world, undefined, undefined, known));
+      expect(issues.some((i) => i.entity === "shop:armorer" && i.message.includes("mystery_cult"))).toBe(true);
+    });
+
+    it("errors when rep gate min > max", () => {
+      const world = makeValidWorld();
+      world.quests = {
+        q1: {
+          name: "Q",
+          giver: "rat",
+          objectives: [{ type: "KILL", targetKey: "rat", count: 1 }],
+          requiredReputation: { faction: "royal_court", min: 500, max: 100 },
+        },
+      };
+      const issues = errors(validateZone(world, undefined, undefined, known));
+      expect(issues.some((i) => i.entity === "quest:q1")).toBe(true);
+    });
+
+    it("accepts known faction refs without warning", () => {
+      const world = makeValidWorld();
+      world.faction = "royal_court";
+      world.mobs!.rat!.faction = "royal_court";
+      const issues = validateZone(world, undefined, undefined, known);
+      expect(issues.filter((i) => i.message.includes("royal_court"))).toHaveLength(0);
+    });
+
+    it("skips faction checks when knownFactions is not provided", () => {
+      const world = makeValidWorld();
+      world.faction = "anything";
+      world.mobs!.rat!.faction = "anything";
+      const issues = validateZone(world);
+      expect(issues.filter((i) => i.message.includes("anything"))).toHaveLength(0);
+    });
+  });
 });

--- a/creator/src/lib/loreTemplates.ts
+++ b/creator/src/lib/loreTemplates.ts
@@ -11,7 +11,15 @@ export const CUSTOM_TEMPLATE_COLORS = [
 export interface TemplateFieldDef {
   key: string;
   label: string;
-  type: "text" | "textarea" | "select" | "tags" | "article_ref" | "article_refs" | "number";
+  type:
+    | "text"
+    | "textarea"
+    | "select"
+    | "tags"
+    | "article_ref"
+    | "article_refs"
+    | "number"
+    | "config_faction_ref";
   options?: { value: string; label: string }[];
   placeholder?: string;
 }
@@ -57,6 +65,7 @@ export const TEMPLATE_SCHEMAS: Record<ArticleTemplate, TemplateSchema> = {
       { key: "leader", label: "Leader", type: "text", placeholder: "Current leader or ruling body" },
       { key: "territory", label: "Territory", type: "text", placeholder: "Regions or strongholds" },
       { key: "values", label: "Values", type: "tags", placeholder: "Add a core value..." },
+      { key: "configFactionId", label: "Game faction", type: "config_faction_ref", placeholder: "Link to a mechanical faction" },
     ],
   },
 

--- a/creator/src/lib/reputationTiers.ts
+++ b/creator/src/lib/reputationTiers.ts
@@ -1,0 +1,26 @@
+import { DEFAULT_REPUTATION_TIERS, type ReputationTier, type FactionConfig } from "@/types/config";
+
+/** Return tiers sorted low→high, falling back to defaults. */
+export function getTiers(config?: FactionConfig | null): ReputationTier[] {
+  const raw = config?.tiers;
+  const tiers = raw && raw.length > 0 ? [...raw] : [...DEFAULT_REPUTATION_TIERS];
+  tiers.sort((a, b) => a.minReputation - b.minReputation);
+  return tiers;
+}
+
+/** Resolve the tier a given reputation value falls into. */
+export function tierForRep(rep: number, config?: FactionConfig | null): ReputationTier {
+  const tiers = getTiers(config);
+  let match = tiers[0]!;
+  for (const t of tiers) {
+    if (rep >= t.minReputation) match = t;
+  }
+  return match;
+}
+
+/** Format a reputation value as "Honored (+1500)" for display. */
+export function formatRep(rep: number, config?: FactionConfig | null): string {
+  const tier = tierForRep(rep, config);
+  const sign = rep >= 0 ? "+" : "";
+  return `${tier.label} (${sign}${rep})`;
+}

--- a/creator/src/lib/runtimeHandoff.ts
+++ b/creator/src/lib/runtimeHandoff.ts
@@ -88,7 +88,10 @@ export function runWorkspaceValidation(): ValidationSummary {
   const validClasses = config?.classes
     ? new Set(Object.keys(config.classes).map((k) => k.toUpperCase()))
     : undefined;
-  const results = validateAllZones(zones, config?.equipmentSlots, validClasses);
+  const knownFactions = config?.factions?.definitions
+    ? new Set(Object.keys(config.factions.definitions))
+    : undefined;
+  const results = validateAllZones(zones, config?.equipmentSlots, validClasses, knownFactions);
 
   if (config) {
     const configIssues = validateConfig(config);

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -683,6 +683,7 @@ function cleanOutput(world: WorldFile): WorldFile {
   if (world.terrain) result.terrain = world.terrain;
   if (world.graphical) result.graphical = true;
   if (world.pvpEnabled) result.pvpEnabled = true;
+  if (world.faction?.trim()) result.faction = world.faction.trim();
   if (world.image) {
     // Strip zoneMap — it's Arcanum-only; the MUD server's ZoneImageDefaults
     // doesn't recognize it and will crash on the unknown field.

--- a/creator/src/lib/saveZone.ts
+++ b/creator/src/lib/saveZone.ts
@@ -17,7 +17,10 @@ export function serializeZone(zoneId: string): string {
   const sanitized = normalizeWorldAssetRefs(sanitizeZone(zone.data));
   const config = useConfigStore.getState().config;
   const validClasses = config ? new Set(Object.keys(config.classes).map((id) => id.toUpperCase())) : undefined;
-  const issues = validateZone(sanitized, config?.equipmentSlots, validClasses);
+  const knownFactions = config?.factions?.definitions
+    ? new Set(Object.keys(config.factions.definitions))
+    : undefined;
+  const issues = validateZone(sanitized, config?.equipmentSlots, validClasses, knownFactions);
   const errors = issues.filter((issue) => issue.severity === "error");
   if (errors.length > 0) {
     const summary = errors.slice(0, 5).map((issue) => `${issue.entity}: ${issue.message}`).join("; ");

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -292,12 +292,19 @@ export function validateZone(
   world: WorldFile,
   equipmentSlots?: Record<string, EquipmentSlotDefinition>,
   validClasses?: ReadonlySet<string>,
+  knownFactions?: ReadonlySet<string>,
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const roomIds = new Set(Object.keys(world.rooms));
   const mobIds = new Set(Object.keys(world.mobs ?? {}));
   const itemIds = new Set(Object.keys(world.items ?? {}));
   const VALID_CLASSES = validClasses ?? DEFAULT_VALID_CLASSES;
+  const factionCheck = (entity: string, factionId: string | undefined, label: string) => {
+    if (!factionId || !knownFactions) return;
+    if (!knownFactions.has(factionId)) {
+      addIssue(issues, "warning", entity, `${label} "${factionId}" is not a defined faction`);
+    }
+  };
 
   if (!world.startRoom) {
     addIssue(issues, "error", "zone", "No start room defined");
@@ -310,6 +317,7 @@ export function validateZone(
   if (world.terrain && !VALID_TERRAINS.has(world.terrain)) {
     addIssue(issues, "warning", "zone", `Terrain "${world.terrain}" is not a recognized terrain type`);
   }
+  factionCheck("zone", world.faction, "Controlling faction");
 
   for (const [roomId, room] of Object.entries(world.rooms)) {
     const entity = `room:${roomId}`;
@@ -338,6 +346,7 @@ export function validateZone(
     const entity = `mob:${mobId}`;
     if (!mob.name?.trim()) addIssue(issues, "warning", entity, "Mob has no name");
     if (!roomIds.has(mob.room)) addIssue(issues, "error", entity, `Room "${mob.room}" does not exist`);
+    factionCheck(entity, mob.faction, "Faction");
     if (mob.category && !VALID_MOB_CATEGORIES.has(mob.category)) {
       addIssue(issues, "warning", entity, `Category "${mob.category}" is not a recognized mob category`);
     }
@@ -424,6 +433,13 @@ export function validateZone(
         addIssue(issues, "warning", entity, `Inventory item "${itemId}" is not a known item in this zone`);
       }
     }
+    if (shop.requiredReputation) {
+      factionCheck(entity, shop.requiredReputation.faction, "Rep gate faction");
+      const { min, max } = shop.requiredReputation;
+      if (min != null && max != null && min > max) {
+        addIssue(issues, "error", entity, `Rep gate min (${min}) must be <= max (${max})`);
+      }
+    }
   }
 
   const trainerRooms = new Set<string>();
@@ -464,6 +480,13 @@ export function validateZone(
         if (obj.count != null && obj.count < 1) {
           addIssue(issues, "error", entity, `Objective #${index + 1} count must be at least 1`);
         }
+      }
+    }
+    if (quest.requiredReputation) {
+      factionCheck(entity, quest.requiredReputation.faction, "Rep gate faction");
+      const { min, max } = quest.requiredReputation;
+      if (min != null && max != null && min > max) {
+        addIssue(issues, "error", entity, `Rep gate min (${min}) must be <= max (${max})`);
       }
     }
   }
@@ -544,10 +567,11 @@ export function validateAllZones(
   zones: Map<string, { data: WorldFile }>,
   equipmentSlots?: Record<string, EquipmentSlotDefinition>,
   validClasses?: ReadonlySet<string>,
+  knownFactions?: ReadonlySet<string>,
 ): Map<string, ValidationIssue[]> {
   const results = new Map<string, ValidationIssue[]>();
   for (const [zoneId, zone] of zones) {
-    const issues = validateZone(zone.data, equipmentSlots, validClasses);
+    const issues = validateZone(zone.data, equipmentSlots, validClasses, knownFactions);
     if (issues.length > 0) {
       results.set(zoneId, issues);
     }

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -340,12 +340,39 @@ export interface FactionDefinition {
   enemies?: string[];
 }
 
+export interface ReputationTier {
+  /** Stable ID used in data (e.g. "honored"). */
+  id: string;
+  /** Display label (e.g. "Honored"). */
+  label: string;
+  /** Minimum reputation (inclusive) for a player to be in this tier. */
+  minReputation: number;
+}
+
+/**
+ * Default reputation tiers. IDs are stable; labels and thresholds can be
+ * overridden per-project. The floor tier's minReputation is the absolute
+ * minimum rep the MUD will allow.
+ */
+export const DEFAULT_REPUTATION_TIERS: ReputationTier[] = [
+  { id: "hated", label: "Hated", minReputation: -20000 },
+  { id: "hostile", label: "Hostile", minReputation: -1000 },
+  { id: "unfriendly", label: "Unfriendly", minReputation: -500 },
+  { id: "neutral", label: "Neutral", minReputation: 0 },
+  { id: "friendly", label: "Friendly", minReputation: 250 },
+  { id: "honored", label: "Honored", minReputation: 1000 },
+  { id: "revered", label: "Revered", minReputation: 5000 },
+  { id: "exalted", label: "Exalted", minReputation: 20000 },
+];
+
 export interface FactionConfig {
   defaultReputation: number;
   killPenalty: number;
   killBonus: number;
   definitions: Record<string, FactionDefinition>;
   questRewards?: Record<string, Record<string, number>>;
+  /** Named reputation bands, ordered low→high. Omitted for the built-in default set. */
+  tiers?: ReputationTier[];
 }
 
 // ─── Navigation ────────────────────────────────────────────────────

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -10,6 +10,8 @@ export interface WorldFile {
   terrain?: string;
   graphical?: boolean;
   pvpEnabled?: boolean;
+  /** Controlling faction ID (references FactionConfig.definitions). Drives "hostile territory" reactions. */
+  faction?: string;
   puzzles?: Record<string, PuzzleFile>;
   image?: ZoneImageDefaults;
   audio?: ZoneAudioDefaults;
@@ -22,6 +24,13 @@ export interface WorldFile {
   gatheringNodes?: Record<string, GatheringNodeFile>;
   recipes?: Record<string, RecipeFile>;
   dungeon?: DungeonFile;
+}
+
+/** Reputation gate: player must have `min ≤ rep ≤ max` with `faction` to use. */
+export interface ReputationRequirement {
+  faction: string;
+  min?: number;
+  max?: number;
 }
 
 export interface ZoneImageDefaults {
@@ -200,6 +209,8 @@ export interface ShopFile {
   room: string;
   items?: string[];
   image?: string;
+  /** Rep gate. Shop refuses to trade when the requirement fails. */
+  requiredReputation?: ReputationRequirement;
 }
 
 export interface TrainerFile {
@@ -228,6 +239,8 @@ export interface QuestFile {
   completionType?: string;
   objectives?: QuestObjectiveFile[];
   rewards?: QuestRewardsFile;
+  /** Rep gate. Giver will not offer the quest when the requirement fails. */
+  requiredReputation?: ReputationRequirement;
 }
 
 export interface QuestObjectiveFile {

--- a/docs/FACTIONS_MUD_CHANGES.md
+++ b/docs/FACTIONS_MUD_CHANGES.md
@@ -1,0 +1,182 @@
+# Factions & Reputation — MUD server changes required
+
+Companion doc to the Arcanum **factions & reputation** PR. Arcanum now writes
+YAML that references fields the MUD server doesn't yet honor. This document
+lists the changes the AmbonMUD side needs to make in order to consume them.
+
+Until the server implements these, the extra fields are harmless — they round
+-trip through Arcanum and sit on disk, but the MUD will ignore them.
+
+## Summary of new data shapes
+
+### Config (`application.yaml → ambonmud.factions`)
+
+```yaml
+factions:
+  defaultReputation: 0
+  killPenalty: 5
+  killBonus: 3
+  tiers:                          # NEW — optional. Omit to use built-in defaults.
+    - id: hated
+      label: Hated
+      minReputation: -20000
+    - id: hostile
+      label: Hostile
+      minReputation: -1000
+    - id: unfriendly
+      label: Unfriendly
+      minReputation: -500
+    - id: neutral
+      label: Neutral
+      minReputation: 0
+    - id: friendly
+      label: Friendly
+      minReputation: 250
+    - id: honored
+      label: Honored
+      minReputation: 1000
+    - id: revered
+      label: Revered
+      minReputation: 5000
+    - id: exalted
+      label: Exalted
+      minReputation: 20000
+  definitions: ...                # unchanged
+  questRewards: ...               # unchanged
+```
+
+Default tiers match the list above; if `tiers` is absent the server should
+fall back to the same defaults rather than treating the absence as "no
+tiers."
+
+### Zone (`<zone>.yaml` root)
+
+```yaml
+zone: thornhaven
+startRoom: ...
+terrain: urban
+faction: royal_court              # NEW — controlling faction for the region
+rooms:
+  ...
+```
+
+### Shop (`<zone>.yaml → shops.<id>`)
+
+```yaml
+shops:
+  court_armorer:
+    name: Court Armorer
+    room: plaza
+    items: [...]
+    requiredReputation:           # NEW — optional rep gate
+      faction: royal_court
+      min: 250                    # optional; omit for no floor
+      max: 20000                  # optional; omit for no ceiling
+```
+
+### Quest (`<zone>.yaml → quests.<id>`)
+
+```yaml
+quests:
+  infiltrate_rebels:
+    name: Infiltrate the Rebels
+    giver: spy_handler
+    requiredReputation:           # NEW — optional rep gate
+      faction: rebel_cell
+      max: -500                   # e.g. only offered while Hostile or lower
+```
+
+## Server-side work
+
+### 1. DTO updates
+
+- `FactionsConfigDTO` — add an optional `tiers: List<ReputationTierDTO>` field.
+- Introduce `ReputationTierDTO { id: String, label: String, minReputation: Int }`.
+- `WorldFileDTO` — add optional `faction: String`.
+- `ShopFileDTO` — add optional `requiredReputation: ReputationRequirementDTO`.
+- `QuestFileDTO` — add optional `requiredReputation: ReputationRequirementDTO`.
+- Introduce `ReputationRequirementDTO { faction: String, min: Int?, max: Int? }`.
+
+All new fields must be nullable / optional; legacy worlds do not set them.
+
+### 2. `WorldLoader` validation
+
+- If `requiredReputation.faction` is not a key in
+  `factions.definitions`, reject the world file with an actionable error.
+- If `min` and `max` are both set and `min > max`, reject.
+- If a zone's `faction` is not in `factions.definitions`, log a WARNING and
+  treat as "no controlling faction."
+
+### 3. Reputation tier resolution
+
+Replace whatever hardcoded tier bands the server uses today with a lookup
+against `FactionsConfig.tiers`, sorted ascending by `minReputation`:
+
+```kotlin
+fun tierFor(rep: Int, tiers: List<ReputationTier>): ReputationTier =
+    tiers.lastOrNull { it.minReputation <= rep } ?: tiers.first()
+```
+
+Commands that print reputation (e.g. `faction status`, `who` tooltips) should
+use `tier.label` rather than inline strings.
+
+### 4. Rep gates on shops
+
+`ShopSystem` (or wherever the buy/sell/browse path lives) needs, before any
+transaction:
+
+```kotlin
+shop.requiredReputation?.let { req ->
+    val rep = player.reputationWith(req.faction)
+    if (req.min != null && rep < req.min) return refuse(shop, "too_low")
+    if (req.max != null && rep > req.max) return refuse(shop, "too_high")
+}
+```
+
+Refusal messages should surface the controlling faction's display name and
+the player's current tier — e.g. *"The armorer scowls: 'Hostile aren't
+welcome here.'"*
+
+### 5. Rep gates on quests
+
+`QuestSystem.offerQuest()` (the giver interaction) should skip quests whose
+`requiredReputation` doesn't match the player's standing. Two subtleties:
+
+- If `max` is set, the quest should *disappear* from the giver's offer list
+  when the player exceeds it (otherwise veteran players see junk).
+- If `min` is set, the giver should still *acknowledge* the quest exists but
+  refuse — a hint nudges the player toward grinding rep rather than wondering
+  why content isn't appearing.
+
+### 6. Zone-level controlling faction
+
+`WorldFile.faction` has two intended effects:
+
+1. **Mob inheritance** — a mob without its own `faction` inherits the zone's
+   faction when spawned.
+2. **Hostile territory reactions** — guard mobs tagged as belonging to that
+   faction should be able to check `player.reputationWith(zone.faction) <
+   thresholdFromTier("unfriendly")` and react (aggro, refuse service, etc.).
+
+Both behaviors are additive; neither is required for v1 of the feature, but
+both become trivial once the field is loaded.
+
+### 7. Migration notes
+
+- The lore-article `organization.configFactionId` field is Arcanum-only. It
+  lives in `lore.yaml` alongside the article and is not exposed to the MUD.
+- `factions.tiers` is purely additive. Existing worlds that don't set it
+  behave identically to today once the server defaults match the above list.
+
+## Testing checklist for the MUD side
+
+- [ ] Legacy world loads without the new fields and runs unchanged.
+- [ ] Tier table override (different thresholds/labels) reflects in rep
+      readout commands.
+- [ ] Shop with `requiredReputation.min` refuses a Neutral player and
+      accepts a Friendly one.
+- [ ] Quest with `requiredReputation.max` disappears from the giver's list
+      once the player crosses the ceiling.
+- [ ] Zone-level `faction` propagates to mobs that lack their own faction.
+- [ ] `WorldLoader` rejects a zone that references an unknown faction in any
+      of the three new places (zone, shop gate, quest gate).


### PR DESCRIPTION
## Summary
- Promotes factions from a standalone config panel into a cross-cutting system: zones, shops, quests, lore articles, validation, and a rivalry graph all know about them.
- Reputation tiers are now editable (with Hated→Exalted defaults); rep gates on shops and quests share a single `ReputationGateEditor`.
- Lore organizations can link to a config faction via a new `configFactionId` field, so a single entity can own both the fiction and the mechanics.
- Server-side work required to actually honor the new YAML fields is described in [`docs/FACTIONS_MUD_CHANGES.md`](docs/FACTIONS_MUD_CHANGES.md).

## What changed
- `FactionConfig.tiers?: ReputationTier[]` with default set in `types/config.ts`; FactionPanel gains a Reputation Tiers editor and a Rivalry Map SVG.
- `WorldFile.faction?: string` surfaces as a zone-level select in `ZoneEditor`.
- `ShopFile.requiredReputation` and `QuestFile.requiredReputation` gate access; `ReputationGateEditor.tsx` is the shared surface.
- `validateZone` gains a `knownFactions` parameter and flags unknown refs (zone / mob / shop-gate / quest-gate) as warnings; rep gate min>max is an error.
- New `lib/reputationTiers.ts` utilities (`getTiers`, `tierForRep`, `formatRep`) power the rep editor dropdowns.
- New `config_faction_ref` lore template field type; `organization` template wires it into the article editor.

## Test plan
- [ ] `bunx tsc --noEmit` clean
- [ ] `bun run test` — new `reputationTiers.test.ts` + expanded `validateZone.test.ts` green (1626 tests total)
- [ ] `cargo check` clean
- [ ] Manual: Add a faction in config, set a zone's controlling faction, gate a shop on min="Honored", verify validation surfaces unknown-faction warnings when the gate references a non-existent ID
- [ ] Manual: Edit tier labels / thresholds, confirm shop-gate "Min tier" dropdown picks up the new labels
- [ ] Manual: Link an `organization` lore article to a config faction via the new picker, save, reload, verify round-trip

## MUD follow-up
New YAML fields (`factions.tiers`, `zone.faction`, `shops.*.requiredReputation`, `quests.*.requiredReputation`) are harmless until the server-side DTOs + loader updates ship. Full spec in [`docs/FACTIONS_MUD_CHANGES.md`](docs/FACTIONS_MUD_CHANGES.md).