### PR TITLE
Surface quest difficulty tiers; flag XP overrides

### DIFF
--- a/creator/src/components/editors/QuestEditor.tsx
+++ b/creator/src/components/editors/QuestEditor.tsx
@@ -24,6 +24,13 @@ import { DeleteEntityButton } from "./EditorShared";
 import { ReputationGateEditor } from "./ReputationGateEditor";
 import { useConfigStore } from "@/stores/configStore";
 import { useConfigOptions } from "@/lib/useConfigOptions";
+import {
+  QUEST_DIFFICULTIES,
+  QUEST_DIFFICULTY_LABELS,
+  QUEST_DIFFICULTY_DESCRIPTIONS,
+  type QuestDifficulty,
+} from "@/types/config";
+import { resolveQuestXp } from "@/lib/resolveQuestXp";
 
 interface QuestEditorProps {
   questId: string;
@@ -44,6 +51,11 @@ const FALLBACK_OBJECTIVE_TYPES = [
   { value: "craft", label: "Craft" },
   { value: "dungeon", label: "Dungeon" },
   { value: "pvpKill", label: "PvP Kill" },
+];
+
+const DIFFICULTY_OPTIONS = [
+  { value: "", label: "— none (authored XP) —" },
+  ...QUEST_DIFFICULTIES.map((d) => ({ value: d, label: QUEST_DIFFICULTY_LABELS[d] })),
 ];
 
 export function QuestEditor({
@@ -99,6 +111,25 @@ export function QuestEditor({
     [rewards, patch],
   );
 
+  const questXpConfig = useConfigStore((s) => s.config?.progression.quests);
+  const resolvedXp = resolveQuestXp(quest, questXpConfig);
+  const xpFieldLabel =
+    resolvedXp.reason === "override"
+      ? `XP (tier would compute: ${resolvedXp.computed})`
+      : resolvedXp.reason === "computed"
+        ? `XP (computed: ${resolvedXp.computed})`
+        : "XP";
+  const xpPlaceholder =
+    resolvedXp.reason === "computed" ? String(resolvedXp.computed) : "0";
+  const xpDescription =
+    resolvedXp.reason === "computed"
+      ? `Difficulty '${QUEST_DIFFICULTY_LABELS[quest.difficulty!]}' at level ${quest.level ?? 1} → ${resolvedXp.computed} XP. Set a value below to override.`
+      : resolvedXp.reason === "override"
+        ? `Authored XP overrides the tier-computed value (${resolvedXp.computed}). Clear the XP field to use the tier.`
+        : resolvedXp.reason === "authored-no-tier"
+          ? "No difficulty set — engine uses the authored XP below as-is. Pick a difficulty to let the engine compute XP instead."
+          : undefined;
+
   return (
     <>
       <EntityHeader type="Quest">
@@ -135,13 +166,28 @@ export function QuestEditor({
           </CompactField>
           <CompactField
             label="Intended level"
-            hint="When set, XP reward diminishes if the player has out-levelled the quest."
+            hint="Engine uses this to compute tier XP and apply diminishing returns."
           >
             <NumberInput
               value={quest.level}
               onCommit={(v) => patch({ level: v && v > 0 ? v : undefined })}
               placeholder="—"
               min={1}
+              dense
+            />
+          </CompactField>
+          <CompactField
+            label="Difficulty"
+            hint={
+              quest.difficulty
+                ? QUEST_DIFFICULTY_DESCRIPTIONS[quest.difficulty]
+                : "Engine computes XP from this tier × level. Leave blank to use the authored XP below."
+            }
+          >
+            <SelectInput
+              value={quest.difficulty ?? ""}
+              options={DIFFICULTY_OPTIONS}
+              onCommit={(v) => patch({ difficulty: (v || undefined) as QuestDifficulty | undefined })}
               dense
             />
           </CompactField>
@@ -208,13 +254,28 @@ export function QuestEditor({
         )}
       </Section>
 
-      <Section title="Rewards" defaultExpanded={false}>
+      <Section
+        title={
+          resolvedXp.reason === "override"
+            ? "Rewards ●"
+            : "Rewards"
+        }
+        defaultExpanded={false}
+        description={xpDescription}
+      >
         <FieldGrid>
-          <CompactField label="XP">
+          <CompactField
+            label={xpFieldLabel}
+            hint={
+              resolvedXp.reason === "computed"
+                ? "Leave blank to use the computed value. Any number here overrides it."
+                : undefined
+            }
+          >
             <NumberInput
               value={rewards.xp}
               onCommit={(v) => handleRewardChange("xp", v)}
-              placeholder="0"
+              placeholder={xpPlaceholder}
               min={0}
               dense
             />

--- a/creator/src/lib/__tests__/resolveQuestXp.test.ts
+++ b/creator/src/lib/__tests__/resolveQuestXp.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { resolveQuestXp } from "../resolveQuestXp";
+import type { QuestFile } from "@/types/world";
+import type { QuestXpConfig } from "@/types/config";
+
+const DEFAULT_CONFIG: QuestXpConfig = {
+  baseline: { baseXp: 50, xpPerLevel: 20 },
+  tiers: { trivial: 0.25, easy: 0.5, standard: 1.0, hard: 1.75, epic: 3.0 },
+};
+
+function quest(overrides: Partial<QuestFile> = {}): QuestFile {
+  return { name: "Test", giver: "giver", ...overrides };
+}
+
+describe("resolveQuestXp", () => {
+  it("returns zero with no data when neither difficulty nor authored xp are set", () => {
+    const result = resolveQuestXp(quest(), DEFAULT_CONFIG);
+    expect(result).toEqual({
+      effective: 0,
+      computed: null,
+      authored: null,
+      overridden: false,
+      reason: "no-data",
+    });
+  });
+
+  it("uses the authored value when no difficulty is set", () => {
+    const result = resolveQuestXp(quest({ rewards: { xp: 123 } }), DEFAULT_CONFIG);
+    expect(result.effective).toBe(123);
+    expect(result.reason).toBe("authored-no-tier");
+    expect(result.overridden).toBe(false);
+  });
+
+  it("computes from difficulty when xp is absent", () => {
+    const result = resolveQuestXp(quest({ difficulty: "standard", level: 5 }), DEFAULT_CONFIG);
+    // baseline at level 5 = 50 + 20*4 = 130, × standard 1.0 = 130
+    expect(result.computed).toBe(130);
+    expect(result.effective).toBe(130);
+    expect(result.reason).toBe("computed");
+    expect(result.overridden).toBe(false);
+  });
+
+  it("applies the tier multiplier", () => {
+    expect(
+      resolveQuestXp(quest({ difficulty: "epic", level: 10 }), DEFAULT_CONFIG).effective,
+    ).toBe(690); // (50 + 20*9) * 3.0
+    expect(
+      resolveQuestXp(quest({ difficulty: "trivial", level: 1 }), DEFAULT_CONFIG).effective,
+    ).toBe(13); // 50 * 0.25 rounded
+  });
+
+  it("authored xp overrides the computed tier value", () => {
+    const result = resolveQuestXp(
+      quest({ difficulty: "standard", level: 5, rewards: { xp: 42 } }),
+      DEFAULT_CONFIG,
+    );
+    expect(result.effective).toBe(42);
+    expect(result.computed).toBe(130);
+    expect(result.authored).toBe(42);
+    expect(result.overridden).toBe(true);
+    expect(result.reason).toBe("override");
+  });
+
+  it("falls back to built-in defaults when config is missing", () => {
+    const result = resolveQuestXp(quest({ difficulty: "standard", level: 3 }), undefined);
+    expect(result.computed).toBe(50 + 20 * 2); // = 90
+    expect(result.reason).toBe("computed");
+  });
+
+  it("clamps level to 1 when missing", () => {
+    expect(
+      resolveQuestXp(quest({ difficulty: "standard" }), DEFAULT_CONFIG).computed,
+    ).toBe(50);
+  });
+
+  it("ignores rewards.xp when it is zero", () => {
+    const result = resolveQuestXp(
+      quest({ difficulty: "easy", level: 5, rewards: { xp: 0 } }),
+      DEFAULT_CONFIG,
+    );
+    expect(result.reason).toBe("computed");
+    expect(result.effective).toBe(65); // 130 * 0.5
+  });
+});

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -230,6 +230,49 @@ describe("validateZone", () => {
     expect(issues.some((i) => i.message.includes("tier curve"))).toBe(false);
   });
 
+  it("warns when a quest XP override breaks its difficulty tier", () => {
+    const world = makeValidWorld();
+    world.mobs!.giver = { name: "Giver", room: "room1" };
+    world.quests = {
+      test_quest: {
+        name: "Test",
+        giver: "giver",
+        level: 5,
+        difficulty: "standard",
+        rewards: { xp: 500 },
+        objectives: [{ type: "kill", targetKey: "rat" }],
+      },
+    };
+    const questXpConfig = {
+      baseline: { baseXp: 50, xpPerLevel: 20 },
+      tiers: { standard: 1.0 } as const,
+    };
+    const issues = warnings(
+      validateZone(world, undefined, undefined, undefined, undefined, undefined, questXpConfig),
+    );
+    const match = issues.find(
+      (i) => i.entity === "quest:test_quest" && i.message.includes("override (500)"),
+    );
+    expect(match).toBeDefined();
+    expect(match!.message).toContain("would compute 130");
+  });
+
+  it("does not warn when a quest uses the computed difficulty XP", () => {
+    const world = makeValidWorld();
+    world.mobs!.giver = { name: "Giver", room: "room1" };
+    world.quests = {
+      test_quest: {
+        name: "Test",
+        giver: "giver",
+        level: 5,
+        difficulty: "standard",
+        objectives: [{ type: "kill", targetKey: "rat" }],
+      },
+    };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.entity === "quest:test_quest" && i.message.includes("override"))).toBe(false);
+  });
+
   // ─── Item checks ────────────────────────────────────────────
   it("errors if item room does not exist", () => {
     const world = makeValidWorld();

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -557,6 +557,28 @@ function parseProgressionConfig(raw: unknown): AppConfig["progression"] {
       baseHp: asNumber(rewards.baseHp, 10),
       baseMana: asNumber(rewards.baseMana, 20),
     },
+    quests: parseQuestXpConfig(s.quests),
+  };
+}
+
+function parseQuestXpConfig(raw: unknown): AppConfig["progression"]["quests"] {
+  if (raw == null) return undefined;
+  const s = raw as Record<string, unknown>;
+  const baseline = (s.baseline ?? {}) as Record<string, unknown>;
+  const tiersRaw = (s.tiers ?? {}) as Record<string, unknown>;
+  const tiers: Partial<Record<import("@/types/config").QuestDifficulty, number>> = {};
+  for (const [key, value] of Object.entries(tiersRaw)) {
+    const normalized = key.toLowerCase() as import("@/types/config").QuestDifficulty;
+    if (["trivial", "easy", "standard", "hard", "epic"].includes(normalized) && typeof value === "number") {
+      tiers[normalized] = value;
+    }
+  }
+  return {
+    baseline: {
+      baseXp: asNumber(baseline.baseXp, 50),
+      xpPerLevel: asNumber(baseline.xpPerLevel, 20),
+    },
+    tiers,
   };
 }
 

--- a/creator/src/lib/resolveQuestXp.ts
+++ b/creator/src/lib/resolveQuestXp.ts
@@ -1,0 +1,70 @@
+// ─── Quest XP Resolver ──────────────────────────────────────────────
+//
+// Mirrors the server's PlayerProgression.computeQuestXp + QuestSystem
+// completion logic: the authored `rewards.xp` (when > 0) always wins as
+// an explicit override; otherwise the engine computes
+//   (baseline.baseXp + baseline.xpPerLevel * (level - 1)) * tiers[difficulty]
+// at the quest's declared level (or the player's level at completion time
+// in scaling zones — which we can't predict from the creator, so we use
+// `quest.level ?? 1` as the preview anchor).
+
+import type { QuestFile } from "@/types/world";
+import type { QuestXpConfig } from "@/types/config";
+
+export interface ResolvedQuestXp {
+  /** XP the engine will actually award (override when set, else computed). */
+  effective: number;
+  /** XP the engine would compute from difficulty + baseline. Null when no difficulty or config. */
+  computed: number | null;
+  /** XP the author explicitly set. Null when unset/0 (falls back to computed). */
+  authored: number | null;
+  /** True when the author's value overrides the computed one. */
+  overridden: boolean;
+  /** Human explanation of why effective is what it is. */
+  reason: "override" | "computed" | "authored-no-tier" | "no-data";
+}
+
+const DEFAULT_BASELINE_XP = 50;
+const DEFAULT_XP_PER_LEVEL = 20;
+const DEFAULT_TIER_MULTIPLIERS = {
+  trivial: 0.25,
+  easy: 0.5,
+  standard: 1.0,
+  hard: 1.75,
+  epic: 3.0,
+} as const;
+
+function baselineXpAt(level: number, config: QuestXpConfig | undefined): number {
+  const baseXp = config?.baseline.baseXp ?? DEFAULT_BASELINE_XP;
+  const xpPerLevel = config?.baseline.xpPerLevel ?? DEFAULT_XP_PER_LEVEL;
+  return baseXp + xpPerLevel * (Math.max(1, level) - 1);
+}
+
+export function resolveQuestXp(
+  quest: QuestFile,
+  config: QuestXpConfig | undefined,
+): ResolvedQuestXp {
+  const authored = (quest.rewards?.xp ?? 0) > 0 ? quest.rewards!.xp! : null;
+  const level = quest.level ?? 1;
+
+  if (quest.difficulty) {
+    const multiplier = config?.tiers?.[quest.difficulty] ?? DEFAULT_TIER_MULTIPLIERS[quest.difficulty];
+    const computed = Math.max(0, Math.round(baselineXpAt(level, config) * multiplier));
+    if (authored != null) {
+      return { effective: authored, computed, authored, overridden: true, reason: "override" };
+    }
+    return { effective: computed, computed, authored: null, overridden: false, reason: "computed" };
+  }
+
+  if (authored != null) {
+    return {
+      effective: authored,
+      computed: null,
+      authored,
+      overridden: false,
+      reason: "authored-no-tier",
+    };
+  }
+
+  return { effective: 0, computed: null, authored: null, overridden: false, reason: "no-data" };
+}

--- a/creator/src/lib/runtimeHandoff.ts
+++ b/creator/src/lib/runtimeHandoff.ts
@@ -94,7 +94,15 @@ export function runWorkspaceValidation(): ValidationSummary {
   const knownAchievements = config?.achievementDefs
     ? new Set(Object.keys(config.achievementDefs))
     : undefined;
-  const results = validateAllZones(zones, config?.equipmentSlots, validClasses, knownFactions, knownAchievements, config?.mobTiers);
+  const results = validateAllZones(
+    zones,
+    config?.equipmentSlots,
+    validClasses,
+    knownFactions,
+    knownAchievements,
+    config?.mobTiers,
+    config?.progression.quests,
+  );
 
   if (config) {
     const configIssues = validateConfig(config);

--- a/creator/src/lib/saveZone.ts
+++ b/creator/src/lib/saveZone.ts
@@ -23,7 +23,15 @@ export function serializeZone(zoneId: string): string {
   const knownAchievements = config?.achievementDefs
     ? new Set(Object.keys(config.achievementDefs))
     : undefined;
-  const issues = validateZone(sanitized, config?.equipmentSlots, validClasses, knownFactions, knownAchievements, config?.mobTiers);
+  const issues = validateZone(
+    sanitized,
+    config?.equipmentSlots,
+    validClasses,
+    knownFactions,
+    knownAchievements,
+    config?.mobTiers,
+    config?.progression.quests,
+  );
   const errors = issues.filter((issue) => issue.severity === "error");
   if (errors.length > 0) {
     const summary = errors.slice(0, 5).map((issue) => `${issue.entity}: ${issue.message}`).join("; ");

--- a/creator/src/lib/tuning/presets.ts
+++ b/creator/src/lib/tuning/presets.ts
@@ -194,6 +194,10 @@ export const CASUAL_PRESET: TuningPreset = {
         baseHp: 15,
         baseMana: 15,
       },
+      quests: {
+        baseline: { baseXp: 40, xpPerLevel: 15 },
+        tiers: { trivial: 0.3, easy: 0.6, standard: 1.0, hard: 1.4, epic: 2.0 },
+      },
     },
 
     // ─── Skill Points ────────────────────────────────────────────────
@@ -500,6 +504,10 @@ export const BALANCED_PRESET: TuningPreset = {
         fullManaOnLevelUp: true,
         baseHp: 10,
         baseMana: 10,
+      },
+      quests: {
+        baseline: { baseXp: 50, xpPerLevel: 20 },
+        tiers: { trivial: 0.25, easy: 0.5, standard: 1.0, hard: 1.75, epic: 3.0 },
       },
     },
 
@@ -808,6 +816,10 @@ export const HARDCORE_PRESET: TuningPreset = {
         baseHp: 8,
         baseMana: 8,
       },
+      quests: {
+        baseline: { baseXp: 60, xpPerLevel: 25 },
+        tiers: { trivial: 0.2, easy: 0.4, standard: 1.0, hard: 2.0, epic: 3.5 },
+      },
     },
 
     // ─── Skill Points ────────────────────────────────────────────────
@@ -992,6 +1004,10 @@ export const SOLO_STORY_PRESET: TuningPreset = {
         },
       },
       rewards: { hpPerLevel: 4, manaPerLevel: 3, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 20, baseMana: 20 },
+      quests: {
+        baseline: { baseXp: 50, xpPerLevel: 30 },
+        tiers: { trivial: 0.3, easy: 0.6, standard: 1.0, hard: 1.5, epic: 2.5 },
+      },
     },
     skillPoints: { interval: 2 },
     multiclass: { minLevel: 8, goldCost: 100 },
@@ -1067,6 +1083,10 @@ export const PVP_ARENA_PRESET: TuningPreset = {
         },
       },
       rewards: { hpPerLevel: 2, manaPerLevel: 1, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 12, baseMana: 10 },
+      quests: {
+        baseline: { baseXp: 50, xpPerLevel: 10 },
+        tiers: { trivial: 0.25, easy: 0.5, standard: 1.0, hard: 1.75, epic: 2.5 },
+      },
     },
     skillPoints: { interval: 3 },
     multiclass: { minLevel: 20, goldCost: 1000 },
@@ -1141,6 +1161,10 @@ export const LORE_EXPLORER_PRESET: TuningPreset = {
         },
       },
       rewards: { hpPerLevel: 8, manaPerLevel: 6, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 50, baseMana: 50 },
+      quests: {
+        baseline: { baseXp: 30, xpPerLevel: 15 },
+        tiers: { trivial: 0.5, easy: 0.8, standard: 1.0, hard: 1.2, epic: 1.5 },
+      },
     },
     skillPoints: { interval: 1 },
     multiclass: { minLevel: 5, goldCost: 50 },

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -15,6 +15,8 @@ import { computeZoneRebalance } from "./zoneRebalance";
 import { exitTarget } from "./zoneEdits";
 import { getTrainerClasses } from "./trainers";
 import { resolveMobStats } from "./resolveMobStats";
+import { resolveQuestXp } from "./resolveQuestXp";
+import type { QuestXpConfig } from "@/types/config";
 
 export type Severity = "error" | "warning";
 
@@ -408,6 +410,7 @@ export function validateZone(
   knownFactions?: ReadonlySet<string>,
   knownAchievements?: ReadonlySet<string>,
   mobTiers?: MobTiersConfig,
+  questXpConfig?: QuestXpConfig,
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const roomIds = new Set(Object.keys(world.rooms));
@@ -703,6 +706,15 @@ export function validateZone(
         "Quest awards >=100 XP but has no intended level — players who out-level this quest will still receive the full flat reward",
       );
     }
+    const resolvedXp = resolveQuestXp(quest, questXpConfig);
+    if (resolvedXp.reason === "override") {
+      addIssue(
+        issues,
+        "warning",
+        entity,
+        `XP override (${resolvedXp.authored}) breaks the difficulty tier — '${quest.difficulty}' at level ${quest.level ?? 1} would compute ${resolvedXp.computed}. Remove rewards.xp to use the tier, or pick a different difficulty.`,
+      );
+    }
   }
 
   for (const [nodeId, node] of Object.entries(world.gatheringNodes ?? {})) {
@@ -784,10 +796,11 @@ export function validateAllZones(
   knownFactions?: ReadonlySet<string>,
   knownAchievements?: ReadonlySet<string>,
   mobTiers?: MobTiersConfig,
+  questXpConfig?: QuestXpConfig,
 ): Map<string, ValidationIssue[]> {
   const results = new Map<string, ValidationIssue[]>();
   for (const [zoneId, zone] of zones) {
-    const issues = validateZone(zone.data, equipmentSlots, validClasses, knownFactions, knownAchievements, mobTiers);
+    const issues = validateZone(zone.data, equipmentSlots, validClasses, knownFactions, knownAchievements, mobTiers, questXpConfig);
     if (issues.length > 0) {
       results.set(zoneId, issues);
     }

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -202,6 +202,39 @@ export interface ProgressionConfig {
   maxLevel: number;
   xp: XpCurveConfig;
   rewards: LevelRewardsConfig;
+  /** Engine-computed XP for quests. Authors pick a difficulty tier; engine computes XP at completion. */
+  quests?: QuestXpConfig;
+}
+
+export type QuestDifficulty = "trivial" | "easy" | "standard" | "hard" | "epic";
+
+export const QUEST_DIFFICULTIES: QuestDifficulty[] = ["trivial", "easy", "standard", "hard", "epic"];
+
+export const QUEST_DIFFICULTY_LABELS: Record<QuestDifficulty, string> = {
+  trivial: "Trivial",
+  easy: "Easy",
+  standard: "Standard",
+  hard: "Hard",
+  epic: "Epic",
+};
+
+export const QUEST_DIFFICULTY_DESCRIPTIONS: Record<QuestDifficulty, string> = {
+  trivial: "Fetch quests, tutorial steps. ~¼ of a standard reward.",
+  easy: "Short side quests. Half of a standard reward.",
+  standard: "Default pacing — baseline reward for the quest level.",
+  hard: "Tough chains or boss fights. ~1.75× the standard reward.",
+  epic: "Capstone / zone finale. ~3× the standard reward.",
+};
+
+export interface QuestBaselineConfig {
+  baseXp: number;
+  xpPerLevel: number;
+}
+
+export interface QuestXpConfig {
+  baseline: QuestBaselineConfig;
+  /** Per-tier XP multiplier applied on top of the baseline. */
+  tiers: Partial<Record<QuestDifficulty, number>>;
 }
 
 // ─── Economy ────────────────────────────────────────────────────────

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -287,6 +287,12 @@ export interface QuestFile {
    * legacy flat-award behaviour.
    */
   level?: number;
+  /**
+   * Engine-driven difficulty tier. When set and `rewards.xp` is absent/0, the
+   * engine computes XP from the progression config's quest baseline × the
+   * tier's multiplier. An explicit positive `rewards.xp` always wins.
+   */
+  difficulty?: import("./config").QuestDifficulty;
 }
 
 export interface QuestObjectiveFile {


### PR DESCRIPTION
## Summary

Companion to [AmbonMUD#1078](https://github.com/jnoecker/AmbonMUD/pull/1078). Authors pick a difficulty tier (`trivial | easy | standard | hard | epic`) in the quest editor; the engine computes XP at completion time from the progression config's quest baseline × tier multiplier. Authored `rewards.xp` still wins as an explicit override.

- **Types**: `QuestDifficulty` + labels + descriptions, `QuestXpConfig` (baseline + tiers map), `QuestBaselineConfig` in `types/config`. `QuestFile.difficulty` added to `types/world`.
- **`resolveQuestXp(quest, config)`** mirrors the MUD's completion math. Returns `{ effective, computed, authored, overridden, reason }` — one source of truth shared by the editor and validator.
- **`parseQuestXpConfig`** in `loader.ts` accepts tier keys case-insensitively so MUD-format YAML (UPPERCASE enum names) and Arcanum-format YAML (lowercase) both round-trip cleanly.
- **QuestEditor**:
  - Basics section gains a Difficulty dropdown beside Intended Level, with hint text describing each tier
  - Rewards section reframes XP: placeholder = computed tier value, label expands to `XP (computed: N)` or `XP (tier would compute: N)` when the author overrides
  - Section title gets an accent dot when overridden; a descriptive sentence explains what the engine will do at completion (override / computed / authored-no-tier)
- **Validator** gains a 7th optional `questXpConfig` parameter (threaded through `saveZone` and `runtimeHandoff`). Emits one warning per quest when authored XP overrides a difficulty tier, listing both numbers so the author can decide.
- **Tuning presets**: every preset now ships a `progression.quests` block shaped to its personality:
  - Casual: `40/15`, tiers `0.3/0.6/1/1.4/2`
  - Balanced: `50/20`, tiers `0.25/0.5/1/1.75/3` (matches MUD default)
  - Hardcore: `60/25`, tiers `0.2/0.4/1/2/3.5`
  - Solo Story: `50/30`, tiers `0.3/0.6/1/1.5/2.5`
  - PvP Arena: `50/10`, tiers `0.25/0.5/1/1.75/2.5`
  - Lore Explorer: `30/15`, tiers `0.5/0.8/1/1.2/1.5`

## Migration

Zero. Every existing quest has `rewards.xp > 0` and no `difficulty`, which triggers the `authored-no-tier` path — behaviour unchanged. Authors opt in quest-by-quest.

## Phase of the plan

3 of 4:

1. ✅ Mob role
2. ✅ Mob tier-driven stats
3. **Quest difficulty tiers** — this PR + #1078
4. Zone-level scaling

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run test` — 1747 tests pass (10 new: 8 in `resolveQuestXp.test.ts`, 2 in `validateZone.test.ts`)
- [ ] Manual: flip Auringold's "Grand Tour" to `difficulty: standard` with no `rewards.xp`, verify editor shows `XP (computed: N)` and deploys YAML with the difficulty field set
- [ ] Manual: apply the Balanced preset and confirm `progression.quests` appears in the diff with the tier table