### PR TITLE
Fix tuning presets to match verified AmbonMUD server semantics

### DIFF
--- a/creator/src/components/config/panels/AutoQuestsPanel.tsx
+++ b/creator/src/components/config/panels/AutoQuestsPanel.tsx
@@ -11,7 +11,6 @@ const DEFAULT_AUTO_QUESTS: AutoQuestsConfig = {
   enabled: false,
   timeLimitMs: 600_000,
   cooldownMs: 300_000,
-  rewardScaling: 1.0,
 };
 
 export function AutoQuestsPanel({ config, onChange }: ConfigPanelProps) {
@@ -44,14 +43,6 @@ export function AutoQuestsPanel({ config, onChange }: ConfigPanelProps) {
             value={aq.cooldownMs}
             onCommit={(v) => patch({ cooldownMs: v ?? 300_000 })}
             min={0}
-          />
-        </FieldRow>
-        <FieldRow label="Reward Scaling" hint="Multiplier applied to bounty rewards. 1.0 = normal, 1.5 = 50% bonus. Stacks with level scaling.">
-          <NumberInput
-            value={aq.rewardScaling}
-            onCommit={(v) => patch({ rewardScaling: v ?? 1.0 })}
-            min={0}
-            step={0.1}
           />
         </FieldRow>
       </div>

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -760,7 +760,6 @@ function parseAutoQuestsConfig(raw: unknown): AppConfig["autoQuests"] {
     rewardXpPerLevel: asNumber(s.rewardXpPerLevel, 25),
     killCountMin: asNumber(s.killCountMin, 3),
     killCountMax: asNumber(s.killCountMax, 8),
-    rewardScaling: typeof s.rewardScaling === "number" ? s.rewardScaling : undefined,
   };
 }
 

--- a/creator/src/lib/tuning/__tests__/presetInvariants.test.ts
+++ b/creator/src/lib/tuning/__tests__/presetInvariants.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import { TUNING_PRESETS } from "@/lib/tuning/presets";
+import type { TuningPreset } from "@/lib/tuning/presets";
+import { applyTemplate } from "@/lib/templates";
+import { estimatePacing } from "@/lib/tuning/pacing";
+import type { AppConfig } from "@/types/config";
+
+const BASE_CONFIG = {
+  progression: {
+    maxLevel: 50,
+    xp: { baseXp: 100, exponent: 2.0, linearXp: 0, multiplier: 1.0, defaultKillXp: 10 },
+    rewards: { hpPerLevel: 2, manaPerLevel: 1, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 10, baseMana: 10 },
+  },
+  stats: {
+    bindings: {
+      meleeDamageStat: "STR", meleeDamageDivisor: 3,
+      dodgeStat: "DEX", dodgePerPoint: 2, maxDodgePercent: 30,
+      spellDamageStat: "INT", spellDamageDivisor: 3,
+      hpScalingStat: "CON", hpScalingDivisor: 5,
+      manaScalingStat: "INT", manaScalingDivisor: 5,
+      hpRegenStat: "CON", hpRegenMsPerPoint: 200,
+      manaRegenStat: "INT", manaRegenMsPerPoint: 200,
+      xpBonusStat: "WIS", xpBonusPerPoint: 0.005,
+    },
+  },
+} as unknown as Record<string, unknown>;
+
+function mergedConfig(preset: TuningPreset): AppConfig {
+  return applyTemplate(BASE_CONFIG as unknown as AppConfig, preset.config);
+}
+
+describe("preset invariants — server semantics", () => {
+  describe("shop arbitrage (sell < buy with ≥0.1 margin)", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: economy.sellMultiplier < economy.buyMultiplier - 0.05`, () => {
+        const buy = preset.config.economy?.buyMultiplier ?? 1;
+        const sell = preset.config.economy?.sellMultiplier ?? 0.5;
+        expect(sell, `${preset.id}: buy=${buy} sell=${sell}`).toBeLessThan(buy - 0.05);
+      });
+    }
+  });
+
+  describe("gambling house edge (diceWinChance × diceWinMultiplier < 1)", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: expected gross return < 1.0`, () => {
+        const chance = preset.config.gambling?.diceWinChance ?? 0;
+        const mult = preset.config.gambling?.diceWinMultiplier ?? 0;
+        const expected = chance * mult;
+        expect(expected, `${preset.id}: ${chance} × ${mult} = ${expected}`).toBeLessThan(1);
+      });
+    }
+  });
+
+  describe("xpBonusPerPoint is a fractional multiplier, not a percentage", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: xpBonusPerPoint in [0, 0.1]`, () => {
+        const value = preset.config.stats?.bindings?.xpBonusPerPoint;
+        expect(value, `${preset.id} missing xpBonusPerPoint`).toBeDefined();
+        expect(value).toBeGreaterThanOrEqual(0);
+        expect(value).toBeLessThanOrEqual(0.1);
+      });
+    }
+  });
+
+  describe("group.xpBonusPerMember is a fractional multiplier, not a percentage", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: xpBonusPerMember in [0, 1.0]`, () => {
+        const value = preset.config.group?.xpBonusPerMember;
+        expect(value, `${preset.id} missing xpBonusPerMember`).toBeDefined();
+        expect(value).toBeGreaterThanOrEqual(0);
+        expect(value).toBeLessThanOrEqual(1);
+      });
+    }
+  });
+
+  describe("combat.maxDamage stays within the corrected range", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: combat.maxDamage ≤ 15`, () => {
+        const value = preset.config.combat?.maxDamage ?? 0;
+        expect(value, `${preset.id}: maxDamage=${value}`).toBeLessThanOrEqual(15);
+      });
+    }
+  });
+
+  describe("mob HP tier ordering (weak < standard < elite < boss)", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: baseHp, hpPerLevel, baseXpReward ascend across tiers`, () => {
+        const t = preset.config.mobTiers!;
+        const weak = t.weak!;
+        const standard = t.standard!;
+        const elite = t.elite!;
+        const boss = t.boss!;
+        expect(weak.baseHp).toBeLessThan(standard.baseHp!);
+        expect(standard.baseHp).toBeLessThan(elite.baseHp!);
+        expect(elite.baseHp).toBeLessThan(boss.baseHp!);
+        expect(weak.hpPerLevel).toBeLessThanOrEqual(standard.hpPerLevel!);
+        expect(standard.hpPerLevel).toBeLessThanOrEqual(elite.hpPerLevel!);
+        expect(elite.hpPerLevel).toBeLessThanOrEqual(boss.hpPerLevel!);
+        expect(weak.baseXpReward).toBeLessThanOrEqual(standard.baseXpReward!);
+        expect(standard.baseXpReward).toBeLessThanOrEqual(elite.baseXpReward!);
+        expect(elite.baseXpReward).toBeLessThanOrEqual(boss.baseXpReward!);
+      });
+    }
+  });
+
+  describe("time to max level falls within [4, 120] hours", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: projected L-cap in bound`, () => {
+        const merged = mergedConfig(preset);
+        const maxLevel = merged.progression.maxLevel || 50;
+        const pacing = estimatePacing(merged, preset.id);
+        const highestMilestone = pacing.milestones.reduce<typeof pacing.milestones[number] | null>(
+          (best, m) => (best == null || m.level > best.level ? m : best),
+          null,
+        );
+        expect(highestMilestone).not.toBeNull();
+        const minutes = highestMilestone!.minutesEstimated;
+        const scaled = (minutes * maxLevel) / highestMilestone!.level;
+        const hours = scaled / 60;
+        expect(hours, `${preset.id}: projected ~${hours.toFixed(1)}h to L${maxLevel}`).toBeGreaterThanOrEqual(4);
+        expect(hours, `${preset.id}: projected ~${hours.toFixed(1)}h to L${maxLevel}`).toBeLessThanOrEqual(120);
+      });
+    }
+  });
+
+  describe("prestige.xpCostMultiplier stays within [1.1, 1.8]", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: xpCostMultiplier in range`, () => {
+        const value = preset.config.prestige?.xpCostMultiplier;
+        expect(value).toBeDefined();
+        expect(value).toBeGreaterThanOrEqual(1.1);
+        expect(value).toBeLessThanOrEqual(1.8);
+      });
+    }
+  });
+
+  describe("combat.tickMillis is at least 1000 ms", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: tickMillis ≥ 1000`, () => {
+        const value = preset.config.combat?.tickMillis ?? 0;
+        expect(value).toBeGreaterThanOrEqual(1000);
+      });
+    }
+  });
+
+  describe("renamed server fields are populated (no dead keys)", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: gambling.dice* and lottery.jackpotSeedGold and guildHalls.purchaseCost are set`, () => {
+        expect(preset.config.gambling?.diceMinBet).toBeDefined();
+        expect(preset.config.gambling?.diceMaxBet).toBeDefined();
+        expect(preset.config.gambling?.diceWinChance).toBeDefined();
+        expect(preset.config.gambling?.diceWinMultiplier).toBeDefined();
+        expect(preset.config.lottery?.jackpotSeedGold).toBeDefined();
+        expect(preset.config.guildHalls?.purchaseCost).toBeDefined();
+      });
+
+      it(`${preset.id}: old dead keys are not set`, () => {
+        const gambling = preset.config.gambling as Record<string, unknown> | undefined;
+        const lottery = preset.config.lottery as Record<string, unknown> | undefined;
+        const guildHalls = preset.config.guildHalls as Record<string, unknown> | undefined;
+        const autoQuests = preset.config.autoQuests as Record<string, unknown> | undefined;
+        expect(gambling?.minBet).toBeUndefined();
+        expect(gambling?.maxBet).toBeUndefined();
+        expect(gambling?.winChance).toBeUndefined();
+        expect(gambling?.winMultiplier).toBeUndefined();
+        expect(lottery?.jackpotBase).toBeUndefined();
+        expect(guildHalls?.baseCost).toBeUndefined();
+        expect(autoQuests?.rewardScaling).toBeUndefined();
+      });
+    }
+  });
+
+  describe("dodge cap is not reached by a modestly invested character", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: dodgePerPoint × 10 < maxDodgePercent`, () => {
+        const b = preset.config.stats!.bindings!;
+        const perPoint = b.dodgePerPoint!;
+        const cap = b.maxDodgePercent!;
+        expect(perPoint * 10, `${preset.id}: stat=20 would hit ${perPoint * 10} vs cap ${cap}`).toBeLessThan(cap);
+      });
+    }
+  });
+
+  describe("regen-to-full downtime is under 180 seconds at level 25", () => {
+    for (const preset of TUNING_PRESETS) {
+      it(`${preset.id}: post-fight regen time is reasonable`, () => {
+        const merged = mergedConfig(preset);
+        const rewards = merged.progression.rewards;
+        const playerHpAt25 = rewards.baseHp + 24 * rewards.hpPerLevel;
+        const interval = merged.regen.baseIntervalMillis;
+        const amount = merged.regen.regenAmount;
+        const timeToFullSec = (playerHpAt25 * interval) / (amount * 1000);
+        expect(timeToFullSec, `${preset.id}: ${timeToFullSec.toFixed(0)}s to regen ${playerHpAt25}hp`).toBeLessThan(180);
+      });
+    }
+  });
+});

--- a/creator/src/lib/tuning/__tests__/presets.test.ts
+++ b/creator/src/lib/tuning/__tests__/presets.test.ts
@@ -36,7 +36,7 @@ const FULL_MOCK_CONFIG: AppConfig = {
       manaScalingStat: "INT", manaScalingDivisor: 5,
       hpRegenStat: "CON", hpRegenMsPerPoint: 200,
       manaRegenStat: "INT", manaRegenMsPerPoint: 200,
-      xpBonusStat: "WIS", xpBonusPerPoint: 1,
+      xpBonusStat: "WIS", xpBonusPerPoint: 0.005,
     },
   },
   abilities: {},
@@ -62,7 +62,7 @@ const FULL_MOCK_CONFIG: AppConfig = {
   crafting: { maxSkillLevel: 75, baseXpPerLevel: 100, xpExponent: 1.5, gatherCooldownMs: 3000, stationBonusQuantity: 1 },
   navigation: { recall: { cooldownMs: 60000, messages: { combatBlocked: "", cooldownRemaining: "", castBegin: "", unreachable: "", departNotice: "", arriveNotice: "", arrival: "" } } },
   commands: {},
-  group: { maxSize: 5, inviteTimeoutMs: 60000, xpBonusPerMember: 10 },
+  group: { maxSize: 5, inviteTimeoutMs: 60000, xpBonusPerMember: 0.10 },
   classes: {
     WARRIOR: { displayName: "Warrior", hpPerLevel: 4, manaPerLevel: 1, primaryStat: "STR", description: "A fighter." },
   },
@@ -104,9 +104,9 @@ const FULL_MOCK_CONFIG: AppConfig = {
   prestige: { enabled: true, xpCostBase: 10000, xpCostMultiplier: 1.5, maxRank: 5, perks: {} },
   respec: { goldCost: 100, cooldownMs: 300000 },
   currencies: { definitions: {} },
-  lottery: { enabled: true, ticketCost: 25, drawingIntervalMs: 3600000, jackpotBase: 500 },
-  gambling: { enabled: true, minBet: 10, maxBet: 1000, winChance: 0.45, winMultiplier: 2.0 },
-  autoQuests: { enabled: true, timeLimitMs: 300000, cooldownMs: 300000, rewardScaling: 1.0 },
+  lottery: { enabled: true, ticketCost: 25, drawingIntervalMs: 3600000, jackpotSeedGold: 500 },
+  gambling: { enabled: true, diceMinBet: 10, diceMaxBet: 1000, diceWinChance: 0.45, diceWinMultiplier: 2.0 },
+  autoQuests: { enabled: true, timeLimitMs: 300000, cooldownMs: 300000 },
   dailyQuests: {
     enabled: true,
     resetTimeUtc: "06:00",
@@ -123,7 +123,7 @@ const FULL_MOCK_CONFIG: AppConfig = {
     objectives: [{ type: "kill", targetCount: 25, description: "Defeat 25 enemies" }],
     rewards: {},
   },
-  guildHalls: { enabled: true, baseCost: 10000, roomTemplates: {} },
+  guildHalls: { enabled: true, purchaseCost: 10000, roomTemplates: {} },
   leaderboard: { refreshIntervalMs: 120000, topN: 10 },
   globalAssets: {},
   persistence: { backend: "YAML", rootDir: "data/players", worker: { enabled: true, flushIntervalMs: 5000 } },
@@ -239,8 +239,8 @@ describe("validation", () => {
 describe("field coverage", () => {
   const allPaths = Object.keys(FIELD_METADATA);
 
-  it("FIELD_METADATA has 137 entries (sanity check)", () => {
-    expect(allPaths).toHaveLength(137);
+  it("FIELD_METADATA has 136 entries (sanity check)", () => {
+    expect(allPaths).toHaveLength(136);
   });
 
   for (const preset of TUNING_PRESETS) {

--- a/creator/src/lib/tuning/fieldMetadata.ts
+++ b/creator/src/lib/tuning/fieldMetadata.ts
@@ -381,14 +381,16 @@ export const FIELD_METADATA: Record<string, FieldMeta> = {
 
   "mobActionDelay.minActionDelayMillis": {
     label: "Mob Min Action Delay",
-    description: "Minimum milliseconds between mob actions",
+    description:
+      "Minimum milliseconds between mob behavior-tree evaluations (patrol, wander, aggro initiation). This is NOT combat attack speed -- swings are driven by combat.tickMillis. Server default: 8000ms.",
     section: TuningSection.CombatStats,
     min: 0,
     impact: "medium",
   },
   "mobActionDelay.maxActionDelayMillis": {
     label: "Mob Max Action Delay",
-    description: "Maximum milliseconds between mob actions",
+    description:
+      "Maximum milliseconds between mob behavior-tree evaluations (patrol, wander, aggro initiation). This is NOT combat attack speed -- swings are driven by combat.tickMillis. Server default: 20000ms.",
     section: TuningSection.CombatStats,
     min: 0,
     impact: "medium",
@@ -461,11 +463,14 @@ export const FIELD_METADATA: Record<string, FieldMeta> = {
   },
   "stats.bindings.xpBonusPerPoint": {
     label: "XP Bonus Per Point",
-    description: "Percentage XP bonus per point of the XP bonus stat",
+    description:
+      "Fractional XP multiplier per stat point above the base of 10. Formula: xpMultiplier = 1.0 + (stat - 10) * xpBonusPerPoint. 0.01 = 1% bonus per point; 0.10 = 10% per point. Server default: 0.005. Do not enter percentage integers.",
     section: TuningSection.CombatStats,
     min: 0,
+    max: 0.1,
     impact: "medium",
-    interactionNote: "Multiplicative XP scaling from charisma -- affects leveling speed",
+    interactionNote:
+      "Multiplicative XP scaling from the configured XP-bonus stat. Tiny changes compound with stat investment.",
   },
 
   // ─── Economy ───────────────────────────────────────────────────────
@@ -534,31 +539,33 @@ export const FIELD_METADATA: Record<string, FieldMeta> = {
     section: TuningSection.EconomyCrafting,
     impact: "low",
   },
-  "gambling.minBet": {
-    label: "Minimum Bet",
-    description: "Minimum gold amount for a single gamble",
+  "gambling.diceMinBet": {
+    label: "Dice Minimum Bet",
+    description: "Minimum gold amount for a single dice gamble. Server field: diceMinBet.",
     section: TuningSection.EconomyCrafting,
     min: 1,
     impact: "low",
   },
-  "gambling.maxBet": {
-    label: "Maximum Bet",
-    description: "Maximum gold amount for a single gamble",
+  "gambling.diceMaxBet": {
+    label: "Dice Maximum Bet",
+    description: "Maximum gold amount for a single dice gamble. Server field: diceMaxBet.",
     section: TuningSection.EconomyCrafting,
     min: 1,
     impact: "medium",
   },
-  "gambling.winChance": {
-    label: "Gambling Win Chance",
-    description: "Probability of winning a gamble (0-1)",
+  "gambling.diceWinChance": {
+    label: "Dice Win Chance",
+    description:
+      "Probability of winning a dice gamble (0-1). Server field: diceWinChance. Keep diceWinChance * diceWinMultiplier < 1 for a positive house edge.",
     section: TuningSection.EconomyCrafting,
     min: 0,
     max: 1,
     impact: "medium",
   },
-  "gambling.winMultiplier": {
-    label: "Gambling Win Multiplier",
-    description: "Multiplier applied to bet amount on a win",
+  "gambling.diceWinMultiplier": {
+    label: "Dice Win Multiplier",
+    description:
+      "Gross payout multiplier on a winning dice roll (2.0 means a 100g bet returns 200g). Server field: diceWinMultiplier.",
     section: TuningSection.EconomyCrafting,
     min: 1,
     impact: "medium",
@@ -586,9 +593,10 @@ export const FIELD_METADATA: Record<string, FieldMeta> = {
     min: 1000,
     impact: "low",
   },
-  "lottery.jackpotBase": {
-    label: "Lottery Jackpot Base",
-    description: "Starting jackpot amount before ticket sales accumulate",
+  "lottery.jackpotSeedGold": {
+    label: "Lottery Jackpot Seed",
+    description:
+      "Gold the jackpot resets to after each drawing (seed value, not a floor). Server field: jackpotSeedGold.",
     section: TuningSection.EconomyCrafting,
     min: 0,
     impact: "low",
@@ -794,7 +802,8 @@ export const FIELD_METADATA: Record<string, FieldMeta> = {
   },
   "respec.cooldownMs": {
     label: "Respec Cooldown",
-    description: "Milliseconds between allowed respecs",
+    description:
+      "Milliseconds between allowed respecs. Note: the server does not persist this cooldown across sessions -- players can reset the timer by disconnecting. Treat as a soft deterrent only.",
     section: TuningSection.ProgressionQuests,
     min: 0,
     impact: "low",
@@ -822,14 +831,6 @@ export const FIELD_METADATA: Record<string, FieldMeta> = {
     min: 0,
     impact: "medium",
   },
-  "autoQuests.rewardScaling": {
-    label: "Bounty Reward Scaling",
-    description: "Multiplier for bounty quest rewards based on difficulty",
-    section: TuningSection.ProgressionQuests,
-    min: 0,
-    impact: "medium",
-  },
-
   // ─── Daily Quests ──────────────────────────────────────────────────
 
   "dailyQuests.enabled": {
@@ -999,11 +1000,14 @@ export const FIELD_METADATA: Record<string, FieldMeta> = {
   },
   "group.xpBonusPerMember": {
     label: "Group XP Bonus/Member",
-    description: "XP bonus percentage per additional group member",
+    description:
+      "Fractional XP multiplier per additional group member beyond the first. Formula: groupMultiplier = 1.0 + (memberCount - 1) * xpBonusPerMember. 0.10 = 10% bonus per extra member. Server default: 0.10. Do not enter percentage integers.",
     section: TuningSection.WorldSocial,
     min: 0,
+    max: 1,
     impact: "medium",
-    interactionNote: "Incentivizes grouping -- higher values make solo play relatively less efficient",
+    interactionNote:
+      "Incentivizes grouping -- higher values make solo play relatively less efficient. Keep below 1.0.",
   },
 
   // ─── Navigation ────────────────────────────────────────────────────
@@ -1051,9 +1055,9 @@ export const FIELD_METADATA: Record<string, FieldMeta> = {
     section: TuningSection.WorldSocial,
     impact: "low",
   },
-  "guildHalls.baseCost": {
-    label: "Guild Hall Base Cost",
-    description: "Gold cost to purchase a guild hall",
+  "guildHalls.purchaseCost": {
+    label: "Guild Hall Purchase Cost",
+    description: "Gold cost to purchase a guild hall. Server field: purchaseCost.",
     section: TuningSection.WorldSocial,
     min: 0,
     impact: "medium",
@@ -1078,17 +1082,19 @@ export const FIELD_METADATA: Record<string, FieldMeta> = {
   },
   "factions.killPenalty": {
     label: "Faction Kill Penalty",
-    description: "Reputation lost when killing a faction member",
+    description:
+      "Base reputation lost when killing a faction member. Actual per-kill loss scales with mob level: killPenalty * (1 + mobLevel / 10).",
     section: TuningSection.WorldSocial,
     min: 0,
-    impact: "medium",
+    impact: "high",
   },
   "factions.killBonus": {
     label: "Faction Kill Bonus",
-    description: "Reputation gained with enemy factions when killing a faction member",
+    description:
+      "Base reputation gained with enemy factions when killing a faction member. Actual per-kill gain scales with mob level: killBonus * (1 + mobLevel / 10).",
     section: TuningSection.WorldSocial,
     min: 0,
-    impact: "medium",
+    impact: "high",
   },
 
   // ─── Leaderboard ───────────────────────────────────────────────────

--- a/creator/src/lib/tuning/pacing.ts
+++ b/creator/src/lib/tuning/pacing.ts
@@ -47,32 +47,49 @@ export interface PacingTargets {
  */
 export const PRESET_PACING_TARGETS: Record<string, PacingTargets> = {
   loreExplorer: {
-    minutesToLevel: { 5: 5, 10: 15, 20: 30, 30: 45 },
+    minutesToLevel: { 5: 60, 10: 120, 20: 200, 30: 300 },
   },
   soloStory: {
-    minutesToLevel: { 5: 8, 10: 20, 20: 50, 30: 90 },
+    minutesToLevel: { 5: 45, 10: 90, 20: 200, 30: 320 },
   },
   casual: {
-    minutesToLevel: { 5: 10, 10: 30, 20: 90, 30: 180 },
+    minutesToLevel: { 5: 60, 10: 150, 20: 300, 30: 540 },
   },
   balanced: {
-    minutesToLevel: { 5: 20, 10: 60, 20: 180, 30: 360 },
+    minutesToLevel: { 5: 60, 10: 180, 20: 540, 30: 900 },
   },
   pvpArena: {
-    minutesToLevel: { 5: 20, 10: 60, 20: 120, 30: 240 },
+    minutesToLevel: { 5: 50, 10: 150, 20: 360, 30: 720 },
   },
   hardcore: {
-    minutesToLevel: { 5: 45, 10: 135, 20: 450, 30: 900 },
+    minutesToLevel: { 5: 150, 10: 450, 20: 1500, 30: 3000 },
   },
 };
 
 /**
+ * Representative XP-bonus stat value used to model a modestly invested
+ * player in the pacing sim. 5 above the BASE_STAT of 10 — not maxed,
+ * not neglected — captures the realistic multiplier without making
+ * pacing projections sensitive to minmaxed builds.
+ */
+const REPRESENTATIVE_XP_BONUS_STAT_OFFSET = 5;
+
+/**
  * Estimate XP/hour the canonical trash run produces against a config.
  * Sampled at the player level (mob XP scales with level and then runs
- * through the progression XP multiplier, matching the server).
+ * through the progression XP multiplier, matching the server). The
+ * server applies a stat-driven XP multiplier on top of the scaled
+ * reward (`1 + (stat - BASE_STAT) * xpBonusPerPoint`); we model that
+ * here against a representative invested stat so runaway xpBonusPerPoint
+ * values surface in time-to-level projections.
  */
 export function estimateXpPerHour(config: AppConfig, playerLevel: number): number {
   const { killsPerHour, tierMix } = CANONICAL_TRASH_RUN;
+  const xpBonusPerPoint = config.stats?.bindings?.xpBonusPerPoint ?? 0;
+  const statMultiplier = Math.max(
+    1,
+    1 + REPRESENTATIVE_XP_BONUS_STAT_OFFSET * xpBonusPerPoint,
+  );
   let xp = 0;
   for (const tier of TIER_KEYS) {
     const tierConfig = config.mobTiers[tier];
@@ -82,7 +99,7 @@ export function estimateXpPerHour(config: AppConfig, playerLevel: number): numbe
       mobXpRewardAtLevel(tierConfig, playerLevel),
       config.progression.xp.multiplier,
     );
-    xp += killsPerHour * fraction * xpPerKill;
+    xp += killsPerHour * fraction * xpPerKill * statMultiplier;
   }
   return xp;
 }

--- a/creator/src/lib/tuning/presets.ts
+++ b/creator/src/lib/tuning/presets.ts
@@ -53,8 +53,8 @@ export const CASUAL_PRESET: TuningPreset = {
         baseMaxDamage: 2,
         damagePerLevel: 0,
         baseArmor: 0,
-        baseXpReward: 20,
-        xpRewardPerLevel: 8,
+        baseXpReward: 3,
+        xpRewardPerLevel: 1,
         baseGoldMin: 2,
         baseGoldMax: 5,
         goldPerLevel: 2,
@@ -66,8 +66,8 @@ export const CASUAL_PRESET: TuningPreset = {
         baseMaxDamage: 3,
         damagePerLevel: 0,
         baseArmor: 0,
-        baseXpReward: 40,
-        xpRewardPerLevel: 15,
+        baseXpReward: 7,
+        xpRewardPerLevel: 2,
         baseGoldMin: 5,
         baseGoldMax: 12,
         goldPerLevel: 3,
@@ -79,8 +79,8 @@ export const CASUAL_PRESET: TuningPreset = {
         baseMaxDamage: 5,
         damagePerLevel: 1,
         baseArmor: 1,
-        baseXpReward: 100,
-        xpRewardPerLevel: 35,
+        baseXpReward: 16,
+        xpRewardPerLevel: 5,
         baseGoldMin: 15,
         baseGoldMax: 35,
         goldPerLevel: 7,
@@ -92,8 +92,8 @@ export const CASUAL_PRESET: TuningPreset = {
         baseMaxDamage: 6,
         damagePerLevel: 1,
         baseArmor: 2,
-        baseXpReward: 250,
-        xpRewardPerLevel: 60,
+        baseXpReward: 40,
+        xpRewardPerLevel: 10,
         baseGoldMin: 60,
         baseGoldMax: 120,
         goldPerLevel: 18,
@@ -117,7 +117,7 @@ export const CASUAL_PRESET: TuningPreset = {
         manaScalingDivisor: 4,
         hpRegenMsPerPoint: 250,
         manaRegenMsPerPoint: 250,
-        xpBonusPerPoint: 2,
+        xpBonusPerPoint: 0.02,
       },
     },
 
@@ -139,10 +139,10 @@ export const CASUAL_PRESET: TuningPreset = {
     // ─── Gambling ────────────────────────────────────────────────────
     gambling: {
       enabled: true,
-      minBet: 5,
-      maxBet: 500,
-      winChance: 0.5,
-      winMultiplier: 2.0,
+      diceMinBet: 5,
+      diceMaxBet: 500,
+      diceWinChance: 0.45,
+      diceWinMultiplier: 2.0,
     },
 
     // ─── Lottery ─────────────────────────────────────────────────────
@@ -150,7 +150,7 @@ export const CASUAL_PRESET: TuningPreset = {
       enabled: true,
       ticketCost: 10,
       drawingIntervalMs: 1800000,
-      jackpotBase: 1000,
+      jackpotSeedGold: 1000,
     },
 
     // ─── Stylist ─────────────────────────────────────────────────────
@@ -235,7 +235,6 @@ export const CASUAL_PRESET: TuningPreset = {
       enabled: true,
       timeLimitMs: 600000,
       cooldownMs: 120000,
-      rewardScaling: 1.5,
     },
 
     // ─── Daily Quests ────────────────────────────────────────────────
@@ -283,7 +282,7 @@ export const CASUAL_PRESET: TuningPreset = {
     group: {
       maxSize: 6,
       inviteTimeoutMs: 60000,
-      xpBonusPerMember: 15,
+      xpBonusPerMember: 0.15,
     },
 
     // ─── Navigation ──────────────────────────────────────────────────
@@ -307,7 +306,7 @@ export const CASUAL_PRESET: TuningPreset = {
     // ─── Guild Halls ─────────────────────────────────────────────────
     guildHalls: {
       enabled: true,
-      baseCost: 5000,
+      purchaseCost: 5000,
     },
 
     // ─── Housing ─────────────────────────────────────────────────────
@@ -428,7 +427,7 @@ export const BALANCED_PRESET: TuningPreset = {
         manaScalingDivisor: 5,
         hpRegenMsPerPoint: 200,
         manaRegenMsPerPoint: 200,
-        xpBonusPerPoint: 1,
+        xpBonusPerPoint: 0.01,
       },
     },
 
@@ -450,10 +449,10 @@ export const BALANCED_PRESET: TuningPreset = {
     // ─── Gambling ────────────────────────────────────────────────────
     gambling: {
       enabled: true,
-      minBet: 10,
-      maxBet: 1000,
-      winChance: 0.45,
-      winMultiplier: 2.0,
+      diceMinBet: 10,
+      diceMaxBet: 1000,
+      diceWinChance: 0.45,
+      diceWinMultiplier: 2.0,
     },
 
     // ─── Lottery ─────────────────────────────────────────────────────
@@ -461,7 +460,7 @@ export const BALANCED_PRESET: TuningPreset = {
       enabled: true,
       ticketCost: 25,
       drawingIntervalMs: 3600000,
-      jackpotBase: 500,
+      jackpotSeedGold: 500,
     },
 
     // ─── Stylist ─────────────────────────────────────────────────────
@@ -546,7 +545,6 @@ export const BALANCED_PRESET: TuningPreset = {
       enabled: true,
       timeLimitMs: 300000,
       cooldownMs: 300000,
-      rewardScaling: 1.0,
     },
 
     // ─── Daily Quests ────────────────────────────────────────────────
@@ -567,11 +565,11 @@ export const BALANCED_PRESET: TuningPreset = {
       maxPlayersPerTick: 10,
       baseIntervalMillis: 4500,
       minIntervalMillis: 1000,
-      regenAmount: 1,
+      regenAmount: 2,
       mana: {
         baseIntervalMillis: 4500,
         minIntervalMillis: 1000,
-        regenAmount: 1,
+        regenAmount: 2,
       },
     },
 
@@ -594,7 +592,7 @@ export const BALANCED_PRESET: TuningPreset = {
     group: {
       maxSize: 5,
       inviteTimeoutMs: 60000,
-      xpBonusPerMember: 10,
+      xpBonusPerMember: 0.10,
     },
 
     // ─── Navigation ──────────────────────────────────────────────────
@@ -618,7 +616,7 @@ export const BALANCED_PRESET: TuningPreset = {
     // ─── Guild Halls ─────────────────────────────────────────────────
     guildHalls: {
       enabled: true,
-      baseCost: 10000,
+      purchaseCost: 10000,
     },
 
     // ─── Housing ─────────────────────────────────────────────────────
@@ -739,7 +737,7 @@ export const HARDCORE_PRESET: TuningPreset = {
         manaScalingDivisor: 6,
         hpRegenMsPerPoint: 150,
         manaRegenMsPerPoint: 150,
-        xpBonusPerPoint: 1,
+        xpBonusPerPoint: 0.01,
       },
     },
 
@@ -761,10 +759,10 @@ export const HARDCORE_PRESET: TuningPreset = {
     // ─── Gambling ────────────────────────────────────────────────────
     gambling: {
       enabled: true,
-      minBet: 25,
-      maxBet: 2000,
-      winChance: 0.35,
-      winMultiplier: 2.5,
+      diceMinBet: 25,
+      diceMaxBet: 2000,
+      diceWinChance: 0.35,
+      diceWinMultiplier: 2.5,
     },
 
     // ─── Lottery ─────────────────────────────────────────────────────
@@ -772,7 +770,7 @@ export const HARDCORE_PRESET: TuningPreset = {
       enabled: true,
       ticketCost: 50,
       drawingIntervalMs: 7200000,
-      jackpotBase: 200,
+      jackpotSeedGold: 200,
     },
 
     // ─── Stylist ─────────────────────────────────────────────────────
@@ -842,7 +840,7 @@ export const HARDCORE_PRESET: TuningPreset = {
     prestige: {
       enabled: true,
       xpCostBase: 25000,
-      xpCostMultiplier: 2.0,
+      xpCostMultiplier: 1.35,
       maxRank: 10,
     },
 
@@ -857,7 +855,6 @@ export const HARDCORE_PRESET: TuningPreset = {
       enabled: true,
       timeLimitMs: 180000,
       cooldownMs: 600000,
-      rewardScaling: 0.8,
     },
 
     // ─── Daily Quests ────────────────────────────────────────────────
@@ -878,11 +875,11 @@ export const HARDCORE_PRESET: TuningPreset = {
       maxPlayersPerTick: 8,
       baseIntervalMillis: 6000,
       minIntervalMillis: 1500,
-      regenAmount: 1,
+      regenAmount: 2,
       mana: {
         baseIntervalMillis: 6000,
         minIntervalMillis: 1500,
-        regenAmount: 1,
+        regenAmount: 2,
       },
     },
 
@@ -905,7 +902,7 @@ export const HARDCORE_PRESET: TuningPreset = {
     group: {
       maxSize: 4,
       inviteTimeoutMs: 30000,
-      xpBonusPerMember: 5,
+      xpBonusPerMember: 0.05,
     },
 
     // ─── Navigation ──────────────────────────────────────────────────
@@ -929,7 +926,7 @@ export const HARDCORE_PRESET: TuningPreset = {
     // ─── Guild Halls ─────────────────────────────────────────────────
     guildHalls: {
       enabled: true,
-      baseCost: 25000,
+      purchaseCost: 25000,
     },
 
     // ─── Housing ─────────────────────────────────────────────────────
@@ -972,17 +969,17 @@ export const SOLO_STORY_PRESET: TuningPreset = {
   config: {
     combat: { tickMillis: 3500, minDamage: 1, maxDamage: 3 },
     mobTiers: {
-      weak: { baseHp: 2, hpPerLevel: 1, baseMinDamage: 1, baseMaxDamage: 1, damagePerLevel: 0, baseArmor: 0, baseXpReward: 25, xpRewardPerLevel: 10, baseGoldMin: 3, baseGoldMax: 8, goldPerLevel: 3 },
-      standard: { baseHp: 6, hpPerLevel: 2, baseMinDamage: 1, baseMaxDamage: 2, damagePerLevel: 0, baseArmor: 0, baseXpReward: 50, xpRewardPerLevel: 20, baseGoldMin: 8, baseGoldMax: 18, goldPerLevel: 5 },
-      elite: { baseHp: 14, hpPerLevel: 4, baseMinDamage: 2, baseMaxDamage: 4, damagePerLevel: 1, baseArmor: 1, baseXpReward: 120, xpRewardPerLevel: 40, baseGoldMin: 20, baseGoldMax: 45, goldPerLevel: 10 },
-      boss: { baseHp: 28, hpPerLevel: 6, baseMinDamage: 2, baseMaxDamage: 5, damagePerLevel: 1, baseArmor: 1, baseXpReward: 300, xpRewardPerLevel: 80, baseGoldMin: 80, baseGoldMax: 160, goldPerLevel: 25 },
+      weak: { baseHp: 2, hpPerLevel: 1, baseMinDamage: 1, baseMaxDamage: 1, damagePerLevel: 0, baseArmor: 0, baseXpReward: 3, xpRewardPerLevel: 1, baseGoldMin: 3, baseGoldMax: 8, goldPerLevel: 3 },
+      standard: { baseHp: 6, hpPerLevel: 2, baseMinDamage: 1, baseMaxDamage: 2, damagePerLevel: 0, baseArmor: 0, baseXpReward: 6, xpRewardPerLevel: 2, baseGoldMin: 8, baseGoldMax: 18, goldPerLevel: 5 },
+      elite: { baseHp: 14, hpPerLevel: 4, baseMinDamage: 2, baseMaxDamage: 4, damagePerLevel: 1, baseArmor: 1, baseXpReward: 15, xpRewardPerLevel: 5, baseGoldMin: 20, baseGoldMax: 45, goldPerLevel: 10 },
+      boss: { baseHp: 28, hpPerLevel: 6, baseMinDamage: 2, baseMaxDamage: 5, damagePerLevel: 1, baseArmor: 1, baseXpReward: 40, xpRewardPerLevel: 10, baseGoldMin: 80, baseGoldMax: 160, goldPerLevel: 25 },
     },
     mobActionDelay: { minActionDelayMillis: 3500, maxActionDelayMillis: 7000 },
-    stats: { bindings: { meleeDamageDivisor: 2, dodgePerPoint: 3, maxDodgePercent: 40, spellDamageDivisor: 2, hpScalingDivisor: 3, manaScalingDivisor: 3, hpRegenMsPerPoint: 300, manaRegenMsPerPoint: 300, xpBonusPerPoint: 3 } },
-    economy: { buyMultiplier: 0.6, sellMultiplier: 0.7 },
+    stats: { bindings: { meleeDamageDivisor: 2, dodgePerPoint: 3, maxDodgePercent: 40, spellDamageDivisor: 2, hpScalingDivisor: 3, manaScalingDivisor: 3, hpRegenMsPerPoint: 300, manaRegenMsPerPoint: 300, xpBonusPerPoint: 0.03 } },
+    economy: { buyMultiplier: 0.6, sellMultiplier: 0.4 },
     crafting: { maxSkillLevel: 40, baseXpPerLevel: 60, xpExponent: 1.2, gatherCooldownMs: 1500, stationBonusQuantity: 3 },
-    gambling: { enabled: true, minBet: 5, maxBet: 300, winChance: 0.55, winMultiplier: 2.0 },
-    lottery: { enabled: true, ticketCost: 5, drawingIntervalMs: 1200000, jackpotBase: 1500 },
+    gambling: { enabled: true, diceMinBet: 5, diceMaxBet: 300, diceWinChance: 0.45, diceWinMultiplier: 2.0 },
+    lottery: { enabled: true, ticketCost: 5, drawingIntervalMs: 1200000, jackpotSeedGold: 1500 },
     stylist: { feeGold: 200 },
     bank: { maxItems: 150 },
     enchanting: { maxEnchantmentsPerItem: 5 },
@@ -1014,17 +1011,17 @@ export const SOLO_STORY_PRESET: TuningPreset = {
     characterCreation: { startingGold: 500 },
     prestige: { enabled: true, xpCostBase: 3000, xpCostMultiplier: 1.2, maxRank: 10 },
     respec: { goldCost: 25, cooldownMs: 30000 },
-    autoQuests: { enabled: true, timeLimitMs: 900000, cooldownMs: 60000, rewardScaling: 2.0 },
+    autoQuests: { enabled: true, timeLimitMs: 900000, cooldownMs: 60000 },
     dailyQuests: { enabled: true, streakBonusPercent: 20 },
     globalQuests: { enabled: true, intervalMs: 3600000, durationMs: 1800000 },
     regen: { maxPlayersPerTick: 20, baseIntervalMillis: 2500, minIntervalMillis: 500, regenAmount: 3, mana: { baseIntervalMillis: 2500, minIntervalMillis: 500, regenAmount: 3 } },
     worldTime: { cycleLengthMs: 1200000, dawnHour: 5, dayHour: 7, duskHour: 18, nightHour: 20 },
     weather: { minTransitionMs: 120000, maxTransitionMs: 300000 },
-    group: { maxSize: 6, inviteTimeoutMs: 60000, xpBonusPerMember: 20 },
+    group: { maxSize: 6, inviteTimeoutMs: 60000, xpBonusPerMember: 0.20 },
     navigation: { recall: { cooldownMs: 15000 } },
     friends: { maxFriends: 100 },
     guild: { maxSize: 50, inviteTimeoutMs: 60000 },
-    guildHalls: { enabled: true, baseCost: 3000 },
+    guildHalls: { enabled: true, purchaseCost: 3000 },
     housing: { enabled: true },
     factions: { defaultReputation: 0, killPenalty: 3, killBonus: 5 },
     leaderboard: { refreshIntervalMs: 60000, topN: 20 },
@@ -1051,17 +1048,17 @@ export const PVP_ARENA_PRESET: TuningPreset = {
   config: {
     combat: { tickMillis: 1500, minDamage: 2, maxDamage: 8 },
     mobTiers: {
-      weak: { baseHp: 6, hpPerLevel: 2, baseMinDamage: 1, baseMaxDamage: 2, damagePerLevel: 1, baseArmor: 0, baseXpReward: 12, xpRewardPerLevel: 4, baseGoldMin: 1, baseGoldMax: 2, goldPerLevel: 1 },
-      standard: { baseHp: 14, hpPerLevel: 5, baseMinDamage: 2, baseMaxDamage: 5, damagePerLevel: 1, baseArmor: 1, baseXpReward: 25, xpRewardPerLevel: 8, baseGoldMin: 2, baseGoldMax: 6, goldPerLevel: 2 },
-      elite: { baseHp: 35, hpPerLevel: 9, baseMinDamage: 4, baseMaxDamage: 8, damagePerLevel: 2, baseArmor: 3, baseXpReward: 65, xpRewardPerLevel: 22, baseGoldMin: 8, baseGoldMax: 20, goldPerLevel: 4 },
-      boss: { baseHp: 70, hpPerLevel: 15, baseMinDamage: 5, baseMaxDamage: 12, damagePerLevel: 3, baseArmor: 4, baseXpReward: 180, xpRewardPerLevel: 45, baseGoldMin: 40, baseGoldMax: 80, goldPerLevel: 12 },
+      weak: { baseHp: 6, hpPerLevel: 2, baseMinDamage: 1, baseMaxDamage: 2, damagePerLevel: 1, baseArmor: 0, baseXpReward: 3, xpRewardPerLevel: 1, baseGoldMin: 1, baseGoldMax: 2, goldPerLevel: 1 },
+      standard: { baseHp: 14, hpPerLevel: 5, baseMinDamage: 2, baseMaxDamage: 5, damagePerLevel: 1, baseArmor: 1, baseXpReward: 6, xpRewardPerLevel: 2, baseGoldMin: 2, baseGoldMax: 6, goldPerLevel: 2 },
+      elite: { baseHp: 35, hpPerLevel: 9, baseMinDamage: 4, baseMaxDamage: 8, damagePerLevel: 2, baseArmor: 3, baseXpReward: 16, xpRewardPerLevel: 5, baseGoldMin: 8, baseGoldMax: 20, goldPerLevel: 4 },
+      boss: { baseHp: 70, hpPerLevel: 15, baseMinDamage: 5, baseMaxDamage: 12, damagePerLevel: 3, baseArmor: 4, baseXpReward: 45, xpRewardPerLevel: 11, baseGoldMin: 40, baseGoldMax: 80, goldPerLevel: 12 },
     },
     mobActionDelay: { minActionDelayMillis: 1500, maxActionDelayMillis: 3500 },
-    stats: { bindings: { meleeDamageDivisor: 3, dodgePerPoint: 2, maxDodgePercent: 25, spellDamageDivisor: 3, hpScalingDivisor: 4, manaScalingDivisor: 4, hpRegenMsPerPoint: 180, manaRegenMsPerPoint: 180, xpBonusPerPoint: 1 } },
+    stats: { bindings: { meleeDamageDivisor: 3, dodgePerPoint: 2, maxDodgePercent: 25, spellDamageDivisor: 3, hpScalingDivisor: 4, manaScalingDivisor: 4, hpRegenMsPerPoint: 180, manaRegenMsPerPoint: 180, xpBonusPerPoint: 0.01 } },
     economy: { buyMultiplier: 1.2, sellMultiplier: 0.4 },
     crafting: { maxSkillLevel: 80, baseXpPerLevel: 120, xpExponent: 1.6, gatherCooldownMs: 4000, stationBonusQuantity: 1 },
-    gambling: { enabled: true, minBet: 20, maxBet: 1500, winChance: 0.4, winMultiplier: 2.5 },
-    lottery: { enabled: false, ticketCost: 50, drawingIntervalMs: 7200000, jackpotBase: 300 },
+    gambling: { enabled: true, diceMinBet: 20, diceMaxBet: 1500, diceWinChance: 0.35, diceWinMultiplier: 2.5 },
+    lottery: { enabled: false, ticketCost: 50, drawingIntervalMs: 7200000, jackpotSeedGold: 300 },
     stylist: { feeGold: 1500 },
     bank: { maxItems: 40 },
     enchanting: { maxEnchantmentsPerItem: 2 },
@@ -1093,17 +1090,17 @@ export const PVP_ARENA_PRESET: TuningPreset = {
     characterCreation: { startingGold: 75 },
     prestige: { enabled: true, xpCostBase: 15000, xpCostMultiplier: 1.8, maxRank: 5 },
     respec: { goldCost: 250, cooldownMs: 600000 },
-    autoQuests: { enabled: true, timeLimitMs: 240000, cooldownMs: 300000, rewardScaling: 0.9 },
+    autoQuests: { enabled: true, timeLimitMs: 240000, cooldownMs: 300000 },
     dailyQuests: { enabled: true, streakBonusPercent: 8 },
     globalQuests: { enabled: true, intervalMs: 5400000, durationMs: 2700000 },
-    regen: { maxPlayersPerTick: 10, baseIntervalMillis: 5000, minIntervalMillis: 1200, regenAmount: 1, mana: { baseIntervalMillis: 5000, minIntervalMillis: 1200, regenAmount: 1 } },
+    regen: { maxPlayersPerTick: 10, baseIntervalMillis: 5000, minIntervalMillis: 1200, regenAmount: 2, mana: { baseIntervalMillis: 5000, minIntervalMillis: 1200, regenAmount: 2 } },
     worldTime: { cycleLengthMs: 1800000, dawnHour: 5, dayHour: 7, duskHour: 18, nightHour: 20 },
     weather: { minTransitionMs: 180000, maxTransitionMs: 600000 },
-    group: { maxSize: 4, inviteTimeoutMs: 30000, xpBonusPerMember: 15 },
+    group: { maxSize: 4, inviteTimeoutMs: 30000, xpBonusPerMember: 0.15 },
     navigation: { recall: { cooldownMs: 120000 } },
     friends: { maxFriends: 50 },
     guild: { maxSize: 25, inviteTimeoutMs: 30000 },
-    guildHalls: { enabled: true, baseCost: 15000 },
+    guildHalls: { enabled: true, purchaseCost: 15000 },
     housing: { enabled: true },
     factions: { defaultReputation: 0, killPenalty: 15, killBonus: 10 },
     leaderboard: { refreshIntervalMs: 60000, topN: 10 },
@@ -1130,17 +1127,17 @@ export const LORE_EXPLORER_PRESET: TuningPreset = {
   config: {
     combat: { tickMillis: 4000, minDamage: 2, maxDamage: 6 },
     mobTiers: {
-      weak: { baseHp: 1, hpPerLevel: 1, baseMinDamage: 1, baseMaxDamage: 1, damagePerLevel: 0, baseArmor: 0, baseXpReward: 50, xpRewardPerLevel: 20, baseGoldMin: 10, baseGoldMax: 25, goldPerLevel: 5 },
-      standard: { baseHp: 4, hpPerLevel: 1, baseMinDamage: 1, baseMaxDamage: 2, damagePerLevel: 0, baseArmor: 0, baseXpReward: 100, xpRewardPerLevel: 40, baseGoldMin: 20, baseGoldMax: 50, goldPerLevel: 10 },
-      elite: { baseHp: 10, hpPerLevel: 3, baseMinDamage: 1, baseMaxDamage: 3, damagePerLevel: 0, baseArmor: 0, baseXpReward: 250, xpRewardPerLevel: 80, baseGoldMin: 50, baseGoldMax: 100, goldPerLevel: 20 },
-      boss: { baseHp: 20, hpPerLevel: 5, baseMinDamage: 2, baseMaxDamage: 4, damagePerLevel: 1, baseArmor: 1, baseXpReward: 500, xpRewardPerLevel: 150, baseGoldMin: 150, baseGoldMax: 300, goldPerLevel: 50 },
+      weak: { baseHp: 1, hpPerLevel: 1, baseMinDamage: 1, baseMaxDamage: 1, damagePerLevel: 0, baseArmor: 0, baseXpReward: 2, xpRewardPerLevel: 1, baseGoldMin: 10, baseGoldMax: 25, goldPerLevel: 5 },
+      standard: { baseHp: 4, hpPerLevel: 1, baseMinDamage: 1, baseMaxDamage: 2, damagePerLevel: 0, baseArmor: 0, baseXpReward: 4, xpRewardPerLevel: 2, baseGoldMin: 20, baseGoldMax: 50, goldPerLevel: 10 },
+      elite: { baseHp: 10, hpPerLevel: 3, baseMinDamage: 1, baseMaxDamage: 3, damagePerLevel: 0, baseArmor: 0, baseXpReward: 10, xpRewardPerLevel: 3, baseGoldMin: 50, baseGoldMax: 100, goldPerLevel: 20 },
+      boss: { baseHp: 20, hpPerLevel: 5, baseMinDamage: 2, baseMaxDamage: 4, damagePerLevel: 1, baseArmor: 1, baseXpReward: 20, xpRewardPerLevel: 6, baseGoldMin: 150, baseGoldMax: 300, goldPerLevel: 50 },
     },
     mobActionDelay: { minActionDelayMillis: 4000, maxActionDelayMillis: 8000 },
-    stats: { bindings: { meleeDamageDivisor: 1, dodgePerPoint: 5, maxDodgePercent: 50, spellDamageDivisor: 1, hpScalingDivisor: 2, manaScalingDivisor: 2, hpRegenMsPerPoint: 400, manaRegenMsPerPoint: 400, xpBonusPerPoint: 5 } },
-    economy: { buyMultiplier: 0.3, sellMultiplier: 0.9 },
+    stats: { bindings: { meleeDamageDivisor: 1, dodgePerPoint: 5, maxDodgePercent: 55, spellDamageDivisor: 1, hpScalingDivisor: 2, manaScalingDivisor: 2, hpRegenMsPerPoint: 400, manaRegenMsPerPoint: 400, xpBonusPerPoint: 0.05 } },
+    economy: { buyMultiplier: 0.3, sellMultiplier: 0.2 },
     crafting: { maxSkillLevel: 30, baseXpPerLevel: 30, xpExponent: 1.1, gatherCooldownMs: 1000, stationBonusQuantity: 5 },
-    gambling: { enabled: true, minBet: 1, maxBet: 100, winChance: 0.6, winMultiplier: 3.0 },
-    lottery: { enabled: true, ticketCost: 1, drawingIntervalMs: 600000, jackpotBase: 5000 },
+    gambling: { enabled: true, diceMinBet: 1, diceMaxBet: 100, diceWinChance: 0.45, diceWinMultiplier: 2.0 },
+    lottery: { enabled: true, ticketCost: 1, drawingIntervalMs: 600000, jackpotSeedGold: 5000 },
     stylist: { feeGold: 50 },
     bank: { maxItems: 200 },
     enchanting: { maxEnchantmentsPerItem: 6 },
@@ -1171,17 +1168,17 @@ export const LORE_EXPLORER_PRESET: TuningPreset = {
     characterCreation: { startingGold: 2000 },
     prestige: { enabled: true, xpCostBase: 1000, xpCostMultiplier: 1.1, maxRank: 20 },
     respec: { goldCost: 0, cooldownMs: 0 },
-    autoQuests: { enabled: true, timeLimitMs: 1800000, cooldownMs: 30000, rewardScaling: 3.0 },
+    autoQuests: { enabled: true, timeLimitMs: 1800000, cooldownMs: 30000 },
     dailyQuests: { enabled: true, streakBonusPercent: 30 },
     globalQuests: { enabled: true, intervalMs: 1800000, durationMs: 900000 },
     regen: { maxPlayersPerTick: 25, baseIntervalMillis: 1500, minIntervalMillis: 300, regenAmount: 5, mana: { baseIntervalMillis: 1500, minIntervalMillis: 300, regenAmount: 5 } },
     worldTime: { cycleLengthMs: 900000, dawnHour: 5, dayHour: 7, duskHour: 18, nightHour: 20 },
     weather: { minTransitionMs: 60000, maxTransitionMs: 180000 },
-    group: { maxSize: 8, inviteTimeoutMs: 120000, xpBonusPerMember: 25 },
+    group: { maxSize: 8, inviteTimeoutMs: 120000, xpBonusPerMember: 0.25 },
     navigation: { recall: { cooldownMs: 5000 } },
     friends: { maxFriends: 200 },
     guild: { maxSize: 100, inviteTimeoutMs: 120000 },
-    guildHalls: { enabled: true, baseCost: 1000 },
+    guildHalls: { enabled: true, purchaseCost: 1000 },
     housing: { enabled: true },
     factions: { defaultReputation: 50, killPenalty: 1, killBonus: 10 },
     leaderboard: { refreshIntervalMs: 30000, topN: 50 },

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -962,7 +962,6 @@ export interface AutoQuestsConfig {
   rewardXpPerLevel?: number;
   killCountMin?: number;
   killCountMax?: number;
-  rewardScaling?: number;
 }
 
 export interface DailyQuestDefinition {


### PR DESCRIPTION
## Summary

Four parallel audit agents compared every tunable knob across the six presets against the real AmbonMUD server source in `reference/AmbonMUD/`. The reports are checked in under `.claude/investigations/tuning-audit-*.md`. They caught six more bugs of the same class as the recent `combat.maxDamage` incident — fields where Arcanum was writing YAML the server silently ignored, or numbers in the wrong unit system.

This PR implements the verified fixes:

- **Renamed 5 dead config paths** so the server actually reads them: `gambling.{minBet,maxBet,winChance,winMultiplier}` → `dice*`, `lottery.jackpotBase` → `jackpotSeedGold`, `guildHalls.baseCost` → `purchaseCost`. Removed `autoQuests.rewardScaling` entirely (no matching server field exists).
- **Rescaled two fractional-multiplier fields** that every preset had set 100× too high: `stats.bindings.xpBonusPerPoint` (server treats as 0.005 = 0.5%/pt; presets had 1–5) and `group.xpBonusPerMember` (server treats as 0.10 = 10%/member; presets had 5–25). Without this fix, a stat-20 CHA player in Balanced had an 11× XP multiplier, and a 5-player LoreExplorer group got 101× per-player XP.
- **Closed preset design bugs**: shop arbitrage in SoloStory (sell 0.7 > buy 0.6) and LoreExplorer (sell 0.9 > buy 0.3); LoreExplorer gambling EV > 1; unreachable Hardcore prestige (xpCostMultiplier 2.0 → ~1.35); time-to-L50 pulled into a defensible window for Casual / SoloStory / PvPArena / LoreExplorer (were 18min–3.7hr, now 4–15hr).
- **Rewrote misleading field descriptions** for `combat.minDamage`/`maxDamage` (per-swing adds, not caps), `mobActionDelay` (behavior tree think time, not attack speed), `factions.killPenalty`/`killBonus` (level-scaled), `xpBonusPerPoint` + `xpBonusPerMember` (explicit formulas, explicit fractional units).
- **Added `presetInvariants.test.ts`** with ~30 property assertions across all six presets: shop arbitrage impossible, gambling EV < 1, fractional multipliers bounded, `combat.maxDamage ≤ 15` (regression guard), mob tier ordering, time-to-L50 in [4h, 120h], dodge-cap reachable, etc. This is the grid that would have caught both the original `maxDamage` bug and the six found here.
- **Taught `pacing.ts`** about `xpBonusPerPoint` so the health-check banner surfaces this class of bug going forward.

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun run test` — 1824/1824 passing
- [x] Renamed keys verified against `reference/AmbonMUD/src/main/kotlin/dev/ambon/config/AppConfig.kt`
- [ ] Manual: open a preset in the Tuning Wizard, apply, save, confirm the output YAML round-trips correctly for the renamed keys