### PR TITLE
Surface zone-level scaling in the editor

### DIFF
--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -216,6 +216,33 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
     const v = e.target.value;
     updateZone(zoneId, { ...zoneState.data, faction: v || undefined });
   }, [zoneState, updateZone, zoneId]);
+  const handleScalingModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (!zoneState) return;
+    const mode = e.target.value as "" | import("@/types/world").ScalingMode;
+    if (!mode || mode === "static") {
+      updateZone(zoneId, { ...zoneState.data, scaling: undefined });
+      return;
+    }
+    const existing = zoneState.data.scaling;
+    const next: import("@/types/world").ZoneScaling =
+      mode === "bounded"
+        ? { mode: "bounded", levelRange: existing?.levelRange ?? [1, 5] }
+        : { mode: "player" };
+    updateZone(zoneId, { ...zoneState.data, scaling: next });
+  }, [zoneState, updateZone, zoneId]);
+  const handleScalingRangeChange = useCallback((idx: 0 | 1, raw: string) => {
+    if (!zoneState) return;
+    const existing = zoneState.data.scaling;
+    if (existing?.mode !== "bounded") return;
+    const n = Math.max(1, Math.round(Number(raw) || 1));
+    const [min, max] = existing.levelRange ?? [1, 5];
+    const next: [number, number] =
+      idx === 0 ? [n, Math.max(n, max)] : [Math.min(min, n), n];
+    updateZone(zoneId, {
+      ...zoneState.data,
+      scaling: { mode: "bounded", levelRange: next },
+    });
+  }, [zoneState, updateZone, zoneId]);
 
   // Auto-close entity panel if the selected entity was removed (e.g. by undo)
   useEffect(() => {
@@ -890,6 +917,49 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
                 </select>
               </label>
             )}
+
+            {/* Level scaling mode */}
+            <label
+              className="flex items-center gap-1.5 text-xs text-text-secondary max-[1100px]:min-h-9"
+              title="How the engine resolves mob and quest levels. Static uses authored numbers; bounded clamps to a range; player matches the reference player exactly."
+            >
+              <span className="whitespace-nowrap">Scaling</span>
+              <select
+                value={zoneState.data.scaling?.mode ?? "static"}
+                onChange={handleScalingModeChange}
+                className="ornate-input px-1.5 py-0.5 text-xs text-text-primary"
+              >
+                <option value="static">Static</option>
+                <option value="bounded">Bounded</option>
+                <option value="player">Player</option>
+              </select>
+              {zoneState.data.scaling?.mode === "bounded" && (
+                <>
+                  <span className="whitespace-nowrap text-2xs text-text-muted">L</span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={99}
+                    step={1}
+                    value={zoneState.data.scaling.levelRange?.[0] ?? 1}
+                    onChange={(e) => handleScalingRangeChange(0, e.target.value)}
+                    className="ornate-input w-12 px-1.5 py-0.5 text-xs text-text-primary"
+                    aria-label="Minimum level"
+                  />
+                  <span className="text-2xs text-text-muted">–</span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={99}
+                    step={1}
+                    value={zoneState.data.scaling.levelRange?.[1] ?? 5}
+                    onChange={(e) => handleScalingRangeChange(1, e.target.value)}
+                    className="ornate-input w-12 px-1.5 py-0.5 text-xs text-text-primary"
+                    aria-label="Maximum level"
+                  />
+                </>
+              )}
+            </label>
           </div>
 
           {/* Compact zone badge — visible only when the right column is hidden */}

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -257,6 +257,41 @@ describe("validateZone", () => {
     expect(match!.message).toContain("would compute 130");
   });
 
+  it("errors when scaling.mode 'bounded' has no levelRange", () => {
+    const world = makeValidWorld();
+    world.scaling = { mode: "bounded" };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.entity === "zone" && i.message.includes("bounded"))).toBe(true);
+  });
+
+  it("errors on an inverted scaling levelRange", () => {
+    const world = makeValidWorld();
+    world.scaling = { mode: "bounded", levelRange: [10, 3] };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.message.includes("max (3)"))).toBe(true);
+  });
+
+  it("accepts a valid bounded scaling config", () => {
+    const world = makeValidWorld();
+    world.scaling = { mode: "bounded", levelRange: [3, 8] };
+    const issues = errors(validateZone(world));
+    expect(issues.filter((i) => i.entity === "zone")).toHaveLength(0);
+  });
+
+  it("accepts player mode with no levelRange", () => {
+    const world = makeValidWorld();
+    world.scaling = { mode: "player" };
+    const issues = errors(validateZone(world));
+    expect(issues.filter((i) => i.entity === "zone")).toHaveLength(0);
+  });
+
+  it("warns when player mode has an unused levelRange", () => {
+    const world = makeValidWorld();
+    world.scaling = { mode: "player", levelRange: [3, 8] };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.entity === "zone" && i.message.includes("ignores levelRange"))).toBe(true);
+  });
+
   it("does not warn when a quest uses the computed difficulty XP", () => {
     const world = makeValidWorld();
     world.mobs!.giver = { name: "Giver", room: "room1" };

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -451,6 +451,35 @@ export function validateZone(
       addIssue(issues, "error", "zone", "levelBand.max must be greater than or equal to levelBand.min");
     }
   }
+  if (world.scaling) {
+    const { mode, levelRange } = world.scaling;
+    if (mode === "bounded") {
+      if (!levelRange || levelRange.length !== 2) {
+        addIssue(issues, "error", "zone", "scaling.mode 'bounded' requires a levelRange [min, max]");
+      } else {
+        const [min, max] = levelRange;
+        if (!isPositiveInteger(min) || !isPositiveInteger(max)) {
+          addIssue(issues, "error", "zone", "scaling.levelRange values must be positive integers");
+        } else if (max < min) {
+          addIssue(issues, "error", "zone", `scaling.levelRange max (${max}) must be >= min (${min})`);
+        }
+      }
+    } else if (mode === "player" && levelRange) {
+      addIssue(
+        issues,
+        "warning",
+        "zone",
+        "scaling.mode 'player' ignores levelRange — content tracks the reference player without bounds.",
+      );
+    } else if (mode === "static" && levelRange) {
+      addIssue(
+        issues,
+        "warning",
+        "zone",
+        "scaling.mode 'static' ignores levelRange — use levelBand for rebalance targets instead.",
+      );
+    }
+  }
   factionCheck("zone", world.faction, "Controlling faction");
 
   for (const [roomId, room] of Object.entries(world.rooms)) {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -3,6 +3,23 @@ export type StatMap = Record<string, number>;
 
 // ─── Zone-level types (mirror world-yaml-dtos) ──────────────────────
 
+/**
+ * Controls how the engine resolves mob and quest levels at runtime.
+ * - "static" — author-authored levels are used verbatim (default).
+ * - "bounded" — content scales to the highest-level player in the zone,
+ *   clamped to `levelRange`. Keeps progression gates intact while letting
+ *   mixed-level parties play the same zone.
+ * - "player" — content tracks the reference player's level directly,
+ *   no bounds. Intended for tutorial zones and endgame social hubs.
+ */
+export type ScalingMode = "static" | "bounded" | "player";
+
+export interface ZoneScaling {
+  mode: ScalingMode;
+  /** Inclusive [min, max] band. Required when mode is "bounded"; ignored otherwise. */
+  levelRange?: [number, number];
+}
+
 export interface WorldFile {
   zone: string;
   lifespan?: number;
@@ -10,6 +27,8 @@ export interface WorldFile {
   terrain?: string;
   graphical?: boolean;
   pvpEnabled?: boolean;
+  /** Dynamic level-scaling config. Omit for static (authored levels) behaviour. */
+  scaling?: ZoneScaling;
   /** Intended level range for this zone. Drives the Rebalance Zone feature. */
   levelBand?: { min: number; max: number };
   /** Intended difficulty profile — informs rebalance stat targets. */


### PR DESCRIPTION
## Summary

Companion to [AmbonMUD#1079](https://github.com/jnoecker/AmbonMUD/pull/1079). Zones can now declare how the engine should resolve mob and quest levels at runtime; this PR puts the field on `WorldFile` and adds a compact toolbar control + validator rules in the creator.

- **Types**: `ScalingMode = "static" | "bounded" | "player"` and `ZoneScaling = { mode, levelRange? }` added to `types/world`. `WorldFile.scaling` is optional — round-trips through the existing YAML pipeline naturally (stringify copies unknown fields verbatim, so no loader change needed).
- **Editor**: the zone toolbar gets a Scaling dropdown alongside the other zone settings (Graphical / PvP / Lifespan / Terrain / Faction). Picking `bounded` reveals a compact `L <min> – <max>` pair; picking `player` hides the range; picking `static` clears the scaling field entirely so default zones serialize clean.
- **Validator**:
  - errors when `mode: bounded` has no levelRange
  - errors when levelRange values aren't positive integers or `max < min`
  - warns when `mode: player` or `mode: static` has a stray levelRange (mode ignores it — use `levelBand` for static-rebalance targets instead)

## Migration

Zero. No existing zone declares scaling; validator and loader both treat missing scaling as static, matching current engine behaviour.

## Phase of the plan — complete

1. ✅ Mob role
2. ✅ Mob tier-driven stats
3. ✅ Quest difficulty tiers
4. **Zone-level scaling** — this PR + #1079

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run test` — 1752 tests pass (5 new in `validateZone.test.ts`)
- [ ] Manual: switch a zone to `bounded`, set levelRange [3, 8], save, verify YAML has `scaling: { mode: bounded, levelRange: [3, 8] }`
- [ ] Manual: paired with MUD#1079 — deploy a bounded zone, enter at level 30, verify mobs and quest XP clamp to the band