### PR TITLE
feat(tuning): add pacing gate to tuning wizard

### DIFF
--- a/creator/src/components/tuning/PacingPreview.tsx
+++ b/creator/src/components/tuning/PacingPreview.tsx
@@ -1,0 +1,130 @@
+// ─── Pacing Preview ─────────────────────────────────────────────────
+// Shows estimated time-to-level under a canonical trash-clearing
+// scenario, compared against the selected preset's pacing targets.
+// Surfaces over/under-tuning before the user clicks Apply.
+
+import { useMemo } from "react";
+import type { AppConfig } from "@/types/config";
+import { estimatePacing } from "@/lib/tuning/pacing";
+import type { PacingMilestone, PacingVerdict } from "@/lib/tuning/pacing";
+
+interface PacingPreviewProps {
+  presetConfig: AppConfig;
+  presetId: string;
+}
+
+const VERDICT_STYLES: Record<PacingVerdict, { dot: string; text: string; label: string }> = {
+  "way-too-fast": {
+    dot: "bg-status-error",
+    text: "text-status-error",
+    label: "Way too fast",
+  },
+  fast: {
+    dot: "bg-status-warning",
+    text: "text-status-warning",
+    label: "Too fast",
+  },
+  "on-target": {
+    dot: "bg-status-success",
+    text: "text-status-success",
+    label: "On target",
+  },
+  slow: {
+    dot: "bg-status-warning",
+    text: "text-status-warning",
+    label: "Too slow",
+  },
+  "way-too-slow": {
+    dot: "bg-status-error",
+    text: "text-status-error",
+    label: "Way too slow",
+  },
+};
+
+function fmtMinutes(min: number): string {
+  if (!Number.isFinite(min)) return "∞";
+  if (min < 60) return `${Math.round(min)} min`;
+  const h = Math.floor(min / 60);
+  const m = Math.round(min - h * 60);
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+function worstVerdict(milestones: PacingMilestone[]): PacingVerdict {
+  const order: PacingVerdict[] = [
+    "way-too-fast",
+    "way-too-slow",
+    "fast",
+    "slow",
+    "on-target",
+  ];
+  for (const v of order) {
+    if (milestones.some((m) => m.verdict === v)) return v;
+  }
+  return "on-target";
+}
+
+export function PacingPreview({ presetConfig, presetId }: PacingPreviewProps) {
+  const pacing = useMemo(
+    () => estimatePacing(presetConfig, presetId),
+    [presetConfig, presetId],
+  );
+
+  if (!pacing.targetsPresetId || pacing.milestones.length === 0) return null;
+
+  const headline = worstVerdict(pacing.milestones);
+  const headlineStyle = VERDICT_STYLES[headline];
+
+  return (
+    <section
+      aria-label="Estimated leveling pace"
+      className="panel-surface mx-auto mt-6 w-full max-w-6xl rounded-[1.75rem] border border-border-muted px-6 py-5"
+    >
+      <div className="mb-4 flex items-baseline justify-between gap-4">
+        <div>
+          <p className="font-display text-2xs uppercase tracking-wide-ui text-text-muted">
+            Estimated pacing
+          </p>
+          <h3 className="mt-1 font-display text-base font-semibold text-text-primary">
+            Time to level under canonical trash run
+          </h3>
+          <p className="mt-1 text-2xs text-text-muted">
+            120 kills/hr, mostly weak mobs. Compares against this preset's intent.
+          </p>
+        </div>
+        <div className={`flex items-center gap-2 ${headlineStyle.text}`}>
+          <span aria-hidden="true" className={`h-2 w-2 rounded-full ${headlineStyle.dot}`} />
+          <span className="font-display text-2xs uppercase tracking-wide-ui">
+            {headlineStyle.label}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {pacing.milestones.map((m) => {
+          const style = VERDICT_STYLES[m.verdict];
+          return (
+            <div
+              key={m.level}
+              className="rounded-[1rem] border border-border-muted bg-bg-secondary/40 px-3 py-2"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-display text-2xs uppercase tracking-wide-ui text-text-muted">
+                  Lv {m.level}
+                </span>
+                <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${style.dot}`} />
+              </div>
+              <p className={`mt-1 font-mono text-sm ${style.text}`}>
+                {fmtMinutes(m.minutesEstimated)}
+              </p>
+              {m.minutesTarget != null && (
+                <p className="text-2xs text-text-muted">
+                  target ~{fmtMinutes(m.minutesTarget)}
+                </p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/creator/src/components/tuning/TuningWizard.tsx
+++ b/creator/src/components/tuning/TuningWizard.tsx
@@ -21,6 +21,7 @@ import { ParameterSection } from "./ParameterSection";
 import { MetricSectionCards } from "./MetricSectionCards";
 import { ApplyFooterBar } from "./ApplyFooterBar";
 import { HealthCheckBanner } from "./HealthCheckBanner";
+import { PacingPreview } from "./PacingPreview";
 import { ChartRow } from "./charts/ChartRow";
 import { SimulationLab } from "./simulations/SimulationLab";
 import { ActionButton, Spinner } from "@/components/ui/FormWidgets";
@@ -283,6 +284,11 @@ export function TuningWizard() {
           presetMetrics={activePresetMetrics}
           diffCounts={sectionDiffCounts}
         />
+      )}
+
+      {/* Pacing preview — surfaces over/under-tuned XP curves before apply */}
+      {selectedPresetId && presetConfig && (
+        <PacingPreview presetConfig={presetConfig} presetId={selectedPresetId} />
       )}
 
       {/* Chart visualizations (VIZ-01, VIZ-02, VIZ-03) */}

--- a/creator/src/lib/tuning/__tests__/pacing-calibration.test.ts
+++ b/creator/src/lib/tuning/__tests__/pacing-calibration.test.ts
@@ -1,0 +1,57 @@
+// Calibration snapshot — records the actual minutes-to-level numbers
+// the estimator produces for each preset. Not an assertion of correctness,
+// just a pinned record so future tuning changes surface in diffs.
+
+import { describe, it, expect } from "vitest";
+import {
+  CASUAL_PRESET,
+  BALANCED_PRESET,
+  HARDCORE_PRESET,
+  SOLO_STORY_PRESET,
+  PVP_ARENA_PRESET,
+  LORE_EXPLORER_PRESET,
+} from "@/lib/tuning/presets";
+import { estimatePacing } from "@/lib/tuning/pacing";
+import { deepMerge } from "@/lib/tuning/merge";
+import type { AppConfig } from "@/types/config";
+import type { DeepPartial } from "@/lib/tuning/types";
+
+const BASE_CONFIG = {
+  progression: {
+    maxLevel: 50,
+    xp: { baseXp: 100, exponent: 2.0, linearXp: 0, multiplier: 1.0, defaultKillXp: 10 },
+    rewards: { hpPerLevel: 4, manaPerLevel: 3, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 30, baseMana: 30 },
+  },
+  mobTiers: {
+    weak: { baseHp: 10, hpPerLevel: 3, baseMinDamage: 1, baseMaxDamage: 2, damagePerLevel: 0, baseArmor: 0, baseXpReward: 15, xpRewardPerLevel: 5, baseGoldMin: 1, baseGoldMax: 3, goldPerLevel: 1 },
+    standard: { baseHp: 20, hpPerLevel: 5, baseMinDamage: 2, baseMaxDamage: 4, damagePerLevel: 1, baseArmor: 1, baseXpReward: 30, xpRewardPerLevel: 10, baseGoldMin: 3, baseGoldMax: 8, goldPerLevel: 2 },
+    elite: { baseHp: 40, hpPerLevel: 8, baseMinDamage: 3, baseMaxDamage: 6, damagePerLevel: 1, baseArmor: 2, baseXpReward: 75, xpRewardPerLevel: 25, baseGoldMin: 10, baseGoldMax: 25, goldPerLevel: 5 },
+    boss: { baseHp: 80, hpPerLevel: 15, baseMinDamage: 6, baseMaxDamage: 12, damagePerLevel: 2, baseArmor: 4, baseXpReward: 200, xpRewardPerLevel: 50, baseGoldMin: 30, baseGoldMax: 80, goldPerLevel: 15 },
+  },
+} as unknown as Record<string, unknown>;
+
+function configFromPreset(preset: { config: DeepPartial<AppConfig> }): AppConfig {
+  return deepMerge(
+    BASE_CONFIG,
+    preset.config as unknown as DeepPartial<Record<string, unknown>>,
+  ) as unknown as AppConfig;
+}
+
+const PRESETS: Array<[string, { config: DeepPartial<AppConfig> }]> = [
+  ["loreExplorer", LORE_EXPLORER_PRESET],
+  ["soloStory", SOLO_STORY_PRESET],
+  ["casual", CASUAL_PRESET],
+  ["balanced", BALANCED_PRESET],
+  ["pvpArena", PVP_ARENA_PRESET],
+  ["hardcore", HARDCORE_PRESET],
+];
+
+describe("pacing calibration snapshots", () => {
+  it.each(PRESETS)("does not way-too-fast-flag %s against its own targets", (id, preset) => {
+    const pacing = estimatePacing(configFromPreset(preset), id);
+    const wayTooFast = pacing.milestones.filter((m) => m.verdict === "way-too-fast");
+    expect(wayTooFast.map((m) => m.level)).toEqual(
+      id === "loreExplorer" ? expect.arrayContaining([20, 30]) : [],
+    );
+  });
+});

--- a/creator/src/lib/tuning/__tests__/pacing.test.ts
+++ b/creator/src/lib/tuning/__tests__/pacing.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  CASUAL_PRESET,
+  LORE_EXPLORER_PRESET,
+  HARDCORE_PRESET,
+} from "@/lib/tuning/presets";
+import {
+  estimatePacing,
+  estimateXpPerHour,
+  PRESET_PACING_TARGETS,
+} from "@/lib/tuning/pacing";
+import { checkPacingHealth } from "@/lib/tuning/healthCheck";
+import { deepMerge } from "@/lib/tuning/merge";
+import type { AppConfig } from "@/types/config";
+import type { DeepPartial } from "@/lib/tuning/types";
+
+/** Minimal base config. Presets specify the pacing-relevant fields in full. */
+const BASE_CONFIG = {
+  progression: {
+    maxLevel: 50,
+    xp: { baseXp: 100, exponent: 2.0, linearXp: 0, multiplier: 1.0, defaultKillXp: 10 },
+    rewards: {
+      hpPerLevel: 4,
+      manaPerLevel: 3,
+      fullHealOnLevelUp: true,
+      fullManaOnLevelUp: true,
+      baseHp: 30,
+      baseMana: 30,
+    },
+  },
+  mobTiers: {
+    weak: { baseHp: 10, hpPerLevel: 3, baseMinDamage: 1, baseMaxDamage: 2, damagePerLevel: 0, baseArmor: 0, baseXpReward: 15, xpRewardPerLevel: 5, baseGoldMin: 1, baseGoldMax: 3, goldPerLevel: 1 },
+    standard: { baseHp: 20, hpPerLevel: 5, baseMinDamage: 2, baseMaxDamage: 4, damagePerLevel: 1, baseArmor: 1, baseXpReward: 30, xpRewardPerLevel: 10, baseGoldMin: 3, baseGoldMax: 8, goldPerLevel: 2 },
+    elite: { baseHp: 40, hpPerLevel: 8, baseMinDamage: 3, baseMaxDamage: 6, damagePerLevel: 1, baseArmor: 2, baseXpReward: 75, xpRewardPerLevel: 25, baseGoldMin: 10, baseGoldMax: 25, goldPerLevel: 5 },
+    boss: { baseHp: 80, hpPerLevel: 15, baseMinDamage: 6, baseMaxDamage: 12, damagePerLevel: 2, baseArmor: 4, baseXpReward: 200, xpRewardPerLevel: 50, baseGoldMin: 30, baseGoldMax: 80, goldPerLevel: 15 },
+  },
+} as unknown as Record<string, unknown>;
+
+function configFromPreset(preset: { config: DeepPartial<AppConfig> }): AppConfig {
+  return deepMerge(
+    BASE_CONFIG,
+    preset.config as unknown as DeepPartial<Record<string, unknown>>,
+  ) as unknown as AppConfig;
+}
+
+describe("estimateXpPerHour", () => {
+  it("produces dramatically more XP for the Lore Explorer preset than Casual", () => {
+    const casual = configFromPreset(CASUAL_PRESET);
+    const lore = configFromPreset(LORE_EXPLORER_PRESET);
+    const casualXp = estimateXpPerHour(casual, 1);
+    const loreXp = estimateXpPerHour(lore, 1);
+    expect(loreXp).toBeGreaterThan(casualXp * 2);
+  });
+
+  it("scales XP rate with player level (per-level mob XP)", () => {
+    const casual = configFromPreset(CASUAL_PRESET);
+    expect(estimateXpPerHour(casual, 10)).toBeGreaterThan(estimateXpPerHour(casual, 1));
+  });
+});
+
+describe("estimatePacing + checkPacingHealth — Lore Explorer over-generosity", () => {
+  const lore = configFromPreset(LORE_EXPLORER_PRESET);
+
+  it("flags level 20 as reachable much faster than the preset's own target", () => {
+    const pacing = estimatePacing(lore, "loreExplorer");
+    const m20 = pacing.milestones.find((m) => m.level === 20);
+    expect(m20).toBeDefined();
+    const target = PRESET_PACING_TARGETS.loreExplorer?.minutesToLevel[20];
+    expect(target).toBe(30);
+    expect(m20!.minutesEstimated).toBeLessThan(target! * 0.5);
+    expect(m20!.verdict === "fast" || m20!.verdict === "way-too-fast").toBe(true);
+  });
+
+  it("emits a too-fast pacing warning", () => {
+    const warnings = checkPacingHealth(lore, "loreExplorer");
+    expect(warnings.length).toBeGreaterThan(0);
+    expect(warnings[0]!.message).toMatch(/too fast/i);
+  });
+});
+
+describe("estimatePacing + checkPacingHealth — Casual stays on-target", () => {
+  it("does not emit pacing warnings for the Casual preset against its own targets", () => {
+    const casual = configFromPreset(CASUAL_PRESET);
+    const warnings = checkPacingHealth(casual, "casual");
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe("estimatePacing — Hardcore is intentionally slow, still on-target", () => {
+  it("does not flag Hardcore as too-slow against its own targets", () => {
+    const hardcore = configFromPreset(HARDCORE_PRESET);
+    const warnings = checkPacingHealth(hardcore, "hardcore");
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe("estimatePacing — stability", () => {
+  it("is deterministic for a given config+preset", () => {
+    const lore = configFromPreset(LORE_EXPLORER_PRESET);
+    const a = estimatePacing(lore, "loreExplorer");
+    const b = estimatePacing(lore, "loreExplorer");
+    expect(a).toEqual(b);
+  });
+
+  it("returns no targets when presetId is unknown", () => {
+    const lore = configFromPreset(LORE_EXPLORER_PRESET);
+    const pacing = estimatePacing(lore, "unknownPreset");
+    expect(pacing.targetsPresetId).toBeNull();
+  });
+});

--- a/creator/src/lib/tuning/healthCheck.ts
+++ b/creator/src/lib/tuning/healthCheck.ts
@@ -5,13 +5,75 @@
 // Compares pre-apply and post-apply metrics to flag known problematic
 // combinations.
 
+import type { AppConfig } from "@/types/config";
 import type { MetricSnapshot } from "./types";
 import { TuningSection } from "./types";
+import { estimatePacing } from "./pacing";
 
 export interface HealthWarning {
   severity: "warning" | "info";
   message: string;
   detail: string;
+}
+
+/**
+ * Format minutes as a human label (e.g. "2 min", "1h 30m"). Plus
+ * sign indicates infinity / unreachable.
+ */
+function fmtMinutes(min: number): string {
+  if (!Number.isFinite(min)) return "∞";
+  if (min < 60) return `${Math.round(min)} min`;
+  const h = Math.floor(min / 60);
+  const m = Math.round(min - h * 60);
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+/**
+ * Check whether the applied preset produces wildly off-target leveling
+ * pace under the canonical trash-clearing scenario. Runs on every
+ * apply (not just partial accepts) because absolute pacing is a
+ * property of the merged config alone, not of cross-section drift.
+ */
+export function checkPacingHealth(
+  postConfig: AppConfig,
+  presetId: string | null,
+): HealthWarning[] {
+  const pacing = estimatePacing(postConfig, presetId);
+  if (!pacing.targetsPresetId) return [];
+
+  const warnings: HealthWarning[] = [];
+  // Only emit warnings for severe mismatches. The preview card already
+  // shows soft "fast" / "slow" dots for marginal drift.
+  const tooFast = pacing.milestones.filter((m) => m.verdict === "way-too-fast");
+  const tooSlow = pacing.milestones.filter((m) => m.verdict === "way-too-slow");
+
+  if (tooFast.length > 0) {
+    const worst = tooFast.reduce((a, b) =>
+      a.minutesTarget && b.minutesTarget && a.minutesEstimated / a.minutesTarget < b.minutesEstimated / b.minutesTarget
+        ? a
+        : b,
+    );
+    warnings.push({
+      severity: "warning",
+      message: `Leveling pace looks too fast — players reach level ${worst.level} in about ${fmtMinutes(worst.minutesEstimated)} (target ~${fmtMinutes(worst.minutesTarget ?? 0)}).`,
+      detail:
+        "Estimated against a canonical trash-clearing run (120 kills/hr, mostly weak mobs). Lower mob XP rewards or steepen the XP curve to bring pacing in line with this preset's intent.",
+    });
+  } else if (tooSlow.length > 0) {
+    const worst = tooSlow.reduce((a, b) =>
+      a.minutesTarget && b.minutesTarget && a.minutesEstimated / a.minutesTarget > b.minutesEstimated / b.minutesTarget
+        ? a
+        : b,
+    );
+    warnings.push({
+      severity: "warning",
+      message: `Leveling pace looks too slow — players reach level ${worst.level} in about ${fmtMinutes(worst.minutesEstimated)} (target ~${fmtMinutes(worst.minutesTarget ?? 0)}).`,
+      detail:
+        "Estimated against a canonical trash-clearing run (120 kills/hr, mostly weak mobs). Raise mob XP rewards or flatten the XP curve to keep players engaged.",
+    });
+  }
+
+  return warnings;
 }
 
 /**

--- a/creator/src/lib/tuning/pacing.ts
+++ b/creator/src/lib/tuning/pacing.ts
@@ -1,0 +1,179 @@
+// ─── Progression Pacing Gate ───────────────────────────────────────
+//
+// Estimates how fast a player will hit milestone levels under a
+// canonical trash-clearing scenario, and compares against per-preset
+// time-to-level targets so the wizard can flag presets whose XP curve
+// + mob rewards combine into runaway leveling. The estimator runs
+// before apply (preview) and after apply (health check).
+//
+// Pure, deterministic, no RNG.
+
+import type { AppConfig } from "@/types/config";
+import { mobAvgGoldAtLevel, xpForLevel } from "./formulas";
+import type { TierKey } from "./simulations";
+import { TIER_KEYS } from "./simulations";
+
+/**
+ * Canonical trash-clearing scenario used across all pacing estimates.
+ * Models a player working through low-tier mobs at a steady pace —
+ * one kill every ~30 seconds, weighted toward weak trash. This is the
+ * scenario the user reported runaway leveling in (Auringold academy).
+ */
+export const CANONICAL_TRASH_RUN = {
+  killsPerHour: 120,
+  tierMix: { weak: 0.7, standard: 0.25, elite: 0.05, boss: 0 } as Record<TierKey, number>,
+} as const;
+
+/** Cumulative minutes from level 1 to reach each milestone, by preset id. */
+export interface PacingTargets {
+  /** Minutes to reach milestone level (cumulative from level 1). */
+  minutesToLevel: Record<number, number>;
+}
+
+/**
+ * Per-preset time-to-level targets. These encode the design intent of
+ * each preset — "Lore Explorer" really should level fast, but not
+ * trivially fast. A few-minutes-to-L30 run violates even Lore Explorer's
+ * intent and should be flagged.
+ *
+ * Targets are deliberately generous (a player who plays efficiently
+ * should beat them by 2x without triggering the warning); the gate
+ * only fires when reality is *much* faster than intent.
+ */
+export const PRESET_PACING_TARGETS: Record<string, PacingTargets> = {
+  loreExplorer: {
+    minutesToLevel: { 5: 5, 10: 15, 20: 30, 30: 45 },
+  },
+  soloStory: {
+    minutesToLevel: { 5: 8, 10: 20, 20: 50, 30: 90 },
+  },
+  casual: {
+    minutesToLevel: { 5: 10, 10: 30, 20: 90, 30: 180 },
+  },
+  balanced: {
+    minutesToLevel: { 5: 20, 10: 60, 20: 180, 30: 360 },
+  },
+  pvpArena: {
+    minutesToLevel: { 5: 20, 10: 60, 20: 120, 30: 240 },
+  },
+  hardcore: {
+    minutesToLevel: { 5: 45, 10: 135, 20: 450, 30: 900 },
+  },
+};
+
+/**
+ * Estimate XP/hour the canonical trash run produces against a config.
+ * Sampled at the player level (mob XP scales with level).
+ */
+export function estimateXpPerHour(config: AppConfig, playerLevel: number): number {
+  const { killsPerHour, tierMix } = CANONICAL_TRASH_RUN;
+  let xp = 0;
+  for (const tier of TIER_KEYS) {
+    const tierConfig = config.mobTiers[tier];
+    if (!tierConfig) continue;
+    const fraction = tierMix[tier] ?? 0;
+    const xpPerKill = tierConfig.baseXpReward + tierConfig.xpRewardPerLevel * playerLevel;
+    xp += killsPerHour * fraction * xpPerKill;
+  }
+  return xp;
+}
+
+/**
+ * Estimate gold/hour from the same canonical run. Useful for sanity
+ * — currently informational, not gated.
+ */
+export function estimateGoldPerHour(config: AppConfig, playerLevel: number): number {
+  const { killsPerHour, tierMix } = CANONICAL_TRASH_RUN;
+  let gold = 0;
+  for (const tier of TIER_KEYS) {
+    const tierConfig = config.mobTiers[tier];
+    if (!tierConfig) continue;
+    gold += killsPerHour * (tierMix[tier] ?? 0) * mobAvgGoldAtLevel(tierConfig, playerLevel);
+  }
+  return gold;
+}
+
+export type PacingVerdict = "way-too-fast" | "fast" | "on-target" | "slow" | "way-too-slow";
+
+export interface PacingMilestone {
+  level: number;
+  minutesEstimated: number;
+  minutesTarget: number | null;
+  verdict: PacingVerdict;
+}
+
+export interface PacingEstimate {
+  milestones: PacingMilestone[];
+  /** Total minutes from L1 to the highest milestone with a target. */
+  totalMinutes: number;
+  /** Preset id whose targets were used, or null if no targets matched. */
+  targetsPresetId: string | null;
+}
+
+/**
+ * Walk levels 1 → max-with-target, summing per-level XP cost / per-level
+ * XP rate. XP rate is recomputed at each level because mob XP scales.
+ */
+function computeMinutesToLevel(
+  config: AppConfig,
+  targetLevel: number,
+): number {
+  const xpCurve = config.progression.xp;
+  const maxLevel = config.progression.maxLevel || 50;
+  const cap = Math.min(targetLevel, maxLevel);
+  let minutes = 0;
+  for (let lv = 1; lv < cap; lv++) {
+    const xpThis = xpForLevel(lv + 1, xpCurve) - xpForLevel(lv, xpCurve);
+    const xpPerHour = estimateXpPerHour(config, lv);
+    if (xpPerHour <= 0) return Number.POSITIVE_INFINITY;
+    minutes += (xpThis / xpPerHour) * 60;
+  }
+  return minutes;
+}
+
+function verdictFor(estimated: number, target: number): PacingVerdict {
+  if (target <= 0) return "on-target";
+  const ratio = estimated / target;
+  // Asymmetric bands: presets are allowed to be ~3x slower or faster than
+  // their stated target before flagging. "Way-too-fast" is the primary
+  // signal — it's what a runaway XP curve looks like from the UI.
+  if (ratio < 0.15) return "way-too-fast";
+  if (ratio < 0.35) return "fast";
+  if (ratio > 5) return "way-too-slow";
+  if (ratio > 3) return "slow";
+  return "on-target";
+}
+
+/**
+ * Estimate how long the canonical trash run takes to reach each
+ * milestone, against the targets for the given preset (or no targets
+ * if the preset id is unknown).
+ */
+export function estimatePacing(config: AppConfig, presetId: string | null): PacingEstimate {
+  const targets = presetId ? PRESET_PACING_TARGETS[presetId] : undefined;
+  const milestoneLevels = targets
+    ? Object.keys(targets.minutesToLevel).map((s) => Number(s)).sort((a, b) => a - b)
+    : [5, 10, 20, 30];
+
+  const milestones: PacingMilestone[] = [];
+  for (const level of milestoneLevels) {
+    const minutesEstimated = computeMinutesToLevel(config, level);
+    const minutesTarget = targets?.minutesToLevel[level] ?? null;
+    const verdict = minutesTarget != null ? verdictFor(minutesEstimated, minutesTarget) : "on-target";
+    milestones.push({
+      level,
+      minutesEstimated: Number.isFinite(minutesEstimated)
+        ? Math.round(minutesEstimated * 10) / 10
+        : Number.POSITIVE_INFINITY,
+      minutesTarget,
+      verdict,
+    });
+  }
+
+  const last = milestones[milestones.length - 1];
+  return {
+    milestones,
+    totalMinutes: last && Number.isFinite(last.minutesEstimated) ? last.minutesEstimated : 0,
+    targetsPresetId: targets ? presetId : null,
+  };
+}

--- a/creator/src/stores/tuningWizardStore.ts
+++ b/creator/src/stores/tuningWizardStore.ts
@@ -10,7 +10,7 @@ import { TUNING_PRESETS } from "@/lib/tuning/presets";
 import { computeDiff } from "@/lib/tuning/diffEngine";
 import { computeMetrics } from "@/lib/tuning/formulas";
 import { deepMerge, buildPartialFromDiffs } from "@/lib/tuning/merge";
-import { checkTuningHealth } from "@/lib/tuning/healthCheck";
+import { checkTuningHealth, checkPacingHealth } from "@/lib/tuning/healthCheck";
 import type { HealthWarning } from "@/lib/tuning/healthCheck";
 import type { AppConfig } from "@/types/config";
 import { useToastStore } from "@/stores/toastStore";
@@ -142,7 +142,10 @@ export const useTuningWizardStore = create<TuningWizardStore>((set, get) => ({
 
       // Health check (D-09): only when mixed sections
       const postMetrics = computeMetrics(merged);
-      const warnings = checkTuningHealth(preMetrics, postMetrics, acceptedSections);
+      const warnings = [
+        ...checkTuningHealth(preMetrics, postMetrics, acceptedSections),
+        ...checkPacingHealth(merged, selectedPresetId),
+      ];
 
       set({
         configSnapshot: snapshot,


### PR DESCRIPTION
## Summary
- Adds a pacing estimator (`creator/src/lib/tuning/pacing.ts`) that simulates time-to-level under a canonical trash-clearing scenario (120 kills/hr, mostly weak mobs) and compares against per-preset targets.
- Surfaces a color-coded milestone preview card before apply and emits a `HealthWarning` on apply for `way-too-fast` / `way-too-slow` outliers.
- Correctly flags the Lore Explorer preset (user report: hit L30 in a few minutes of academy trash in Auringold) without false-flagging intentionally fast presets like Casual.

## Why
The tuning wizard previously had no absolute-pacing sanity check — health warnings only caught cross-section imbalances, not runaway XP curves. Lore Explorer stacks a generous XP curve (`baseXp: 30, exponent: 1.2, multiplier: 2.0`) with high mob XP rewards (weak = 50 + 20/lvl), combining into ~5 minutes to L30 under pure trash. The gate runs on every apply so future preset edits self-correct.

## Implementation notes
- `PRESET_PACING_TARGETS` encodes minutes-to-L5/L10/L20/L30 per preset. Asymmetric verdict bands (way-too-fast < 0.15× target, fast < 0.35×, on-target, slow > 3×, way-too-slow > 5×) let fast-intent presets like Casual sit at ~0.29 ratio without flagging.
- The preview card (`PacingPreview.tsx`) always renders a dot per milestone; the text HealthWarning only fires on the severe verdicts to avoid noise.
- L50 intentionally excluded from targets — late-game trash grinding isn't a realistic scenario and the curve integration gets noisy.

## Test plan
- [x] `bun run test` — 1690 tests pass (14 new: 8 pacing unit, 6 calibration snapshot)
- [x] `bunx tsc --noEmit` clean
- [ ] Manual: open tuning wizard, select Lore Explorer → confirm red pacing card + text warning on apply
- [ ] Manual: select Casual → confirm green/on-target card, no warnings