### PR TITLE
feat(zone): rebalance zone to a target level band

### DIFF
--- a/creator/src/components/zone/RebalanceZoneDialog.tsx
+++ b/creator/src/components/zone/RebalanceZoneDialog.tsx
@@ -1,0 +1,342 @@
+// ─── Rebalance Zone Dialog ──────────────────────────────────────────
+// Modal for retargeting a zone's level band + difficulty. Shows a
+// per-mob diff (named mobs require review, trash auto-applies) and an
+// estimated time-to-clear under the chosen band so designers can
+// calibrate against world progression.
+
+import { useMemo, useState } from "react";
+import { useConfigStore } from "@/stores/configStore";
+import { useZoneStore } from "@/stores/zoneStore";
+import { useFocusTrap } from "@/lib/useFocusTrap";
+import {
+  applyZoneRebalance,
+  computeZoneRebalance,
+  inferLevelBand,
+  type MobRebalanceDiff,
+  type OverrideAction,
+  type ZoneRebalanceTarget,
+} from "@/lib/zoneRebalance";
+import { estimateXpPerHour } from "@/lib/tuning/pacing";
+import { xpForLevel } from "@/lib/tuning/formulas";
+
+interface RebalanceZoneDialogProps {
+  zoneId: string;
+  onClose: () => void;
+}
+
+const TIER_LABELS: Record<string, string> = {
+  weak: "Weak",
+  standard: "Standard",
+  elite: "Elite",
+  boss: "Boss",
+};
+
+const DIFFICULTY_LABELS: Array<{ value: ZoneRebalanceTarget["difficultyHint"]; label: string }> = [
+  { value: "casual", label: "Casual" },
+  { value: "standard", label: "Standard" },
+  { value: "challenging", label: "Challenging" },
+];
+
+const ACTION_LABELS: Record<OverrideAction, string> = {
+  drop: "reset to tier",
+  keep: "kept",
+  flag: "kept (diverges)",
+};
+
+function fmtMinutes(min: number): string {
+  if (!Number.isFinite(min) || min <= 0) return "—";
+  if (min < 60) return `${Math.round(min)} min`;
+  const h = Math.floor(min / 60);
+  const m = Math.round(min - h * 60);
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+function MobRow({
+  diff,
+  accepted,
+  onToggle,
+}: {
+  diff: MobRebalanceDiff;
+  accepted: boolean;
+  onToggle: () => void;
+}) {
+  const levelLabel =
+    diff.currentLevel != null
+      ? `L${diff.currentLevel} → L${diff.targetLevel}`
+      : `tier-default → L${diff.targetLevel}`;
+  const overrideSummary = diff.overrideChanges.length
+    ? diff.overrideChanges
+        .map((c) => `${c.field}: ${c.currentOverride} ${ACTION_LABELS[c.action]} (~${c.tierBaseline})`)
+        .join(", ")
+    : "no override changes";
+
+  return (
+    <li className="flex items-start gap-3 px-3 py-2">
+      <input
+        id={`reb-mob-${diff.mobId}`}
+        type="checkbox"
+        checked={accepted}
+        onChange={onToggle}
+        className="mt-1"
+      />
+      <label htmlFor={`reb-mob-${diff.mobId}`} className="min-w-0 flex-1 cursor-pointer">
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-display text-sm text-text-primary">{diff.displayName}</span>
+          <span className="font-mono text-2xs text-text-muted">
+            {TIER_LABELS[diff.tier] ?? diff.tier} · {levelLabel}
+          </span>
+        </div>
+        <p className="mt-0.5 text-2xs leading-snug text-text-muted">{overrideSummary}</p>
+      </label>
+    </li>
+  );
+}
+
+export function RebalanceZoneDialog({ zoneId, onClose }: RebalanceZoneDialogProps) {
+  const config = useConfigStore((s) => s.config);
+  const zoneState = useZoneStore((s) => s.zones.get(zoneId));
+  const updateZone = useZoneStore((s) => s.updateZone);
+  const trapRef = useFocusTrap<HTMLDivElement>(onClose);
+
+  const initialBand = useMemo(
+    () => (zoneState?.data ? inferLevelBand(zoneState.data) : { min: 1, max: 5 }),
+    [zoneState?.data],
+  );
+  const [bandMin, setBandMin] = useState(initialBand.min);
+  const [bandMax, setBandMax] = useState(initialBand.max);
+  const [difficulty, setDifficulty] = useState<ZoneRebalanceTarget["difficultyHint"]>(
+    zoneState?.data?.difficultyHint,
+  );
+
+  const target: ZoneRebalanceTarget = {
+    levelBand: { min: bandMin, max: Math.max(bandMin, bandMax) },
+    difficultyHint: difficulty,
+  };
+
+  const diff = useMemo(() => {
+    if (!zoneState?.data || !config) return null;
+    return computeZoneRebalance(zoneState.data, config, target);
+  }, [zoneState?.data, config, target]);
+
+  const namedMobs = diff?.mobs.filter((m) => m.classification === "named") ?? [];
+  const trashMobs = diff?.mobs.filter((m) => m.classification === "trash") ?? [];
+
+  const [acceptedMobIds, setAcceptedMobIds] = useState<Set<string>>(() => new Set());
+
+  const trashWithChanges = useMemo(
+    () => trashMobs.filter((m) => m.levelChanged || m.overrideChanges.length > 0),
+    [trashMobs],
+  );
+  const allTrashAccepted =
+    trashWithChanges.length > 0 && trashWithChanges.every((m) => acceptedMobIds.has(m.mobId));
+
+  const toggleMob = (mobId: string) => {
+    setAcceptedMobIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(mobId)) next.delete(mobId);
+      else next.add(mobId);
+      return next;
+    });
+  };
+
+  const toggleAllTrash = () => {
+    setAcceptedMobIds((prev) => {
+      const next = new Set(prev);
+      if (allTrashAccepted) {
+        for (const m of trashWithChanges) next.delete(m.mobId);
+      } else {
+        for (const m of trashWithChanges) next.add(m.mobId);
+      }
+      return next;
+    });
+  };
+
+  // Pacing readout: estimated minutes to clear levels across the band
+  const pacingEstimate = useMemo(() => {
+    if (!config) return null;
+    const xpRate = estimateXpPerHour(config, Math.round((bandMin + bandMax) / 2));
+    if (xpRate <= 0) return null;
+    const xpCurve = config.progression.xp;
+    const xpForBand = xpForLevel(bandMax + 1, xpCurve) - xpForLevel(bandMin, xpCurve);
+    const minutes = (xpForBand / xpRate) * 60;
+    return { minutes, xpRate: Math.round(xpRate) };
+  }, [config, bandMin, bandMax]);
+
+  const handleApply = () => {
+    if (!zoneState?.data || !diff) return;
+    const next = applyZoneRebalance(zoneState.data, diff, { acceptedMobIds });
+    updateZone(zoneId, next);
+    onClose();
+  };
+
+  const acceptedCount = acceptedMobIds.size;
+  const canApply = acceptedCount > 0 || zoneState?.data?.levelBand?.min !== bandMin || zoneState?.data?.levelBand?.max !== bandMax;
+
+  if (!zoneState || !config) {
+    return null;
+  }
+
+  return (
+    <div className="modal-overlay">
+      <div
+        ref={trapRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rebalance-zone-title"
+        className="mx-4 flex max-h-[85vh] w-full max-w-3xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl"
+      >
+        <div className="border-b border-border-default px-5 py-3">
+          <h2 id="rebalance-zone-title" className="font-display text-sm tracking-wide text-text-primary">
+            Rebalance Zone — {zoneState.data.zone}
+          </h2>
+        </div>
+
+        <div className="flex flex-col gap-5 overflow-y-auto px-5 py-4">
+          {/* Target controls */}
+          <section className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div>
+              <label className="mb-1 block text-2xs uppercase tracking-wider text-text-muted" htmlFor="rb-level-min">
+                Level min
+              </label>
+              <input
+                id="rb-level-min"
+                type="number"
+                min={1}
+                value={bandMin}
+                onChange={(e) => setBandMin(Math.max(1, Number(e.target.value) || 1))}
+                className="h-8 w-full rounded border border-border-default bg-bg-primary px-2 font-mono text-xs text-text-primary outline-none focus:border-accent"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-2xs uppercase tracking-wider text-text-muted" htmlFor="rb-level-max">
+                Level max
+              </label>
+              <input
+                id="rb-level-max"
+                type="number"
+                min={1}
+                value={bandMax}
+                onChange={(e) => setBandMax(Math.max(1, Number(e.target.value) || 1))}
+                className="h-8 w-full rounded border border-border-default bg-bg-primary px-2 font-mono text-xs text-text-primary outline-none focus:border-accent"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-2xs uppercase tracking-wider text-text-muted" htmlFor="rb-difficulty">
+                Difficulty hint
+              </label>
+              <select
+                id="rb-difficulty"
+                value={difficulty ?? ""}
+                onChange={(e) => setDifficulty((e.target.value || undefined) as ZoneRebalanceTarget["difficultyHint"])}
+                className="h-8 w-full rounded border border-border-default bg-bg-primary px-2 text-xs text-text-primary outline-none focus:border-accent"
+              >
+                <option value="">—</option>
+                {DIFFICULTY_LABELS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
+          </section>
+
+          {/* Pacing readout */}
+          {pacingEstimate && (
+            <section className="rounded border border-border-default bg-bg-primary px-3 py-2">
+              <p className="text-2xs uppercase tracking-wider text-text-muted">
+                Estimated time to clear band L{bandMin}–L{bandMax}
+              </p>
+              <p className="mt-1 font-mono text-sm text-text-primary">
+                {fmtMinutes(pacingEstimate.minutes)}
+                <span className="ml-2 text-2xs text-text-muted">
+                  at {pacingEstimate.xpRate.toLocaleString()} XP/hr (canonical trash run)
+                </span>
+              </p>
+            </section>
+          )}
+
+          {/* Named mobs — review required */}
+          {namedMobs.length > 0 && (
+            <section>
+              <header className="mb-2 flex items-baseline justify-between">
+                <h3 className="font-display text-2xs uppercase tracking-wide text-text-secondary">
+                  Review required ({namedMobs.length})
+                </h3>
+                <span className="text-2xs text-text-muted">Bosses, quest-givers, mobs with drops</span>
+              </header>
+              <ul className="divide-y divide-border-default rounded border border-border-default bg-bg-primary">
+                {namedMobs.map((m) => (
+                  <MobRow
+                    key={m.mobId}
+                    diff={m}
+                    accepted={acceptedMobIds.has(m.mobId)}
+                    onToggle={() => toggleMob(m.mobId)}
+                  />
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {/* Trash mobs — auto-apply block */}
+          {trashWithChanges.length > 0 && (
+            <section>
+              <header className="mb-2 flex items-baseline justify-between">
+                <h3 className="font-display text-2xs uppercase tracking-wide text-text-secondary">
+                  Trash mobs ({trashWithChanges.length})
+                </h3>
+                <button
+                  type="button"
+                  onClick={toggleAllTrash}
+                  className="text-2xs text-accent underline-offset-2 hover:underline"
+                >
+                  {allTrashAccepted ? "Deselect all" : "Accept all"}
+                </button>
+              </header>
+              <ul className="divide-y divide-border-default rounded border border-border-default bg-bg-primary">
+                {trashWithChanges.map((m) => (
+                  <MobRow
+                    key={m.mobId}
+                    diff={m}
+                    accepted={acceptedMobIds.has(m.mobId)}
+                    onToggle={() => toggleMob(m.mobId)}
+                  />
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {diff && diff.mobs.length === 0 && (
+            <p className="text-xs text-text-muted">No mobs to rebalance in this zone.</p>
+          )}
+          {diff && trashWithChanges.length === 0 && namedMobs.length === 0 && diff.mobs.length > 0 && (
+            <p className="text-xs text-text-muted">All mobs already match the target band.</p>
+          )}
+          {diff && diff.skippedMobIds.length > 0 && (
+            <p className="text-2xs text-status-warning">
+              Skipped (unknown tier): {diff.skippedMobIds.join(", ")}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-2 border-t border-border-default px-5 py-3">
+          <span className="text-2xs text-text-muted">
+            {acceptedCount} mob{acceptedCount === 1 ? "" : "s"} selected
+          </span>
+          <div className="flex gap-2">
+            <button
+              onClick={onClose}
+              className="rounded bg-bg-elevated px-4 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-bg-hover"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleApply}
+              disabled={!canApply}
+              className="rounded bg-accent px-4 py-1.5 text-xs font-medium text-accent-emphasis transition-[color,background-color,box-shadow,filter,opacity] hover:shadow-[var(--glow-aurum)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Apply Rebalance
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -35,6 +35,7 @@ import { DirectionPicker } from "./DirectionPicker";
 import { BatchArtGenerator } from "./BatchArtGenerator";
 import { RethemeDialog } from "./RethemeDialog";
 import { DuplicateZoneDialog } from "@/components/DuplicateZoneDialog";
+import { RebalanceZoneDialog } from "@/components/zone/RebalanceZoneDialog";
 import { AI_ENABLED } from "@/lib/featureFlags";
 import { BulkBgRemoval, type BulkBgTarget } from "@/components/ui/BulkBgRemoval";
 import { ZoneAssetWorkbench } from "./ZoneAssetWorkbench";
@@ -173,6 +174,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
   const [showBatchArt, setShowBatchArt] = useState(false);
   const [showBulkBgRemoval, setShowBulkBgRemoval] = useState(false);
   const [showDuplicate, setShowDuplicate] = useState(false);
+  const [showRebalance, setShowRebalance] = useState(false);
   const [showRetheme, setShowRetheme] = useState(false);
   const assetsDir = useAssetStore((s) => s.assetsDir);
   const [viewMode, setViewMode] = useState<ViewMode>("map");
@@ -688,6 +690,15 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
             >
               Duplicate
             </button>
+            <button
+              onClick={() => setShowRebalance(true)}
+              disabled={!zoneState || Object.keys(zoneState.data.mobs ?? {}).length === 0}
+              className="h-6 rounded px-2 text-xs text-text-secondary transition-colors hover:bg-[var(--chrome-highlight)] hover:text-text-primary disabled:opacity-30 max-[1100px]:h-9"
+              title="Adjust mob levels and stats to a target band"
+              aria-label="Rebalance zone"
+            >
+              Rebalance
+            </button>
             {AI_ENABLED && (
               <button
                 onClick={() => setShowRetheme(true)}
@@ -1047,6 +1058,14 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
               <DuplicateZoneDialog
                 zoneId={zoneId}
                 onClose={() => setShowDuplicate(false)}
+              />
+            )}
+
+            {/* Rebalance zone */}
+            {showRebalance && (
+              <RebalanceZoneDialog
+                zoneId={zoneId}
+                onClose={() => setShowRebalance(false)}
               />
             )}
 

--- a/creator/src/lib/__tests__/zoneRebalance.test.ts
+++ b/creator/src/lib/__tests__/zoneRebalance.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyZoneRebalance,
+  classifyMob,
+  computeZoneRebalance,
+  inferLevelBand,
+  targetLevelForTier,
+} from "@/lib/zoneRebalance";
+import type { AppConfig } from "@/types/config";
+import type { MobFile, WorldFile } from "@/types/world";
+
+const TIER_CONFIG = {
+  weak: { baseHp: 10, hpPerLevel: 3, baseMinDamage: 1, baseMaxDamage: 2, damagePerLevel: 0, baseArmor: 0, baseXpReward: 15, xpRewardPerLevel: 5, baseGoldMin: 1, baseGoldMax: 3, goldPerLevel: 1 },
+  standard: { baseHp: 20, hpPerLevel: 5, baseMinDamage: 2, baseMaxDamage: 4, damagePerLevel: 1, baseArmor: 1, baseXpReward: 30, xpRewardPerLevel: 10, baseGoldMin: 3, baseGoldMax: 8, goldPerLevel: 2 },
+  elite: { baseHp: 40, hpPerLevel: 8, baseMinDamage: 3, baseMaxDamage: 6, damagePerLevel: 1, baseArmor: 2, baseXpReward: 75, xpRewardPerLevel: 25, baseGoldMin: 10, baseGoldMax: 25, goldPerLevel: 5 },
+  boss: { baseHp: 80, hpPerLevel: 15, baseMinDamage: 6, baseMaxDamage: 12, damagePerLevel: 2, baseArmor: 4, baseXpReward: 200, xpRewardPerLevel: 50, baseGoldMin: 30, baseGoldMax: 80, goldPerLevel: 15 },
+};
+
+const MOCK_CONFIG = { mobTiers: TIER_CONFIG } as unknown as AppConfig;
+
+function mob(overrides: Partial<MobFile> = {}): MobFile {
+  return {
+    name: "Test Mob",
+    room: "room_1",
+    tier: "weak",
+    ...overrides,
+  };
+}
+
+function zoneWith(mobs: Record<string, MobFile>): WorldFile {
+  return {
+    zone: "test_zone",
+    startRoom: "room_1",
+    rooms: { room_1: { description: "" } as never },
+    mobs,
+  };
+}
+
+describe("targetLevelForTier", () => {
+  it("places weak at the floor and boss at the ceiling", () => {
+    const band = { min: 3, max: 7 };
+    expect(targetLevelForTier("weak", band)).toBe(3);
+    expect(targetLevelForTier("standard", band)).toBe(5);
+    expect(targetLevelForTier("elite", band)).toBe(6);
+    expect(targetLevelForTier("boss", band)).toBe(7);
+  });
+
+  it("clamps elite to band floor for narrow bands", () => {
+    expect(targetLevelForTier("elite", { min: 5, max: 5 })).toBe(5);
+  });
+});
+
+describe("classifyMob", () => {
+  it("classifies bare weak/standard mobs as trash", () => {
+    expect(classifyMob(mob({ tier: "weak" }))).toBe("trash");
+    expect(classifyMob(mob({ tier: "standard" }))).toBe("trash");
+  });
+
+  it("classifies bosses, elites, and quest-givers as named", () => {
+    expect(classifyMob(mob({ tier: "boss" }))).toBe("named");
+    expect(classifyMob(mob({ tier: "elite" }))).toBe("named");
+    expect(classifyMob(mob({ tier: "weak", quests: ["q1"] }))).toBe("named");
+    expect(classifyMob(mob({ tier: "standard", drops: [{ itemId: "i1", chance: 0.1 }] }))).toBe("named");
+  });
+});
+
+describe("inferLevelBand", () => {
+  it("uses explicit levels when present", () => {
+    const zone = zoneWith({
+      a: mob({ level: 4 }),
+      b: mob({ level: 9 }),
+    });
+    expect(inferLevelBand(zone)).toEqual({ min: 4, max: 9 });
+  });
+
+  it("falls back to tier-only heuristic when no levels are set", () => {
+    const zone = zoneWith({
+      a: mob({ tier: "weak" }),
+      b: mob({ tier: "boss" }),
+    });
+    expect(inferLevelBand(zone)).toEqual({ min: 5, max: 10 });
+  });
+
+  it("returns the existing band when zone already has one", () => {
+    const zone = zoneWith({ a: mob({ level: 4 }) });
+    zone.levelBand = { min: 2, max: 8 };
+    expect(inferLevelBand(zone)).toEqual({ min: 2, max: 8 });
+  });
+});
+
+describe("computeZoneRebalance", () => {
+  it("classifies trash separately from named and sorts named first", () => {
+    const zone = zoneWith({
+      goblin: mob({ tier: "weak" }),
+      boss_fight: mob({ tier: "boss" }),
+      shopkeep: mob({ tier: "standard", quests: ["q1"] }),
+    });
+    const diff = computeZoneRebalance(zone, MOCK_CONFIG, {
+      levelBand: { min: 3, max: 7 },
+    });
+    const ids = diff.mobs.map((m) => m.mobId);
+    expect(ids.slice(0, 2).sort()).toEqual(["boss_fight", "shopkeep"]);
+    expect(ids[2]).toBe("goblin");
+    expect(diff.mobs.find((m) => m.mobId === "goblin")?.classification).toBe("trash");
+    expect(diff.mobs.find((m) => m.mobId === "boss_fight")?.classification).toBe("named");
+  });
+
+  it("flags level changes when current differs from target", () => {
+    const zone = zoneWith({ goblin: mob({ tier: "weak", level: 12 }) });
+    const diff = computeZoneRebalance(zone, MOCK_CONFIG, {
+      levelBand: { min: 3, max: 7 },
+    });
+    const goblin = diff.mobs[0]!;
+    expect(goblin.targetLevel).toBe(3);
+    expect(goblin.levelChanged).toBe(true);
+  });
+
+  it("marks within-tolerance overrides as 'drop' and divergent as 'flag'", () => {
+    // weak tier @ L3: hp = 10 + 3*3 = 19, xpReward = 15 + 5*3 = 30
+    const zone = zoneWith({
+      close: mob({ tier: "weak", hp: 20 }),       // within 10% of 19 → drop
+      far: mob({ tier: "weak", hp: 200 }),         // way off → flag
+      authoredXp: mob({ tier: "weak", xpReward: 9999 }),
+    });
+    const diff = computeZoneRebalance(zone, MOCK_CONFIG, {
+      levelBand: { min: 3, max: 3 },
+    });
+    const close = diff.mobs.find((m) => m.mobId === "close")!;
+    const far = diff.mobs.find((m) => m.mobId === "far")!;
+    const authored = diff.mobs.find((m) => m.mobId === "authoredXp")!;
+    expect(close.overrideChanges[0]?.action).toBe("drop");
+    expect(far.overrideChanges[0]?.action).toBe("flag");
+    expect(authored.overrideChanges[0]?.action).toBe("flag");
+  });
+
+  it("skips mobs whose tier is not in config", () => {
+    const zone = zoneWith({ mystery: mob({ tier: "phantom" }) });
+    const diff = computeZoneRebalance(zone, MOCK_CONFIG, {
+      levelBand: { min: 3, max: 7 },
+    });
+    expect(diff.mobs).toEqual([]);
+    expect(diff.skippedMobIds).toEqual(["mystery"]);
+  });
+});
+
+describe("applyZoneRebalance", () => {
+  it("sets level on accepted mobs, leaves un-accepted alone, persists levelBand", () => {
+    const zone = zoneWith({
+      goblin: mob({ tier: "weak", level: 1 }),
+      brute: mob({ tier: "standard", level: 1 }),
+    });
+    const diff = computeZoneRebalance(zone, MOCK_CONFIG, {
+      levelBand: { min: 5, max: 9 },
+      difficultyHint: "standard",
+    });
+    const next = applyZoneRebalance(zone, diff, {
+      acceptedMobIds: new Set(["goblin"]),
+    });
+
+    expect(next.levelBand).toEqual({ min: 5, max: 9 });
+    expect(next.difficultyHint).toBe("standard");
+    expect(next.mobs?.goblin?.level).toBe(5);
+    expect(next.mobs?.brute?.level).toBe(1);
+  });
+
+  it("drops within-tolerance overrides and keeps flagged ones by default", () => {
+    const zone = zoneWith({
+      goblin: mob({ tier: "weak", hp: 20, xpReward: 9999 }),
+    });
+    const diff = computeZoneRebalance(zone, MOCK_CONFIG, {
+      levelBand: { min: 3, max: 3 },
+    });
+    const next = applyZoneRebalance(zone, diff, {
+      acceptedMobIds: new Set(["goblin"]),
+    });
+    expect(next.mobs?.goblin?.hp).toBeUndefined();      // dropped
+    expect(next.mobs?.goblin?.xpReward).toBe(9999);     // kept
+  });
+
+  it("respects per-field overrides (drop → keep)", () => {
+    const zone = zoneWith({ goblin: mob({ tier: "weak", hp: 20 }) });
+    const diff = computeZoneRebalance(zone, MOCK_CONFIG, {
+      levelBand: { min: 3, max: 3 },
+    });
+    const next = applyZoneRebalance(zone, diff, {
+      acceptedMobIds: new Set(["goblin"]),
+      overrideOverrides: new Map([["goblin", new Map([["hp", "keep"]])]]),
+    });
+    expect(next.mobs?.goblin?.hp).toBe(20);
+  });
+
+  it("does not mutate the input zone", () => {
+    const zone = zoneWith({ goblin: mob({ tier: "weak", level: 1 }) });
+    const before = JSON.stringify(zone);
+    const diff = computeZoneRebalance(zone, MOCK_CONFIG, { levelBand: { min: 5, max: 5 } });
+    applyZoneRebalance(zone, diff, { acceptedMobIds: new Set(["goblin"]) });
+    expect(JSON.stringify(zone)).toBe(before);
+  });
+});

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -683,6 +683,21 @@ function cleanOutput(world: WorldFile): WorldFile {
   if (world.terrain) result.terrain = world.terrain;
   if (world.graphical) result.graphical = true;
   if (world.pvpEnabled) result.pvpEnabled = true;
+  if (
+    world.levelBand &&
+    Number.isFinite(world.levelBand.min) &&
+    Number.isFinite(world.levelBand.max) &&
+    world.levelBand.max >= world.levelBand.min
+  ) {
+    result.levelBand = { min: world.levelBand.min, max: world.levelBand.max };
+  }
+  if (
+    world.difficultyHint === "casual" ||
+    world.difficultyHint === "standard" ||
+    world.difficultyHint === "challenging"
+  ) {
+    result.difficultyHint = world.difficultyHint;
+  }
   if (world.faction?.trim()) result.faction = world.faction.trim();
   if (world.image) {
     // Strip zoneMap — it's Arcanum-only; the MUD server's ZoneImageDefaults

--- a/creator/src/lib/zoneRebalance.ts
+++ b/creator/src/lib/zoneRebalance.ts
@@ -1,0 +1,285 @@
+// ─── Zone Rebalance Engine ──────────────────────────────────────────
+//
+// Pure functions for computing and applying a level/difficulty rebalance
+// across a zone's mobs. Given a target level band, computes per-mob
+// level changes and surfaces stat overrides that diverge from the tier
+// baseline at the new level.
+//
+// Mobs are classified as "trash" (auto-apply safe) or "named" (require
+// review) based on tier + presence of quests / dialogue / drops.
+
+import type { AppConfig, MobTierConfig } from "@/types/config";
+import type { MobFile, WorldFile } from "@/types/world";
+import {
+  mobAvgGoldAtLevel,
+  mobHpAtLevel,
+} from "./tuning/formulas";
+
+export type MobClassification = "trash" | "named";
+
+export type OverrideField =
+  | "hp"
+  | "minDamage"
+  | "maxDamage"
+  | "armor"
+  | "xpReward"
+  | "goldMin"
+  | "goldMax";
+
+export type OverrideAction = "drop" | "keep" | "flag";
+
+export interface OverrideChange {
+  field: OverrideField;
+  currentOverride: number;
+  tierBaseline: number;
+  action: OverrideAction;
+}
+
+export interface MobRebalanceDiff {
+  mobId: string;
+  displayName: string;
+  tier: string;
+  currentLevel: number | null;
+  targetLevel: number;
+  levelChanged: boolean;
+  classification: MobClassification;
+  overrideChanges: OverrideChange[];
+}
+
+export interface ZoneRebalanceTarget {
+  levelBand: { min: number; max: number };
+  difficultyHint?: "casual" | "standard" | "challenging";
+}
+
+export interface ZoneRebalanceDiff {
+  target: ZoneRebalanceTarget;
+  mobs: MobRebalanceDiff[];
+  /** Mob IDs without a known tier in config — engine couldn't compute baselines. */
+  skippedMobIds: string[];
+}
+
+// ─── Heuristics ─────────────────────────────────────────────────────
+
+/**
+ * Distribute mob levels by tier within the band.
+ * weak → min, standard → mid, elite → max-1 (clamped), boss → max.
+ */
+export function targetLevelForTier(
+  tier: string,
+  band: { min: number; max: number },
+): number {
+  const { min, max } = band;
+  const mid = Math.round((min + max) / 2);
+  switch (tier) {
+    case "weak":
+      return min;
+    case "elite":
+      return Math.max(min, max - 1);
+    case "boss":
+      return max;
+    case "standard":
+    default:
+      return mid;
+  }
+}
+
+/**
+ * Classify a mob as trash (auto-apply) or named (review-required).
+ * Named: boss tier, or has quests/dialogue/drops attached. Anything
+ * else is trash.
+ */
+export function classifyMob(mob: MobFile): MobClassification {
+  if (mob.tier === "boss" || mob.tier === "elite") return "named";
+  if (mob.quests && mob.quests.length > 0) return "named";
+  if (mob.dialogue && Object.keys(mob.dialogue).length > 0) return "named";
+  if (mob.drops && mob.drops.length > 0) return "named";
+  return "trash";
+}
+
+/** Within ±10% — small enough to drop the override and let tier formula take over. */
+function withinTolerance(actual: number, baseline: number, tolerance = 0.1): boolean {
+  if (baseline === 0) return actual === 0;
+  return Math.abs(actual - baseline) / Math.abs(baseline) <= tolerance;
+}
+
+function computeOverrideChange(
+  field: OverrideField,
+  currentOverride: number,
+  tierBaseline: number,
+): OverrideChange {
+  const action: OverrideAction = withinTolerance(currentOverride, tierBaseline)
+    ? "drop"
+    : "flag";
+  return {
+    field,
+    currentOverride,
+    tierBaseline: Math.round(tierBaseline * 10) / 10,
+    action,
+  };
+}
+
+/**
+ * For a mob's set overrides (hp, damage, xp, gold), compute whether
+ * each diverges from the tier baseline at the new level enough to
+ * preserve, or is close enough to drop.
+ */
+function diffMobOverrides(
+  mob: MobFile,
+  tier: MobTierConfig,
+  targetLevel: number,
+): OverrideChange[] {
+  const changes: OverrideChange[] = [];
+
+  if (mob.hp != null) {
+    changes.push(computeOverrideChange("hp", mob.hp, mobHpAtLevel(tier, targetLevel)));
+  }
+  const tierMinDmg = tier.baseMinDamage + tier.damagePerLevel * targetLevel;
+  const tierMaxDmg = tier.baseMaxDamage + tier.damagePerLevel * targetLevel;
+  if (mob.minDamage != null) {
+    changes.push(computeOverrideChange("minDamage", mob.minDamage, tierMinDmg));
+  }
+  if (mob.maxDamage != null) {
+    changes.push(computeOverrideChange("maxDamage", mob.maxDamage, tierMaxDmg));
+  }
+  if (mob.armor != null) {
+    changes.push(computeOverrideChange("armor", mob.armor, tier.baseArmor));
+  }
+  const tierXp = tier.baseXpReward + tier.xpRewardPerLevel * targetLevel;
+  if (mob.xpReward != null) {
+    changes.push(computeOverrideChange("xpReward", mob.xpReward, tierXp));
+  }
+  const tierGoldAvg = mobAvgGoldAtLevel(tier, targetLevel);
+  if (mob.goldMin != null) {
+    changes.push(computeOverrideChange("goldMin", mob.goldMin, tier.baseGoldMin + tier.goldPerLevel * targetLevel));
+  }
+  if (mob.goldMax != null) {
+    changes.push(computeOverrideChange("goldMax", mob.goldMax, tier.baseGoldMax + tier.goldPerLevel * targetLevel));
+  }
+  // quiet "tierGoldAvg used to derive both min and max" — currently informational
+  void tierGoldAvg;
+
+  return changes;
+}
+
+// ─── Public API ─────────────────────────────────────────────────────
+
+/**
+ * Infer a sensible default level band from the zone's existing mobs,
+ * using whichever signal is available: explicit levels, then tier mix,
+ * then a generic fallback.
+ */
+export function inferLevelBand(zone: WorldFile): { min: number; max: number } {
+  if (zone.levelBand) return zone.levelBand;
+  const mobs = Object.values(zone.mobs ?? {});
+  const explicit = mobs.map((m) => m.level).filter((l): l is number => l != null && l > 0);
+  if (explicit.length > 0) {
+    return { min: Math.min(...explicit), max: Math.max(...explicit) };
+  }
+  // Tier-only zones: rough span based on present tiers.
+  const tiers = new Set(mobs.map((m) => m.tier).filter((t): t is string => !!t));
+  if (tiers.has("boss") || tiers.has("elite")) return { min: 5, max: 10 };
+  if (tiers.has("standard")) return { min: 3, max: 7 };
+  if (tiers.has("weak")) return { min: 1, max: 5 };
+  return { min: 1, max: 5 };
+}
+
+/**
+ * Compute a structured diff describing how each mob would change under
+ * the given target. Pure — does not mutate the zone.
+ */
+export function computeZoneRebalance(
+  zone: WorldFile,
+  config: AppConfig,
+  target: ZoneRebalanceTarget,
+): ZoneRebalanceDiff {
+  const mobs: MobRebalanceDiff[] = [];
+  const skippedMobIds: string[] = [];
+
+  for (const [mobId, mob] of Object.entries(zone.mobs ?? {})) {
+    const tierKey = mob.tier ?? "standard";
+    const tier = config.mobTiers?.[tierKey as keyof typeof config.mobTiers];
+    if (!tier) {
+      skippedMobIds.push(mobId);
+      continue;
+    }
+    const targetLevel = targetLevelForTier(tierKey, target.levelBand);
+    const currentLevel = mob.level ?? null;
+    mobs.push({
+      mobId,
+      displayName: mob.name || mobId,
+      tier: tierKey,
+      currentLevel,
+      targetLevel,
+      levelChanged: currentLevel !== targetLevel,
+      classification: classifyMob(mob),
+      overrideChanges: diffMobOverrides(mob, tier, targetLevel),
+    });
+  }
+
+  // Stable sort: named first (so review work groups at top), then by id.
+  mobs.sort((a, b) => {
+    if (a.classification !== b.classification) {
+      return a.classification === "named" ? -1 : 1;
+    }
+    return a.mobId.localeCompare(b.mobId);
+  });
+
+  return { target, mobs, skippedMobIds };
+}
+
+// ─── Apply ──────────────────────────────────────────────────────────
+
+export interface ApplySelection {
+  /** Mob IDs whose level change should be applied. */
+  acceptedMobIds: Set<string>;
+  /**
+   * Per-mob, per-field override decisions. Missing entries default to
+   * the action computed in the diff. Lets the UI override "drop" → "keep"
+   * for individual fields the designer wants to preserve.
+   */
+  overrideOverrides?: Map<string, Map<OverrideField, OverrideAction>>;
+}
+
+/**
+ * Produce a new WorldFile reflecting the accepted parts of the diff.
+ * Sets `zone.levelBand` and `zone.difficultyHint` so the choice is
+ * persistent for future rebalances.
+ */
+export function applyZoneRebalance(
+  zone: WorldFile,
+  diff: ZoneRebalanceDiff,
+  selection: ApplySelection,
+): WorldFile {
+  const next: WorldFile = {
+    ...zone,
+    levelBand: { ...diff.target.levelBand },
+    mobs: { ...(zone.mobs ?? {}) },
+  };
+  if (diff.target.difficultyHint) {
+    next.difficultyHint = diff.target.difficultyHint;
+  }
+
+  for (const mobDiff of diff.mobs) {
+    if (!selection.acceptedMobIds.has(mobDiff.mobId)) continue;
+    const original = zone.mobs?.[mobDiff.mobId];
+    if (!original) continue;
+
+    const updated: MobFile = { ...original };
+    if (mobDiff.levelChanged) {
+      updated.level = mobDiff.targetLevel;
+    }
+
+    const fieldOverrides = selection.overrideOverrides?.get(mobDiff.mobId);
+    for (const change of mobDiff.overrideChanges) {
+      const action = fieldOverrides?.get(change.field) ?? change.action;
+      if (action === "drop") {
+        delete updated[change.field];
+      }
+      // "keep" / "flag" → leave existing override in place
+    }
+
+    next.mobs![mobDiff.mobId] = updated;
+  }
+
+  return next;
+}

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -10,6 +10,10 @@ export interface WorldFile {
   terrain?: string;
   graphical?: boolean;
   pvpEnabled?: boolean;
+  /** Intended level range for this zone. Drives the Rebalance Zone feature. */
+  levelBand?: { min: number; max: number };
+  /** Intended difficulty profile — informs rebalance stat targets. */
+  difficultyHint?: "casual" | "standard" | "challenging";
   /** Controlling faction ID (references FactionConfig.definitions). Drives "hostile territory" reactions. */
   faction?: string;
   puzzles?: Record<string, PuzzleFile>;


### PR DESCRIPTION
## Summary
- Adds a Rebalance Zone feature: pick a level band + difficulty hint, the wizard distributes mob levels by tier (weak→min, standard→mid, elite→max-1, boss→max), classifies mobs as trash (auto-apply) vs named (review), and surfaces stat overrides that diverge from the tier baseline.
- Reaches the user via a new \"Rebalance\" button in the zone toolbar, mirroring the Duplicate / Re-layout / Batch Art pattern.
- Persists \`levelBand\` and \`difficultyHint\` on the zone so future rebalances start from the declared intent rather than re-inferring.

## Why
Zones currently encode difficulty implicitly through individual mob authoring. A designer who wants to retarget Pixel Haven from \"first academy (L1–5)\" to \"intermediate (L6–10)\" has to walk every mob by hand. The wizard makes this a single declarative action while preserving authored-intent overrides on bosses and quest-givers.

## Implementation notes
- \`creator/src/lib/zoneRebalance.ts\` — pure engine. \`computeZoneRebalance(zone, config, target)\` returns a structured diff; \`applyZoneRebalance(zone, diff, selection)\` produces a new \`WorldFile\`. No mutation; per-field override decisions are exposed for the UI to flip if needed.
- For mobs with explicit stat overrides (\`hp\`, \`minDamage\`, etc.), within ±10% of the tier baseline at the new level → drop the override (let tier handle it); otherwise → keep + flag as authored intent.
- Mob classification: \`tier=elite\`/\`boss\` or any \`quests\`/\`dialogue\`/\`drops\` → \"named\" (review-required). Everything else → \"trash\" (one-click \"Accept all\").
- \`WorldFile\` gains optional \`levelBand: { min, max }\` and \`difficultyHint: \"casual\" | \"standard\" | \"challenging\"\`. Sanitizer preserves both. Non-breaking.
- Pacing readout in the modal reuses \`estimateXpPerHour\` from the existing pacing lib (#207) so the same canonical-trash-run assumption drives both global tuning and per-zone rebalance.
- Apply commits through \`updateZone\`, so undo/redo via zundo works automatically.

## Server compatibility caveat
\`levelBand\` / \`difficultyHint\` are written to zone YAML. If AmbonMUD's zone loader rejects unknown root fields, this will need to be either (a) namespaced under an \`arcanum:\` block the server ignores, or (b) stripped at MUD-export time. Worth a quick check before users start setting bands; easy follow-up if it bites.

## Test plan
- [x] \`bun run test\` — 1705 tests pass (15 new for rebalance engine)
- [x] \`bunx tsc --noEmit\` clean
- [x] Vite dev server boots without errors
- [ ] **Manual (Tauri)**: open Auringold's Pixel Haven → click Rebalance → set band 3–7, casual → confirm boss + quest-givers appear in \"Review required\", trash in \"Trash mobs\" with \"Accept all\", apply → verify mob YAML now has \`level\` set and zone has \`levelBand\`
- [ ] **Manual**: confirm undo (Ctrl+Z) reverts the rebalance in one step
- [ ] **Server check**: load the rebalanced zone in AmbonMUD, confirm \`levelBand\` is tolerated