### PR TITLE
Add MobRole to editor and validator

### DIFF
--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
-import type { WorldFile, MobFile, MobDropFile, MobSpellFile } from "@/types/world";
+import type { WorldFile, MobFile, MobDropFile, MobSpellFile, MobRole } from "@/types/world";
+import { MOB_ROLES, MOB_ROLE_LABELS, MOB_ROLE_DESCRIPTIONS } from "@/types/world";
 import { updateMob, deleteMob } from "@/lib/zoneEdits";
 import { useEntityEditor } from "@/lib/useEntityEditor";
 import { useArrayField } from "@/lib/useArrayField";
@@ -36,6 +37,8 @@ const TIER_OPTIONS = [
   { value: "elite", label: "Elite" },
   { value: "boss", label: "Boss" },
 ];
+
+const ROLE_OPTIONS = MOB_ROLES.map((r) => ({ value: r, label: MOB_ROLE_LABELS[r] }));
 
 const CATEGORY_OPTIONS = [
   { value: "humanoid", label: "Humanoid" },
@@ -81,6 +84,13 @@ export function MobEditor({
     onDelete,
   );
   if (!mob) return null;
+
+  const role: MobRole = mob.role ?? "combat";
+  const isCombatant = role === "combat";
+  const visibleTabs = isCombatant
+    ? MOB_TABS
+    : MOB_TABS.filter((t) => t.value !== "rewards");
+  const effectiveTab: MobTab = !isCombatant && activeTab === "rewards" ? "mob" : activeTab;
 
   const zoneQuests = Object.entries(world.quests ?? {}).map(([id, q]) => ({
     id,
@@ -193,35 +203,48 @@ export function MobEditor({
         />
       </EntityHeader>
 
-      <TabBar tabs={MOB_TABS} active={activeTab} onChange={setActiveTab} />
+      <TabBar tabs={visibleTabs} active={activeTab} onChange={setActiveTab} />
 
-      {activeTab === "mob" && (
+      {effectiveTab === "mob" && (
         <>
           <Section title="Basics">
             <FieldGrid>
-              <CompactField label="Tier">
+              <CompactField label="Role" hint={MOB_ROLE_DESCRIPTIONS[role]} span>
                 <SelectInput
-                  value={mob.tier ?? "standard"}
-                  options={TIER_OPTIONS}
-                  onCommit={(v) => patch({ tier: v })}
+                  value={role}
+                  options={ROLE_OPTIONS}
+                  onCommit={(v) =>
+                    patch({ role: v === "combat" ? undefined : (v as MobRole) })
+                  }
                 />
               </CompactField>
-              <CompactField label="Level">
-                <NumberInput
-                  value={mob.level}
-                  onCommit={(v) => patch({ level: v })}
-                  placeholder="1"
-                  min={1}
-                />
-              </CompactField>
-              <CompactField label="Respawn (s)">
-                <NumberInput
-                  value={mob.respawnSeconds}
-                  onCommit={(v) => patch({ respawnSeconds: v })}
-                  placeholder="Default"
-                  min={0}
-                />
-              </CompactField>
+              {isCombatant && (
+                <>
+                  <CompactField label="Tier">
+                    <SelectInput
+                      value={mob.tier ?? "standard"}
+                      options={TIER_OPTIONS}
+                      onCommit={(v) => patch({ tier: v })}
+                    />
+                  </CompactField>
+                  <CompactField label="Level">
+                    <NumberInput
+                      value={mob.level}
+                      onCommit={(v) => patch({ level: v })}
+                      placeholder="1"
+                      min={1}
+                    />
+                  </CompactField>
+                  <CompactField label="Respawn (s)">
+                    <NumberInput
+                      value={mob.respawnSeconds}
+                      onCommit={(v) => patch({ respawnSeconds: v })}
+                      placeholder="Default"
+                      min={0}
+                    />
+                  </CompactField>
+                </>
+              )}
               <CompactField label="Category">
                 <div className="flex items-center gap-1.5">
                   {CATEGORY_ICONS[mob.category ?? "humanoid"] && (
@@ -244,6 +267,8 @@ export function MobEditor({
             </FieldGrid>
           </Section>
 
+          {isCombatant && (
+          <>
           <Section title="Behavior">
             <div className="flex flex-col gap-1.5">
               <FieldRow label="Template">
@@ -478,10 +503,12 @@ export function MobEditor({
               </CompactField>
             </FieldGrid>
           </Section>
+          </>
+          )}
         </>
       )}
 
-      {activeTab === "rewards" && (
+      {effectiveTab === "rewards" && isCombatant && (
         <>
           <Section
             title={`Drops (${mob.drops?.length ?? 0})`}
@@ -546,7 +573,7 @@ export function MobEditor({
         </>
       )}
 
-      {activeTab === "dialogue" && (
+      {effectiveTab === "dialogue" && (
         <DialogueEditor
           mobId={mobId}
           world={world}
@@ -554,7 +581,7 @@ export function MobEditor({
         />
       )}
 
-      {activeTab === "media" && (
+      {effectiveTab === "media" && (
         <MediaSection
           image={mob.image}
           onImageChange={(v) => patch({ image: v })}

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -173,6 +173,36 @@ describe("validateZone", () => {
     expect(issues.some((i) => i.message.includes("root"))).toBe(true);
   });
 
+  it("warns when a prop mob has quests or dialogue", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.role = "prop";
+    world.mobs!.rat.quests = ["test:someQuest"];
+    world.quests = { "test:someQuest": { name: "Q", giver: "rat", objectives: [{ type: "kill", targetKey: "rat" }] } };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.entity === "mob:rat" && i.message.toLowerCase().includes("prop"))).toBe(true);
+  });
+
+  it("warns when a non-combat mob has combat-stat overrides", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.role = "vendor";
+    world.mobs!.rat.hp = 500;
+    world.mobs!.rat.xpReward = 100;
+    const issues = warnings(validateZone(world));
+    expect(
+      issues.some(
+        (i) => i.entity === "mob:rat" && i.message.toLowerCase().includes("ignore"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not warn when a combat mob has combat-stat overrides", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.hp = 500;
+    world.mobs!.rat.xpReward = 100;
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.entity === "mob:rat" && i.message.toLowerCase().includes("ignore"))).toBe(false);
+  });
+
   // ─── Item checks ────────────────────────────────────────────
   it("errors if item room does not exist", () => {
     const world = makeValidWorld();

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -492,6 +492,28 @@ export function validateZone(
       addIssue(issues, "error", entity, "Respawn seconds must be greater than 0");
     }
 
+    const mobRole = mob.role ?? "combat";
+    if (mobRole === "prop" && ((mob.quests?.length ?? 0) > 0 || Object.keys(mob.dialogue ?? {}).length > 0)) {
+      addIssue(
+        issues,
+        "warning",
+        entity,
+        "Props can't offer quests or dialogue — consider role 'quest_giver' or 'dialog' instead.",
+      );
+    }
+    if (mobRole !== "combat") {
+      const combatFieldsSet =
+        mob.hp != null || mob.xpReward != null || mob.minDamage != null || mob.maxDamage != null || mob.armor != null;
+      if (combatFieldsSet) {
+        addIssue(
+          issues,
+          "warning",
+          entity,
+          `Role '${mobRole}' ignores combat stats (hp/xpReward/damage/armor). Remove the overrides to keep the editor clean.`,
+        );
+      }
+    }
+
     const resolvedDamage = resolveMobDamage(mob, mobTiers);
     if (resolvedDamage && resolvedDamage.max < resolvedDamage.min) {
       addIssue(

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -108,10 +108,41 @@ export interface FeatureFile {
   text?: string;
 }
 
+/**
+ * Classifies what a mob is *for*, independent of how tough it is. Gates
+ * which behaviours the engine exposes — combatants can be attacked and award
+ * XP; vendors/quest-givers/dialog mobs surface their social affordances but
+ * refuse combat; props are examine-only set dressing.
+ */
+export type MobRole = "combat" | "vendor" | "quest_giver" | "dialog" | "prop";
+
+export const MOB_ROLES: MobRole[] = ["combat", "vendor", "quest_giver", "dialog", "prop"];
+
+export const MOB_ROLE_LABELS: Record<MobRole, string> = {
+  combat: "Combat",
+  vendor: "Vendor",
+  quest_giver: "Quest Giver",
+  dialog: "Dialog",
+  prop: "Prop",
+};
+
+export const MOB_ROLE_DESCRIPTIONS: Record<MobRole, string> = {
+  combat: "Can be attacked, fights back, awards XP and loot.",
+  vendor: "Shopkeeper. Cannot be attacked.",
+  quest_giver: "Offers and accepts quests. Cannot be attacked.",
+  dialog: "Conversational NPC. Cannot be attacked.",
+  prop: "Examine-only flavour entity. No interaction beyond look.",
+};
+
 export interface MobFile {
   name: string;
   description?: string;
   room: string;
+  /**
+   * What this mob is *for*. Omitted/missing defaults to "combat" to preserve
+   * legacy behaviour. Non-combat roles refuse attack commands server-side.
+   */
+  role?: MobRole;
   tier?: string;
   level?: number;
   category?: string;


### PR DESCRIPTION
## Summary

Companion to [AmbonMUD#1077](https://github.com/jnoecker/AmbonMUD/pull/1077). The server now classifies mobs by role and refuses combat on non-combat roles; this PR brings the concept into Arcanum and slims down the editor when role ≠ combat.

- **Type**: `MobRole = "combat" | "vendor" | "quest_giver" | "dialog" | "prop"` added to `world.ts`, plus label + description maps. Omitting role serializes to nothing so legacy zones round-trip cleanly.
- **Editor**: Role dropdown at the top of the Mob tab's Basics section, with hint text describing each role. When `role ≠ combat`, the entire Behavior, Spells, and Stat Overrides sections are hidden, and the Rewards tab is removed from the tab bar. Authoring a shopkeeper is now name + description + inventory, not 14 combat stats.
- **Validator warnings**:
  - Props that have quests or dialogue (*"consider role quest_giver/dialog"*)
  - Non-combat mobs with combat-stat overrides set (*"Role vendor ignores hp/xpReward/damage/armor — remove the overrides to keep the editor clean."*)

### What I deliberately deferred

- **Infer-role migration helper.** The original plan included a one-click button in the editor to guess role from a mob's shop/quests/dialogue footprint. The backward-compat default (combat) means every existing zone keeps working untouched, so authors can flip roles one mob at a time. Can add the helper later if bulk migration becomes painful.

## Phase of the plan

Phase 1 of the four-phase tier-based content model:

1. **Mob role** — this PR + #1077.
2. Mob tier-driven stat computation.
3. Quest difficulty tiers.
4. Zone-level scaling (`scaling: static | bounded | player`).

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run test` — 1728 tests pass (3 new in `validateZone.test.ts`)
- [ ] Manual: open a quest-giver mob in the editor, flip role to `quest_giver`, verify Behavior / Spells / Stat Overrides sections disappear and the Rewards tab is hidden; save, reopen, confirm role persists and no combat-stat warnings appear