### PR TITLE
Split mob templates from spawn placements

### DIFF
--- a/creator/src-tauri/Cargo.lock
+++ b/creator/src-tauri/Cargo.lock
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "arcanum"
-version = "3.13.87"
+version = "3.14.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import type { WorldFile, MobFile, MobDropFile, MobSpellFile, MobRole } from "@/types/world";
+import type { WorldFile, MobFile, MobDropFile, MobSpellFile, MobRole, SpawnEntry } from "@/types/world";
 import { MOB_ROLES, MOB_ROLE_LABELS, MOB_ROLE_DESCRIPTIONS } from "@/types/world";
 import { updateMob, deleteMob } from "@/lib/zoneEdits";
 import { useEntityEditor } from "@/lib/useEntityEditor";
@@ -101,6 +101,45 @@ export function MobEditor({
 
   const role: MobRole = mob.role ?? "combat";
   const isCombatant = role === "combat";
+  const requiresUniqueSpawn = role === "quest_giver";
+  const spawns = mob.spawns ?? [];
+
+  const handleAddSpawn = useCallback(() => {
+    const fallback = rooms[0]?.value ?? "";
+    const next: SpawnEntry[] = [...spawns, { room: fallback }];
+    patch({ spawns: next });
+  }, [spawns, rooms, patch]);
+
+  const handleUpdateSpawnRoom = useCallback(
+    (index: number, room: string) => {
+      const next = spawns.map((s, i) => (i === index ? { ...s, room } : s));
+      patch({ spawns: next });
+    },
+    [spawns, patch],
+  );
+
+  const handleUpdateSpawnCount = useCallback(
+    (index: number, count: number | undefined) => {
+      const next = spawns.map((s, i) => {
+        if (i !== index) return s;
+        if (count == null || count <= 1) {
+          const { count: _drop, ...rest } = s;
+          return rest;
+        }
+        return { ...s, count };
+      });
+      patch({ spawns: next });
+    },
+    [spawns, patch],
+  );
+
+  const handleRemoveSpawn = useCallback(
+    (index: number) => {
+      const next = spawns.filter((_, i) => i !== index);
+      patch({ spawns: next.length > 0 ? next : undefined });
+    },
+    [spawns, patch],
+  );
   const visibleTabs = isCombatant
     ? MOB_TABS
     : MOB_TABS.filter((t) => t.value !== "rewards");
@@ -224,17 +263,66 @@ export function MobEditor({
             vibe={zoneId ? useVibeStore.getState().getVibe(zoneId) : undefined}
           />
         </div>
-        <SelectInput
-          value={mob.room}
-          options={rooms}
-          onCommit={(v) => patch({ room: v })}
-        />
+        <div className="text-xs text-text-muted">
+          {spawns.length === 0
+            ? "No spawn locations — set one below"
+            : `${spawns.length} spawn${spawns.length === 1 ? "" : "s"} · ${spawns.reduce((n, s) => n + (s.count ?? 1), 0)} instance${spawns.reduce((n, s) => n + (s.count ?? 1), 0) === 1 ? "" : "s"}`}
+        </div>
       </EntityHeader>
 
       <TabBar tabs={visibleTabs} active={activeTab} onChange={setActiveTab} />
 
       {effectiveTab === "mob" && (
         <>
+          <Section
+            title="Spawns"
+            actions={
+              !(requiresUniqueSpawn && spawns.length >= 1) && (
+                <IconButton onClick={handleAddSpawn} title="Add spawn">+</IconButton>
+              )
+            }
+          >
+            {spawns.length === 0 ? (
+              <p className="text-xs text-text-muted">
+                No spawn locations. Add one to place this mob in the world.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-1.5">
+                {spawns.map((spawn, i) => (
+                  <ArrayRow key={i} onRemove={() => handleRemoveSpawn(i)}>
+                    <div className="flex items-center gap-1">
+                      <div className="min-w-0 flex-1">
+                        <SelectInput
+                          value={spawn.room}
+                          options={rooms}
+                          onCommit={(v) => handleUpdateSpawnRoom(i, v)}
+                        />
+                      </div>
+                      {!requiresUniqueSpawn && (
+                        <>
+                          <span className="text-2xs text-text-muted">×</span>
+                          <div className="w-14 shrink-0">
+                            <NumberInput
+                              value={spawn.count ?? 1}
+                              onCommit={(v) => handleUpdateSpawnCount(i, v)}
+                              min={1}
+                              placeholder="1"
+                            />
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  </ArrayRow>
+                ))}
+              </div>
+            )}
+            {requiresUniqueSpawn && (
+              <p className="mt-1.5 text-2xs text-text-muted">
+                Quest givers are unique NPCs — only one spawn allowed.
+              </p>
+            )}
+          </Section>
+
           <Section title="Basics">
             <FieldGrid>
               <CompactField label="Role" hint={MOB_ROLE_DESCRIPTIONS[role]} span>

--- a/creator/src/components/playtest/PlaytestPanel.tsx
+++ b/creator/src/components/playtest/PlaytestPanel.tsx
@@ -131,7 +131,7 @@ function resolveExitTarget(
 function collectRoomMobs(world: WorldFile, roomId: string): Array<[string, MobFile]> {
   const out: Array<[string, MobFile]> = [];
   for (const [id, mob] of Object.entries(world.mobs ?? {})) {
-    if (mob.room === roomId) out.push([id, mob]);
+    if (mob.spawns?.some((s) => s.room === roomId)) out.push([id, mob]);
   }
   return out;
 }

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -276,7 +276,7 @@ export function RoomPanel({
 
   // Find entities in this room
   const mobs = useMemo(
-    () => Object.entries(world.mobs ?? {}).filter(([, m]) => m.room === roomId),
+    () => Object.entries(world.mobs ?? {}).filter(([, m]) => m.spawns?.some((s) => s.room === roomId) ?? false),
     [world.mobs, roomId],
   );
   const items = useMemo(
@@ -304,7 +304,7 @@ export function RoomPanel({
         const giverMob = Object.entries(world.mobs ?? {}).find(
           ([mobId]) => mobId === q.giver || `${zoneId}:${mobId}` === q.giver,
         );
-        return giverMob && giverMob[1].room === roomId;
+        return !!giverMob && (giverMob[1].spawns?.some((s) => s.room === roomId) ?? false);
       }),
     [world.quests, world.mobs, zoneId, roomId],
   );

--- a/creator/src/lib/__tests__/duplicateZone.test.ts
+++ b/creator/src/lib/__tests__/duplicateZone.test.ts
@@ -14,7 +14,7 @@ function sampleWorld(): WorldFile {
       },
       next: { title: "Next", description: ".", exits: { s: "start" } },
     },
-    mobs: { goblin: { name: "Goblin", description: "g", room: "start", hp: 50 } },
+    mobs: { goblin: { name: "Goblin", description: "g", spawns: [{ room: "start" }], hp: 50 } },
     items: { sword: { displayName: "Sword", description: "s", room: "next", damage: 10 } },
     shops: {},
     quests: {},

--- a/creator/src/lib/__tests__/generateZoneContent.test.ts
+++ b/creator/src/lib/__tests__/generateZoneContent.test.ts
@@ -235,7 +235,7 @@ describe("renameRoomsByTitle", () => {
         room_0: { title: "Crystal Lagoon", description: ".", exits: { e: "room_1" } },
         room_1: { title: "Obsidian Path", description: ".", exits: { w: "room_0" } },
       },
-      mobs: { slime: { name: "Slime", description: ".", tier: "weak", room: "room_1" } },
+      mobs: { slime: { name: "Slime", description: ".", tier: "weak", spawns: [{ room: "room_1" }] } },
       items: { blade: { displayName: "Blade", description: ".", room: "room_0" } },
       shops: {},
       quests: {},
@@ -249,7 +249,7 @@ describe("renameRoomsByTitle", () => {
     expect(out.startRoom).toBe("crystal_lagoon");
     expect(out.rooms["crystal_lagoon"]?.exits?.e).toBe("obsidian_path");
     expect(out.rooms["obsidian_path"]?.exits?.w).toBe("crystal_lagoon");
-    expect(out.mobs?.slime?.room).toBe("obsidian_path");
+    expect(out.mobs?.slime?.spawns?.[0]?.room).toBe("obsidian_path");
     expect(out.items?.blade?.room).toBe("crystal_lagoon");
   });
 

--- a/creator/src/lib/__tests__/refactorId.test.ts
+++ b/creator/src/lib/__tests__/refactorId.test.ts
@@ -19,7 +19,7 @@ function makeWorld(overrides?: Partial<WorldFile>): WorldFile {
       },
     },
     mobs: {
-      rat: { name: "Rat", room: "room1" },
+      rat: { name: "Rat", spawns: [{ room: "room1" }] },
     },
     items: {
       sword: { displayName: "Sword", room: "room1" },
@@ -43,7 +43,7 @@ describe("renameRoom", () => {
     expect(result.rooms["room1"]).toBeUndefined();
     expect(result.startRoom).toBe("tavern");
     expect(result.rooms["room2"]!.exits!["s"]).toBe("tavern");
-    expect(result.mobs!["rat"]!.room).toBe("tavern");
+    expect(result.mobs!["rat"]!.spawns).toEqual([{ room: "tavern" }]);
     expect(result.items!["sword"]!.room).toBe("tavern");
   });
 
@@ -52,7 +52,7 @@ describe("renameRoom", () => {
       mobs: {
         guard: {
           name: "Guard",
-          room: "room1",
+          spawns: [{ room: "room1" }],
           behavior: {
             template: "patrol",
             params: { patrolRoute: ["room1", "room2", "room1"] },
@@ -98,7 +98,7 @@ describe("renameItem", () => {
       mobs: {
         rat: {
           name: "Rat",
-          room: "room1",
+          spawns: [{ room: "room1" }],
           drops: [{ itemId: "sword", chance: 50 }],
         },
       },
@@ -130,7 +130,7 @@ describe("renameQuest", () => {
   it("renames a quest key and updates mob.quests", () => {
     const world = makeWorld({
       mobs: {
-        rat: { name: "Rat", room: "room1", quests: ["fetch"] },
+        rat: { name: "Rat", spawns: [{ room: "room1" }], quests: ["fetch"] },
       },
     });
     const result = renameQuest(world, "fetch", "retrieve");

--- a/creator/src/lib/__tests__/resolveMobStats.test.ts
+++ b/creator/src/lib/__tests__/resolveMobStats.test.ts
@@ -59,7 +59,7 @@ const MOB_TIERS: MobTiersConfig = {
 };
 
 function mob(overrides: Partial<MobFile> = {}): MobFile {
-  return { name: "Test", room: "r1", tier: "standard", level: 1, ...overrides };
+  return { name: "Test", spawns: [{ room: "r1" }], tier: "standard", level: 1, ...overrides };
 }
 
 describe("resolveMobStats", () => {

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -116,16 +116,17 @@ describe("sanitizeZone — ID remapping", () => {
     expect(exits3002.s).toBe("room_3001");
   });
 
-  it("renames numeric mob IDs and updates room ref", () => {
+  it("renames numeric mob IDs and updates spawn room ref", () => {
     const world = makeWorld({
       mobs: {
-        "100": { name: "Goblin", room: "room_a" },
+        "100": { name: "Goblin", spawns: [{ room: "room_a" }] },
       },
     });
 
     const result = sanitizeZone(world);
     expect(result.mobs!["mob_100"]).toBeDefined();
-    expect(result.mobs!["mob_100"]!.room).toBe("room_a");
+    expect(result.mobs!["mob_100"]!.spawns).toEqual([{ room: "room_a" }]);
+    expect(result.mobs!["mob_100"]!.room).toBeUndefined();
     expect(result.mobs!["100"]).toBeUndefined();
   });
 
@@ -139,7 +140,7 @@ describe("sanitizeZone — ID remapping", () => {
         armory: { name: "Armory", room: "room_a", items: ["200", "201"] },
       },
       mobs: {
-        goblin: { name: "Goblin", room: "room_a", drops: [{ itemId: "200", chance: 50 }] },
+        goblin: { name: "Goblin", spawns: [{ room: "room_a" }], drops: [{ itemId: "200", chance: 50 }] },
       },
     });
 
@@ -163,7 +164,7 @@ describe("sanitizeZone — ID remapping", () => {
 
   it("renames numeric quest IDs and cascades to mob.quests", () => {
     const world = makeWorld({
-      mobs: { guard: { name: "Guard", room: "room_a", quests: ["10"] } },
+      mobs: { guard: { name: "Guard", spawns: [{ room: "room_a" }], quests: ["10"] } },
       quests: { "10": { name: "Fetch Sword", giver: "guard", objectives: [] } },
     });
 
@@ -192,8 +193,8 @@ describe("sanitizeZone — invalid entity stripping", () => {
   it("removes mobs with non-existent room refs", () => {
     const world = makeWorld({
       mobs: {
-        good_mob: { name: "Good", room: "room_a" },
-        bad_mob: { name: "Bad", room: "nonexistent" },
+        good_mob: { name: "Good", spawns: [{ room: "room_a" }] },
+        bad_mob: { name: "Bad", spawns: [{ room: "nonexistent" }] },
       },
     });
 
@@ -244,7 +245,7 @@ describe("sanitizeZone — invalid entity stripping", () => {
 
   it("defaults blank mob name to ID", () => {
     const world = makeWorld({
-      mobs: { goblin: { name: "", room: "room_a" } },
+      mobs: { goblin: { name: "", spawns: [{ room: "room_a" }] } },
     });
 
     const result = sanitizeZone(world);
@@ -314,7 +315,7 @@ describe("sanitizeZone — dangling reference cleanup", () => {
       mobs: {
         goblin: {
           name: "Goblin",
-          room: "room_a",
+          spawns: [{ room: "room_a" }],
           drops: [
             { itemId: "gold", chance: 0.5 },
             { itemId: "nonexistent", chance: 0.3 },
@@ -331,7 +332,7 @@ describe("sanitizeZone — dangling reference cleanup", () => {
     const world = makeWorld({
       quests: { fetch: { name: "Fetch", giver: "guard", objectives: [] } },
       mobs: {
-        guard: { name: "Guard", room: "room_a", quests: ["fetch", "nonexistent"] },
+        guard: { name: "Guard", spawns: [{ room: "room_a" }], quests: ["fetch", "nonexistent"] },
       },
     });
 
@@ -539,8 +540,8 @@ describe("sanitizeZone — end-to-end", () => {
         },
       },
       mobs: {
-        "100": { name: "City Guard", room: "3001", quests: ["500"] },
-        "101": { name: "Lost Traveler", room: "9999" },
+        "100": { name: "City Guard", spawns: [{ room: "3001" }], quests: ["500"] },
+        "101": { name: "Lost Traveler", spawns: [{ room: "9999" }] },
       },
       items: {
         "200": { displayName: "Iron Sword", stats: { strength: 3, dexterity: 0 } },
@@ -573,7 +574,7 @@ describe("sanitizeZone — end-to-end", () => {
 
     // Mob with valid room kept, mob with invalid room stripped
     expect(result.mobs!["mob_100"]).toBeDefined();
-    expect(result.mobs!["mob_100"]!.room).toBe("room_3001");
+    expect(result.mobs!["mob_100"]!.spawns).toEqual([{ room: "room_3001" }]);
     expect(result.mobs!["mob_101"]).toBeUndefined();
 
     // Quest ID remapped, mob.quests updated

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -26,7 +26,7 @@ function makeValidWorld(): WorldFile {
       },
     },
     mobs: {
-      rat: { name: "Rat", room: "room1" },
+      rat: { name: "Rat", spawns: [{ room: "room1" }] },
     },
     items: {
       sword: { displayName: "Sword", room: "room1" },
@@ -104,9 +104,9 @@ describe("validateZone", () => {
   });
 
   // ─── Mob checks ──────────────────────────────────────────────
-  it("errors if mob room does not exist", () => {
+  it("errors if mob spawn room does not exist", () => {
     const world = makeValidWorld();
-    world.mobs!.rat.room = "missing";
+    world.mobs!.rat.spawns = [{ room: "missing" }];
     const issues = errors(validateZone(world));
     expect(issues.some((i) => i.entity === "mob:rat")).toBe(true);
   });
@@ -232,7 +232,7 @@ describe("validateZone", () => {
 
   it("warns when a quest XP override breaks its difficulty tier", () => {
     const world = makeValidWorld();
-    world.mobs!.giver = { name: "Giver", room: "room1" };
+    world.mobs!.giver = { name: "Giver", spawns: [{ room: "room1" }] };
     world.quests = {
       test_quest: {
         name: "Test",
@@ -294,7 +294,7 @@ describe("validateZone", () => {
 
   it("does not warn when a quest uses the computed difficulty XP", () => {
     const world = makeValidWorld();
-    world.mobs!.giver = { name: "Giver", room: "room1" };
+    world.mobs!.giver = { name: "Giver", spawns: [{ room: "room1" }] };
     world.quests = {
       test_quest: {
         name: "Test",
@@ -592,7 +592,7 @@ describe("validateZone", () => {
   describe("mob damage invariant", () => {
     it("errors when maxDamage override < tier-resolved minDamage", () => {
       const world = makeValidWorld();
-      world.mobs!.rat = { name: "Rat", room: "room1", tier: "weak", level: 3, maxDamage: 1 };
+      world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], tier: "weak", level: 3, maxDamage: 1 };
       const issues = errors(validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS));
       // weak tier at level 3: minDamage = 1 + 1*(3 - 1) = 3, so maxDamage=1 < 3
       expect(issues.some((i) => i.entity === "mob:rat" && i.message.includes("maxDamage") && i.message.includes("minDamage"))).toBe(true);
@@ -600,21 +600,21 @@ describe("validateZone", () => {
 
     it("errors when both overrides set and max < min", () => {
       const world = makeValidWorld();
-      world.mobs!.rat = { name: "Rat", room: "room1", minDamage: 5, maxDamage: 3 };
+      world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], minDamage: 5, maxDamage: 3 };
       const issues = errors(validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS));
       expect(issues.some((i) => i.entity === "mob:rat")).toBe(true);
     });
 
     it("accepts matching explicit overrides", () => {
       const world = makeValidWorld();
-      world.mobs!.rat = { name: "Rat", room: "room1", tier: "weak", level: 3, minDamage: 1, maxDamage: 1 };
+      world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], tier: "weak", level: 3, minDamage: 1, maxDamage: 1 };
       const issues = errors(validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS));
       expect(issues.filter((i) => i.entity === "mob:rat")).toHaveLength(0);
     });
 
     it("skips the check when no tier config is provided and only one side is overridden", () => {
       const world = makeValidWorld();
-      world.mobs!.rat = { name: "Rat", room: "room1", tier: "weak", level: 3, maxDamage: 1 };
+      world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], tier: "weak", level: 3, maxDamage: 1 };
       const issues = errors(validateZone(world));
       expect(issues.filter((i) => i.entity === "mob:rat" && i.message.includes("maxDamage"))).toHaveLength(0);
     });
@@ -624,7 +624,7 @@ describe("validateZone", () => {
     it("warns when a mob level drifts outside the zone target band", () => {
       const world = makeValidWorld();
       world.levelBand = { min: 3, max: 7 };
-      world.mobs!.rat = { name: "Rat", room: "room1", tier: "weak", level: 12 };
+      world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], tier: "weak", level: 12 };
 
       const issues = warnings(validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS));
 
@@ -635,7 +635,7 @@ describe("validateZone", () => {
     it("warns when authored overrides diverge from the target tier baseline", () => {
       const world = makeValidWorld();
       world.levelBand = { min: 3, max: 3 };
-      world.mobs!.rat = { name: "Rat", room: "room1", tier: "weak", level: 3, hp: 200, xpReward: 9999 };
+      world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], tier: "weak", level: 3, hp: 200, xpReward: 9999 };
 
       const issues = warnings(validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS));
 
@@ -646,7 +646,7 @@ describe("validateZone", () => {
     it("warns when a zone target cannot be validated because the mob tier is unknown", () => {
       const world = makeValidWorld();
       world.levelBand = { min: 3, max: 7 };
-      world.mobs!.rat = { name: "Rat", room: "room1", tier: "phantom", level: 5 };
+      world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], tier: "phantom", level: 5 };
 
       const issues = warnings(validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS));
 
@@ -656,7 +656,7 @@ describe("validateZone", () => {
     it("stays quiet when the mob already matches the zone target", () => {
       const world = makeValidWorld();
       world.levelBand = { min: 3, max: 7 };
-      world.mobs!.rat = { name: "Rat", room: "room1", tier: "weak", level: 3 };
+      world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], tier: "weak", level: 3 };
 
       const issues = validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS);
 

--- a/creator/src/lib/__tests__/yaml-roundtrip.test.ts
+++ b/creator/src/lib/__tests__/yaml-roundtrip.test.ts
@@ -89,10 +89,12 @@ describe("YAML zone structure", () => {
       const mobs = zone.mobs ?? {};
       const localRooms = new Set(Object.keys(zone.rooms));
       for (const [mobId, mob] of Object.entries(mobs)) {
-        const roomRef = mob.room;
-        // Cross-zone refs contain ":"
-        if (!roomRef.includes(":")) {
-          expect(localRooms.has(roomRef), `mob ${mobId} references unknown room: ${roomRef}`).toBe(true);
+        // Accept either legacy shorthand `room` or the new `spawns` list.
+        const roomRefs = mob.spawns?.map((s) => s.room) ?? (mob.room ? [mob.room] : []);
+        for (const roomRef of roomRefs) {
+          if (!roomRef.includes(":")) {
+            expect(localRooms.has(roomRef), `mob ${mobId} references unknown room: ${roomRef}`).toBe(true);
+          }
         }
       }
     });

--- a/creator/src/lib/__tests__/zoneEdits.test.ts
+++ b/creator/src/lib/__tests__/zoneEdits.test.ts
@@ -60,7 +60,7 @@ function makeWorld(): WorldFile {
       },
     },
     mobs: {
-      rat: { name: "Rat", room: "room1", level: 1 },
+      rat: { name: "Rat", spawns: [{ room: "room1" }], level: 1 },
     },
     items: {
       sword: { displayName: "Sword", room: "room1" },
@@ -245,7 +245,7 @@ describe("generateRoomId", () => {
 describe("addMob", () => {
   it("adds a mob to the world", () => {
     const world = makeWorld();
-    const next = addMob(world, "goblin", { name: "Goblin", room: "room1" });
+    const next = addMob(world, "goblin", { name: "Goblin", spawns: [{ room: "room1" }] });
     expect(next.mobs?.goblin?.name).toBe("Goblin");
     expect(world.mobs?.goblin).toBeUndefined();
   });
@@ -253,14 +253,14 @@ describe("addMob", () => {
   it("throws if mob already exists", () => {
     const world = makeWorld();
     expect(() =>
-      addMob(world, "rat", { name: "Rat2", room: "room1" }),
+      addMob(world, "rat", { name: "Rat2", spawns: [{ room: "room1" }] }),
     ).toThrow("already exists");
   });
 
   it("throws if room does not exist", () => {
     const world = makeWorld();
     expect(() =>
-      addMob(world, "goblin", { name: "Goblin", room: "no_room" }),
+      addMob(world, "goblin", { name: "Goblin", spawns: [{ room: "no_room" }] }),
     ).toThrow("does not exist");
   });
 });

--- a/creator/src/lib/__tests__/zoneRebalance.test.ts
+++ b/creator/src/lib/__tests__/zoneRebalance.test.ts
@@ -21,7 +21,7 @@ const MOCK_CONFIG = { mobTiers: TIER_CONFIG } as unknown as AppConfig;
 function mob(overrides: Partial<MobFile> = {}): MobFile {
   return {
     name: "Test Mob",
-    room: "room_1",
+    spawns: [{ room: "room_1" }],
     tier: "weak",
     ...overrides,
   };

--- a/creator/src/lib/__tests__/zoneRetheme.test.ts
+++ b/creator/src/lib/__tests__/zoneRetheme.test.ts
@@ -24,7 +24,7 @@ function world(): WorldFile {
       altar: { title: "Altar", description: "A stone altar.", exits: { s: "nave" } },
     },
     mobs: {
-      priest: { name: "Old Priest", description: "Bent with age.", room: "nave", hp: 40 },
+      priest: { name: "Old Priest", description: "Bent with age.", spawns: [{ room: "nave" }], hp: 40 },
     },
     items: {
       relic: { displayName: "Saint's Relic", description: "A bone.", room: "altar", damage: 2 },

--- a/creator/src/lib/__tests__/zoneToGraph.test.ts
+++ b/creator/src/lib/__tests__/zoneToGraph.test.ts
@@ -81,8 +81,8 @@ describe("zoneToGraph", () => {
       },
       {
         mobs: {
-          mob1: { name: "Mob", room: "room1", tier: "weak" },
-          mob2: { name: "Mob 2", room: "room1", tier: "weak" },
+          mob1: { name: "Mob", spawns: [{ room: "room1" }], tier: "weak" },
+          mob2: { name: "Mob 2", spawns: [{ room: "room1" }], tier: "weak" },
         },
         items: {
           item1: { displayName: "Item", room: "room1" },

--- a/creator/src/lib/generateZoneContent.ts
+++ b/creator/src/lib/generateZoneContent.ts
@@ -541,11 +541,12 @@ function buildMobs(
   const result: Record<string, MobFile> = {};
   for (const mob of mobs) {
     if (!mob.id) continue;
+    const room = roomIds.has(mob.room) ? mob.room : fallbackRoomId;
     result[mob.id] = {
       name: mob.name,
       description: mob.description,
       tier: mob.tier || "standard",
-      room: roomIds.has(mob.room) ? mob.room : fallbackRoomId,
+      spawns: [{ room }],
     };
   }
   return result;
@@ -653,7 +654,10 @@ function renameRoomsByTitle(world: WorldFile): WorldFile {
 
   const newMobs: Record<string, MobFile> = {};
   for (const [id, mob] of Object.entries(world.mobs ?? {})) {
-    newMobs[id] = { ...mob, room: remap.get(mob.room) ?? mob.room };
+    newMobs[id] = {
+      ...mob,
+      spawns: (mob.spawns ?? []).map((s) => ({ ...s, room: remap.get(s.room) ?? s.room })),
+    };
   }
 
   const newItems: Record<string, ItemFile> = {};

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -4,7 +4,7 @@ import { parseDocument } from "yaml";
 import type { WorldFile } from "@/types/world";
 import type { AppConfig } from "@/types/config";
 import type { Project } from "@/types/project";
-import { normalizeExitDirections } from "@/lib/zoneEdits";
+import { normalizeExitDirections, normalizeMobSpawns } from "@/lib/zoneEdits";
 import {
   DEFAULT_ACHIEVEMENT_CATEGORIES,
   DEFAULT_ACHIEVEMENT_CRITERION_TYPES,
@@ -45,6 +45,7 @@ export async function loadAllZones(
 
         if (data.zone && data.rooms) {
           normalizeExitDirections(data);
+          normalizeMobSpawns(data);
           result[data.zone] = { filePath, data };
         }
       } catch (err) {
@@ -1280,6 +1281,7 @@ async function loadStandaloneZones(
 
         if (data.zone && data.rooms) {
           normalizeExitDirections(data);
+          normalizeMobSpawns(data);
           result[data.zone] = { filePath, data };
         }
       } catch (err) {

--- a/creator/src/lib/mudImport.ts
+++ b/creator/src/lib/mudImport.ts
@@ -536,7 +536,13 @@ export function applyZoneResets(
       case "M": {
         const mob = reset.mobVnum ? worldFile.mobs?.[reset.mobVnum] : undefined;
         if (reset.mobVnum && reset.roomVnum && mob) {
-          mob.room = reset.roomVnum;
+          if (!mob.spawns) mob.spawns = [];
+          const existing = mob.spawns.find((s) => s.room === reset.roomVnum);
+          if (existing) {
+            existing.count = (existing.count ?? 1) + 1;
+          } else {
+            mob.spawns.push({ room: reset.roomVnum });
+          }
           lastMobId = reset.mobVnum;
         } else if (reset.mobVnum) {
           warnings.push(`Zone reset: mob ${reset.mobVnum} not found in converted data`);
@@ -664,7 +670,7 @@ export function assembleWorldFile(
   for (const m of mobs) {
     mobMap[m.id] = {
       name: m.name,
-      room: "", // filled by zone resets
+      spawns: [], // filled by zone resets
       ...(m.description ? { description: m.description } : {}),
       ...(m.level ? { level: m.level } : {}),
       ...(m.hp ? { hp: m.hp } : {}),
@@ -703,12 +709,13 @@ export function assembleWorldFile(
     };
   }
 
-  // Derive shop rooms from keeper mob rooms
+  // Derive shop rooms from keeper mob spawn rooms
   for (const s of shops) {
     const keeper = s.keeperMobId ? mobMap[s.keeperMobId] : undefined;
     const shop = shopMap[s.id];
-    if (keeper && shop) {
-      shop.room = keeper.room;
+    const keeperRoom = keeper?.spawns?.[0]?.room;
+    if (keeper && shop && keeperRoom) {
+      shop.room = keeperRoom;
     }
   }
 

--- a/creator/src/lib/refactorId.ts
+++ b/creator/src/lib/refactorId.ts
@@ -30,11 +30,16 @@ export function renameRoom(world: WorldFile, oldId: string, newId: string): Worl
     if (changed) rooms[roomId] = { ...room, exits };
   }
 
-  // Update mob.room
+  // Update mob spawn rooms
   const mobs = world.mobs ? { ...world.mobs } : undefined;
   if (mobs) {
     for (const [mobId, mob] of Object.entries(mobs)) {
-      if (mob.room === oldId) mobs[mobId] = { ...mob, room: newId };
+      if (mob.spawns?.some((s) => s.room === oldId)) {
+        mobs[mobId] = {
+          ...mob,
+          spawns: mob.spawns.map((s) => (s.room === oldId ? { ...s, room: newId } : s)),
+        };
+      }
       if (mob.behavior?.params?.patrolRoute) {
         const route = mob.behavior.params.patrolRoute;
         if (route.includes(oldId)) {
@@ -273,7 +278,7 @@ export function countReferences(world: WorldFile, category: EntityCategory, enti
       }
     }
     for (const mob of Object.values(world.mobs ?? {})) {
-      if (mob.room === entityId) count++;
+      count += (mob.spawns ?? []).filter((s) => s.room === entityId).length;
       if (mob.behavior?.params?.patrolRoute?.includes(entityId)) count++;
     }
     for (const item of Object.values(world.items ?? {})) {

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -254,14 +254,18 @@ function applyIdRemaps(world: WorldFile, t: RemapTables): WorldFile {
     rooms[key ?? oldId] = r2;
   }
 
-  // Mobs: remap keys, room, drops, quests, patrol routes, BT routes
+  // Mobs: remap keys, spawn rooms, drops, quests, patrol routes, BT routes
   let mobs: Record<string, MobFile> | undefined;
   if (world.mobs) {
     mobs = {};
     for (const [oldId, mob] of Object.entries(world.mobs)) {
       const key = t.mob.get(oldId);
       if (key === "") continue;
-      let m: MobFile = { ...mob, room: rId(mob.room, t.room) };
+      const remappedSpawns = (mob.spawns ?? [])
+        .map((s) => ({ ...s, room: rId(s.room, t.room) }))
+        .filter((s) => t.room.get(s.room) !== "");
+      if (remappedSpawns.length === 0) continue;
+      let m: MobFile = { ...mob, spawns: remappedSpawns, room: undefined };
       if (mob.drops) m.drops = mob.drops.map((d) => ({
         ...d,
         itemId: rId(d.itemId, t.item),
@@ -441,20 +445,21 @@ function stripInvalidEntities(world: WorldFile): WorldFile {
     };
   }
 
-  // Mobs: remove if room doesn't exist, default name. Also strip the
-  // legacy `housingBroker` flag — the MUD's MobFile has no such field and
-  // the HousingSystem never checks the player's location for `house buy`,
-  // so the flag was dead weight in the YAML. Drop it on next save so old
-  // projects get cleaned up automatically.
+  // Mobs: drop spawns whose room doesn't exist; drop the mob if no spawns
+  // remain. Default name. Also strip the legacy `housingBroker` flag — the
+  // MUD's MobFile has no such field and the HousingSystem never checks the
+  // player's location for `house buy`, so the flag was dead weight in the
+  // YAML. Drop it on next save so old projects get cleaned up automatically.
   let mobs: Record<string, MobFile> | undefined;
   if (world.mobs) {
     mobs = {};
     for (const [id, mob] of Object.entries(world.mobs)) {
-      if (!roomIds.has(mob.room)) continue;
-      const { housingBroker: _legacyBroker, ...cleanMob } = mob as MobFile & {
+      const spawns = (mob.spawns ?? []).filter((s) => roomIds.has(s.room));
+      if (spawns.length === 0) continue;
+      const { housingBroker: _legacyBroker, room: _legacyRoom, ...cleanMob } = mob as MobFile & {
         housingBroker?: unknown;
       };
-      mobs[id] = { ...cleanMob, name: mob.name?.trim() || id };
+      mobs[id] = { ...cleanMob, spawns, name: mob.name?.trim() || id };
     }
   }
 

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -19,6 +19,18 @@ import { resolveMobStats } from "./resolveMobStats";
 import { resolveQuestXp } from "./resolveQuestXp";
 import type { QuestXpConfig } from "@/types/config";
 
+/**
+ * A mob is a "unique NPC" iff it places exactly one runtime instance —
+ * a single spawn entry with count <= 1. Quest givers and turn-in NPCs
+ * must satisfy this so quest dialogue can resolve to a single mob.
+ */
+function isUniqueSpawn(mob: MobFile): boolean {
+  const spawns = mob.spawns ?? [];
+  if (spawns.length !== 1) return false;
+  const spawn = spawns[0]!;
+  return (spawn.count ?? 1) <= 1;
+}
+
 export type Severity = "error" | "warning";
 
 export interface ValidationIssue {
@@ -517,7 +529,20 @@ export function validateZone(
   for (const [mobId, mob] of Object.entries(world.mobs ?? {})) {
     const entity = `mob:${mobId}`;
     if (!mob.name?.trim()) addIssue(issues, "warning", entity, "Mob has no name");
-    if (!roomIds.has(mob.room)) addIssue(issues, "error", entity, `Room "${mob.room}" does not exist`);
+    const spawns = mob.spawns ?? [];
+    if (spawns.length === 0) {
+      addIssue(issues, "error", entity, "Mob has no spawns");
+    }
+    for (const [index, spawn] of spawns.entries()) {
+      if (!spawn.room) {
+        addIssue(issues, "error", entity, `Spawn #${index + 1} has no room`);
+      } else if (!roomIds.has(spawn.room)) {
+        addIssue(issues, "error", entity, `Spawn #${index + 1} room "${spawn.room}" does not exist`);
+      }
+      if (spawn.count != null && (!Number.isInteger(spawn.count) || spawn.count < 1)) {
+        addIssue(issues, "error", entity, `Spawn #${index + 1} count must be a positive integer`);
+      }
+    }
     factionCheck(entity, mob.faction, "Faction");
     if (mob.category && !VALID_MOB_CATEGORIES.has(mob.category)) {
       addIssue(issues, "warning", entity, `Category "${mob.category}" is not a recognized mob category`);
@@ -714,14 +739,36 @@ export function validateZone(
       addIssue(issues, "warning", entity, "Quest has no giver");
     } else if (!mobIds.has(quest.giver)) {
       addIssue(issues, "warning", entity, `Giver mob "${quest.giver}" is not a known mob in this zone`);
+    } else {
+      const giverMob = world.mobs?.[quest.giver];
+      if (giverMob && !isUniqueSpawn(giverMob)) {
+        addIssue(
+          issues,
+          "error",
+          entity,
+          `Giver mob "${quest.giver}" must have exactly one spawn with count 1 — quest givers are unique NPCs`,
+        );
+      }
     }
-    if (quest.turnInMob && !mobIds.has(quest.turnInMob)) {
-      addIssue(
-        issues,
-        "warning",
-        entity,
-        `Turn-in mob "${quest.turnInMob}" is not a known mob in this zone — the engine still qualifies it with the zone id, so this is only valid if the mob lives elsewhere`,
-      );
+    if (quest.turnInMob) {
+      if (!mobIds.has(quest.turnInMob)) {
+        addIssue(
+          issues,
+          "warning",
+          entity,
+          `Turn-in mob "${quest.turnInMob}" is not a known mob in this zone — the engine still qualifies it with the zone id, so this is only valid if the mob lives elsewhere`,
+        );
+      } else {
+        const turnInMob = world.mobs?.[quest.turnInMob];
+        if (turnInMob && !isUniqueSpawn(turnInMob)) {
+          addIssue(
+            issues,
+            "error",
+            entity,
+            `Turn-in mob "${quest.turnInMob}" must have exactly one spawn with count 1 — turn-in NPCs are unique`,
+          );
+        }
+      }
     }
     if (!quest.objectives || quest.objectives.length === 0) {
       addIssue(issues, "error", entity, "Quest must have at least one objective");

--- a/creator/src/lib/zoneEdits.ts
+++ b/creator/src/lib/zoneEdits.ts
@@ -55,6 +55,26 @@ export function normalizeDir(dir: string): string {
 }
 
 /**
+ * Migrate the legacy `mob.room` shorthand to a single-entry `spawns` list.
+ * Idempotent: mobs that already declare `spawns` are left as-is, with their
+ * stale `room` field stripped. Mutates in place and returns the same world.
+ */
+export function normalizeMobSpawns(world: WorldFile): WorldFile {
+  if (!world.mobs) return world;
+  for (const mob of Object.values(world.mobs)) {
+    if (mob.spawns && mob.spawns.length > 0) {
+      delete mob.room;
+      continue;
+    }
+    if (mob.room) {
+      mob.spawns = [{ room: mob.room }];
+      delete mob.room;
+    }
+  }
+  return world;
+}
+
+/**
  * Normalize all exit direction keys in a WorldFile from long-form
  * ("north", "south") to abbreviated form ("n", "s").
  * Mutates in place and returns the same object.
@@ -151,7 +171,19 @@ function removeEntity(
 
 /** Remove all entities in a given room across room-bound collections. */
 function removeEntitiesInRoom(world: WorldFile, roomId: string): void {
-  const collections: EntityCollection[] = ["mobs", "items", "shops", "trainers", "gatheringNodes"];
+  // Mobs: drop matching spawn entries; delete the mob entirely if no spawns remain.
+  if (world.mobs) {
+    for (const [id, mob] of Object.entries(world.mobs)) {
+      const spawns = (mob.spawns ?? []).filter((s) => s.room !== roomId);
+      if (spawns.length === 0) {
+        delete world.mobs[id];
+      } else if (spawns.length !== (mob.spawns?.length ?? 0)) {
+        world.mobs[id] = { ...mob, spawns };
+      }
+    }
+  }
+  // Other room-bound collections: delete entity if its single room matches.
+  const collections: EntityCollection[] = ["items", "shops", "trainers", "gatheringNodes"];
   for (const col of collections) {
     const map = world[col] as Record<string, { room?: string }> | undefined;
     if (!map) continue;
@@ -635,7 +667,7 @@ export function exitTarget(exit: string | ExitValue): string {
 // ─── Mob operations ─────────────────────────────────────────────────
 
 export function addMob(world: WorldFile, mobId: string, mob: MobFile): WorldFile {
-  return addEntity(world, "mobs", mobId, mob, mob.room);
+  return addEntity(world, "mobs", mobId, mob, mob.spawns?.[0]?.room);
 }
 
 export function updateMob(world: WorldFile, mobId: string, patch: Partial<MobFile>): WorldFile {

--- a/creator/src/lib/zoneEdits.ts
+++ b/creator/src/lib/zoneEdits.ts
@@ -58,17 +58,29 @@ export function normalizeDir(dir: string): string {
  * Migrate the legacy `mob.room` shorthand to a single-entry `spawns` list.
  * Idempotent: mobs that already declare `spawns` are left as-is, with their
  * stale `room` field stripped. Mutates in place and returns the same world.
+ *
+ * For migrating legacy entries we rebuild the mob object so `spawns` lands
+ * in the same key position `room` used to occupy — this keeps the YAML diff
+ * minimal on the next save (matching the MUD-side migrated format).
  */
 export function normalizeMobSpawns(world: WorldFile): WorldFile {
   if (!world.mobs) return world;
-  for (const mob of Object.values(world.mobs)) {
+  for (const [id, mob] of Object.entries(world.mobs)) {
     if (mob.spawns && mob.spawns.length > 0) {
-      delete mob.room;
+      if (mob.room !== undefined) delete mob.room;
       continue;
     }
     if (mob.room) {
-      mob.spawns = [{ room: mob.room }];
-      delete mob.room;
+      const room = mob.room;
+      const next: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(mob)) {
+        if (k === "room") {
+          next.spawns = [{ room }];
+        } else {
+          next[k] = v;
+        }
+      }
+      world.mobs[id] = next as unknown as MobFile;
     }
   }
   return world;

--- a/creator/src/lib/zoneToGraph.ts
+++ b/creator/src/lib/zoneToGraph.ts
@@ -105,7 +105,10 @@ export function zoneToGraph(
   const gatheringNodesPerRoom = new Map<string, number>();
 
   for (const mob of Object.values(world.mobs ?? {})) {
-    mobsPerRoom.set(mob.room, (mobsPerRoom.get(mob.room) ?? 0) + 1);
+    for (const spawn of mob.spawns ?? []) {
+      const n = spawn.count ?? 1;
+      mobsPerRoom.set(spawn.room, (mobsPerRoom.get(spawn.room) ?? 0) + n);
+    }
   }
   for (const item of Object.values(world.items ?? {})) {
     if (item.room) {
@@ -127,7 +130,12 @@ export function zoneToGraph(
     arr.push(sprite);
   };
   for (const [id, mob] of Object.entries(world.mobs ?? {})) {
-    pushEntity(mob.room, { id, kind: "mob", name: mob.name, image: mob.image });
+    const seenRooms = new Set<string>();
+    for (const spawn of mob.spawns ?? []) {
+      if (seenRooms.has(spawn.room)) continue;
+      seenRooms.add(spawn.room);
+      pushEntity(spawn.room, { id, kind: "mob", name: mob.name, image: mob.image });
+    }
   }
   for (const [id, item] of Object.entries(world.items ?? {})) {
     if (item.room) {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -153,10 +153,28 @@ export const MOB_ROLE_DESCRIPTIONS: Record<MobRole, string> = {
   prop: "Examine-only flavour entity. No interaction beyond look.",
 };
 
+/**
+ * One placement of a mob template in the world. A mob can have multiple
+ * spawn entries; each entry may produce `count` runtime instances. The
+ * legacy single-room `room` field on `MobFile` is no longer authored —
+ * loaders normalize it into `spawns: [{ room }]` on read.
+ */
+export interface SpawnEntry {
+  room: string;
+  count?: number;
+}
+
 export interface MobFile {
   name: string;
   description?: string;
-  room: string;
+  /**
+   * Where this mob template gets placed in the zone. New content always
+   * uses `spawns`; the loader synthesizes a single-entry list for legacy
+   * mobs that still have a top-level `room` shorthand, then drops `room`.
+   */
+  spawns?: SpawnEntry[];
+  /** @deprecated Legacy single-room placement — loaders migrate to `spawns`. */
+  room?: string;
   /**
    * What this mob is *for*. Omitted/missing defaults to "combat" to preserve
    * legacy behaviour. Non-combat roles refuse attack commands server-side.


### PR DESCRIPTION
## Summary

- Mobs now declare a `spawns: [{ room, count? }]` list instead of a single top-level `room`. One template, many placements.
- Loader auto-migrates legacy `room:` shorthand on read; saver always writes the new shape, so zones land in the new format the next time they're edited.
- Validator enforces the unique-NPC contract: any mob referenced as a quest giver or turn-in must have exactly one spawn with count <= 1.
- MobEditor gains an add/remove spawn list (locked to a single row for quest-giver roles); zone graph renders mobs in every spawn room with instance counts.

Pairs with the matching MUD-side change. Migration is zero-touch — existing zones load with the legacy shorthand, get normalized in memory, and save in the new shape on next edit.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 1855 tests pass (data-layer tests cover loader normalization, sanitize phase 1+2, validator, refactor-id cascade, generator/MUD-import, graph counting)
- [x] `cargo check` clean
- [ ] Manual: open a legacy zone, save, confirm `mobs:` block is rewritten with `spawns:`
- [ ] Manual: add a second spawn to a combat mob, verify it shows in both rooms on the zone graph with the correct instance count
- [ ] Manual: try to mark a multi-spawn mob as quest_giver and confirm the validator surfaces an error