### PR TITLE
feat: self-registration for Arcanum Hub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,17 +134,26 @@ All public functions exposed to the frontend are `#[tauri::command]` and return 
   - `<slug>.arcanum-hub.com/` — per-world showcase SPA + `/showcase.json` + `/images/<hash>.webp`
   - `admin.arcanum-hub.com/` — admin SPA, transparently reverse-proxied by the Worker to `arcanum-hub-admin.pages.dev`
 - **Worker bindings** (`hub-worker/wrangler.toml`):
-  - `DB` — D1 `arcanum-hub` (users, worlds, AI quotas)
+  - `DB` — D1 `arcanum-hub` (users, worlds, AI quotas, verification_codes, signup_attempts)
   - `BUCKET` — R2 `arcanum-hub` (`worlds/<slug>/showcase.json` + `worlds/<slug>/images/<hash>.webp`)
   - `ASSETS` — showcase `dist/` ships alongside the Worker; `not_found_handling = "single-page-application"` + `run_worker_first = true` so API paths aren't absorbed by SPA fallback
-  - Secrets: `HUB_ADMIN_KEY`, `RUNWARE_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`
+  - Secrets: `HUB_ADMIN_KEY`, `RESEND_API_KEY`, `TURNSTILE_SECRET_KEY`, `RUNWARE_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`
+  - Vars: `FROM_EMAIL` (sender for verification codes, must be on a Resend-verified domain), `TURNSTILE_SITE_KEY` (public, paired with the secret)
+- **Self-registration** (public, `api.<root>`):
+  - Three tiers: `demo` (self-signup, 10 images/20 prompts, no publish), `full` (email-verified, 500 images/5000 prompts, publish), `publish` (admin-issued BYOK, publish-only).
+  - `POST /signup/demo` — Turnstile-gated anonymous signup. Returns `hubk_demo_…` key.
+  - `POST /signup/request` + `POST /signup/verify` — email + 6-digit code → `hubk_full_…` key. Resend delivers the email; dev stubs log to `wrangler tail` when `RESEND_API_KEY` is unset.
+  - `POST /account/upgrade/request` + `/verify` — promotes an authenticated demo user to full. Rotates the key, resets usage counters.
+  - `POST /account/rotate-key`, `GET /account`, `GET /config` (public Turnstile site key).
+  - Rate limit: 3 signup attempts per IP per rolling hour, tracked in `signup_attempts` and pruned opportunistically. Code expires in 15 minutes, 5 attempts per code.
+  - Publish endpoints gate on `email_verified` — demo users get a `publish_requires_verification` 403 until they upgrade.
 - **Publish API** (Bearer auth): `POST /publish/check-existing`, `PUT /publish/image/<hash>.webp`, `POST /publish/manifest`. Slug ownership enforced per publish. Creator side: `creator/src-tauri/src/hub.rs::publish_to_hub`.
 - **AI proxy** (Bearer auth, per-user lifetime quotas — default 500 images / 5000 LLM calls, stored on `users`, reset on API key rotation):
   - `POST /ai/image/generate` → Runware (`runware:400@2` FLUX.2, `openai:4@1` GPT Image 1.5)
   - `POST /ai/llm/complete` → OpenRouter DeepSeek V3.2 (`deepseek/deepseek-v3.2-20251201`)
   - `POST /ai/llm/vision` → Claude Sonnet 4.6
   - Vision calls bill against `prompts_used`. Model allowlist + guardrails (steps ≤ 32, dimensions ≤ 1024, GPT quality forced to `"low"`) enforced server-side.
-- **Admin API** (X-Admin-Key header): `GET/POST /admin/users`, `DELETE /admin/users/<id>`, `POST /admin/users/<id>/regenerate-key` (zeros usage counters), `POST /admin/users/<id>/quotas`, `GET /admin/worlds`, `DELETE /admin/worlds/<slug>`.
+- **Admin API** (X-Admin-Key header): `GET/POST /admin/users`, `DELETE /admin/users/<id>`, `POST /admin/users/<id>/regenerate-key` (zeros usage counters), `POST /admin/users/<id>/tier`, `POST /admin/users/<id>/quotas`, `GET /admin/worlds`, `DELETE /admin/worlds/<slug>`. Admin-minted users default to `email_verified=1`.
 - **Reserved subdomains** — `admin`, `www`, `hub`, `mail`, `ftp`, `ns1`, `ns2` are refused by `isValidSlug()` so nobody can claim them as world slugs. The Worker's `handleReservedSubdomain` proxies `admin.` to the Pages deployment and 301s `www.` to the apex.
 - **Hub AI mode on the client** — flipped via `settings.use_hub_ai` (user-level boolean in `~/.tauri/settings.json`). When on, the existing image/LLM/vision Tauri commands check `hub_ai::is_enabled(&settings)` at the top and short-circuit to `hub_ai::generate_image` / `hub_ai::complete` / `hub_ai::complete_with_vision` before touching direct-provider code. The frontend doesn't know about hub mode at all — same command names, same response shapes.
 

--- a/creator/src/components/config/panels/HubAccountStatus.tsx
+++ b/creator/src/components/config/panels/HubAccountStatus.tsx
@@ -1,0 +1,383 @@
+import { useEffect, useState } from "react";
+import {
+  fetchAccount,
+  fetchHubConfig,
+  rotateKey,
+  upgradeRequest,
+  upgradeVerify,
+  type HubAccount,
+} from "@/lib/hubClient";
+import { TurnstileWidget } from "@/components/onboarding/TurnstileWidget";
+import { useAssetStore } from "@/stores/assetStore";
+
+interface HubAccountStatusProps {
+  apiKey: string;
+  apiUrl: string;
+}
+
+/**
+ * Shows the user's current hub account — tier, quota usage, email
+ * verification state — and exposes demo→full upgrade and key
+ * rotation. Lives at the top of HubSettingsPanel.
+ */
+export function HubAccountStatus({ apiKey, apiUrl }: HubAccountStatusProps) {
+  const settings = useAssetStore((s) => s.settings);
+  const saveSettings = useAssetStore((s) => s.saveSettings);
+  const [account, setAccount] = useState<HubAccount | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [showUpgrade, setShowUpgrade] = useState(false);
+
+  const refresh = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { account } = await fetchAccount(apiKey, apiUrl);
+      setAccount(account);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (apiKey) void refresh();
+    else setAccount(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiKey, apiUrl]);
+
+  const handleRotate = async () => {
+    if (!settings) return;
+    if (!confirm("Rotate your API key? The current key will be invalidated and usage counters will reset.")) return;
+    try {
+      setLoading(true);
+      const { apiKey: fresh } = await rotateKey(apiKey, apiUrl);
+      await saveSettings({ ...settings, hub_api_key: fresh });
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!apiKey) {
+    return (
+      <div className="rounded-lg border border-border-default bg-bg-primary px-4 py-3 text-xs text-text-muted">
+        No API key configured — enter one below or complete the onboarding flow from the toolbar.
+      </div>
+    );
+  }
+
+  if (loading && !account) {
+    return (
+      <div className="rounded-lg border border-border-default bg-bg-primary px-4 py-3 text-xs text-text-muted">
+        Loading account…
+      </div>
+    );
+  }
+
+  if (error && !account) {
+    return (
+      <div className="rounded-lg border border-status-error/50 bg-bg-primary px-4 py-3 text-xs text-status-error">
+        {error}
+        <button onClick={refresh} className="ml-2 underline">Retry</button>
+      </div>
+    );
+  }
+
+  if (!account) return null;
+
+  const imagePct = pct(account.usage.imagesUsed, account.usage.imagesQuota);
+  const promptPct = pct(account.usage.promptsUsed, account.usage.promptsQuota);
+
+  return (
+    <div className="rounded-lg border border-border-default bg-bg-primary px-4 py-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col">
+          <span className="font-display text-xs uppercase tracking-widest text-text-primary">
+            {account.displayName}
+          </span>
+          <span className="mt-0.5 text-2xs text-text-muted">
+            {account.email ?? "no email on file"}
+            {account.emailVerified && (
+              <span className="ml-2 rounded-full bg-accent/20 px-2 py-0.5 text-[10px] uppercase tracking-wider text-accent">
+                verified
+              </span>
+            )}
+          </span>
+        </div>
+        <TierBadge tier={account.tier} />
+      </div>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        <UsageBar
+          label="Images"
+          used={account.usage.imagesUsed}
+          quota={account.usage.imagesQuota}
+          pct={imagePct}
+        />
+        <UsageBar
+          label="Prompts"
+          used={account.usage.promptsUsed}
+          quota={account.usage.promptsQuota}
+          pct={promptPct}
+        />
+      </div>
+
+      {account.tier === "demo" && !showUpgrade && (
+        <div className="mt-3 flex items-center justify-between gap-3 rounded border border-accent/40 bg-accent/10 px-3 py-2 text-2xs text-text-secondary">
+          <span>
+            <span className="text-text-primary">Unlock publishing + higher quotas</span> by verifying
+            your email.
+          </span>
+          <button
+            onClick={() => setShowUpgrade(true)}
+            className="rounded-full bg-accent/30 px-3 py-1 text-[11px] uppercase tracking-wider text-text-primary hover:bg-accent/50"
+          >
+            Upgrade
+          </button>
+        </div>
+      )}
+
+      {showUpgrade && (
+        <UpgradePanel
+          apiKey={apiKey}
+          apiUrl={apiUrl}
+          defaultDisplayName={account.displayName}
+          onDone={async () => {
+            setShowUpgrade(false);
+            await refresh();
+          }}
+          onCancel={() => setShowUpgrade(false)}
+        />
+      )}
+
+      <div className="mt-3 flex items-center justify-between gap-2 text-2xs text-text-muted">
+        <span>Rotating your key starts a fresh usage allowance.</span>
+        <button
+          onClick={handleRotate}
+          disabled={loading}
+          className="rounded border border-border-default px-3 py-1 text-text-secondary transition hover:border-accent/50 hover:text-text-primary disabled:opacity-50"
+        >
+          Rotate key
+        </button>
+      </div>
+      {error && <p className="mt-2 text-2xs text-status-error">{error}</p>}
+    </div>
+  );
+}
+
+function TierBadge({ tier }: { tier: HubAccount["tier"] }) {
+  const style =
+    tier === "demo"
+      ? "border-border-default bg-bg-elevated text-text-muted"
+      : tier === "full"
+        ? "border-accent/40 bg-accent/20 text-accent"
+        : "border-border-default bg-bg-elevated text-text-secondary";
+  return (
+    <span className={`rounded-full border px-2.5 py-0.5 text-[10px] uppercase tracking-wider ${style}`}>
+      {tier}
+    </span>
+  );
+}
+
+function UsageBar({ label, used, quota, pct }: { label: string; used: number; quota: number; pct: number }) {
+  return (
+    <div>
+      <div className="flex items-baseline justify-between text-2xs">
+        <span className="uppercase tracking-ui text-text-muted">{label}</span>
+        <span className="font-mono text-text-secondary">
+          {used} / {quota}
+        </span>
+      </div>
+      <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-bg-elevated">
+        <div
+          className={`h-full ${pct >= 90 ? "bg-status-error" : pct >= 70 ? "bg-warm" : "bg-accent"}`}
+          style={{ width: `${Math.min(100, pct)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function pct(a: number, b: number): number {
+  if (!b) return 0;
+  return Math.round((a / b) * 100);
+}
+
+// ─── Upgrade flow ────────────────────────────────────────────────────
+
+function UpgradePanel({
+  apiKey,
+  apiUrl,
+  defaultDisplayName,
+  onDone,
+  onCancel,
+}: {
+  apiKey: string;
+  apiUrl: string;
+  defaultDisplayName: string;
+  onDone: () => Promise<void>;
+  onCancel: () => void;
+}) {
+  const settings = useAssetStore((s) => s.settings);
+  const saveSettings = useAssetStore((s) => s.saveSettings);
+
+  const [stage, setStage] = useState<"request" | "verify">("request");
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState(defaultDisplayName);
+  const [code, setCode] = useState("");
+  const [turnstileSiteKey, setTurnstileSiteKey] = useState("");
+  const [turnstileToken, setTurnstileToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchHubConfig(apiUrl)
+      .then((cfg) => setTurnstileSiteKey(cfg.turnstileSiteKey))
+      .catch(() => setTurnstileSiteKey(""));
+  }, [apiUrl]);
+
+  const doRequest = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await upgradeRequest(
+        apiKey,
+        { email: email.trim(), displayName: displayName.trim(), turnstileToken },
+        apiUrl,
+      );
+      setStage("verify");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doVerify = async () => {
+    if (!settings) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await upgradeVerify(apiKey, { email: email.trim(), code: code.trim() }, apiUrl);
+      await saveSettings({ ...settings, hub_api_key: res.apiKey });
+      await onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 rounded border border-accent/40 bg-bg-primary p-3">
+      {stage === "request" && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void doRequest();
+          }}
+          className="flex flex-col gap-3"
+        >
+          <p className="text-2xs leading-5 text-text-muted">
+            Enter your email — we'll send a 6-digit code to verify it. Once verified, your account is
+            promoted to full (500 images / 5000 prompts) and publishing is enabled.
+          </p>
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-wider text-text-muted">Email</span>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              required
+              disabled={busy}
+              className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:border-accent/50"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-wider text-text-muted">Display name</span>
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              required
+              disabled={busy}
+              className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted focus:border-accent/50"
+            />
+          </label>
+          <TurnstileWidget
+            siteKey={turnstileSiteKey}
+            onToken={setTurnstileToken}
+            onError={setError}
+          />
+          {error && <p className="text-2xs text-status-error">{error}</p>}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="text-2xs uppercase tracking-ui text-text-muted hover:text-text-primary"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy || !email.trim() || !displayName.trim() || (Boolean(turnstileSiteKey) && !turnstileToken)}
+              className="rounded-full border border-accent/40 bg-accent/30 px-4 py-1.5 text-xs text-text-primary transition hover:bg-accent/50 disabled:opacity-50"
+            >
+              {busy ? "Sending…" : "Send code"}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {stage === "verify" && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void doVerify();
+          }}
+          className="flex flex-col gap-3"
+        >
+          <p className="text-2xs leading-5 text-text-muted">
+            We sent a 6-digit code to <span className="text-text-primary">{email}</span>. Expires in
+            15 minutes.
+          </p>
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-wider text-text-muted">Code</span>
+            <input
+              inputMode="numeric"
+              pattern="\d{6}"
+              maxLength={6}
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+              required
+              disabled={busy}
+              className="w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-center font-mono tracking-[0.4em] text-sm text-text-primary focus:border-accent/50"
+            />
+          </label>
+          {error && <p className="text-2xs text-status-error">{error}</p>}
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setStage("request")}
+              className="text-2xs uppercase tracking-ui text-text-muted hover:text-text-primary"
+            >
+              ← Back
+            </button>
+            <button
+              type="submit"
+              disabled={busy || code.length !== 6}
+              className="rounded-full border border-accent/40 bg-accent/30 px-4 py-1.5 text-xs text-text-primary transition hover:bg-accent/50 disabled:opacity-50"
+            >
+              {busy ? "Verifying…" : "Verify"}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/creator/src/components/config/panels/HubSettingsPanel.tsx
+++ b/creator/src/components/config/panels/HubSettingsPanel.tsx
@@ -3,6 +3,7 @@ import { useAssetStore } from "@/stores/assetStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { AI_ENABLED } from "@/lib/featureFlags";
 import type { ProjectSettings, Settings } from "@/types/assets";
+import { HubAccountStatus } from "./HubAccountStatus";
 
 type HubAccountDraft = Pick<Settings, "hub_api_url" | "hub_api_key" | "use_hub_ai">;
 type HubWorldDraft = Pick<
@@ -108,14 +109,25 @@ export function HubSettingsPanel() {
 
   return (
     <div className="flex flex-col gap-6">
-      {/* ─── Account ─────────────────────────────────────────── */}
+      {/* ─── Account status ──────────────────────────────────── */}
       <section>
+        <h3 className="mb-3 font-display text-sm uppercase tracking-widest text-text-primary">
+          Account
+        </h3>
+        <HubAccountStatus
+          apiKey={settings?.hub_api_key ?? ""}
+          apiUrl={(settings?.hub_api_url || "https://api.arcanum-hub.com").trim()}
+        />
+      </section>
+
+      {/* ─── Connection ──────────────────────────────────────── */}
+      <section className="border-t border-border-default pt-5">
         <h3 className="mb-1 font-display text-sm uppercase tracking-widest text-text-primary">
           Connection
         </h3>
         <p className="mb-4 text-2xs text-text-muted">
-          The hub is a shared playtest service. One key per user — the hub admin issues it,
-          and rotating the key refreshes your generation quota.
+          Your API key and the hub URL. Sign up in the onboarding flow, or paste an existing key below
+          if you already have one.
         </p>
         <div className="flex flex-col gap-3">
           <div>

--- a/creator/src/components/onboarding/HubKeyStep.tsx
+++ b/creator/src/components/onboarding/HubKeyStep.tsx
@@ -1,7 +1,17 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAssetStore } from "@/stores/assetStore";
+import {
+  fetchHubConfig,
+  signupDemo,
+  signupRequest,
+  signupVerify,
+  type HubUser,
+} from "@/lib/hubClient";
+import { TurnstileWidget } from "./TurnstileWidget";
 
 const DEFAULT_HUB_API_URL = "https://api.arcanum-hub.com";
+
+type Mode = "choose" | "demo" | "fullRequest" | "fullVerify" | "paste";
 
 interface HubKeyStepProps {
   onDone: () => void;
@@ -10,93 +20,412 @@ interface HubKeyStepProps {
 export function HubKeyStep({ onDone }: HubKeyStepProps) {
   const settings = useAssetStore((s) => s.settings);
   const saveSettings = useAssetStore((s) => s.saveSettings);
-  const [key, setKey] = useState(settings?.hub_api_key ?? "");
-  const [saving, setSaving] = useState(false);
+  const [mode, setMode] = useState<Mode>("choose");
+  const [turnstileSiteKey, setTurnstileSiteKey] = useState<string>("");
+  const [turnstileToken, setTurnstileToken] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
 
-  const handleSubmit = async () => {
-    if (!settings) {
-      setError("Settings not loaded yet — give it a moment and try again.");
-      return;
-    }
-    const trimmed = key.trim();
-    if (!trimmed) {
-      setError("Enter your Arcanum Hub API key to continue.");
-      return;
-    }
-    setSaving(true);
+  // Shared form state across sub-flows
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [code, setCode] = useState("");
+  const [pastedKey, setPastedKey] = useState(settings?.hub_api_key ?? "");
+
+  useEffect(() => {
+    fetchHubConfig()
+      .then((cfg) => setTurnstileSiteKey(cfg.turnstileSiteKey))
+      .catch(() => {
+        // Unreachable hub shouldn't crash onboarding — Turnstile just stays off.
+        setTurnstileSiteKey("");
+      });
+  }, []);
+
+  const apiUrl = settings?.hub_api_url?.trim() || DEFAULT_HUB_API_URL;
+
+  const persistKeyAndFinish = async (apiKey: string, _user?: HubUser) => {
+    if (!settings) throw new Error("Settings not loaded");
+    await saveSettings({
+      ...settings,
+      hub_api_key: apiKey,
+      hub_api_url: apiUrl,
+      use_hub_ai: true,
+    });
+    onDone();
+  };
+
+  const runDemo = async () => {
+    setBusy(true);
     setError(null);
     try {
-      await saveSettings({
-        ...settings,
-        hub_api_key: trimmed,
-        hub_api_url: settings.hub_api_url?.trim() || DEFAULT_HUB_API_URL,
-        use_hub_ai: true,
-      });
-      onDone();
+      const res = await signupDemo({ displayName: displayName.trim() || undefined, turnstileToken }, apiUrl);
+      await persistKeyAndFinish(res.apiKey, res.user);
     } catch (e) {
-      setError(String(e));
-      setSaving(false);
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && !saving) {
-      void handleSubmit();
+  const runFullRequest = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await signupRequest(
+        { email: email.trim(), displayName: displayName.trim(), turnstileToken },
+        apiUrl,
+      );
+      setMode("fullVerify");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runFullVerify = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await signupVerify({ email: email.trim(), code: code.trim() }, apiUrl);
+      await persistKeyAndFinish(res.apiKey, res.user);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const runPaste = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const trimmed = pastedKey.trim();
+      if (!trimmed) throw new Error("Enter your Arcanum Hub API key to continue.");
+      await persistKeyAndFinish(trimmed);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setBusy(false);
     }
   };
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="space-y-3">
+      <div className="space-y-2">
         <p className="text-sm leading-7 text-text-secondary">
-          Arcanum Hub handles AI generation for you — no API keys to manage, no provider accounts to
-          juggle. Drop in the key you were given and we'll have you sketching worlds in about a
-          minute.
+          Arcanum Hub handles AI generation and world hosting for you — no API keys to juggle, no cloud
+          accounts to set up.
         </p>
         <p className="text-xs leading-6 text-text-muted">
-          Your key is saved to this machine only. You can revoke or rotate it later from the Hub admin
-          console.
+          Everything is saved locally to this machine. You can change it later in Settings → Arcanum Hub.
         </p>
       </div>
 
-      <div className="flex flex-col gap-2">
-        <label htmlFor="hub-api-key" className="text-2xs uppercase tracking-ui text-text-muted">
-          Arcanum Hub API Key
-        </label>
-        <input
-          id="hub-api-key"
-          type="password"
-          value={key}
-          onChange={(e) => setKey(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="arch_live_..."
-          autoFocus
-          className="ornate-input w-full rounded-xl border border-border-default bg-bg-primary px-4 py-3 font-mono text-sm text-text-primary placeholder:text-text-muted focus:border-accent/60 focus-visible:ring-2 focus-visible:ring-border-active"
+      {mode === "choose" && (
+        <ChooseMode
+          onDemo={() => {
+            setError(null);
+            setMode("demo");
+          }}
+          onSignup={() => {
+            setError(null);
+            setMode("fullRequest");
+          }}
+          onPaste={() => {
+            setError(null);
+            setMode("paste");
+          }}
         />
-        {error && <p className="text-2xs text-status-error">{error}</p>}
-      </div>
+      )}
 
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-2xs text-text-muted">
-          Don't have one?{" "}
-          <a
-            href="https://arcanum-hub.com"
-            target="_blank"
-            rel="noreferrer"
-            className="text-text-link underline-offset-2 hover:underline"
-          >
-            Request access at arcanum-hub.com
-          </a>
-        </p>
-        <button
-          onClick={handleSubmit}
-          disabled={saving || !settings}
-          className="rounded-full border border-[var(--border-accent-ring)] bg-[linear-gradient(135deg,rgb(var(--accent-rgb)/0.3),rgb(var(--surface-rgb)/0.18))] px-6 py-2 text-sm font-medium text-text-primary transition hover:shadow-[0_14px_34px_rgb(var(--accent-rgb)/0.2)] disabled:cursor-not-allowed disabled:opacity-50"
+      {mode === "demo" && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void runDemo();
+          }}
+          className="flex flex-col gap-4"
         >
-          {saving ? "Saving..." : "Continue"}
-        </button>
-      </div>
+          <h3 className="font-display text-sm uppercase tracking-widest text-text-primary">
+            Try it free
+          </h3>
+          <p className="text-xs leading-6 text-text-muted">
+            A demo account gets you 10 image generations and 20 prompt enhancements — enough to sketch
+            one small world and see how everything fits together. No email required. Upgrade for free
+            later with email verification.
+          </p>
+          <Field label="Display name (optional)">
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="e.g. jnoecker"
+              className={inputClasses}
+              autoFocus
+              disabled={busy}
+            />
+          </Field>
+          <TurnstileWidget
+            siteKey={turnstileSiteKey}
+            onToken={setTurnstileToken}
+            onError={setError}
+          />
+          {error && <p className="text-2xs text-status-error">{error}</p>}
+          <Actions
+            onBack={() => setMode("choose")}
+            disabled={busy || (Boolean(turnstileSiteKey) && !turnstileToken)}
+            busy={busy}
+            primary="Create demo account"
+          />
+        </form>
+      )}
+
+      {mode === "fullRequest" && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void runFullRequest();
+          }}
+          className="flex flex-col gap-4"
+        >
+          <h3 className="font-display text-sm uppercase tracking-widest text-text-primary">
+            Create your account
+          </h3>
+          <p className="text-xs leading-6 text-text-muted">
+            Verify your email to unlock full quotas (500 images, 5000 prompts) and the ability to
+            publish worlds to the public hub. We'll email a 6-digit code in a moment.
+          </p>
+          <Field label="Email">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              className={inputClasses}
+              autoFocus
+              required
+              disabled={busy}
+            />
+          </Field>
+          <Field label="Display name">
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="How you want to be credited"
+              className={inputClasses}
+              required
+              disabled={busy}
+            />
+          </Field>
+          <TurnstileWidget
+            siteKey={turnstileSiteKey}
+            onToken={setTurnstileToken}
+            onError={setError}
+          />
+          {error && <p className="text-2xs text-status-error">{error}</p>}
+          <Actions
+            onBack={() => setMode("choose")}
+            disabled={
+              busy ||
+              !email.trim() ||
+              !displayName.trim() ||
+              (Boolean(turnstileSiteKey) && !turnstileToken)
+            }
+            busy={busy}
+            primary="Send verification code"
+          />
+        </form>
+      )}
+
+      {mode === "fullVerify" && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void runFullVerify();
+          }}
+          className="flex flex-col gap-4"
+        >
+          <h3 className="font-display text-sm uppercase tracking-widest text-text-primary">
+            Enter verification code
+          </h3>
+          <p className="text-xs leading-6 text-text-muted">
+            We sent a 6-digit code to <span className="text-text-primary">{email}</span>. It expires in
+            15 minutes.
+          </p>
+          <Field label="Code">
+            <input
+              inputMode="numeric"
+              pattern="\d{6}"
+              maxLength={6}
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+              placeholder="123456"
+              className={`${inputClasses} text-center font-mono tracking-[0.4em]`}
+              autoFocus
+              required
+              disabled={busy}
+            />
+          </Field>
+          {error && <p className="text-2xs text-status-error">{error}</p>}
+          <Actions
+            onBack={() => setMode("fullRequest")}
+            disabled={busy || code.length !== 6}
+            busy={busy}
+            primary="Verify and continue"
+          />
+        </form>
+      )}
+
+      {mode === "paste" && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void runPaste();
+          }}
+          className="flex flex-col gap-4"
+        >
+          <h3 className="font-display text-sm uppercase tracking-widest text-text-primary">
+            Use an existing key
+          </h3>
+          <p className="text-xs leading-6 text-text-muted">
+            If you already have an Arcanum Hub API key, paste it below.
+          </p>
+          <Field label="Arcanum Hub API Key">
+            <input
+              type="password"
+              value={pastedKey}
+              onChange={(e) => setPastedKey(e.target.value)}
+              placeholder="hubk_full_..."
+              className={`${inputClasses} font-mono`}
+              autoFocus
+              required
+              disabled={busy}
+            />
+          </Field>
+          {error && <p className="text-2xs text-status-error">{error}</p>}
+          <Actions
+            onBack={() => setMode("choose")}
+            disabled={busy || !pastedKey.trim()}
+            busy={busy}
+            primary="Save and continue"
+          />
+        </form>
+      )}
     </div>
   );
 }
+
+// ─── Subcomponents ───────────────────────────────────────────────────
+
+function ChooseMode({
+  onDemo,
+  onSignup,
+  onPaste,
+}: {
+  onDemo: () => void;
+  onSignup: () => void;
+  onPaste: () => void;
+}) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      <ChoiceCard
+        title="Try it free"
+        description="Jump in with 10 images / 20 prompts. No email needed."
+        cta="Demo account"
+        onClick={onDemo}
+        primary
+      />
+      <ChoiceCard
+        title="Create an account"
+        description="Verify email for full quotas (500 images / 5000 prompts) and publishing."
+        cta="Sign up"
+        onClick={onSignup}
+      />
+      <ChoiceCard
+        title="I have a key"
+        description="Paste an existing Arcanum Hub API key."
+        cta="Paste key"
+        onClick={onPaste}
+        span
+      />
+    </div>
+  );
+}
+
+function ChoiceCard({
+  title,
+  description,
+  cta,
+  onClick,
+  primary = false,
+  span = false,
+}: {
+  title: string;
+  description: string;
+  cta: string;
+  onClick: () => void;
+  primary?: boolean;
+  span?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex flex-col items-start gap-2 rounded-xl border px-5 py-4 text-left transition ${
+        span ? "sm:col-span-2" : ""
+      } ${
+        primary
+          ? "border-[var(--border-accent-ring)] bg-[linear-gradient(135deg,rgb(var(--accent-rgb)/0.22),rgb(var(--surface-rgb)/0.1))] hover:shadow-[0_14px_34px_rgb(var(--accent-rgb)/0.2)]"
+          : "border-border-default bg-bg-primary hover:border-accent/50"
+      }`}
+    >
+      <span className="font-display text-sm uppercase tracking-widest text-text-primary">{title}</span>
+      <span className="text-xs leading-6 text-text-muted">{description}</span>
+      <span className="mt-1 text-2xs uppercase tracking-ui text-accent">{cta} →</span>
+    </button>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-2xs uppercase tracking-ui text-text-muted">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Actions({
+  onBack,
+  primary,
+  disabled,
+  busy,
+}: {
+  onBack: () => void;
+  primary: string;
+  disabled: boolean;
+  busy: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <button
+        type="button"
+        onClick={onBack}
+        className="text-2xs uppercase tracking-ui text-text-muted transition hover:text-text-primary"
+      >
+        ← Back
+      </button>
+      <button
+        type="submit"
+        disabled={disabled}
+        className="rounded-full border border-[var(--border-accent-ring)] bg-[linear-gradient(135deg,rgb(var(--accent-rgb)/0.3),rgb(var(--surface-rgb)/0.18))] px-6 py-2 text-sm font-medium text-text-primary transition hover:shadow-[0_14px_34px_rgb(var(--accent-rgb)/0.2)] disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {busy ? "Working…" : primary}
+      </button>
+    </div>
+  );
+}
+
+const inputClasses =
+  "w-full rounded-xl border border-border-default bg-bg-primary px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-accent/60 focus-visible:ring-2 focus-visible:ring-border-active";

--- a/creator/src/components/onboarding/TurnstileWidget.tsx
+++ b/creator/src/components/onboarding/TurnstileWidget.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef } from "react";
+
+// ─── Cloudflare Turnstile widget ─────────────────────────────────────
+//
+// Loads the CF Turnstile script and renders an invisible/managed
+// widget in the supplied container. The widget calls `onToken` with
+// the verification token once the challenge is solved; we pass that
+// token along to the hub's signup endpoints.
+//
+// If `siteKey` is empty we render nothing and immediately fire
+// `onToken("")` so the caller can still POST — the hub also skips
+// verification in dev when TURNSTILE_SECRET_KEY is unset.
+//
+// Turnstile's widget runs in its own iframe with its own origin
+// checks against the site-key's allowed domains. For Tauri we add
+// `tauri.localhost` (Windows) + `localhost` to the allowed list in
+// the Cloudflare dashboard when the site key is created.
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        target: HTMLElement,
+        opts: {
+          sitekey: string;
+          callback: (token: string) => void;
+          "error-callback"?: () => void;
+          "expired-callback"?: () => void;
+          appearance?: "always" | "interaction-only";
+          theme?: "light" | "dark" | "auto";
+        },
+      ) => string;
+      reset: (widgetId: string) => void;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+
+let scriptPromise: Promise<void> | null = null;
+
+function loadTurnstile(): Promise<void> {
+  if (typeof window === "undefined") return Promise.resolve();
+  if (window.turnstile) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise((resolve, reject) => {
+    const s = document.createElement("script");
+    s.src = SCRIPT_SRC;
+    s.async = true;
+    s.defer = true;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error("Turnstile failed to load"));
+    document.head.appendChild(s);
+  });
+  return scriptPromise;
+}
+
+interface TurnstileWidgetProps {
+  siteKey: string;
+  onToken: (token: string) => void;
+  onError?: (message: string) => void;
+}
+
+export function TurnstileWidget({ siteKey, onToken, onError }: TurnstileWidgetProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const widgetIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    // No site key — skip verification entirely and let the caller
+    // continue. The hub will also skip, so this matches production
+    // when Turnstile is intentionally disabled.
+    if (!siteKey) {
+      onToken("");
+      return;
+    }
+    let cancelled = false;
+    loadTurnstile()
+      .then(() => {
+        if (cancelled || !ref.current || !window.turnstile) return;
+        widgetIdRef.current = window.turnstile.render(ref.current, {
+          sitekey: siteKey,
+          theme: "dark",
+          appearance: "interaction-only",
+          callback: (token) => onToken(token),
+          "error-callback": () => onError?.("Turnstile error. Try again in a moment."),
+          "expired-callback": () => onToken(""),
+        });
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) onError?.(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+      if (widgetIdRef.current && window.turnstile) {
+        try {
+          window.turnstile.remove(widgetIdRef.current);
+        } catch {
+          // ignore
+        }
+      }
+    };
+  }, [siteKey, onToken, onError]);
+
+  if (!siteKey) return null;
+  return <div ref={ref} className="mt-2" />;
+}

--- a/creator/src/lib/hubClient.ts
+++ b/creator/src/lib/hubClient.ts
@@ -1,0 +1,170 @@
+// ─── Arcanum Hub API client (frontend) ───────────────────────────────
+//
+// Minimal fetch wrapper used by onboarding + settings UI. Talks
+// directly to api.arcanum-hub.com (CORS: *). For Tauri, the webview
+// allows cross-origin fetch by default as long as the response
+// carries the right headers. The hub's util.corsHeaders() does.
+//
+// All endpoints return JSON. On non-2xx we try to surface
+// `body.error` (or `body.message`) so the UI can show a useful toast.
+
+const DEFAULT_HUB_API_URL = "https://api.arcanum-hub.com";
+
+export interface HubUser {
+  id: string;
+  displayName: string;
+  tier: "demo" | "full" | "publish";
+  email: string | null;
+  emailVerified: boolean;
+  imagesQuota: number;
+  promptsQuota: number;
+}
+
+export interface HubAccount {
+  id: string;
+  displayName: string;
+  email: string | null;
+  emailVerified: boolean;
+  tier: "demo" | "full" | "publish";
+  createdAt: number;
+  lastPublishAt: number | null;
+  canPublish: boolean;
+  usage: {
+    imagesUsed: number;
+    imagesQuota: number;
+    promptsUsed: number;
+    promptsQuota: number;
+  };
+}
+
+export interface HubWorldSummary {
+  slug: string;
+  displayName: string | null;
+  listed: boolean;
+  lastPublishAt: number | null;
+  bytesUsed: number;
+}
+
+function baseUrl(override?: string): string {
+  const url = (override ?? DEFAULT_HUB_API_URL).trim().replace(/\/+$/, "");
+  return url || DEFAULT_HUB_API_URL;
+}
+
+async function readJson<T>(resp: Response): Promise<T> {
+  const text = await resp.text();
+  if (!resp.ok) {
+    let msg = `Hub ${resp.status}`;
+    try {
+      const body = JSON.parse(text) as { error?: string; message?: string };
+      msg = body.error ?? body.message ?? msg;
+    } catch {
+      if (text) msg = `${msg}: ${text.slice(0, 200)}`;
+    }
+    throw new Error(msg);
+  }
+  return JSON.parse(text) as T;
+}
+
+export interface HubConfig {
+  turnstileSiteKey: string;
+}
+
+export async function fetchHubConfig(apiUrl?: string): Promise<HubConfig> {
+  const resp = await fetch(`${baseUrl(apiUrl)}/config`);
+  return await readJson<HubConfig>(resp);
+}
+
+// ─── Signup ──────────────────────────────────────────────────────────
+
+export interface SignupResult {
+  apiKey: string;
+  user: HubUser;
+  upgraded?: boolean;
+}
+
+export async function signupDemo(
+  input: { displayName?: string; turnstileToken?: string },
+  apiUrl?: string,
+): Promise<SignupResult> {
+  const resp = await fetch(`${baseUrl(apiUrl)}/signup/demo`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return await readJson<SignupResult>(resp);
+}
+
+export async function signupRequest(
+  input: { email: string; displayName: string; turnstileToken?: string; existingApiKey?: string },
+  apiUrl?: string,
+): Promise<{ ok: boolean; email: string; expiresInMinutes: number }> {
+  const resp = await fetch(`${baseUrl(apiUrl)}/signup/request`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return await readJson(resp);
+}
+
+export async function signupVerify(
+  input: { email: string; code: string },
+  apiUrl?: string,
+): Promise<SignupResult> {
+  const resp = await fetch(`${baseUrl(apiUrl)}/signup/verify`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return await readJson<SignupResult>(resp);
+}
+
+// ─── Account ─────────────────────────────────────────────────────────
+
+function authHeaders(apiKey: string): HeadersInit {
+  return { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
+}
+
+export async function fetchAccount(
+  apiKey: string,
+  apiUrl?: string,
+): Promise<{ account: HubAccount; worlds: HubWorldSummary[] }> {
+  const resp = await fetch(`${baseUrl(apiUrl)}/account`, { headers: authHeaders(apiKey) });
+  return await readJson(resp);
+}
+
+export async function rotateKey(
+  apiKey: string,
+  apiUrl?: string,
+): Promise<{ apiKey: string }> {
+  const resp = await fetch(`${baseUrl(apiUrl)}/account/rotate-key`, {
+    method: "POST",
+    headers: authHeaders(apiKey),
+  });
+  return await readJson(resp);
+}
+
+export async function upgradeRequest(
+  apiKey: string,
+  input: { email: string; displayName?: string; turnstileToken?: string },
+  apiUrl?: string,
+): Promise<{ ok: boolean; email: string; expiresInMinutes: number }> {
+  const resp = await fetch(`${baseUrl(apiUrl)}/account/upgrade/request`, {
+    method: "POST",
+    headers: authHeaders(apiKey),
+    body: JSON.stringify(input),
+  });
+  return await readJson(resp);
+}
+
+export async function upgradeVerify(
+  apiKey: string,
+  input: { email: string; code: string },
+  apiUrl?: string,
+): Promise<{ apiKey: string; account: HubAccount }> {
+  const resp = await fetch(`${baseUrl(apiUrl)}/account/upgrade/verify`, {
+    method: "POST",
+    headers: authHeaders(apiKey),
+    body: JSON.stringify(input),
+  });
+  return await readJson(resp);
+}

--- a/hub-worker/README.md
+++ b/hub-worker/README.md
@@ -30,8 +30,13 @@ wrangler r2 bucket create arcanum-hub
 npm run db:init:local      # dev
 npm run db:init:remote     # prod
 
-# Set the admin master key (prod):
-wrangler secret put HUB_ADMIN_KEY
+# Set secrets (prod):
+wrangler secret put HUB_ADMIN_KEY         # admin dashboard master key
+wrangler secret put RESEND_API_KEY        # transactional email (https://resend.com)
+wrangler secret put TURNSTILE_SECRET_KEY  # CF Turnstile (pair with TURNSTILE_SITE_KEY in [vars])
+wrangler secret put RUNWARE_API_KEY       # image generation
+wrangler secret put OPENROUTER_API_KEY    # text LLM
+wrangler secret put ANTHROPIC_API_KEY     # vision LLM
 
 # Dev server on http://127.0.0.1:8787:
 npm run dev
@@ -39,6 +44,33 @@ npm run dev
 # Deploy:
 npm run deploy
 ```
+
+### Applying migrations
+
+Schema edits go in `src/migrations/NNNN_name.sql`. Apply them in
+order against the target environment:
+
+```bash
+wrangler d1 execute arcanum-hub --remote --file=./src/migrations/0004_self_registration.sql
+```
+
+### Self-registration setup
+
+Public signup (`/signup/*`) and account management (`/account/*`)
+require two external services:
+
+1. **Resend** — create an account, verify the domain you'll send from
+   (`arcanum-hub.com`), set `FROM_EMAIL` in `[vars]` to something on
+   that domain, and `wrangler secret put RESEND_API_KEY`. Without a
+   key the worker logs verification codes to `wrangler tail` instead
+   of emailing them — fine for dev, broken for users.
+2. **Cloudflare Turnstile** — create a site in the CF dashboard, add
+   `arcanum-hub.com`, `*.arcanum-hub.com`, `tauri.localhost`, and
+   `localhost` to the allowed domains. Put the public site key in
+   `wrangler.toml` `[vars].TURNSTILE_SITE_KEY` and
+   `wrangler secret put TURNSTILE_SECRET_KEY` for the server secret.
+   Without either, Turnstile verification is skipped (rate limits
+   + email verification still apply).
 
 ## Development routing
 

--- a/hub-worker/src/db.ts
+++ b/hub-worker/src/db.ts
@@ -1,6 +1,6 @@
 import type { Env } from "./env";
 
-export type UserTier = "full" | "publish";
+export type UserTier = "full" | "publish" | "demo";
 
 export interface UserRow {
   id: string;
@@ -14,6 +14,26 @@ export interface UserRow {
   prompts_used: number;
   prompts_quota: number;
   tier: UserTier;
+  email_verified: number;
+}
+
+// Default lifetime quotas by tier. Demo is deliberately tight — just
+// enough to experience the features end-to-end without costing real
+// money. Full is what email-verified signups get; publish is BYOK.
+export const DEFAULT_QUOTAS: Record<UserTier, { images: number; prompts: number }> = {
+  demo: { images: 10, prompts: 20 },
+  full: { images: 500, prompts: 5000 },
+  publish: { images: 0, prompts: 0 },
+};
+
+export interface VerificationCodeRow {
+  email: string;
+  code_hash: string;
+  display_name: string;
+  existing_user_id: string | null;
+  expires_at: number;
+  attempts: number;
+  created_at: number;
 }
 
 export interface WorldRow {
@@ -62,13 +82,67 @@ export async function createUser(
     email: string | null;
     api_key_hash: string;
     tier: UserTier;
+    email_verified?: boolean;
+    images_quota?: number;
+    prompts_quota?: number;
   },
 ): Promise<void> {
   const now = Date.now();
+  const quotas = DEFAULT_QUOTAS[user.tier];
+  const imagesQuota = user.images_quota ?? quotas.images;
+  const promptsQuota = user.prompts_quota ?? quotas.prompts;
+  const verified = user.email_verified ? 1 : 0;
   await env.DB.prepare(
-    "INSERT INTO users (id, display_name, email, api_key_hash, created_at, tier) VALUES (?, ?, ?, ?, ?, ?)",
+    `INSERT INTO users (id, display_name, email, api_key_hash, created_at, tier,
+       email_verified, images_quota, prompts_quota)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   )
-    .bind(user.id, user.display_name, user.email, user.api_key_hash, now, user.tier)
+    .bind(
+      user.id,
+      user.display_name,
+      user.email,
+      user.api_key_hash,
+      now,
+      user.tier,
+      verified,
+      imagesQuota,
+      promptsQuota,
+    )
+    .run();
+}
+
+export async function getUserByEmail(env: Env, email: string): Promise<UserRow | null> {
+  return await env.DB.prepare("SELECT * FROM users WHERE email = ?").bind(email).first<UserRow>();
+}
+
+/**
+ * Promote a demo user to full tier. Rotates the API key (zeroing
+ * usage counters), attaches the verified email + display name, and
+ * bumps quotas to full defaults. All-in-one so callers don't have to
+ * juggle half-upgraded states.
+ */
+export async function promoteUserToFull(
+  env: Env,
+  userId: string,
+  email: string,
+  displayName: string,
+  apiKeyHash: string,
+): Promise<void> {
+  const { images, prompts } = DEFAULT_QUOTAS.full;
+  await env.DB.prepare(
+    `UPDATE users
+       SET tier = 'full',
+           email = ?,
+           display_name = ?,
+           email_verified = 1,
+           api_key_hash = ?,
+           images_used = 0,
+           prompts_used = 0,
+           images_quota = ?,
+           prompts_quota = ?
+     WHERE id = ?`,
+  )
+    .bind(email, displayName, apiKeyHash, images, prompts, userId)
     .run();
 }
 
@@ -231,4 +305,82 @@ export async function updateWorldPublish(
 
 export async function deleteWorld(env: Env, slug: string): Promise<void> {
   await env.DB.prepare("DELETE FROM worlds WHERE slug = ?").bind(slug).run();
+}
+
+// ─── Verification codes ──────────────────────────────────────────────
+
+export async function upsertVerificationCode(
+  env: Env,
+  row: {
+    email: string;
+    code_hash: string;
+    display_name: string;
+    existing_user_id: string | null;
+    expires_at: number;
+  },
+): Promise<void> {
+  const now = Date.now();
+  await env.DB.prepare(
+    `INSERT INTO verification_codes
+       (email, code_hash, display_name, existing_user_id, expires_at, attempts, created_at)
+     VALUES (?, ?, ?, ?, ?, 0, ?)
+     ON CONFLICT(email) DO UPDATE SET
+       code_hash = excluded.code_hash,
+       display_name = excluded.display_name,
+       existing_user_id = excluded.existing_user_id,
+       expires_at = excluded.expires_at,
+       attempts = 0,
+       created_at = excluded.created_at`,
+  )
+    .bind(row.email, row.code_hash, row.display_name, row.existing_user_id, row.expires_at, now)
+    .run();
+}
+
+export async function getVerificationCode(
+  env: Env,
+  email: string,
+): Promise<VerificationCodeRow | null> {
+  return await env.DB.prepare("SELECT * FROM verification_codes WHERE email = ?")
+    .bind(email)
+    .first<VerificationCodeRow>();
+}
+
+export async function bumpVerificationAttempts(env: Env, email: string): Promise<void> {
+  await env.DB.prepare(
+    "UPDATE verification_codes SET attempts = attempts + 1 WHERE email = ?",
+  )
+    .bind(email)
+    .run();
+}
+
+export async function deleteVerificationCode(env: Env, email: string): Promise<void> {
+  await env.DB.prepare("DELETE FROM verification_codes WHERE email = ?").bind(email).run();
+}
+
+// ─── Signup rate-limiting ────────────────────────────────────────────
+
+export async function recordSignupAttempt(env: Env, ip: string): Promise<void> {
+  await env.DB.prepare("INSERT INTO signup_attempts (ip, attempted_at) VALUES (?, ?)")
+    .bind(ip, Date.now())
+    .run();
+}
+
+export async function countRecentSignupAttempts(
+  env: Env,
+  ip: string,
+  windowMs: number,
+): Promise<number> {
+  const since = Date.now() - windowMs;
+  const row = await env.DB.prepare(
+    "SELECT COUNT(*) as n FROM signup_attempts WHERE ip = ? AND attempted_at >= ?",
+  )
+    .bind(ip, since)
+    .first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
+/** Prune entries older than retainMs — called opportunistically. */
+export async function pruneOldSignupAttempts(env: Env, retainMs: number): Promise<void> {
+  const cutoff = Date.now() - retainMs;
+  await env.DB.prepare("DELETE FROM signup_attempts WHERE attempted_at < ?").bind(cutoff).run();
 }

--- a/hub-worker/src/email.ts
+++ b/hub-worker/src/email.ts
@@ -1,0 +1,85 @@
+import type { Env } from "./env";
+
+// ─── Resend transactional email ──────────────────────────────────────
+//
+// Thin wrapper around the Resend /emails REST API. The worker never
+// depends on the full Resend SDK (it would balloon the bundle); we
+// just POST JSON. FROM_EMAIL must be on a domain that's verified in
+// the Resend console — otherwise Resend returns 403 and the signup
+// flow surfaces that to the user.
+
+export interface SendResult {
+  ok: boolean;
+  error?: string;
+}
+
+export async function sendEmail(
+  env: Env,
+  to: string,
+  subject: string,
+  html: string,
+  text: string,
+): Promise<SendResult> {
+  if (!env.RESEND_API_KEY) {
+    // Dev fallback — log the mail instead of sending so the
+    // verification flow stays testable without Resend credentials.
+    console.log(`[email stub] to=${to} subject=${subject}\n${text}`);
+    return { ok: true };
+  }
+
+  const resp = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: env.FROM_EMAIL,
+      to,
+      subject,
+      html,
+      text,
+    }),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    return { ok: false, error: `Resend ${resp.status}: ${body.slice(0, 400)}` };
+  }
+  return { ok: true };
+}
+
+/**
+ * Build the verification-code email. We keep both an HTML and a text
+ * body; some clients still reject HTML-only mail as spam and Resend
+ * bills the same either way.
+ */
+export function verificationEmail(code: string, minutesValid: number): { subject: string; html: string; text: string } {
+  const subject = `Your Arcanum Hub verification code: ${code}`;
+  const text = `Welcome to Arcanum Hub!
+
+Your verification code is: ${code}
+
+This code expires in ${minutesValid} minutes. Enter it in the app to finish creating your account.
+
+If you didn't request this, you can safely ignore this email.
+— Arcanum Hub
+`;
+  const html = `<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:24px;background:#0b1418;font-family:Georgia,'Times New Roman',serif;color:#d9c8ad;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;margin:0 auto;background:#11212a;border:1px solid #2b4750;border-radius:8px;">
+      <tr>
+        <td style="padding:28px 28px 16px 28px;">
+          <h1 style="margin:0 0 12px 0;font-family:'Cinzel',Georgia,serif;font-size:20px;letter-spacing:0.12em;color:#f6e3b3;text-transform:uppercase;">Arcanum Hub</h1>
+          <p style="margin:0 0 16px 0;font-size:15px;line-height:1.6;">Welcome! Enter this code in the app to finish creating your account:</p>
+          <div style="font-family:'JetBrains Mono',ui-monospace,monospace;font-size:32px;letter-spacing:0.35em;color:#f6e3b3;background:#0b1418;border:1px solid #2b4750;border-radius:6px;padding:16px 20px;text-align:center;">${code}</div>
+          <p style="margin:16px 0 0 0;font-size:13px;line-height:1.6;color:#8da3a8;">This code expires in ${minutesValid} minutes.</p>
+          <p style="margin:8px 0 0 0;font-size:13px;line-height:1.6;color:#8da3a8;">If you didn't request this, you can safely ignore this email.</p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+  return { subject, html, text };
+}

--- a/hub-worker/src/env.ts
+++ b/hub-worker/src/env.ts
@@ -10,4 +10,14 @@ export interface Env {
   RUNWARE_API_KEY: string;
   OPENROUTER_API_KEY: string;
   ANTHROPIC_API_KEY: string;
+  // ─── Self-registration ──────────────────────────────────────────────
+  // Resend transactional email for verification codes. Domain must be
+  // verified in the Resend console and FROM_EMAIL must be on that domain.
+  RESEND_API_KEY: string;
+  FROM_EMAIL: string;
+  // Cloudflare Turnstile — TURNSTILE_SITE_KEY is public (safe in [vars]).
+  // TURNSTILE_SECRET_KEY is a secret. If both are empty the worker
+  // skips Turnstile verification, which is the expected state in dev.
+  TURNSTILE_SITE_KEY: string;
+  TURNSTILE_SECRET_KEY: string;
 }

--- a/hub-worker/src/handlers/account.ts
+++ b/hub-worker/src/handlers/account.ts
@@ -1,0 +1,185 @@
+import type { Env } from "../env";
+import type { UserRow, UserTier } from "../db";
+import {
+  bumpVerificationAttempts,
+  deleteVerificationCode,
+  getUserByEmail,
+  getUserById,
+  getVerificationCode,
+  listWorldsForUser,
+  promoteUserToFull,
+  recordSignupAttempt,
+  upsertVerificationCode,
+  updateUserApiKeyHash,
+} from "../db";
+import {
+  clientIp,
+  error,
+  generateApiKey,
+  generateVerificationCode,
+  isValidEmail,
+  json,
+  normalizeEmail,
+  sha256Hex,
+} from "../util";
+import { sendEmail, verificationEmail } from "../email";
+import { verifyTurnstile } from "../turnstile";
+
+// ─── Account endpoints ───────────────────────────────────────────────
+//
+// All require Bearer auth (authenticateUser at the router). The
+// upgrade flow lets a demo user promote to full via email
+// verification — we pass the user.id in the pending record so the
+// verify step knows to promote instead of creating a new account.
+
+const cors = { origin: "*" } as const;
+const CODE_TTL_MS = 15 * 60 * 1000;
+const CODE_TTL_MIN = 15;
+const MAX_CODE_ATTEMPTS = 5;
+
+function toAccountView(user: UserRow) {
+  return {
+    id: user.id,
+    displayName: user.display_name,
+    email: user.email,
+    emailVerified: Boolean(user.email_verified),
+    tier: user.tier as UserTier,
+    createdAt: user.created_at,
+    lastPublishAt: user.last_publish_at,
+    canPublish: Boolean(user.email_verified) && user.tier !== "demo",
+    usage: {
+      imagesUsed: user.images_used,
+      imagesQuota: user.images_quota,
+      promptsUsed: user.prompts_used,
+      promptsQuota: user.prompts_quota,
+    },
+  };
+}
+
+// ─── GET /account ────────────────────────────────────────────────────
+
+export async function getAccount(_req: Request, env: Env, user: UserRow): Promise<Response> {
+  const worlds = await listWorldsForUser(env, user.id);
+  return json(
+    {
+      account: toAccountView(user),
+      worlds: worlds.map((w) => ({
+        slug: w.slug,
+        displayName: w.display_name,
+        listed: Boolean(w.listed),
+        lastPublishAt: w.last_publish_at,
+        bytesUsed: w.bytes_used,
+      })),
+    },
+    {},
+    cors,
+  );
+}
+
+// ─── POST /account/rotate-key ────────────────────────────────────────
+
+export async function rotateKey(_req: Request, env: Env, user: UserRow): Promise<Response> {
+  const { plain, hash } = await generateApiKey(user.tier);
+  await updateUserApiKeyHash(env, user.id, hash);
+  return json({ apiKey: plain }, {}, cors);
+}
+
+// ─── POST /account/upgrade/request ───────────────────────────────────
+
+export async function upgradeRequest(req: Request, env: Env, user: UserRow): Promise<Response> {
+  if (user.tier !== "demo") {
+    return error(400, "This account is already verified.", cors);
+  }
+
+  let body: { email?: string; displayName?: string; turnstileToken?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return error(400, "Invalid JSON body", cors);
+  }
+
+  const email = normalizeEmail((body.email ?? "").trim());
+  const displayName = (body.displayName ?? "").trim() || user.display_name;
+  if (!isValidEmail(email)) return error(400, "Enter a valid email address.", cors);
+
+  const ip = clientIp(req);
+  const turnstile = await verifyTurnstile(env, body.turnstileToken, ip);
+  if (!turnstile.ok) {
+    return error(400, `Verification failed: ${turnstile.reason ?? "unknown"}`, cors);
+  }
+
+  // Don't let two demo accounts upgrade to the same email.
+  const owned = await getUserByEmail(env, email);
+  if (owned && owned.id !== user.id) {
+    return error(
+      409,
+      "That email already has an account. Use the existing account's API key instead.",
+      cors,
+    );
+  }
+
+  await recordSignupAttempt(env, ip);
+
+  const code = generateVerificationCode();
+  const codeHash = await sha256Hex(code);
+  await upsertVerificationCode(env, {
+    email,
+    code_hash: codeHash,
+    display_name: displayName,
+    existing_user_id: user.id,
+    expires_at: Date.now() + CODE_TTL_MS,
+  });
+
+  const mail = verificationEmail(code, CODE_TTL_MIN);
+  const sent = await sendEmail(env, email, mail.subject, mail.html, mail.text);
+  if (!sent.ok) {
+    return error(502, `Could not send verification email: ${sent.error ?? "unknown"}`, cors);
+  }
+  return json({ ok: true, email, expiresInMinutes: CODE_TTL_MIN }, {}, cors);
+}
+
+// ─── POST /account/upgrade/verify ────────────────────────────────────
+
+export async function upgradeVerify(req: Request, env: Env, user: UserRow): Promise<Response> {
+  if (user.tier !== "demo") {
+    return error(400, "This account is already verified.", cors);
+  }
+
+  let body: { email?: string; code?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return error(400, "Invalid JSON body", cors);
+  }
+
+  const email = normalizeEmail((body.email ?? "").trim());
+  const code = (body.code ?? "").trim();
+  if (!isValidEmail(email)) return error(400, "Enter a valid email address.", cors);
+  if (!/^\d{6}$/.test(code)) return error(400, "Enter the 6-digit code from the email.", cors);
+
+  const pending = await getVerificationCode(env, email);
+  if (!pending || pending.existing_user_id !== user.id) {
+    return error(400, "No verification in progress for that email.", cors);
+  }
+  if (pending.expires_at < Date.now()) {
+    await deleteVerificationCode(env, email);
+    return error(400, "That code has expired. Request a new one.", cors);
+  }
+  if (pending.attempts >= MAX_CODE_ATTEMPTS) {
+    await deleteVerificationCode(env, email);
+    return error(429, "Too many attempts. Request a new code.", cors);
+  }
+
+  const candidateHash = await sha256Hex(code);
+  if (candidateHash !== pending.code_hash) {
+    await bumpVerificationAttempts(env, email);
+    return error(400, "That code doesn't match. Try again.", cors);
+  }
+
+  const { plain, hash } = await generateApiKey("full");
+  await promoteUserToFull(env, user.id, email, pending.display_name, hash);
+  await deleteVerificationCode(env, email);
+  const fresh = await getUserById(env, user.id);
+  if (!fresh) return error(500, "Upgrade succeeded but user unreadable", cors);
+  return json({ apiKey: plain, account: toAccountView(fresh) }, {}, cors);
+}

--- a/hub-worker/src/handlers/admin.ts
+++ b/hub-worker/src/handlers/admin.ts
@@ -23,6 +23,7 @@ interface AdminUserView {
   id: string;
   displayName: string;
   email: string | null;
+  emailVerified: boolean;
   createdAt: number;
   lastPublishAt: number | null;
   tier: UserTier;
@@ -36,7 +37,7 @@ interface AdminUserView {
 }
 
 function parseTier(raw: unknown): UserTier | null {
-  if (raw === "full" || raw === "publish") return raw;
+  if (raw === "full" || raw === "publish" || raw === "demo") return raw;
   return null;
 }
 
@@ -63,6 +64,7 @@ function toUserView(user: UserRow, worlds: WorldRow[]): AdminUserView {
     id: user.id,
     displayName: user.display_name,
     email: user.email,
+    emailVerified: Boolean(user.email_verified),
     createdAt: user.created_at,
     lastPublishAt: user.last_publish_at,
     tier: user.tier,
@@ -174,7 +176,16 @@ async function adminCreateUser(req: Request, env: Env, c: Cors): Promise<Respons
   const { plain, hash } = await generateApiKey(tier);
   const id = newId();
   try {
-    await createUser(env, { id, display_name: displayName, email, api_key_hash: hash, tier });
+    await createUser(env, {
+      id,
+      display_name: displayName,
+      email,
+      api_key_hash: hash,
+      tier,
+      // Admin-minted users are trusted — no need to make them verify
+      // an email before publishing.
+      email_verified: true,
+    });
   } catch (e) {
     return error(500, `Failed to create user: ${String(e)}`, c);
   }

--- a/hub-worker/src/handlers/ai.ts
+++ b/hub-worker/src/handlers/ai.ts
@@ -66,10 +66,11 @@ export async function handleAi(
   if (req.method === "OPTIONS") return preflight(CORS);
 
   // Tier gate. Publish-only users have valid credentials for /publish/*
-  // but cannot spend AI budget. D1 is the authoritative tier — the
-  // `hubk_pub_` prefix on their key is just a UX hint the creator
-  // reads to disable the toggle. Never trust the prefix; check here.
-  if (user.tier !== "full") {
+  // but cannot spend AI budget. Demo and full tiers can — demo just
+  // has much tighter quotas via DEFAULT_QUOTAS at signup time. D1 is
+  // the authoritative tier; the `hubk_*_` prefix on the key is just a
+  // UX hint the creator reads. Never trust the prefix; check here.
+  if (user.tier === "publish") {
     return json(
       {
         error: "tier_forbidden",

--- a/hub-worker/src/handlers/signup.ts
+++ b/hub-worker/src/handlers/signup.ts
@@ -1,0 +1,318 @@
+import type { Env } from "../env";
+import {
+  countRecentSignupAttempts,
+  createUser,
+  deleteVerificationCode,
+  getUserByEmail,
+  getUserById,
+  getVerificationCode,
+  promoteUserToFull,
+  pruneOldSignupAttempts,
+  recordSignupAttempt,
+  bumpVerificationAttempts,
+  upsertVerificationCode,
+  type UserTier,
+} from "../db";
+import {
+  clientIp,
+  error,
+  generateApiKey,
+  generateVerificationCode,
+  isValidEmail,
+  json,
+  newId,
+  normalizeEmail,
+  sha256Hex,
+} from "../util";
+import { sendEmail, verificationEmail } from "../email";
+import { verifyTurnstile } from "../turnstile";
+
+// ─── Signup flow ─────────────────────────────────────────────────────
+//
+// Two paths, one worker:
+//
+//   POST /signup/demo    — Turnstile only. Creates a demo-tier user
+//                          with tight quotas and no publish rights.
+//   POST /signup/request — Turnstile + email. Sends a 6-digit code
+//                          and stashes a pending record.
+//   POST /signup/verify  — email + code. Creates a full-tier user
+//                          (or upgrades a demo user that's already
+//                          signed in, via existing_user_id on the
+//                          pending record).
+//
+// Rate limit: per-IP rolling window counted in signup_attempts. A
+// single window covers both /demo and /request so we can't be spun
+// up by alternating endpoints.
+
+const SIGNUP_WINDOW_MS = 60 * 60 * 1000; // 1h
+const SIGNUP_MAX_PER_WINDOW = 3;
+const SIGNUP_RETAIN_MS = 24 * 60 * 60 * 1000; // prune after 24h
+
+const CODE_TTL_MS = 15 * 60 * 1000;
+const CODE_TTL_MIN = 15;
+const MAX_CODE_ATTEMPTS = 5;
+
+const cors = { origin: "*" } as const;
+
+// ─── POST /signup/demo ───────────────────────────────────────────────
+
+export async function signupDemo(req: Request, env: Env): Promise<Response> {
+  let body: { turnstileToken?: string; displayName?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return error(400, "Invalid JSON body", cors);
+  }
+
+  const ip = clientIp(req);
+  const rate = await enforceSignupRateLimit(env, ip);
+  if (rate) return rate;
+
+  const turnstile = await verifyTurnstile(env, body.turnstileToken, ip);
+  if (!turnstile.ok) {
+    return error(400, `Verification failed: ${turnstile.reason ?? "unknown"}`, cors);
+  }
+
+  await recordSignupAttempt(env, ip);
+
+  const displayName = (body.displayName ?? "").trim() || "Demo User";
+  const id = newId();
+  const { plain, hash } = await generateApiKey("demo");
+
+  try {
+    await createUser(env, {
+      id,
+      display_name: displayName,
+      email: null,
+      api_key_hash: hash,
+      tier: "demo",
+      email_verified: false,
+    });
+  } catch (e) {
+    return error(500, `Failed to create demo user: ${String(e)}`, cors);
+  }
+
+  const user = await getUserById(env, id);
+  if (!user) return error(500, "User created but not readable", cors);
+
+  return json(
+    {
+      apiKey: plain,
+      user: {
+        id: user.id,
+        displayName: user.display_name,
+        tier: user.tier as UserTier,
+        email: user.email,
+        emailVerified: Boolean(user.email_verified),
+        imagesQuota: user.images_quota,
+        promptsQuota: user.prompts_quota,
+      },
+    },
+    { status: 201 },
+    cors,
+  );
+}
+
+// ─── POST /signup/request ────────────────────────────────────────────
+
+export async function signupRequest(req: Request, env: Env): Promise<Response> {
+  let body: { email?: string; displayName?: string; turnstileToken?: string; existingApiKey?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return error(400, "Invalid JSON body", cors);
+  }
+
+  const rawEmail = (body.email ?? "").trim();
+  const email = normalizeEmail(rawEmail);
+  const displayName = (body.displayName ?? "").trim();
+  if (!isValidEmail(email)) return error(400, "Enter a valid email address.", cors);
+  if (!displayName) return error(400, "Display name is required.", cors);
+
+  const ip = clientIp(req);
+  const rate = await enforceSignupRateLimit(env, ip);
+  if (rate) return rate;
+
+  const turnstile = await verifyTurnstile(env, body.turnstileToken, ip);
+  if (!turnstile.ok) {
+    return error(400, `Verification failed: ${turnstile.reason ?? "unknown"}`, cors);
+  }
+
+  // If an existing demo user is upgrading, we need to tie the
+  // pending code to their user_id so the verify step upgrades that
+  // record instead of creating a fresh one. Auth happens via the
+  // bearer token on the existing-key path, but we accept a plain
+  // key here too so the web landing page (which may have a key in
+  // localStorage) can request an upgrade without its own Bearer
+  // header dance.
+  let existingUserId: string | null = null;
+  const rawExisting = (body.existingApiKey ?? "").trim();
+  if (rawExisting) {
+    const hash = await sha256Hex(rawExisting);
+    const existing = await env.DB
+      .prepare("SELECT id, tier, email FROM users WHERE api_key_hash = ?")
+      .bind(hash)
+      .first<{ id: string; tier: string; email: string | null }>();
+    if (existing) {
+      if (existing.tier !== "demo") {
+        return error(400, "This account is already verified.", cors);
+      }
+      existingUserId = existing.id;
+    }
+    // Unknown key is silently ignored — we still send the code so an
+    // attacker can't probe for valid keys via this endpoint.
+  }
+
+  // Reject if another user already owns that email (unless the
+  // upgrading demo user is the match). Don't leak which emails are
+  // taken — bail with a generic message.
+  if (!existingUserId) {
+    const taken = await getUserByEmail(env, email);
+    if (taken) {
+      return error(
+        409,
+        "That email already has an account. Sign in with your existing API key instead.",
+        cors,
+      );
+    }
+  }
+
+  await recordSignupAttempt(env, ip);
+
+  const code = generateVerificationCode();
+  const codeHash = await sha256Hex(code);
+  await upsertVerificationCode(env, {
+    email,
+    code_hash: codeHash,
+    display_name: displayName,
+    existing_user_id: existingUserId,
+    expires_at: Date.now() + CODE_TTL_MS,
+  });
+
+  const mail = verificationEmail(code, CODE_TTL_MIN);
+  const sent = await sendEmail(env, email, mail.subject, mail.html, mail.text);
+  if (!sent.ok) {
+    return error(502, `Could not send verification email: ${sent.error ?? "unknown"}`, cors);
+  }
+
+  return json({ ok: true, email, expiresInMinutes: CODE_TTL_MIN }, {}, cors);
+}
+
+// ─── POST /signup/verify ─────────────────────────────────────────────
+
+export async function signupVerify(req: Request, env: Env): Promise<Response> {
+  let body: { email?: string; code?: string };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return error(400, "Invalid JSON body", cors);
+  }
+
+  const email = normalizeEmail((body.email ?? "").trim());
+  const code = (body.code ?? "").trim();
+  if (!isValidEmail(email)) return error(400, "Enter a valid email address.", cors);
+  if (!/^\d{6}$/.test(code)) return error(400, "Enter the 6-digit code from the email.", cors);
+
+  const pending = await getVerificationCode(env, email);
+  if (!pending) return error(400, "No verification in progress for that email.", cors);
+
+  if (pending.expires_at < Date.now()) {
+    await deleteVerificationCode(env, email);
+    return error(400, "That code has expired. Request a new one.", cors);
+  }
+  if (pending.attempts >= MAX_CODE_ATTEMPTS) {
+    await deleteVerificationCode(env, email);
+    return error(429, "Too many attempts. Request a new code.", cors);
+  }
+
+  const candidateHash = await sha256Hex(code);
+  if (candidateHash !== pending.code_hash) {
+    await bumpVerificationAttempts(env, email);
+    return error(400, "That code doesn't match. Try again.", cors);
+  }
+
+  // Upgrade path: demo user becoming full.
+  if (pending.existing_user_id) {
+    const existing = await getUserById(env, pending.existing_user_id);
+    if (!existing) {
+      await deleteVerificationCode(env, email);
+      return error(410, "The account you're upgrading no longer exists.", cors);
+    }
+    const { plain, hash } = await generateApiKey("full");
+    await promoteUserToFull(env, existing.id, email, pending.display_name, hash);
+    await deleteVerificationCode(env, email);
+    const fresh = await getUserById(env, existing.id);
+    if (!fresh) return error(500, "Upgrade succeeded but user unreadable", cors);
+    return json(
+      {
+        apiKey: plain,
+        upgraded: true,
+        user: {
+          id: fresh.id,
+          displayName: fresh.display_name,
+          tier: fresh.tier as UserTier,
+          email: fresh.email,
+          emailVerified: Boolean(fresh.email_verified),
+          imagesQuota: fresh.images_quota,
+          promptsQuota: fresh.prompts_quota,
+        },
+      },
+      {},
+      cors,
+    );
+  }
+
+  // Fresh signup.
+  const id = newId();
+  const { plain, hash } = await generateApiKey("full");
+  try {
+    await createUser(env, {
+      id,
+      display_name: pending.display_name,
+      email,
+      api_key_hash: hash,
+      tier: "full",
+      email_verified: true,
+    });
+  } catch (e) {
+    return error(500, `Failed to create user: ${String(e)}`, cors);
+  }
+  await deleteVerificationCode(env, email);
+  const user = await getUserById(env, id);
+  if (!user) return error(500, "User created but not readable", cors);
+
+  return json(
+    {
+      apiKey: plain,
+      upgraded: false,
+      user: {
+        id: user.id,
+        displayName: user.display_name,
+        tier: user.tier as UserTier,
+        email: user.email,
+        emailVerified: Boolean(user.email_verified),
+        imagesQuota: user.images_quota,
+        promptsQuota: user.prompts_quota,
+      },
+    },
+    { status: 201 },
+    cors,
+  );
+}
+
+// ─── Shared: per-IP rate limit ──────────────────────────────────────
+
+async function enforceSignupRateLimit(env: Env, ip: string): Promise<Response | null> {
+  // Best-effort prune so signup_attempts doesn't grow forever; we
+  // don't wait on it failing.
+  try {
+    await pruneOldSignupAttempts(env, SIGNUP_RETAIN_MS);
+  } catch {
+    // ignore
+  }
+  const count = await countRecentSignupAttempts(env, ip, SIGNUP_WINDOW_MS);
+  if (count >= SIGNUP_MAX_PER_WINDOW) {
+    return error(429, "Too many signup attempts from this network. Try again later.", cors);
+  }
+  return null;
+}

--- a/hub-worker/src/index.ts
+++ b/hub-worker/src/index.ts
@@ -5,6 +5,13 @@ import { handleAdmin, adminCorsHeaders } from "./handlers/admin";
 import { handleAi } from "./handlers/ai";
 import { checkExisting, uploadImage, uploadManifest } from "./handlers/publish";
 import { serveHubIndex, serveImage, serveShowcaseJson } from "./handlers/showcase";
+import { signupDemo, signupRequest, signupVerify } from "./handlers/signup";
+import {
+  getAccount,
+  rotateKey,
+  upgradeRequest,
+  upgradeVerify,
+} from "./handlers/account";
 import { injectOgForWorld } from "./og";
 import { corsHeaders, error, parseHost, preflight, RESERVED_SUBDOMAINS } from "./util";
 
@@ -97,6 +104,16 @@ async function routeApi(req: Request, env: Env, pathname: string): Promise<Respo
     if (req.method === "OPTIONS") return preflight({ origin: "*" });
     const user = await authenticateUser(req, env);
     if (!user) return error(401, "API key required", { origin: "*" });
+    // Publish is gated on email_verified. Demo users haven't verified,
+    // so we reject them with a distinct error code the creator can map
+    // to the "verify your email to publish" toast.
+    if (!user.email_verified || user.tier === "demo") {
+      return error(
+        403,
+        "publish_requires_verification: Verify your email to enable publishing.",
+        { origin: "*" },
+      );
+    }
 
     if (pathname === "/publish/check-existing" && req.method === "POST") {
       return await checkExisting(req, env, user);
@@ -108,6 +125,50 @@ async function routeApi(req: Request, env: Env, pathname: string): Promise<Respo
       return await uploadImage(req, env, user);
     }
     return error(404, "Not found", { origin: "*" });
+  }
+
+  // Signup endpoints — no auth, rate limited + Turnstile gated.
+  if (pathname.startsWith("/signup/")) {
+    if (req.method === "OPTIONS") return preflight({ origin: "*" });
+    if (pathname === "/signup/demo" && req.method === "POST") return await signupDemo(req, env);
+    if (pathname === "/signup/request" && req.method === "POST") return await signupRequest(req, env);
+    if (pathname === "/signup/verify" && req.method === "POST") return await signupVerify(req, env);
+    return error(404, "Not found", { origin: "*" });
+  }
+
+  // Account endpoints — Bearer auth.
+  if (pathname.startsWith("/account")) {
+    if (req.method === "OPTIONS") return preflight({ origin: "*" });
+    const user = await authenticateUser(req, env);
+    if (!user) return error(401, "API key required", { origin: "*" });
+    if (pathname === "/account" && req.method === "GET") return await getAccount(req, env, user);
+    if (pathname === "/account/rotate-key" && req.method === "POST") return await rotateKey(req, env, user);
+    if (pathname === "/account/upgrade/request" && req.method === "POST") {
+      return await upgradeRequest(req, env, user);
+    }
+    if (pathname === "/account/upgrade/verify" && req.method === "POST") {
+      return await upgradeVerify(req, env, user);
+    }
+    return error(404, "Not found", { origin: "*" });
+  }
+
+  // Public config for signup widgets — lets the frontend discover
+  // whether Turnstile is enabled and which site key to render with
+  // without baking it into the bundle at build time.
+  if (pathname === "/config") {
+    if (req.method === "OPTIONS") return preflight({ origin: "*" });
+    if (req.method !== "GET") return error(405, "Method not allowed", { origin: "*" });
+    return new Response(
+      JSON.stringify({ turnstileSiteKey: env.TURNSTILE_SITE_KEY ?? "" }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "public, max-age=300",
+          "Access-Control-Allow-Origin": "*",
+        },
+      },
+    );
   }
 
   // AI generation endpoints (hub-proxied) — same Bearer auth as publish.

--- a/hub-worker/src/migrations/0004_self_registration.sql
+++ b/hub-worker/src/migrations/0004_self_registration.sql
@@ -1,0 +1,41 @@
+-- 0004_self_registration
+-- Opens the hub to public signup. Two paths:
+--   1. Anonymous "demo" tier — no email, tiny quotas, no publish.
+--   2. Email-verified "full" tier — 6-digit code, normal quotas, publish.
+--
+-- Existing users (all admin-created) are grandfathered as email_verified=1
+-- so publish gating doesn't retroactively break them.
+--
+-- Apply with:
+--   wrangler d1 execute arcanum-hub --remote --file=./src/migrations/0004_self_registration.sql
+
+ALTER TABLE users ADD COLUMN email_verified INTEGER NOT NULL DEFAULT 0;
+UPDATE users SET email_verified = 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email) WHERE email IS NOT NULL;
+
+-- Pending email verifications. One row per email — a fresh /signup/request
+-- for the same address overwrites the prior code.
+CREATE TABLE IF NOT EXISTS verification_codes (
+  email TEXT PRIMARY KEY,
+  code_hash TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  -- If set, the verify step upgrades this existing demo user to full
+  -- instead of creating a new record. Lets demo users keep their
+  -- user_id (and any worlds they'd try to publish) across upgrade.
+  existing_user_id TEXT,
+  expires_at INTEGER NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_verification_expires ON verification_codes(expires_at);
+
+-- Per-IP signup attempt log. We count rows within a rolling window to
+-- enforce the rate limit; old rows are pruned lazily on each attempt.
+CREATE TABLE IF NOT EXISTS signup_attempts (
+  ip TEXT NOT NULL,
+  attempted_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_signup_attempts_ip_time ON signup_attempts(ip, attempted_at);

--- a/hub-worker/src/schema.sql
+++ b/hub-worker/src/schema.sql
@@ -18,10 +18,39 @@ CREATE TABLE IF NOT EXISTS users (
   images_used INTEGER NOT NULL DEFAULT 0,
   images_quota INTEGER NOT NULL DEFAULT 500,
   prompts_used INTEGER NOT NULL DEFAULT 0,
-  prompts_quota INTEGER NOT NULL DEFAULT 5000
+  prompts_quota INTEGER NOT NULL DEFAULT 5000,
+  -- Tier: 'demo' (self-signup, tiny quotas, no publish),
+  -- 'full' (email-verified, normal quotas, publish),
+  -- 'publish' (BYOK user, publish-only, no hub AI).
+  tier TEXT NOT NULL DEFAULT 'full',
+  -- Email-verified users can publish. Demo users can't until they
+  -- verify an email (which promotes them to tier='full').
+  email_verified INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_users_api_key_hash ON users(api_key_hash);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email) WHERE email IS NOT NULL;
+
+-- Pending email verifications for self-signup and demo→full upgrades.
+CREATE TABLE IF NOT EXISTS verification_codes (
+  email TEXT PRIMARY KEY,
+  code_hash TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  existing_user_id TEXT,
+  expires_at INTEGER NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_verification_expires ON verification_codes(expires_at);
+
+-- Per-IP rate-limit log for signup endpoints.
+CREATE TABLE IF NOT EXISTS signup_attempts (
+  ip TEXT NOT NULL,
+  attempted_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_signup_attempts_ip_time ON signup_attempts(ip, attempted_at);
 
 CREATE TABLE IF NOT EXISTS worlds (
   slug TEXT PRIMARY KEY,

--- a/hub-worker/src/turnstile.ts
+++ b/hub-worker/src/turnstile.ts
@@ -1,0 +1,50 @@
+import type { Env } from "./env";
+
+// ─── Cloudflare Turnstile verification ───────────────────────────────
+//
+// Frontend (landing + creator onboarding) renders the Turnstile
+// widget using TURNSTILE_SITE_KEY and POSTs the resulting token to
+// our signup endpoints. This module verifies that token with
+// Cloudflare's siteverify endpoint.
+//
+// If no secret key is configured we treat verification as disabled
+// (useful in dev against wrangler dev + local D1). Don't ship a
+// production deploy without a secret.
+
+export interface TurnstileResult {
+  ok: boolean;
+  /** Machine-readable reason if ok=false, for UI messaging. */
+  reason?: string;
+}
+
+export async function verifyTurnstile(
+  env: Env,
+  token: string | null | undefined,
+  remoteIp: string,
+): Promise<TurnstileResult> {
+  // Dev/disabled: no secret configured, treat every call as valid
+  // but log it so "why did my signup skip verification?" is at least
+  // discoverable in wrangler tail.
+  if (!env.TURNSTILE_SECRET_KEY) {
+    console.log("[turnstile] disabled — no TURNSTILE_SECRET_KEY set");
+    return { ok: true };
+  }
+  if (!token) return { ok: false, reason: "missing_token" };
+
+  const form = new FormData();
+  form.set("secret", env.TURNSTILE_SECRET_KEY);
+  form.set("response", token);
+  if (remoteIp && remoteIp !== "unknown") form.set("remoteip", remoteIp);
+
+  const resp = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+    method: "POST",
+    body: form,
+  });
+  if (!resp.ok) {
+    return { ok: false, reason: `siteverify_${resp.status}` };
+  }
+  const data = (await resp.json()) as { success?: boolean; "error-codes"?: string[] };
+  if (data.success) return { ok: true };
+  const reason = data["error-codes"]?.[0] ?? "turnstile_failed";
+  return { ok: false, reason };
+}

--- a/hub-worker/src/util.ts
+++ b/hub-worker/src/util.ts
@@ -83,26 +83,58 @@ export async function sha256Hex(input: string | ArrayBuffer): Promise<string> {
  * Generate a new API key. Returns both the plain text (shown once)
  * and its SHA-256 hash (stored).
  *
- * The tier is encoded in the prefix (`hubk_full_...` / `hubk_pub_...`)
- * so the creator can auto-detect publish-only keys and disable its
- * "Use Hub AI" toggle. The prefix is purely a UX hint — the worker
- * still looks up the authoritative tier in D1 on every `/ai/*` call.
- * Legacy `hub_<random>` keys (no tier segment) from before this
- * feature keep working; they're all tagged `tier='full'` by the
- * 0002 migration.
+ * The tier is encoded in the prefix (`hubk_full_…`, `hubk_pub_…`,
+ * `hubk_demo_…`) so the creator can auto-detect capability without
+ * a round-trip. The prefix is purely a UX hint — the worker still
+ * looks up the authoritative tier in D1 on every request. Legacy
+ * `hub_<random>` keys (no tier segment) from before the tier feature
+ * keep working; they're all tagged `tier='full'` by 0002.
  */
 export async function generateApiKey(
-  tier: "full" | "publish",
+  tier: "full" | "publish" | "demo",
 ): Promise<{ plain: string; hash: string }> {
   const bytes = new Uint8Array(24);
   crypto.getRandomValues(bytes);
   const tail = Array.from(bytes)
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
-  const segment = tier === "publish" ? "pub" : "full";
+  const segment = tier === "publish" ? "pub" : tier === "demo" ? "demo" : "full";
   const plain = `hubk_${segment}_${tail}`;
   const hash = await sha256Hex(plain);
   return { plain, hash };
+}
+
+/**
+ * Generate a zero-padded 6-digit verification code. Uses
+ * crypto.getRandomValues for uniform distribution across 000000-999999.
+ */
+export function generateVerificationCode(): string {
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  const n =
+    ((bytes[0]! << 24) | (bytes[1]! << 16) | (bytes[2]! << 8) | bytes[3]!) >>> 0;
+  return (n % 1_000_000).toString().padStart(6, "0");
+}
+
+/**
+ * Very small email shape check. Not RFC-5322 — just enough to reject
+ * obvious garbage before we send a code to it.
+ */
+export function isValidEmail(email: string): boolean {
+  if (!email || email.length > 254) return false;
+  const trimmed = email.trim();
+  if (trimmed !== email) return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+/** Strip obvious whitespace and lowercase so email uniqueness is stable. */
+export function normalizeEmail(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+/** Client IP for rate-limiting. Falls back to "unknown" off-CF. */
+export function clientIp(req: Request): string {
+  return req.headers.get("CF-Connecting-IP") ?? req.headers.get("X-Forwarded-For") ?? "unknown";
 }
 
 // ─── ID generation ───────────────────────────────────────────────────

--- a/hub-worker/wrangler.toml
+++ b/hub-worker/wrangler.toml
@@ -71,7 +71,7 @@ ADMIN_ORIGIN = "https://admin.arcanum-hub.com,https://arcanum-hub-admin.pages.de
 FROM_EMAIL = "Arcanum Hub <no-reply@arcanum-hub.com>"
 # Public Turnstile site key — safe to ship. Leave empty to disable
 # Turnstile verification (useful in dev).
-TURNSTILE_SITE_KEY = ""
+TURNSTILE_SITE_KEY = "0x4AAAAAAC-tx5qpomJo9lmk"
 
 # Secrets (set with `wrangler secret put`):
 #   HUB_ADMIN_KEY          — master key for admin dashboard login

--- a/hub-worker/wrangler.toml
+++ b/hub-worker/wrangler.toml
@@ -66,6 +66,16 @@ HUB_ROOT_DOMAIN = "arcanum-hub.com"
 # wired up as a Pages custom domain, and at the pages.dev fallback
 # either way.
 ADMIN_ORIGIN = "https://admin.arcanum-hub.com,https://arcanum-hub-admin.pages.dev"
+# Sender address for verification-code emails. Must be on a domain
+# that's verified in the Resend console.
+FROM_EMAIL = "Arcanum Hub <no-reply@arcanum-hub.com>"
+# Public Turnstile site key — safe to ship. Leave empty to disable
+# Turnstile verification (useful in dev).
+TURNSTILE_SITE_KEY = ""
 
 # Secrets (set with `wrangler secret put`):
-#   HUB_ADMIN_KEY   — master key for admin dashboard login
+#   HUB_ADMIN_KEY          — master key for admin dashboard login
+#   RESEND_API_KEY         — transactional email (https://resend.com)
+#   TURNSTILE_SECRET_KEY   — CF Turnstile secret; pair with the public
+#                            site key in [vars]. Leave unset to skip
+#                            Turnstile verification.

--- a/showcase/src/App.tsx
+++ b/showcase/src/App.tsx
@@ -14,17 +14,25 @@ const StoriesPage = lazy(() => import("@/pages/StoriesPage").then(m => ({ defaul
 const StoryPlayerPage = lazy(() => import("@/pages/StoryPlayerPage").then(m => ({ default: m.StoryPlayerPage })));
 const NotFoundPage = lazy(() => import("@/pages/NotFoundPage").then(m => ({ default: m.NotFoundPage })));
 const HubIndexPage = lazy(() => import("@/pages/HubIndexPage").then(m => ({ default: m.HubIndexPage })));
+const SignupPage = lazy(() => import("@/pages/SignupPage").then(m => ({ default: m.SignupPage })));
+const AccountPage = lazy(() => import("@/pages/AccountPage").then(m => ({ default: m.AccountPage })));
 
 export function App() {
   const { loading, error, reload, isHubRoot } = useShowcase();
   const isOffline = typeof navigator !== "undefined" && !navigator.onLine;
 
-  // Hub root: no per-world data, just render the directory. Skips the
-  // normal Layout (which pulls a world name from data that doesn't exist here).
+  // Hub root: no per-world data. Small router for the landing +
+  // signup/account pages, all rendered without the per-world Layout
+  // (which depends on world metadata that doesn't exist here).
   if (isHubRoot) {
     return (
       <Suspense fallback={null}>
-        <HubIndexPage />
+        <Routes>
+          <Route path="/" element={<HubIndexPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+          <Route path="/account" element={<AccountPage />} />
+          <Route path="*" element={<HubIndexPage />} />
+        </Routes>
       </Suspense>
     );
   }

--- a/showcase/src/components/TurnstileWidget.tsx
+++ b/showcase/src/components/TurnstileWidget.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from "react";
+
+// Duplicate of creator/src/components/onboarding/TurnstileWidget.tsx
+// — separate build targets, no shared package. Keep in sync.
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        target: HTMLElement,
+        opts: {
+          sitekey: string;
+          callback: (token: string) => void;
+          "error-callback"?: () => void;
+          "expired-callback"?: () => void;
+          appearance?: "always" | "interaction-only";
+          theme?: "light" | "dark" | "auto";
+        },
+      ) => string;
+      reset: (widgetId: string) => void;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+const SCRIPT_SRC = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+
+let scriptPromise: Promise<void> | null = null;
+
+function loadTurnstile(): Promise<void> {
+  if (typeof window === "undefined") return Promise.resolve();
+  if (window.turnstile) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise((resolve, reject) => {
+    const s = document.createElement("script");
+    s.src = SCRIPT_SRC;
+    s.async = true;
+    s.defer = true;
+    s.onload = () => resolve();
+    s.onerror = () => reject(new Error("Turnstile failed to load"));
+    document.head.appendChild(s);
+  });
+  return scriptPromise;
+}
+
+interface TurnstileWidgetProps {
+  siteKey: string;
+  onToken: (token: string) => void;
+  onError?: (message: string) => void;
+}
+
+export function TurnstileWidget({ siteKey, onToken, onError }: TurnstileWidgetProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const widgetIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!siteKey) {
+      onToken("");
+      return;
+    }
+    let cancelled = false;
+    loadTurnstile()
+      .then(() => {
+        if (cancelled || !ref.current || !window.turnstile) return;
+        widgetIdRef.current = window.turnstile.render(ref.current, {
+          sitekey: siteKey,
+          theme: "dark",
+          appearance: "interaction-only",
+          callback: (token) => onToken(token),
+          "error-callback": () => onError?.("Turnstile error. Try again in a moment."),
+          "expired-callback": () => onToken(""),
+        });
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) onError?.(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+      if (widgetIdRef.current && window.turnstile) {
+        try {
+          window.turnstile.remove(widgetIdRef.current);
+        } catch {
+          // ignore
+        }
+      }
+    };
+  }, [siteKey, onToken, onError]);
+
+  if (!siteKey) return null;
+  return <div ref={ref} className="mt-2" />;
+}

--- a/showcase/src/lib/hubClient.ts
+++ b/showcase/src/lib/hubClient.ts
@@ -1,0 +1,182 @@
+// ─── Hub API client for the landing SPA ──────────────────────────────
+//
+// Mirrors creator/src/lib/hubClient.ts. We duplicate rather than
+// share because showcase is a separate build target with no import
+// path into the creator package. Any protocol change needs to be
+// applied in both files.
+
+const DEFAULT_HUB_API_URL = "https://api.arcanum-hub.com";
+
+export interface HubUser {
+  id: string;
+  displayName: string;
+  tier: "demo" | "full" | "publish";
+  email: string | null;
+  emailVerified: boolean;
+  imagesQuota: number;
+  promptsQuota: number;
+}
+
+export interface HubAccount {
+  id: string;
+  displayName: string;
+  email: string | null;
+  emailVerified: boolean;
+  tier: "demo" | "full" | "publish";
+  createdAt: number;
+  lastPublishAt: number | null;
+  canPublish: boolean;
+  usage: {
+    imagesUsed: number;
+    imagesQuota: number;
+    promptsUsed: number;
+    promptsQuota: number;
+  };
+}
+
+export interface HubWorldSummary {
+  slug: string;
+  displayName: string | null;
+  listed: boolean;
+  lastPublishAt: number | null;
+  bytesUsed: number;
+}
+
+function baseUrl(): string {
+  // On the hub root, the worker answers api.* for us. In dev we can
+  // override via VITE_HUB_API_URL if needed.
+  const override = (import.meta.env.VITE_HUB_API_URL as string | undefined)?.trim();
+  return (override ?? DEFAULT_HUB_API_URL).replace(/\/+$/, "");
+}
+
+async function readJson<T>(resp: Response): Promise<T> {
+  const text = await resp.text();
+  if (!resp.ok) {
+    let msg = `Hub ${resp.status}`;
+    try {
+      const body = JSON.parse(text) as { error?: string; message?: string };
+      msg = body.error ?? body.message ?? msg;
+    } catch {
+      if (text) msg = `${msg}: ${text.slice(0, 200)}`;
+    }
+    throw new Error(msg);
+  }
+  return JSON.parse(text) as T;
+}
+
+export async function fetchHubConfig(): Promise<{ turnstileSiteKey: string }> {
+  const resp = await fetch(`${baseUrl()}/config`);
+  return await readJson(resp);
+}
+
+export async function signupDemo(input: {
+  displayName?: string;
+  turnstileToken?: string;
+}): Promise<{ apiKey: string; user: HubUser }> {
+  const resp = await fetch(`${baseUrl()}/signup/demo`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return await readJson(resp);
+}
+
+export async function signupRequest(input: {
+  email: string;
+  displayName: string;
+  turnstileToken?: string;
+  existingApiKey?: string;
+}): Promise<{ ok: boolean; email: string; expiresInMinutes: number }> {
+  const resp = await fetch(`${baseUrl()}/signup/request`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return await readJson(resp);
+}
+
+export async function signupVerify(input: {
+  email: string;
+  code: string;
+}): Promise<{ apiKey: string; user: HubUser; upgraded: boolean }> {
+  const resp = await fetch(`${baseUrl()}/signup/verify`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  return await readJson(resp);
+}
+
+function authHeaders(apiKey: string): HeadersInit {
+  return { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" };
+}
+
+export async function fetchAccount(
+  apiKey: string,
+): Promise<{ account: HubAccount; worlds: HubWorldSummary[] }> {
+  const resp = await fetch(`${baseUrl()}/account`, { headers: authHeaders(apiKey) });
+  return await readJson(resp);
+}
+
+export async function rotateKey(apiKey: string): Promise<{ apiKey: string }> {
+  const resp = await fetch(`${baseUrl()}/account/rotate-key`, {
+    method: "POST",
+    headers: authHeaders(apiKey),
+  });
+  return await readJson(resp);
+}
+
+export async function upgradeRequest(
+  apiKey: string,
+  input: { email: string; displayName?: string; turnstileToken?: string },
+): Promise<{ ok: boolean; email: string; expiresInMinutes: number }> {
+  const resp = await fetch(`${baseUrl()}/account/upgrade/request`, {
+    method: "POST",
+    headers: authHeaders(apiKey),
+    body: JSON.stringify(input),
+  });
+  return await readJson(resp);
+}
+
+export async function upgradeVerify(
+  apiKey: string,
+  input: { email: string; code: string },
+): Promise<{ apiKey: string; account: HubAccount }> {
+  const resp = await fetch(`${baseUrl()}/account/upgrade/verify`, {
+    method: "POST",
+    headers: authHeaders(apiKey),
+    body: JSON.stringify(input),
+  });
+  return await readJson(resp);
+}
+
+// ─── Local persistence for "sign in with your key" ──────────────────
+// Keeping the key in localStorage on arcanum-hub.com is comparable to
+// the creator's on-disk settings. Users can paste it in once and come
+// back to the account page.
+
+const KEY_STORAGE = "arcanum-hub-api-key";
+
+export function loadStoredKey(): string {
+  try {
+    return localStorage.getItem(KEY_STORAGE) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function storeKey(apiKey: string): void {
+  try {
+    localStorage.setItem(KEY_STORAGE, apiKey);
+  } catch {
+    // ignore (Safari private mode, etc.)
+  }
+}
+
+export function clearStoredKey(): void {
+  try {
+    localStorage.removeItem(KEY_STORAGE);
+  } catch {
+    // ignore
+  }
+}

--- a/showcase/src/pages/AccountPage.tsx
+++ b/showcase/src/pages/AccountPage.tsx
@@ -1,0 +1,436 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  clearStoredKey,
+  fetchAccount,
+  fetchHubConfig,
+  loadStoredKey,
+  rotateKey,
+  storeKey,
+  upgradeRequest,
+  upgradeVerify,
+  type HubAccount,
+  type HubWorldSummary,
+} from "@/lib/hubClient";
+import { TurnstileWidget } from "@/components/TurnstileWidget";
+import { showcaseButtonClassNames } from "@/components/ShowcasePrimitives";
+
+/**
+ * Public account page at arcanum-hub.com/account.
+ *
+ * Sign-in is "paste your key" — same model as the creator. We store
+ * it in localStorage so the visitor doesn't have to paste it every
+ * time on the same machine. No passwords, no OAuth; a stolen key
+ * gets rotated away.
+ */
+export function AccountPage() {
+  const [apiKey, setApiKeyState] = useState(() => loadStoredKey());
+  const [account, setAccount] = useState<HubAccount | null>(null);
+  const [worlds, setWorlds] = useState<HubWorldSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [input, setInput] = useState("");
+  const [showUpgrade, setShowUpgrade] = useState(false);
+
+  const refresh = async () => {
+    if (!apiKey) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchAccount(apiKey);
+      setAccount(res.account);
+      setWorlds(res.worlds);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setAccount(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (apiKey) void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apiKey]);
+
+  const handleSignIn = () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    storeKey(trimmed);
+    setApiKeyState(trimmed);
+    setInput("");
+  };
+
+  const handleSignOut = () => {
+    clearStoredKey();
+    setApiKeyState("");
+    setAccount(null);
+    setWorlds([]);
+  };
+
+  const handleRotate = async () => {
+    if (!confirm("Rotate your API key? The current key will be invalidated and usage counters will reset.")) return;
+    setLoading(true);
+    try {
+      const { apiKey: fresh } = await rotateKey(apiKey);
+      storeKey(fresh);
+      setApiKeyState(fresh);
+      await refresh();
+      alert(`New key:\n\n${fresh}\n\nCopy it somewhere safe — it replaces your old one in this browser already.`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+      <header className="border-b border-[var(--border)] px-6 py-4">
+        <div className="mx-auto flex max-w-3xl items-center justify-between">
+          <Link to="/" className="font-display text-sm uppercase tracking-[0.2em] text-accent">
+            Arcanum Hub
+          </Link>
+          {apiKey ? (
+            <button onClick={handleSignOut} className="text-xs uppercase tracking-wider text-text-muted hover:text-text-primary">
+              Sign out
+            </button>
+          ) : (
+            <Link to="/signup" className="text-xs uppercase tracking-wider text-text-muted hover:text-text-primary">
+              Create account
+            </Link>
+          )}
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-6 py-12">
+        {!apiKey && (
+          <section className="rounded-xl border border-[var(--border)] bg-[var(--panel)] p-6">
+            <h1 className="font-display text-2xl uppercase tracking-[0.18em]">Sign in</h1>
+            <p className="mt-2 text-sm leading-7 text-text-muted">
+              Paste your Arcanum Hub API key below. It's stored in this browser so you don't have to
+              paste it again on this machine.
+            </p>
+            <form
+              className="mt-5 flex flex-col gap-3 sm:flex-row"
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleSignIn();
+              }}
+            >
+              <input
+                type="password"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="hubk_full_..."
+                className="flex-1 rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 font-mono text-sm text-text-primary placeholder:text-text-muted focus:border-accent/60 focus:outline-none"
+              />
+              <button type="submit" className={showcaseButtonClassNames.primary} disabled={!input.trim()}>
+                Sign in
+              </button>
+            </form>
+            <p className="mt-4 text-xs text-text-muted">
+              Don't have a key? <Link to="/signup" className="text-accent underline">Create one</Link>.
+            </p>
+          </section>
+        )}
+
+        {apiKey && loading && !account && (
+          <p className="text-sm text-text-muted">Loading account…</p>
+        )}
+
+        {apiKey && error && !account && (
+          <div className="rounded-xl border border-status-error/40 bg-[var(--panel)] p-6 text-sm text-status-error">
+            {error}
+            <div className="mt-3 flex gap-2">
+              <button onClick={refresh} className={showcaseButtonClassNames.secondary}>Retry</button>
+              <button onClick={handleSignOut} className={showcaseButtonClassNames.quiet}>Sign out</button>
+            </div>
+          </div>
+        )}
+
+        {apiKey && account && (
+          <div className="space-y-6">
+            <section className="rounded-xl border border-[var(--border)] bg-[var(--panel)] p-6">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h1 className="font-display text-2xl uppercase tracking-[0.18em]">{account.displayName}</h1>
+                  <p className="mt-1 text-xs text-text-muted">
+                    {account.email ?? "no email on file"}
+                    {account.emailVerified && (
+                      <span className="ml-2 rounded-full bg-accent/20 px-2 py-0.5 text-[10px] uppercase tracking-wider text-accent">
+                        verified
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <TierBadge tier={account.tier} />
+              </div>
+
+              <div className="mt-6 grid gap-5 sm:grid-cols-2">
+                <UsageBar
+                  label="Image generations"
+                  used={account.usage.imagesUsed}
+                  quota={account.usage.imagesQuota}
+                />
+                <UsageBar
+                  label="Prompt calls"
+                  used={account.usage.promptsUsed}
+                  quota={account.usage.promptsQuota}
+                />
+              </div>
+
+              {account.tier === "demo" && !showUpgrade && (
+                <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded border border-accent/40 bg-accent/10 px-4 py-3 text-sm text-text-secondary">
+                  <span>
+                    Verify your email to upgrade to <strong className="text-text-primary">full tier</strong>{" "}
+                    (500 images, 5000 prompts, plus publishing).
+                  </span>
+                  <button onClick={() => setShowUpgrade(true)} className={showcaseButtonClassNames.primary}>
+                    Upgrade
+                  </button>
+                </div>
+              )}
+
+              {showUpgrade && (
+                <UpgradePanel
+                  apiKey={apiKey}
+                  defaultDisplayName={account.displayName}
+                  onDone={async (newKey) => {
+                    storeKey(newKey);
+                    setApiKeyState(newKey);
+                    setShowUpgrade(false);
+                    await refresh();
+                  }}
+                  onCancel={() => setShowUpgrade(false)}
+                />
+              )}
+
+              <div className="mt-5 flex items-center justify-between gap-3 text-xs text-text-muted">
+                <span>Rotating your key resets your usage counters and invalidates the old key.</span>
+                <button onClick={handleRotate} disabled={loading} className={showcaseButtonClassNames.secondary}>
+                  Rotate key
+                </button>
+              </div>
+            </section>
+
+            {worlds.length > 0 && (
+              <section className="rounded-xl border border-[var(--border)] bg-[var(--panel)] p-6">
+                <h2 className="font-display text-sm uppercase tracking-widest text-text-primary">Your worlds</h2>
+                <ul className="mt-4 divide-y divide-[var(--border)]">
+                  {worlds.map((w) => (
+                    <li key={w.slug} className="flex items-center justify-between py-3 text-sm">
+                      <div className="min-w-0">
+                        <a
+                          href={`https://${w.slug}.arcanum-hub.com/`}
+                          className="font-display uppercase tracking-wider text-accent hover:underline"
+                        >
+                          {w.displayName ?? w.slug}
+                        </a>
+                        <p className="text-xs text-text-muted">
+                          {w.listed ? "listed" : "unlisted"}{" "}
+                          {w.lastPublishAt && (
+                            <>
+                              · last published {new Date(w.lastPublishAt).toLocaleDateString()}
+                            </>
+                          )}
+                        </p>
+                      </div>
+                      <span className="text-xs text-text-muted">
+                        {(w.bytesUsed / 1024 / 1024).toFixed(1)} MB
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+// ─── Subcomponents ───────────────────────────────────────────────────
+
+function TierBadge({ tier }: { tier: HubAccount["tier"] }) {
+  const style =
+    tier === "demo"
+      ? "border-[var(--border)] bg-[var(--bg)] text-text-muted"
+      : tier === "full"
+        ? "border-accent/40 bg-accent/20 text-accent"
+        : "border-[var(--border)] bg-[var(--bg)] text-text-secondary";
+  return (
+    <span className={`rounded-full border px-3 py-1 text-xs uppercase tracking-wider ${style}`}>
+      {tier}
+    </span>
+  );
+}
+
+function UsageBar({ label, used, quota }: { label: string; used: number; quota: number }) {
+  const pct = quota ? Math.round((used / quota) * 100) : 0;
+  return (
+    <div>
+      <div className="flex items-baseline justify-between text-xs">
+        <span className="uppercase tracking-wider text-text-muted">{label}</span>
+        <span className="font-mono text-text-secondary">{used} / {quota}</span>
+      </div>
+      <div className="mt-2 h-2 overflow-hidden rounded-full bg-[var(--bg)]">
+        <div
+          className={`h-full ${pct >= 90 ? "bg-status-error" : pct >= 70 ? "bg-warm" : "bg-accent"}`}
+          style={{ width: `${Math.min(100, pct)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function UpgradePanel({
+  apiKey,
+  defaultDisplayName,
+  onDone,
+  onCancel,
+}: {
+  apiKey: string;
+  defaultDisplayName: string;
+  onDone: (newKey: string) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [stage, setStage] = useState<"request" | "verify">("request");
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState(defaultDisplayName);
+  const [code, setCode] = useState("");
+  const [turnstileSiteKey, setTurnstileSiteKey] = useState("");
+  const [turnstileToken, setTurnstileToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchHubConfig()
+      .then((c) => setTurnstileSiteKey(c.turnstileSiteKey))
+      .catch(() => setTurnstileSiteKey(""));
+  }, []);
+
+  const doRequest = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await upgradeRequest(apiKey, { email: email.trim(), displayName: displayName.trim(), turnstileToken });
+      setStage("verify");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doVerify = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await upgradeVerify(apiKey, { email: email.trim(), code: code.trim() });
+      await onDone(res.apiKey);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mt-5 rounded-xl border border-accent/40 bg-[var(--bg)] p-5">
+      {stage === "request" && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void doRequest();
+          }}
+          className="flex flex-col gap-3"
+        >
+          <Field label="Email">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoFocus
+              disabled={busy}
+              className={inputClasses}
+            />
+          </Field>
+          <Field label="Display name">
+            <input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              required
+              disabled={busy}
+              className={inputClasses}
+            />
+          </Field>
+          <TurnstileWidget siteKey={turnstileSiteKey} onToken={setTurnstileToken} onError={setError} />
+          {error && <p className="text-xs text-status-error">{error}</p>}
+          <div className="flex items-center justify-end gap-2">
+            <button type="button" onClick={onCancel} className={showcaseButtonClassNames.quiet}>
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy || !email.trim() || !displayName.trim() || (Boolean(turnstileSiteKey) && !turnstileToken)}
+              className={showcaseButtonClassNames.primary}
+            >
+              {busy ? "Sending…" : "Send code"}
+            </button>
+          </div>
+        </form>
+      )}
+      {stage === "verify" && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void doVerify();
+          }}
+          className="flex flex-col gap-3"
+        >
+          <p className="text-xs text-text-muted">
+            We sent a code to <span className="text-text-primary">{email}</span>. Expires in 15 minutes.
+          </p>
+          <Field label="Code">
+            <input
+              inputMode="numeric"
+              pattern="\d{6}"
+              maxLength={6}
+              value={code}
+              onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+              required
+              autoFocus
+              disabled={busy}
+              className={`${inputClasses} text-center font-mono tracking-[0.4em] text-lg`}
+            />
+          </Field>
+          {error && <p className="text-xs text-status-error">{error}</p>}
+          <div className="flex items-center justify-end gap-2">
+            <button type="button" onClick={() => setStage("request")} className={showcaseButtonClassNames.quiet}>
+              ← Back
+            </button>
+            <button type="submit" disabled={busy || code.length !== 6} className={showcaseButtonClassNames.primary}>
+              {busy ? "Verifying…" : "Verify"}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-xs uppercase tracking-wider text-text-muted">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+const inputClasses =
+  "w-full rounded-lg border border-[var(--border)] bg-[var(--panel)] px-4 py-2.5 text-sm text-text-primary placeholder:text-text-muted focus:border-accent/60 focus:outline-none";

--- a/showcase/src/pages/HubIndexPage.tsx
+++ b/showcase/src/pages/HubIndexPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { fetchHubIndex, type HubIndexWorld } from "@/lib/hubMode";
 import { ShowcaseEmptyState } from "@/components/ShowcasePrimitives";
 
@@ -123,6 +124,20 @@ export function HubIndexPage() {
           A living atlas of worlds built in Arcanum. Each entry links to its own
           showcase — lore, maps, and stories published directly from the tool.
         </p>
+        <div className="mt-6 flex items-center justify-center gap-3 text-xs">
+          <Link
+            to="/signup"
+            className="rounded-full border border-accent/50 bg-accent/10 px-5 py-2 uppercase tracking-[0.18em] text-accent transition hover:bg-accent/20"
+          >
+            Get started free
+          </Link>
+          <Link
+            to="/account"
+            className="rounded-full border border-border-muted/50 px-5 py-2 uppercase tracking-[0.18em] text-text-muted transition hover:border-accent/50 hover:text-text-primary"
+          >
+            Sign in
+          </Link>
+        </div>
       </header>
 
       {totalWorlds > 0 && (

--- a/showcase/src/pages/SignupPage.tsx
+++ b/showcase/src/pages/SignupPage.tsx
@@ -1,0 +1,338 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import {
+  fetchHubConfig,
+  signupDemo,
+  signupRequest,
+  signupVerify,
+  storeKey,
+} from "@/lib/hubClient";
+import { TurnstileWidget } from "@/components/TurnstileWidget";
+import { showcaseButtonClassNames } from "@/components/ShowcasePrimitives";
+
+type Mode = "choose" | "demo" | "fullRequest" | "fullVerify" | "done";
+
+/**
+ * Public signup page served at arcanum-hub.com/signup. Same three
+ * paths as the creator onboarding — kept in sync intentionally.
+ * The final "done" state shows the API key once, with instructions
+ * on how to drop it into the Arcanum creator app.
+ */
+export function SignupPage() {
+  const navigate = useNavigate();
+  const [mode, setMode] = useState<Mode>("choose");
+  const [turnstileSiteKey, setTurnstileSiteKey] = useState("");
+  const [turnstileToken, setTurnstileToken] = useState("");
+
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [code, setCode] = useState("");
+  const [apiKey, setApiKey] = useState("");
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchHubConfig()
+      .then((c) => setTurnstileSiteKey(c.turnstileSiteKey))
+      .catch(() => setTurnstileSiteKey(""));
+  }, []);
+
+  const doDemo = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await signupDemo({ displayName: displayName.trim() || undefined, turnstileToken });
+      storeKey(res.apiKey);
+      setApiKey(res.apiKey);
+      setMode("done");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doFullRequest = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await signupRequest({ email: email.trim(), displayName: displayName.trim(), turnstileToken });
+      setMode("fullVerify");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doFullVerify = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await signupVerify({ email: email.trim(), code: code.trim() });
+      storeKey(res.apiKey);
+      setApiKey(res.apiKey);
+      setMode("done");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+      <header className="border-b border-[var(--border)] px-6 py-4">
+        <div className="mx-auto flex max-w-3xl items-center justify-between">
+          <Link to="/" className="font-display text-sm uppercase tracking-[0.2em] text-accent">
+            Arcanum Hub
+          </Link>
+          <Link to="/account" className="text-xs uppercase tracking-wider text-text-muted hover:text-text-primary">
+            Have a key? Sign in
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-xl px-6 py-12">
+        <h1 className="font-display text-3xl uppercase tracking-[0.18em] text-[var(--text)]">Create your account</h1>
+        <p className="mt-3 text-sm leading-7 text-text-muted">
+          Arcanum Hub hosts AI image generation, LLM prompts, and published world showcases. Pick the
+          path that fits — no credit card required for either one.
+        </p>
+
+        {mode === "choose" && (
+          <div className="mt-8 grid gap-3 sm:grid-cols-2">
+            <ChoiceCard
+              title="Try it free"
+              description="10 image generations, 20 prompts. No email required. You can upgrade later."
+              cta="Demo account"
+              onClick={() => {
+                setError(null);
+                setMode("demo");
+              }}
+              primary
+            />
+            <ChoiceCard
+              title="Create an account"
+              description="Verify your email for 500 images, 5000 prompts, and the ability to publish."
+              cta="Sign up"
+              onClick={() => {
+                setError(null);
+                setMode("fullRequest");
+              }}
+            />
+          </div>
+        )}
+
+        {mode === "demo" && (
+          <Form onSubmit={doDemo} onBack={() => setMode("choose")} primary="Create demo account" busy={busy} disabled={Boolean(turnstileSiteKey) && !turnstileToken}>
+            <p className="text-xs leading-6 text-text-muted">
+              A demo account gets you enough quota to sketch one small world and see how Arcanum feels.
+              We'll show you the API key once — keep it somewhere safe.
+            </p>
+            <Field label="Display name (optional)">
+              <input
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                className={inputClasses}
+                placeholder="Anonymous Explorer"
+                autoFocus
+                disabled={busy}
+              />
+            </Field>
+            <TurnstileWidget siteKey={turnstileSiteKey} onToken={setTurnstileToken} onError={setError} />
+            {error && <p className="text-xs text-status-error">{error}</p>}
+          </Form>
+        )}
+
+        {mode === "fullRequest" && (
+          <Form
+            onSubmit={doFullRequest}
+            onBack={() => setMode("choose")}
+            primary="Send verification code"
+            busy={busy}
+            disabled={!email.trim() || !displayName.trim() || (Boolean(turnstileSiteKey) && !turnstileToken)}
+          >
+            <p className="text-xs leading-6 text-text-muted">
+              We'll email a 6-digit code. Enter it on the next screen to finish signup.
+            </p>
+            <Field label="Email">
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoFocus
+                disabled={busy}
+                className={inputClasses}
+                placeholder="you@example.com"
+              />
+            </Field>
+            <Field label="Display name">
+              <input
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                required
+                disabled={busy}
+                className={inputClasses}
+                placeholder="How you want to be credited"
+              />
+            </Field>
+            <TurnstileWidget siteKey={turnstileSiteKey} onToken={setTurnstileToken} onError={setError} />
+            {error && <p className="text-xs text-status-error">{error}</p>}
+          </Form>
+        )}
+
+        {mode === "fullVerify" && (
+          <Form onSubmit={doFullVerify} onBack={() => setMode("fullRequest")} primary="Verify and finish" busy={busy} disabled={code.length !== 6}>
+            <p className="text-xs leading-6 text-text-muted">
+              We sent a code to <span className="text-text-primary">{email}</span>. It expires in 15
+              minutes.
+            </p>
+            <Field label="Code">
+              <input
+                inputMode="numeric"
+                pattern="\d{6}"
+                maxLength={6}
+                value={code}
+                onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+                required
+                autoFocus
+                disabled={busy}
+                className={`${inputClasses} text-center font-mono text-lg tracking-[0.4em]`}
+                placeholder="123456"
+              />
+            </Field>
+            {error && <p className="text-xs text-status-error">{error}</p>}
+          </Form>
+        )}
+
+        {mode === "done" && (
+          <div className="mt-8 space-y-5">
+            <div className="rounded-xl border border-accent/40 bg-accent/10 p-5">
+              <p className="text-xs uppercase tracking-wider text-accent">Your API key — shown once</p>
+              <code className="mt-3 block break-all rounded bg-[var(--bg)] px-3 py-3 font-mono text-sm text-text-primary">
+                {apiKey}
+              </code>
+              <p className="mt-3 text-xs leading-6 text-text-muted">
+                We also saved it in this browser so you can come back to{" "}
+                <Link to="/account" className="underline">/account</Link>. You won't see it here again
+                after you leave — copy it now if you want to use it elsewhere.
+              </p>
+              <button
+                onClick={() => void navigator.clipboard.writeText(apiKey)}
+                className="mt-3 text-xs uppercase tracking-wider text-accent underline-offset-2 hover:underline"
+              >
+                Copy to clipboard
+              </button>
+            </div>
+
+            <div className="rounded-xl border border-[var(--border)] bg-[var(--panel)] p-5">
+              <h2 className="font-display text-sm uppercase tracking-widest text-text-primary">Next: open Arcanum</h2>
+              <ol className="mt-3 list-decimal space-y-2 pl-5 text-xs leading-6 text-text-muted">
+                <li>Install the Arcanum creator (download link TBD).</li>
+                <li>Run it, choose "I have a key" in the onboarding, and paste the key above.</li>
+                <li>Start building — you'll see your quotas in Settings → Arcanum Hub.</li>
+              </ol>
+            </div>
+
+            <div className="flex items-center justify-between text-xs">
+              <Link to="/" className="text-text-muted hover:text-text-primary">
+                ← Back to the world directory
+              </Link>
+              <button
+                onClick={() => navigate("/account")}
+                className={showcaseButtonClassNames.secondary}
+              >
+                Open account page
+              </button>
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+// ─── Subcomponents ───────────────────────────────────────────────────
+
+function ChoiceCard({
+  title,
+  description,
+  cta,
+  onClick,
+  primary = false,
+}: {
+  title: string;
+  description: string;
+  cta: string;
+  onClick: () => void;
+  primary?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex flex-col items-start gap-2 rounded-xl border px-5 py-5 text-left transition ${
+        primary
+          ? "border-accent/50 bg-accent/10 hover:border-accent"
+          : "border-[var(--border)] bg-[var(--panel)] hover:border-accent/50"
+      }`}
+    >
+      <span className="font-display text-sm uppercase tracking-widest text-text-primary">{title}</span>
+      <span className="text-xs leading-6 text-text-muted">{description}</span>
+      <span className="mt-1 text-xs uppercase tracking-wider text-accent">{cta} →</span>
+    </button>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-xs uppercase tracking-wider text-text-muted">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Form({
+  children,
+  onSubmit,
+  onBack,
+  primary,
+  busy,
+  disabled,
+}: {
+  children: React.ReactNode;
+  onSubmit: () => void | Promise<void>;
+  onBack: () => void;
+  primary: string;
+  busy: boolean;
+  disabled: boolean;
+}) {
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        void onSubmit();
+      }}
+      className="mt-8 flex flex-col gap-4"
+    >
+      {children}
+      <div className="mt-2 flex items-center justify-between">
+        <button type="button" onClick={onBack} className="text-xs uppercase tracking-wider text-text-muted hover:text-text-primary">
+          ← Back
+        </button>
+        <button type="submit" disabled={busy || disabled} className={`${showcaseButtonClassNames.primary} disabled:opacity-50`}>
+          {busy ? "Working…" : primary}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+const inputClasses =
+  "w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-accent/60 focus:outline-none";


### PR DESCRIPTION
## Summary

Opens the hub to public signup so anyone can try Arcanum end-to-end without an admin-minted key. Two paths, one worker:

- **Try it free** — Turnstile-only, no email, 10 images / 20 prompts, no publish. `hubk_demo_…`
- **Create an account** — email + 6-digit code, 500 images / 5000 prompts, publishing enabled. `hubk_full_…`
- **Upgrade** — authenticated demo users can promote to full by verifying an email (key rotated, counters reset, user_id preserved)

All three flows work inside the Tauri creator onboarding *and* on the landing page at `arcanum-hub.com/signup`. Publish endpoints now return `publish_requires_verification` (403) until email is verified, so demo users get AI but not free publishing.

### What's in here

- **Hub worker** — new `/signup/{demo,request,verify}`, `/account`, `/account/upgrade/{request,verify}`, `/account/rotate-key`, `/config`. Abuse controls: Cloudflare Turnstile siteverify, per-IP rate limit (3 signups/hour in a new `signup_attempts` table), code-attempt cap (5/code, 15 min expiry). Resend for transactional email with a dev stub that logs codes to ` wrangler tail` when `RESEND_API_KEY` is unset.
- **Creator** — reworked `HubKeyStep` with three-path chooser; new Hub settings panel section showing tier badge, usage bars, inline upgrade flow, and rotate-key. Shared `hubClient.ts` + Turnstile widget.
- **Showcase landing** — `/signup` and `/account` pages; \"Get started free\" + \"Sign in\" CTAs on the hub index. localStorage-backed sign-in with paste-your-key.
- **Docs** — README walks through Resend + Turnstile setup; CLAUDE.md documents the tier gates (`demo` = AI only, `full` = AI + publish, `publish` = BYOK) so future changes don't accidentally grant publishing to demo users.

### Deploy prerequisites

1. Apply the migration:
   \`\`\`
   wrangler d1 execute arcanum-hub --remote --file=./hub-worker/src/migrations/0004_self_registration.sql
   \`\`\`
2. \`wrangler secret put RESEND_API_KEY\` (sender domain must be verified in Resend)
3. \`wrangler secret put TURNSTILE_SECRET_KEY\` + set \`TURNSTILE_SITE_KEY\` in \`wrangler.toml [vars]\` (allowed domains in CF: \`arcanum-hub.com\`, \`*.arcanum-hub.com\`, \`tauri.localhost\`, \`localhost\`)
4. \`cd hub-worker && npm run deploy\`

Without the secrets, signup still works in a degraded mode (codes logged to tail, Turnstile skipped) — fine for dev, not production.

## Test plan

- [ ] Apply 0004 migration against a local D1 (\`wrangler d1 execute arcanum-hub --local --file=...\`)
- [ ] \`cd hub-worker && npm run dev\` + \`curl -X POST http://127.0.0.1:8787/api/signup/demo -H 'content-type: application/json' -d '{}'\` returns a \`hubk_demo_\` key
- [ ] \`curl -X POST /api/signup/request -d '{\"email\":\"you@example.com\",\"displayName\":\"Test\"}'\` → code shows in tail; \`/api/signup/verify\` with that code returns \`hubk_full_\` key
- [ ] Demo key rejected from \`POST /api/publish/manifest\` with \`publish_requires_verification\`
- [ ] Demo key allowed on \`POST /api/ai/image/generate\` but capped at 10 images / 20 prompts
- [ ] Upgrade demo→full via \`/api/account/upgrade/*\` keeps same user.id, rotates key, promotes tier
- [ ] Creator: \`bun run tauri dev\`, trigger onboarding, walk demo + full signup paths, confirm key persists into Settings → Arcanum Hub
- [ ] Creator: in Hub settings, rotate key (usage counters reset), upgrade a demo key to full (tier badge flips, quotas expand)
- [ ] Landing: \`arcanum-hub.com/signup\` both paths; \`/account\` sign-in with key, rotate, upgrade
- [ ] \`bunx tsc --noEmit\` in creator + \`npm run typecheck\` in hub-worker + showcase — all green
- [ ] \`cd creator && bun run test\` — 1666 tests pass