### PR TITLE
Add quest dialogue-flag gating and turn-in NPC override

### DIFF
--- a/creator/src/components/editors/DialogueEditor.tsx
+++ b/creator/src/components/editors/DialogueEditor.tsx
@@ -421,7 +421,10 @@ const ChoiceRow = memo(function ChoiceRow({ choice, nextOptions, onUpdate, onDel
               placeholder="Any"
             />
           </FieldRow>
-          <FieldRow label="Action">
+          <FieldRow
+            label="Action"
+            hint="Trigger when chosen. Common: `unlock_flag:<name>` (sets a global flag — quests can gate on it via Requires dialogue flag), `accept_quest:<id>` (offers a quest)."
+          >
             <TextInput
               value={choice.action ?? ""}
               onCommit={(v) => onUpdate({ action: v || undefined })}

--- a/creator/src/components/editors/QuestEditor.tsx
+++ b/creator/src/components/editors/QuestEditor.tsx
@@ -156,9 +156,22 @@ export function QuestEditor({
               dense
             />
           </CompactField>
+          <CompactField
+            label="Turn-in NPC"
+            hint="Override the NPC that accepts the turn-in. Leave blank to default to the giver."
+          >
+            <SelectInput
+              value={quest.turnInMob ?? ""}
+              options={zoneMobs}
+              onCommit={(v) => patch({ turnInMob: v || undefined })}
+              placeholder="— same as giver —"
+              allowEmpty
+              dense
+            />
+          </CompactField>
           <CompactField label="Completion">
             <SelectInput
-              value={quest.completionType ?? "AUTO"}
+              value={quest.completionType ?? "NPC_TURN_IN"}
               options={completionOptions}
               onCommit={(v) => patch({ completionType: v })}
               dense
@@ -188,6 +201,17 @@ export function QuestEditor({
               value={quest.difficulty ?? ""}
               options={DIFFICULTY_OPTIONS}
               onCommit={(v) => patch({ difficulty: (v || undefined) as QuestDifficulty | undefined })}
+              dense
+            />
+          </CompactField>
+          <CompactField
+            label="Requires dialogue flag"
+            hint="Hidden until a dialogue choice action `unlock_flag:<name>` (on any NPC) sets this flag. Leave blank for no gate."
+          >
+            <TextInput
+              value={quest.requiresDialogueFlag ?? ""}
+              onCommit={(v) => patch({ requiresDialogueFlag: v.trim() || undefined })}
+              placeholder="— no gate —"
               dense
             />
           </CompactField>

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -715,6 +715,14 @@ export function validateZone(
     } else if (!mobIds.has(quest.giver)) {
       addIssue(issues, "warning", entity, `Giver mob "${quest.giver}" is not a known mob in this zone`);
     }
+    if (quest.turnInMob && !mobIds.has(quest.turnInMob)) {
+      addIssue(
+        issues,
+        "warning",
+        entity,
+        `Turn-in mob "${quest.turnInMob}" is not a known mob in this zone — the engine still qualifies it with the zone id, so this is only valid if the mob lives elsewhere`,
+      );
+    }
     if (!quest.objectives || quest.objectives.length === 0) {
       addIssue(issues, "error", entity, "Quest must have at least one objective");
     } else {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -337,6 +337,20 @@ export interface QuestFile {
    * tier's multiplier. An explicit positive `rewards.xp` always wins.
    */
   difficulty?: import("./config").QuestDifficulty;
+  /**
+   * Optional dialogue-flag gate. When set, the quest stays hidden from
+   * `qoffers`, the canvas Quest indicator, and `accept` until the player has
+   * the named flag in their dialogueFlags set. Flags are added by dialogue
+   * choice actions of the form `unlock_flag:<name>` and are global strings,
+   * so the unlocking conversation can be on any NPC in any zone.
+   */
+  requiresDialogueFlag?: string;
+  /**
+   * Optional override for the NPC that accepts turn-ins. Bare mob keyword
+   * (e.g. `headmaster_aldric`); the loader qualifies it with the zone id.
+   * Defaults to `giver` when null/empty.
+   */
+  turnInMob?: string;
 }
 
 export interface QuestObjectiveFile {


### PR DESCRIPTION
## Summary

Mirrors AmbonMUD commit [97c9abfc](https://github.com/jnoecker/AmbonMUD/commit/97c9abfc) (Dialogue-flag quest gating + flexible turn-in NPC), which landed today and added two optional fields to `QuestFile` that Arcanum's editor + validator did not yet know about.

- **`requiresDialogueFlag?: string`** — quest is hidden from `qoffers` / canvas indicator / `accept` until the player has the named flag. Flags are global and set by dialogue choice actions of the form `unlock_flag:<name>`, so the unlocking conversation can live on any NPC in any zone.
- **`turnInMob?: string`** — overrides the default "turn in to giver" rule. Bare mob keyword; the server qualifies it with the zone id at load time. Defaults to `giver` when empty.

Both fields round-trip through the generic YAML loader/saver, so the only changes needed are: type definition, editor UI, and validator.

## Changes

- `types/world.ts` — add `requiresDialogueFlag` and `turnInMob` to `QuestFile`.
- `components/editors/QuestEditor.tsx` — surface both in the Basics grid. Empty Turn-in NPC select means "same as giver". Default `completionType` placeholder bumped to `NPC_TURN_IN` to match the server-side default that flipped in 3d5b009a.
- `lib/validateZone.ts` — warn when `turnInMob` references a mob outside this zone (the engine still qualifies it with the zone id, so cross-zone refs would fail at runtime).
- `components/editors/DialogueEditor.tsx` — hint on the choice Action field documenting `unlock_flag:<name>` and `accept_quest:<id>` conventions, so authors discover the way to satisfy a `requiresDialogueFlag` gate.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 1855 tests pass
- [ ] Manual: open a zone with a quest, set Turn-in NPC to a different mob, save, reload — field round-trips.
- [ ] Manual: set Requires dialogue flag to `scholar_research`, save, reload — value round-trips.
- [ ] Manual: set Turn-in NPC to a non-existent mob keyword — validator warns.
- [ ] Manual: open a dialogue choice action field — hint reads correctly.