### PR TITLE
feat(lore): expand chat retrieval via @mention backlinks

### DIFF
--- a/creator/src/lib/__tests__/loreChatContext.test.ts
+++ b/creator/src/lib/__tests__/loreChatContext.test.ts
@@ -58,6 +58,71 @@ describe("buildLoreChatPrompt", () => {
     expect(articlesUsed).not.toContain("f0");
   });
 
+  it("expands via @mention backlinks so facts on other articles surface", () => {
+    const many: Article[] = [];
+    for (let i = 0; i < 45; i++) {
+      many.push(mkArticle({ id: `f${i}`, title: `Filler ${i}`, content: "nothing relevant" }));
+    }
+    // Sylflorae article has no mention of its creator; that fact lives on Astriel's page.
+    many.push(
+      mkArticle({
+        id: "sylflorae",
+        title: "Sylflorae",
+        content: "Ancient forest-folk of the deep glens.",
+      }),
+    );
+    // Astriel's content @mentions Sylflorae via a TipTap mention node.
+    const astrielContent = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Astriel shaped the " },
+            { type: "mention", attrs: { id: "sylflorae", label: "Sylflorae" } },
+            { type: "text", text: " in the first age." },
+          ],
+        },
+      ],
+    });
+    many.push(
+      mkArticle({ id: "astriel", title: "Astriel", content: astrielContent }),
+    );
+    const lore = mkLore(many);
+
+    const { articlesUsed } = buildLoreChatPrompt(lore, "Who created the Sylflorae?");
+    expect(articlesUsed).toContain("sylflorae");
+    // Backlink expansion pulls Astriel in even though the query doesn't name them.
+    expect(articlesUsed).toContain("astriel");
+  });
+
+  it("expands via forward @mentions from a primary match", () => {
+    const many: Article[] = [];
+    for (let i = 0; i < 45; i++) {
+      many.push(mkArticle({ id: `f${i}`, title: `Filler ${i}`, content: "nothing relevant" }));
+    }
+    const hostContent = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "The scribe references " },
+            { type: "mention", attrs: { id: "artifact", label: "Codex" } },
+            { type: "text", text: "." },
+          ],
+        },
+      ],
+    });
+    many.push(mkArticle({ id: "scribe", title: "Scribe of the Veil", content: hostContent }));
+    many.push(mkArticle({ id: "artifact", title: "Codex", content: "An old book." }));
+    const lore = mkLore(many);
+
+    const { articlesUsed } = buildLoreChatPrompt(lore, "tell me about the scribe");
+    expect(articlesUsed).toContain("scribe");
+    expect(articlesUsed).toContain("artifact");
+  });
+
   it("embeds history and new question into user prompt", () => {
     const lore = mkLore([mkArticle({ id: "a", title: "Alpha" })]);
     const { userPrompt } = buildLoreChatPrompt(

--- a/creator/src/lib/loreChatContext.ts
+++ b/creator/src/lib/loreChatContext.ts
@@ -1,5 +1,5 @@
 import type { Article, WorldLore } from "@/types/lore";
-import { tiptapToPlainText } from "./loreRelations";
+import { extractMentions, tiptapToPlainText } from "./loreRelations";
 
 export interface LoreChatTurn {
   role: "user" | "assistant";
@@ -94,6 +94,37 @@ function selectArticlesSmallWorld(
   return Object.values(articles);
 }
 
+/**
+ * Build a map from articleId → set of article IDs that mention it via @mentions
+ * in their TipTap content. Used to expand retrieval so that facts living on
+ * a *different* article (e.g. "Astriel created the Sylflorae" on Astriel's
+ * page) still surface when the question names the mentioned subject.
+ */
+function buildMentionIndex(
+  articles: Record<string, Article>,
+): { forward: Map<string, Set<string>>; backward: Map<string, Set<string>> } {
+  const forward = new Map<string, Set<string>>();
+  const backward = new Map<string, Set<string>>();
+  for (const a of Object.values(articles)) {
+    const mentions = extractMentions(a.content ?? "");
+    if (mentions.length === 0) continue;
+    const outgoing = new Set<string>();
+    for (const m of mentions) {
+      if (!articles[m.targetId]) continue;
+      if (m.targetId === a.id) continue;
+      outgoing.add(m.targetId);
+      let back = backward.get(m.targetId);
+      if (!back) {
+        back = new Set<string>();
+        backward.set(m.targetId, back);
+      }
+      back.add(a.id);
+    }
+    if (outgoing.size > 0) forward.set(a.id, outgoing);
+  }
+  return { forward, backward };
+}
+
 function selectArticlesLargeWorld(
   articles: Record<string, Article>,
   question: string,
@@ -130,6 +161,7 @@ function selectArticlesLargeWorld(
   }
   scored.sort((a, b) => b.score - a.score);
 
+  const { forward, backward } = buildMentionIndex(articles);
   const primary = scored.slice(0, PRIMARY_MATCH_CAP).map((s) => s.article);
   const expanded = new Map<string, Article>();
   for (const a of primary) {
@@ -140,6 +172,20 @@ function selectArticlesLargeWorld(
     for (const r of a.relations ?? []) {
       const target = articles[r.targetId];
       if (target) expanded.set(target.id, target);
+    }
+    const outgoing = forward.get(a.id);
+    if (outgoing) {
+      for (const id of outgoing) {
+        const target = articles[id];
+        if (target) expanded.set(id, target);
+      }
+    }
+    const incoming = backward.get(a.id);
+    if (incoming) {
+      for (const id of incoming) {
+        const source = articles[id];
+        if (source) expanded.set(id, source);
+      }
     }
   }
   return Array.from(expanded.values()).slice(0, MAX_SELECTED_ARTICLES);


### PR DESCRIPTION
## Summary
- Lore chat retrieval only expanded primary keyword matches along parent + explicit relation edges, so facts that lived in the prose of another article via an `@mention` were invisible. Concrete failure: "Who created the Sylflorae?" — Astriel's page mentions Sylflorae, but Sylflorae's page doesn't know its creator, so the archivist answered with "the lore doesn't say."
- Added `buildMentionIndex()` which scans every article's TipTap content once per prompt (via the existing `extractMentions` helper) and produces forward (`A mentions X`) and backward (`X is mentioned by A`) maps.
- `selectArticlesLargeWorld` now expands each primary match along both mention directions in addition to parent + relations.

## Test plan
- [x] `bunx tsc --noEmit` in `creator/`
- [x] `bun run test` in `creator/` — all 1676 tests pass, including two new cases: the Sylflorae/Astriel backlink scenario and a forward-mention expansion check.
- [ ] Manual: open the lore chat in a world where one article mentions another only in prose, ask a question whose answer lives on the mentioning article, confirm the archivist now answers and cites the source article.