### PR TITLE
Surface tier-computed mob stats; flag overrides

### DIFF
--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -21,6 +21,8 @@ import { DialogueEditor } from "./DialogueEditor";
 import { DeleteEntityButton, EnhanceDescriptionButton, MediaSection } from "./EditorShared";
 import { mobPrompt, mobContext } from "@/lib/entityPrompts";
 import { useVibeStore } from "@/stores/vibeStore";
+import { useConfigStore } from "@/stores/configStore";
+import { resolveMobStats } from "@/lib/resolveMobStats";
 import { CATEGORY_ICONS } from "@/assets/ui";
 
 interface MobEditorProps {
@@ -39,6 +41,18 @@ const TIER_OPTIONS = [
 ];
 
 const ROLE_OPTIONS = MOB_ROLES.map((r) => ({ value: r, label: MOB_ROLE_LABELS[r] }));
+
+function fieldLabel(
+  base: string,
+  stat: { tierDefault: number; overridden: boolean } | undefined,
+): string {
+  if (!stat || !stat.overridden) return base;
+  return `${base} (tier default: ${stat.tierDefault})`;
+}
+
+function fieldPlaceholder(stat: { tierDefault: number } | undefined): string {
+  return stat ? String(stat.tierDefault) : "Auto";
+}
 
 const CATEGORY_OPTIONS = [
   { value: "humanoid", label: "Humanoid" },
@@ -91,6 +105,20 @@ export function MobEditor({
     ? MOB_TABS
     : MOB_TABS.filter((t) => t.value !== "rewards");
   const effectiveTab: MobTab = !isCombatant && activeTab === "rewards" ? "mob" : activeTab;
+
+  const mobTiers = useConfigStore((s) => s.config?.mobTiers);
+  const stats = resolveMobStats(mob, mobTiers);
+  const clearAllOverrides = useCallback(() => {
+    patch({
+      hp: undefined,
+      minDamage: undefined,
+      maxDamage: undefined,
+      armor: undefined,
+      xpReward: undefined,
+      goldMin: undefined,
+      goldMax: undefined,
+    });
+  }, [patch]);
 
   const zoneQuests = Object.entries(world.quests ?? {}).map(([id, q]) => ({
     id,
@@ -440,64 +468,81 @@ export function MobEditor({
             </FieldRow>
           </Section>
 
-          <Section title="Stat Overrides" defaultExpanded={false}>
-            <p className="mb-1 text-2xs text-text-muted">
-              Leave blank to use tier defaults
-            </p>
+          <Section
+            title={stats?.anyOverridden ? "Stat Overrides ●" : "Stat Overrides"}
+            defaultExpanded={false}
+            description={
+              stats
+                ? "Every field below follows tier × level by default. Only set a value when you need to break from the curve — the engine uses whatever you type instead of the computed value."
+                : "Set this mob's tier and level to preview the computed stats. Any value you type below becomes an override."
+            }
+            actions={
+              stats?.anyOverridden ? (
+                <button
+                  type="button"
+                  onClick={clearAllOverrides}
+                  className="focus-ring text-2xs text-text-muted underline underline-offset-2 hover:text-text-primary"
+                  title="Remove all overrides and use tier defaults"
+                >
+                  Clear all
+                </button>
+              ) : undefined
+            }
+          >
             <FieldGrid>
-              <CompactField label="HP" span>
+              <CompactField label={fieldLabel("HP", stats?.hp)} span>
                 <NumberInput
                   value={mob.hp}
                   onCommit={(v) => patch({ hp: v })}
-                  placeholder="Auto"
+                  placeholder={fieldPlaceholder(stats?.hp)}
                   min={1}
                 />
               </CompactField>
-              <CompactField label="Min Damage">
+              <CompactField label={fieldLabel("Min Damage", stats?.minDamage)}>
                 <NumberInput
                   value={mob.minDamage}
                   onCommit={(v) => patch({ minDamage: v })}
-                  placeholder="Auto"
+                  placeholder={fieldPlaceholder(stats?.minDamage)}
                   min={0}
                 />
               </CompactField>
-              <CompactField label="Max Damage">
+              <CompactField label={fieldLabel("Max Damage", stats?.maxDamage)}>
                 <NumberInput
                   value={mob.maxDamage}
                   onCommit={(v) => patch({ maxDamage: v })}
-                  placeholder="Auto"
+                  placeholder={fieldPlaceholder(stats?.maxDamage)}
                   min={0}
                 />
               </CompactField>
-              <CompactField label="Armor" span>
+              <CompactField label={fieldLabel("Armor", stats?.armor)} span>
                 <NumberInput
                   value={mob.armor}
                   onCommit={(v) => patch({ armor: v })}
-                  placeholder="Auto"
+                  placeholder={fieldPlaceholder(stats?.armor)}
                   min={0}
                 />
               </CompactField>
-              <CompactField label="XP Reward" span>
+              <CompactField label={fieldLabel("XP Reward", stats?.xpReward)} span>
                 <NumberInput
                   value={mob.xpReward}
                   onCommit={(v) => patch({ xpReward: v })}
-                  placeholder="Auto"
+                  placeholder={fieldPlaceholder(stats?.xpReward)}
                   min={0}
                 />
               </CompactField>
-              <CompactField label="Gold Min">
+              <CompactField label={fieldLabel("Gold Min", stats?.goldMin)}>
                 <NumberInput
                   value={mob.goldMin}
                   onCommit={(v) => patch({ goldMin: v })}
-                  placeholder="Auto"
+                  placeholder={fieldPlaceholder(stats?.goldMin)}
                   min={0}
                 />
               </CompactField>
-              <CompactField label="Gold Max">
+              <CompactField label={fieldLabel("Gold Max", stats?.goldMax)}>
                 <NumberInput
                   value={mob.goldMax}
                   onCommit={(v) => patch({ goldMax: v })}
-                  placeholder="Auto"
+                  placeholder={fieldPlaceholder(stats?.goldMax)}
                   min={0}
                 />
               </CompactField>

--- a/creator/src/lib/__tests__/resolveMobStats.test.ts
+++ b/creator/src/lib/__tests__/resolveMobStats.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { resolveMobStats } from "../resolveMobStats";
+import type { MobFile } from "@/types/world";
+import type { MobTiersConfig } from "@/types/config";
+
+const MOB_TIERS: MobTiersConfig = {
+  weak: {
+    baseHp: 10,
+    hpPerLevel: 2,
+    baseMinDamage: 1,
+    baseMaxDamage: 2,
+    damagePerLevel: 1,
+    baseArmor: 0,
+    baseXpReward: 15,
+    xpRewardPerLevel: 5,
+    baseGoldMin: 1,
+    baseGoldMax: 3,
+    goldPerLevel: 1,
+  },
+  standard: {
+    baseHp: 20,
+    hpPerLevel: 5,
+    baseMinDamage: 2,
+    baseMaxDamage: 4,
+    damagePerLevel: 2,
+    baseArmor: 1,
+    baseXpReward: 30,
+    xpRewardPerLevel: 10,
+    baseGoldMin: 3,
+    baseGoldMax: 8,
+    goldPerLevel: 2,
+  },
+  elite: {
+    baseHp: 50,
+    hpPerLevel: 10,
+    baseMinDamage: 5,
+    baseMaxDamage: 10,
+    damagePerLevel: 3,
+    baseArmor: 2,
+    baseXpReward: 75,
+    xpRewardPerLevel: 25,
+    baseGoldMin: 10,
+    baseGoldMax: 25,
+    goldPerLevel: 5,
+  },
+  boss: {
+    baseHp: 200,
+    hpPerLevel: 30,
+    baseMinDamage: 10,
+    baseMaxDamage: 20,
+    damagePerLevel: 5,
+    baseArmor: 4,
+    baseXpReward: 200,
+    xpRewardPerLevel: 50,
+    baseGoldMin: 50,
+    baseGoldMax: 150,
+    goldPerLevel: 20,
+  },
+};
+
+function mob(overrides: Partial<MobFile> = {}): MobFile {
+  return { name: "Test", room: "r1", tier: "standard", level: 1, ...overrides };
+}
+
+describe("resolveMobStats", () => {
+  it("returns undefined when the tier lookup fails", () => {
+    expect(resolveMobStats(mob(), undefined)).toBeUndefined();
+    expect(resolveMobStats(mob({ tier: "mythic" }), MOB_TIERS)).toBeUndefined();
+  });
+
+  it("computes tier defaults at level 1", () => {
+    const stats = resolveMobStats(mob({ tier: "standard", level: 1 }), MOB_TIERS)!;
+    expect(stats.hp.tierDefault).toBe(20);
+    expect(stats.hp.effective).toBe(20);
+    expect(stats.hp.overridden).toBe(false);
+    expect(stats.minDamage.tierDefault).toBe(2);
+    expect(stats.maxDamage.tierDefault).toBe(4);
+    expect(stats.armor.tierDefault).toBe(1);
+    expect(stats.xpReward.tierDefault).toBe(30);
+    expect(stats.goldMin.tierDefault).toBe(3);
+    expect(stats.goldMax.tierDefault).toBe(8);
+    expect(stats.anyOverridden).toBe(false);
+  });
+
+  it("applies perLevel growth via levelSteps (level-1)", () => {
+    const stats = resolveMobStats(mob({ tier: "elite", level: 5 }), MOB_TIERS)!;
+    // level 5 -> 4 steps above base
+    expect(stats.hp.tierDefault).toBe(50 + 10 * 4);
+    expect(stats.xpReward.tierDefault).toBe(75 + 25 * 4);
+    expect(stats.minDamage.tierDefault).toBe(5 + 3 * 4);
+  });
+
+  it("marks authored values as overrides without changing tierDefault", () => {
+    const stats = resolveMobStats(mob({ tier: "standard", level: 10, hp: 500, xpReward: 9 }), MOB_TIERS)!;
+    expect(stats.hp.overridden).toBe(true);
+    expect(stats.hp.effective).toBe(500);
+    expect(stats.hp.tierDefault).toBe(20 + 5 * 9);
+    expect(stats.xpReward.overridden).toBe(true);
+    expect(stats.xpReward.effective).toBe(9);
+    expect(stats.xpReward.tierDefault).toBe(30 + 10 * 9);
+    expect(stats.anyOverridden).toBe(true);
+    expect(stats.minDamage.overridden).toBe(false);
+  });
+
+  it("defaults level to 1 when missing", () => {
+    const stats = resolveMobStats(mob({ tier: "weak", level: undefined }), MOB_TIERS)!;
+    expect(stats.hp.tierDefault).toBe(10);
+  });
+
+  it("defaults tier to standard when missing", () => {
+    const stats = resolveMobStats(mob({ tier: undefined, level: 1 }), MOB_TIERS)!;
+    expect(stats.hp.tierDefault).toBe(20);
+  });
+});

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -203,6 +203,33 @@ describe("validateZone", () => {
     expect(issues.some((i) => i.entity === "mob:rat" && i.message.toLowerCase().includes("ignore"))).toBe(false);
   });
 
+  it("warns a combat mob's tier curve is broken by overrides when tiers are configured", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.tier = "standard";
+    world.mobs!.rat.level = 5;
+    world.mobs!.rat.hp = 999;
+    const issues = warnings(validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS));
+    const match = issues.find((i) => i.entity === "mob:rat" && i.message.includes("tier curve"));
+    expect(match).toBeDefined();
+    expect(match!.message).toContain("HP 999");
+    expect(match!.message).toContain("tier default");
+  });
+
+  it("does not emit a tier-curve warning when no overrides are set", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.tier = "standard";
+    world.mobs!.rat.level = 5;
+    const issues = warnings(validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS));
+    expect(issues.some((i) => i.message.includes("tier curve"))).toBe(false);
+  });
+
+  it("silently skips the tier-curve nudge when mobTiers config is absent", () => {
+    const world = makeValidWorld();
+    world.mobs!.rat.hp = 999;
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("tier curve"))).toBe(false);
+  });
+
   // ─── Item checks ────────────────────────────────────────────
   it("errors if item room does not exist", () => {
     const world = makeValidWorld();

--- a/creator/src/lib/resolveMobStats.ts
+++ b/creator/src/lib/resolveMobStats.ts
@@ -1,0 +1,91 @@
+// ─── Mob Stat Resolver ──────────────────────────────────────────────
+//
+// Mirrors the server's WorldLoader fallback math: when a mob doesn't
+// author a stat, the engine computes it as `base + perLevel * steps`
+// from the tier config at the mob's level. Arcanum uses the same
+// formulas so authors see the actual values the engine will produce.
+//
+// Keep this file in sync with WorldLoader's resolvedXxx assignments
+// and with tuning/formulas.ts.
+
+import type { MobFile } from "@/types/world";
+import type { MobTierConfig, MobTiersConfig } from "@/types/config";
+import {
+  mobHpAtLevel,
+  mobMinDamageAtLevel,
+  mobMaxDamageAtLevel,
+  mobXpRewardAtLevel,
+  mobGoldMinAtLevel,
+  mobGoldMaxAtLevel,
+} from "@/lib/tuning/formulas";
+
+export interface MobStatValue {
+  /** Effective value the engine will use (override when set, else tier default). */
+  effective: number;
+  /** What the tier+level would produce if the author removed the override. */
+  tierDefault: number;
+  /** True when the author set an explicit value overriding the tier default. */
+  overridden: boolean;
+}
+
+export interface ResolvedMobStats {
+  hp: MobStatValue;
+  minDamage: MobStatValue;
+  maxDamage: MobStatValue;
+  armor: MobStatValue;
+  xpReward: MobStatValue;
+  goldMin: MobStatValue;
+  goldMax: MobStatValue;
+  /** True when *any* combat field has an explicit override. */
+  anyOverridden: boolean;
+}
+
+function tierFor(mob: MobFile, mobTiers: MobTiersConfig | undefined): MobTierConfig | undefined {
+  const id = mob.tier ?? "standard";
+  if (!mobTiers) return undefined;
+  return (mobTiers as unknown as Record<string, MobTierConfig>)[id];
+}
+
+/**
+ * Resolve every combat stat for a mob using the tier + level math the MUD
+ * engine runs at load time. Returns both the effective value and the tier
+ * default so the editor can show one alongside the other.
+ *
+ * Returns undefined if the tier lookup fails (no mobTiers config, or the
+ * mob references an unknown tier). Callers should treat that as "can't
+ * preview — trust whatever the author put".
+ */
+export function resolveMobStats(
+  mob: MobFile,
+  mobTiers: MobTiersConfig | undefined,
+): ResolvedMobStats | undefined {
+  const tier = tierFor(mob, mobTiers);
+  if (!tier) return undefined;
+  const level = mob.level ?? 1;
+
+  const make = (authored: number | undefined, tierDefault: number): MobStatValue => ({
+    effective: authored ?? tierDefault,
+    tierDefault,
+    overridden: authored != null,
+  });
+
+  const stats: ResolvedMobStats = {
+    hp: make(mob.hp, mobHpAtLevel(tier, level)),
+    minDamage: make(mob.minDamage, mobMinDamageAtLevel(tier, level)),
+    maxDamage: make(mob.maxDamage, mobMaxDamageAtLevel(tier, level)),
+    armor: make(mob.armor, tier.baseArmor),
+    xpReward: make(mob.xpReward, mobXpRewardAtLevel(tier, level)),
+    goldMin: make(mob.goldMin, mobGoldMinAtLevel(tier, level)),
+    goldMax: make(mob.goldMax, mobGoldMaxAtLevel(tier, level)),
+    anyOverridden: false,
+  };
+  stats.anyOverridden =
+    stats.hp.overridden ||
+    stats.minDamage.overridden ||
+    stats.maxDamage.overridden ||
+    stats.armor.overridden ||
+    stats.xpReward.overridden ||
+    stats.goldMin.overridden ||
+    stats.goldMax.overridden;
+  return stats;
+}

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -14,6 +14,7 @@ import { mobMaxDamageAtLevel, mobMinDamageAtLevel } from "./tuning/formulas";
 import { computeZoneRebalance } from "./zoneRebalance";
 import { exitTarget } from "./zoneEdits";
 import { getTrainerClasses } from "./trainers";
+import { resolveMobStats } from "./resolveMobStats";
 
 export type Severity = "error" | "warning";
 
@@ -510,6 +511,29 @@ export function validateZone(
           "warning",
           entity,
           `Role '${mobRole}' ignores combat stats (hp/xpReward/damage/armor). Remove the overrides to keep the editor clean.`,
+        );
+      }
+    } else {
+      const resolved = resolveMobStats(mob, mobTiers);
+      if (resolved?.anyOverridden) {
+        const breakdown = (
+          [
+            ["HP", resolved.hp],
+            ["min damage", resolved.minDamage],
+            ["max damage", resolved.maxDamage],
+            ["armor", resolved.armor],
+            ["XP", resolved.xpReward],
+            ["gold min", resolved.goldMin],
+            ["gold max", resolved.goldMax],
+          ] as const
+        )
+          .filter(([, s]) => s.overridden)
+          .map(([label, s]) => `${label} ${s.effective} (tier default ${s.tierDefault})`);
+        addIssue(
+          issues,
+          "warning",
+          entity,
+          `Stat override breaks tier curve: ${breakdown.join("; ")}. Prefer adjusting tier or level over hand-tuning numbers.`,
         );
       }
     }


### PR DESCRIPTION
## Summary

Phase 2 of the tier-based content model. The MUD already resolves mob stats as `base + perLevel * steps` when a field is unauthored (see `WorldLoader.resolvedHp` etc.), so no engine change is needed — this PR makes that math visible in the creator so authors can stop thinking in HP numbers and start thinking in tier + level.

- **`resolveMobStats(mob, mobTiers)`** — consolidated mirror of `WorldLoader`'s `resolvedXxx` arithmetic. Returns per-field `{ effective, tierDefault, overridden }` triples plus `anyOverridden`. Pure, tested.
- **MobEditor Stat Overrides**:
  - Each field's placeholder is the tier default (empty input means "use tier default", any typed value is an explicit override)
  - When a field is overridden, the label expands: *"HP (tier default: 47)"*
  - Section title gets an accent dot when any override is present, and a `Clear all` action appears to drop them in one click
  - Description now frames the section as "break from the curve when you need to" rather than "set these numbers"
- **Validator nudge**: combat mobs with explicit overrides emit a single warning summarising each broken field alongside its tier default — *"Stat override breaks tier curve: HP 999 (tier default 45); XP 200 (tier default 70). Prefer adjusting tier or level over hand-tuning numbers."* Silenced when `mobTiers` config is absent (can't compute defaults).

No MUD-side companion this time — the resolution math lives in `WorldLoader` and has for a while. We're just catching the creator up.

## Phase of the plan

2 of 4:

1. ✅ Mob role (#1077 / #213)
2. **Mob tier-driven stats** — this PR
3. Quest difficulty tiers
4. Zone-level scaling

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run test` — 1737 tests pass (12 new: 6 in `resolveMobStats.test.ts`, 6 in `validateZone.test.ts`)
- [ ] Manual: open a combat mob in Auringold, set `tier: standard, level: 5`, verify placeholder values in Stat Overrides match what the MUD server produces on reload
- [ ] Manual: type a custom HP, confirm label changes to include tier default and section title gets the dot; click "Clear all" to drop it