### PR TITLE
Surface quest level + tighten diminishing across presets

### DIFF
--- a/creator/src/components/config/panels/ProgressionPanel.tsx
+++ b/creator/src/components/config/panels/ProgressionPanel.tsx
@@ -86,7 +86,7 @@ export function ProgressionPanel({ config, onChange }: ConfigPanelProps) {
 
       <Section
         title="Diminishing Returns"
-        description="Scales down kill XP when a player over-levels a mob, so high-level characters can't farm trash for easy XP. Each threshold applies when the player is at least `levelsBelow` levels above the mob; the largest matching threshold wins."
+        description="Scales down XP when a player has out-levelled the source — applies to kills (mob level) and to quests or puzzles that declare an intended level. Each threshold kicks in when the gap is at least `levelsBelow`, and the largest matching threshold wins. Prevents trivial trash farming and flat-reward quest ladders from running away with progression."
       >
         <DiminishingReturnsEditor
           value={p.xp.diminishing}

--- a/creator/src/components/editors/QuestEditor.tsx
+++ b/creator/src/components/editors/QuestEditor.tsx
@@ -133,6 +133,18 @@ export function QuestEditor({
               dense
             />
           </CompactField>
+          <CompactField
+            label="Intended level"
+            hint="When set, XP reward diminishes if the player has out-levelled the quest."
+          >
+            <NumberInput
+              value={quest.level}
+              onCommit={(v) => patch({ level: v && v > 0 ? v : undefined })}
+              placeholder="—"
+              min={1}
+              dense
+            />
+          </CompactField>
         </FieldGrid>
       </Section>
 

--- a/creator/src/lib/tuning/presets.ts
+++ b/creator/src/lib/tuning/presets.ts
@@ -177,6 +177,14 @@ export const CASUAL_PRESET: TuningPreset = {
         linearXp: 10,
         multiplier: 0.8,
         defaultKillXp: 15,
+        diminishing: {
+          enabled: true,
+          thresholds: [
+            { levelsBelow: 4, multiplier: 0.5 },
+            { levelsBelow: 7, multiplier: 0.2 },
+            { levelsBelow: 10, multiplier: 0.0 },
+          ],
+        },
       },
       rewards: {
         hpPerLevel: 3,
@@ -472,10 +480,18 @@ export const BALANCED_PRESET: TuningPreset = {
       maxLevel: 50,
       xp: {
         baseXp: 100,
-        exponent: 1.8,
-        linearXp: 0,
+        exponent: 2.2,
+        linearXp: 150,
         multiplier: 1.0,
         defaultKillXp: 10,
+        diminishing: {
+          enabled: true,
+          thresholds: [
+            { levelsBelow: 3, multiplier: 0.5 },
+            { levelsBelow: 5, multiplier: 0.2 },
+            { levelsBelow: 8, multiplier: 0.0 },
+          ],
+        },
       },
       rewards: {
         hpPerLevel: 2,
@@ -771,10 +787,18 @@ export const HARDCORE_PRESET: TuningPreset = {
       maxLevel: 50,
       xp: {
         baseXp: 120,
-        exponent: 2.2,
-        linearXp: 0,
+        exponent: 2.4,
+        linearXp: 200,
         multiplier: 1.0,
         defaultKillXp: 5,
+        diminishing: {
+          enabled: true,
+          thresholds: [
+            { levelsBelow: 2, multiplier: 0.5 },
+            { levelsBelow: 4, multiplier: 0.2 },
+            { levelsBelow: 6, multiplier: 0.0 },
+          ],
+        },
       },
       rewards: {
         hpPerLevel: 1,
@@ -952,7 +976,21 @@ export const SOLO_STORY_PRESET: TuningPreset = {
     enchanting: { maxEnchantmentsPerItem: 5 },
     progression: {
       maxLevel: 40,
-      xp: { baseXp: 70, exponent: 1.45, linearXp: 5, multiplier: 0.7, defaultKillXp: 20 },
+      xp: {
+        baseXp: 70,
+        exponent: 1.45,
+        linearXp: 5,
+        multiplier: 0.7,
+        defaultKillXp: 20,
+        diminishing: {
+          enabled: true,
+          thresholds: [
+            { levelsBelow: 5, multiplier: 0.5 },
+            { levelsBelow: 8, multiplier: 0.2 },
+            { levelsBelow: 12, multiplier: 0.0 },
+          ],
+        },
+      },
       rewards: { hpPerLevel: 4, manaPerLevel: 3, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 20, baseMana: 20 },
     },
     skillPoints: { interval: 2 },
@@ -1013,7 +1051,21 @@ export const PVP_ARENA_PRESET: TuningPreset = {
     enchanting: { maxEnchantmentsPerItem: 2 },
     progression: {
       maxLevel: 50,
-      xp: { baseXp: 90, exponent: 1.7, linearXp: 5, multiplier: 1.0, defaultKillXp: 8 },
+      xp: {
+        baseXp: 90,
+        exponent: 1.7,
+        linearXp: 5,
+        multiplier: 1.0,
+        defaultKillXp: 8,
+        diminishing: {
+          enabled: true,
+          thresholds: [
+            { levelsBelow: 3, multiplier: 0.5 },
+            { levelsBelow: 5, multiplier: 0.2 },
+            { levelsBelow: 8, multiplier: 0.0 },
+          ],
+        },
+      },
       rewards: { hpPerLevel: 2, manaPerLevel: 1, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 12, baseMana: 10 },
     },
     skillPoints: { interval: 3 },
@@ -1074,7 +1126,20 @@ export const LORE_EXPLORER_PRESET: TuningPreset = {
     enchanting: { maxEnchantmentsPerItem: 6 },
     progression: {
       maxLevel: 30,
-      xp: { baseXp: 40, exponent: 1.3, linearXp: 5, multiplier: 0.25, defaultKillXp: 50 },
+      xp: {
+        baseXp: 40,
+        exponent: 1.3,
+        linearXp: 5,
+        multiplier: 0.25,
+        defaultKillXp: 50,
+        diminishing: {
+          enabled: true,
+          thresholds: [
+            { levelsBelow: 5, multiplier: 0.5 },
+            { levelsBelow: 10, multiplier: 0.0 },
+          ],
+        },
+      },
       rewards: { hpPerLevel: 8, manaPerLevel: 6, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 50, baseMana: 50 },
     },
     skillPoints: { interval: 1 },

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -646,6 +646,17 @@ export function validateZone(
         addIssue(issues, "error", entity, `Rep gate min (${min}) must be <= max (${max})`);
       }
     }
+    if (quest.level != null && quest.level < 1) {
+      addIssue(issues, "error", entity, `Intended level (${quest.level}) must be at least 1`);
+    }
+    if (quest.level == null && (quest.rewards?.xp ?? 0) >= 100) {
+      addIssue(
+        issues,
+        "warning",
+        entity,
+        "Quest awards >=100 XP but has no intended level — players who out-level this quest will still receive the full flat reward",
+      );
+    }
   }
 
   for (const [nodeId, node] of Object.entries(world.gatheringNodes ?? {})) {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -249,6 +249,13 @@ export interface QuestFile {
   rewards?: QuestRewardsFile;
   /** Rep gate. Giver will not offer the quest when the requirement fails. */
   requiredReputation?: ReputationRequirement;
+  /**
+   * Intended player level. When set, XP rewards are scaled by the same
+   * diminishing-returns curve used for kills — players who have out-levelled
+   * the quest receive reduced XP rather than the flat reward. Omit to keep
+   * legacy flat-award behaviour.
+   */
+  level?: number;
 }
 
 export interface QuestObjectiveFile {


### PR DESCRIPTION
## Summary

Companion to [AmbonMUD#1076](https://github.com/jnoecker/AmbonMUD/pull/1076). The MUD side now runs quest XP through the same diminishing-returns curve as kills when a quest declares a `level`; this PR adds the creator-side field, validation nudge, and lines up the tuning-wizard presets so applying one doesn't silently overwrite the MUD's newly tightened defaults.

- `QuestFile` gains `level?: number`; `QuestEditor` surfaces it as an "Intended level" field in the Basics section. Existing quests without a level keep the legacy flat-award behaviour.
- `validateZone` warns when a quest awards ≥100 XP without declaring a level, and errors on `level < 1`.
- Every tuning-wizard preset now carries an explicit `diminishing` block (previously absent, so applying a preset left thresholds undefined). Shaped per-preset:
  - Hardcore: `2/0.5, 4/0.2, 6/0.0`
  - Balanced / PvP Arena: `3/0.5, 5/0.2, 8/0.0` (matches new MUD default)
  - Casual / Lore Explorer: `4/0.5, 7/0.2, 10/0.0`
  - Solo Story: `5/0.5, 10/0.0`
- Balanced and Hardcore XP curves now match the MUD retune (Balanced: exponent 1.8→2.2, linearXp 0→150; Hardcore: exponent 2.2→2.4, linearXp 0→200).
- `ProgressionPanel` diminishing-returns description updated to mention that it now applies to quests and puzzles as well as kills.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run test` — 1725 tests pass
- [ ] Load a world in the creator, open a quest, set "Intended level", save, and confirm the YAML round-trips with `level:` preserved
- [ ] Apply each preset in the tuning wizard and verify the emitted diminishing block shows up in the diff preview