### PR TITLE
[codex] Redesign timeline editor layout

### DIFF
--- a/creator/src/components/AppShell.tsx
+++ b/creator/src/components/AppShell.tsx
@@ -104,7 +104,7 @@ export function AppShell({ onNewProject }: AppShellProps) {
         <div className="absolute bottom-[-14rem] right-[-12rem] h-[40rem] w-[40rem] rounded-full bg-[radial-gradient(circle,rgb(var(--accent-rgb)/0.10),transparent_72%)] blur-3xl" />
       </div>
       <header className="shrink-0"><Toolbar onNewProject={onNewProject} onToggleGuide={handleToggleGuide} guideOpen={showGuide} /></header>
-      <div className="relative z-10 flex min-h-0 flex-1 flex-col gap-3 px-4 pb-3 pt-5 lg:flex-row">
+      <div className="relative z-10 flex min-h-0 flex-1 flex-col gap-2 px-2 pb-2 pt-2 lg:flex-row">
         <Sidebar />
         <main
           aria-label="Content"

--- a/creator/src/components/MainArea.tsx
+++ b/creator/src/components/MainArea.tsx
@@ -45,7 +45,7 @@ function IslandBackPill({ island }: { island: Island }) {
   const def = ISLANDS[island];
   if (!def) return null;
   return (
-    <div className="flex-none px-4 pt-3 pb-1">
+    <div className="flex-none px-2 pb-1 pt-1">
       <button
         type="button"
         onClick={() => openIsland(island)}

--- a/creator/src/components/lore/LorePanelHost.tsx
+++ b/creator/src/components/lore/LorePanelHost.tsx
@@ -140,7 +140,13 @@ export function LorePanelHost({ panelId }: { panelId: string }) {
             panelId === "loreTimeline" ? "max-w-none" : (def?.maxWidth ?? "max-w-5xl")
           }`}
         >
-          <div className="pointer-events-auto absolute right-5 top-5 z-20 flex items-center justify-end gap-2">
+          <div
+            className={`pointer-events-auto z-20 flex items-center justify-end gap-2 ${
+              panelId === "loreTimeline"
+                ? "mb-2 self-end"
+                : "absolute right-5 top-5"
+            }`}
+          >
             <UndoRedoButtons
               canUndo={undoDepth > 0}
               canRedo={redoDepth > 0}

--- a/creator/src/components/lore/LorePanelHost.tsx
+++ b/creator/src/components/lore/LorePanelHost.tsx
@@ -135,8 +135,12 @@ export function LorePanelHost({ panelId }: { panelId: string }) {
           />
         </div>
 
-        <div className={`relative z-10 mx-auto flex flex-col gap-6 px-6 py-5 ${def?.maxWidth ?? "max-w-5xl"}`}>
-          <div className="pointer-events-auto sticky top-3 z-20 flex items-center justify-end gap-2">
+        <div
+          className={`relative z-10 flex min-h-full w-full flex-col px-3 py-3 ${
+            panelId === "loreTimeline" ? "max-w-none" : (def?.maxWidth ?? "max-w-5xl")
+          }`}
+        >
+          <div className="pointer-events-auto absolute right-5 top-5 z-20 flex items-center justify-end gap-2">
             <UndoRedoButtons
               canUndo={undoDepth > 0}
               canRedo={redoDepth > 0}

--- a/creator/src/components/lore/TimelineInferencePanel.tsx
+++ b/creator/src/components/lore/TimelineInferencePanel.tsx
@@ -55,13 +55,13 @@ export function TimelineInferencePanel() {
         title: s.title,
         year: s.year,
         eraId: s.eraId,
-        calendarId: lore?.calendarSystems?.[0]?.id ?? "",
+        calendarId: s.calendarId,
         importance: s.importance,
         articleId: s.articleId,
         description: s.evidence,
       });
     },
-    [lore, addTimelineEvent],
+    [addTimelineEvent],
   );
 
   const handleApproveAll = useCallback(
@@ -169,13 +169,13 @@ export function TimelineInferencePanel() {
                 <div className="ml-auto flex gap-2">
                   <button
                     onClick={onApprove}
-                    className="rounded-full border border-accent/30 bg-accent/10 px-2.5 py-1 text-2xs text-accent hover:bg-accent/20"
+                    className="min-h-9 rounded-full border border-accent/30 bg-accent/10 px-3 py-1.5 text-2xs text-accent hover:bg-accent/20"
                   >
                     Approve
                   </button>
                   <button
                     onClick={onDismiss}
-                    className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted hover:bg-[var(--chrome-highlight-strong)]"
+                    className="min-h-9 rounded-full border border-[var(--chrome-stroke)] px-3 py-1.5 text-2xs text-text-muted hover:bg-[var(--chrome-highlight-strong)]"
                   >
                     Deny
                   </button>

--- a/creator/src/components/lore/TimelinePanel.tsx
+++ b/creator/src/components/lore/TimelinePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo, memo, useRef, type ReactNode } from "react";
+import { useState, useCallback, useEffect, useMemo, memo, useRef, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from "react";
 import { useLoreStore, selectArticles, selectCalendars, selectEvents } from "@/stores/loreStore";
 import type { CalendarSystem, CalendarEra, TimelineEvent } from "@/types/lore";
 import {
@@ -929,30 +929,21 @@ const ChronicleEventRow = memo(function ChronicleEventRow({
   entry,
   selected,
   onSelect,
-  onMoveSelection,
 }: {
   entry: ResolvedTimelineEvent;
   selected: boolean;
   onSelect: () => void;
-  onMoveSelection: (direction: "prev" | "next") => void;
 }) {
   const style = importanceClasses(entry.event.importance);
 
   return (
     <button
       type="button"
+      id={`chronicle-row-${entry.event.id}`}
+      role="option"
+      aria-selected={selected}
+      tabIndex={-1}
       onClick={onSelect}
-      onKeyDown={(e) => {
-        if (e.key === "ArrowDown") {
-          e.preventDefault();
-          onMoveSelection("next");
-        }
-        if (e.key === "ArrowUp") {
-          e.preventDefault();
-          onMoveSelection("prev");
-        }
-      }}
-      aria-pressed={selected}
       className={`focus-ring group relative grid w-full grid-cols-[0.8rem_5rem_minmax(0,1fr)] items-center gap-3 rounded-[0.45rem] border px-3 py-2 text-left transition md:grid-cols-[0.8rem_5rem_minmax(0,1fr)_7rem_10rem] ${
         selected
           ? "border-[var(--border-accent-ring)] bg-[linear-gradient(90deg,rgb(var(--accent-rgb)/0.12),rgb(var(--bg-rgb)/0.30))] shadow-[var(--shadow-glow)]"
@@ -978,6 +969,23 @@ const ChronicleEventRow = memo(function ChronicleEventRow({
 
 // ─── Event List ──────────────────────────────────────────────────────────
 
+function flattenDisplayedEvents(
+  groups: ReturnType<typeof buildChronicleGroups>,
+  sortMode: "year" | "importance",
+): ResolvedTimelineEvent[] {
+  const flat: ResolvedTimelineEvent[] = [];
+  for (const calendarGroup of groups) {
+    for (const eraGroup of calendarGroup.eras) {
+      if (eraGroup.events.length === 0) continue;
+      const ordered = sortMode === "importance"
+        ? [...eraGroup.events].sort((a, b) => importanceWeight(b.event.importance) - importanceWeight(a.event.importance))
+        : eraGroup.events;
+      for (const entry of ordered) flat.push(entry);
+    }
+  }
+  return flat;
+}
+
 function EventList({
   groups,
   totalVisible,
@@ -994,6 +1002,52 @@ function EventList({
   floatingInspector?: ReactNode;
 }) {
   const [sortMode, setSortMode] = useState<"year" | "importance">("year");
+
+  useEffect(() => {
+    if (!selectedEventId) return;
+    document.getElementById(`chronicle-row-${selectedEventId}`)?.scrollIntoView({ block: "nearest" });
+  }, [selectedEventId]);
+
+  const handleListKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      onMoveSelection("next");
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      onMoveSelection("prev");
+      return;
+    }
+    if (e.key === "Home") {
+      e.preventDefault();
+      const flat = flattenDisplayedEvents(groups, sortMode);
+      const first = flat[0];
+      if (first) onSelect(first.event.id);
+      return;
+    }
+    if (e.key === "End") {
+      e.preventDefault();
+      const flat = flattenDisplayedEvents(groups, sortMode);
+      const last = flat[flat.length - 1];
+      if (last) onSelect(last.event.id);
+      return;
+    }
+    if (e.key === "PageDown" || e.key === "PageUp") {
+      e.preventDefault();
+      const flat = flattenDisplayedEvents(groups, sortMode);
+      if (flat.length === 0) return;
+      const currentIdx = selectedEventId
+        ? flat.findIndex((entry) => entry.event.id === selectedEventId)
+        : -1;
+      const step = e.key === "PageDown" ? 10 : -10;
+      const baseIdx = currentIdx === -1 ? (e.key === "PageDown" ? -1 : flat.length) : currentIdx;
+      const nextIdx = Math.max(0, Math.min(flat.length - 1, baseIdx + step));
+      const target = flat[nextIdx];
+      if (target) onSelect(target.event.id);
+      return;
+    }
+  };
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[0.9rem] border border-border-muted/40 bg-[linear-gradient(180deg,rgb(var(--bg-rgb)/0.88),rgb(var(--abyss-rgb)/0.94))] shadow-[var(--shadow-panel)]">
@@ -1020,7 +1074,14 @@ function EventList({
       </div>
 
       <div className={`grid min-h-0 flex-1 overflow-hidden ${floatingInspector ? "xl:grid-cols-[minmax(0,1fr)_22rem]" : ""}`}>
-        <div className="min-h-0 overflow-y-auto p-2">
+        <div
+          role="listbox"
+          aria-label="Timeline events"
+          aria-activedescendant={selectedEventId ? `chronicle-row-${selectedEventId}` : undefined}
+          tabIndex={0}
+          onKeyDown={handleListKeyDown}
+          className="focus-ring min-h-0 overflow-y-auto p-2"
+        >
           {groups.map((calendarGroup) =>
               calendarGroup.eras.map((eraGroup) => {
             if (eraGroup.events.length === 0) return null;
@@ -1030,9 +1091,9 @@ function EventList({
             return (
               <section key={`${calendarGroup.id}:${eraGroup.id}`} className="border-b border-border-muted/25 last:border-b-0">
                 <div className="flex items-baseline gap-4 bg-[linear-gradient(90deg,rgb(var(--accent-rgb)/0.10),transparent_72%)] px-4 py-2">
-                  <p className="font-display text-2xs uppercase tracking-[0.28em] text-[var(--color-warm)]/85">
+                  <h3 className="font-display text-2xs uppercase tracking-[0.28em] text-[var(--color-warm)]/85">
                     {eraGroup.eraName}
-                  </p>
+                  </h3>
                   {eraGroup.startYear !== null && (
                     <p className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">
                       {formatYear(eraGroup.startYear)} – {formatYear(eraEndYear(calendarGroup, eraGroup))}
@@ -1046,7 +1107,6 @@ function EventList({
                       entry={entry}
                       selected={entry.event.id === selectedEventId}
                       onSelect={() => onSelect(entry.event.id)}
-                      onMoveSelection={onMoveSelection}
                     />
                   ))}
                 </div>

--- a/creator/src/components/lore/TimelinePanel.tsx
+++ b/creator/src/components/lore/TimelinePanel.tsx
@@ -26,15 +26,30 @@ import { TimelineInferencePanel } from "./TimelineInferencePanel";
 
 type ViewMode = "timeline" | "list";
 
-// Solid era anchors — keep parity with TimelineView.tsx ERA_COLORS.
 const ERA_PALETTE = [
-  "#ff9d3d", // ember
-  "#35a1b0", // stellar blue
-  "#d4b66e", // soft gold
-  "#7cb66d", // moss green
-  "#a897d2", // lavender
-  "#6ec0c2", // pale teal
+  "var(--color-status-warning)",
+  "var(--color-stellar-blue)",
+  "#d4b66e",
+  "var(--color-status-success)",
+  "#a897d2",
+  "#6ec0c2",
 ];
+
+function XGlyph() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+      <path d="M4 4l8 8M12 4l-8 8" />
+    </svg>
+  );
+}
+
+function PlusGlyph() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden="true">
+      <path d="M8 3v10M3 8h10" />
+    </svg>
+  );
+}
 
 const IMPORTANCE_OPTIONS: Array<{ value: TimelineEvent["importance"]; label: string }> = [
   { value: "minor", label: "Minor" },
@@ -171,10 +186,10 @@ function CalendarEditor({
               onChange={(e) => patchCalendar(calendar.id, { name: e.target.value })}
             />
             <IconButton onClick={() => addEra(calendar.id)} title="Add era">
-              +
+              <span className="flex h-full w-full items-center justify-center"><PlusGlyph /></span>
             </IconButton>
             <IconButton onClick={() => deleteCalendar(calendar.id)} title="Delete calendar" danger>
-              x
+              <span className="flex h-full w-full items-center justify-center"><XGlyph /></span>
             </IconButton>
           </div>
 
@@ -210,7 +225,7 @@ function CalendarEditor({
                   />
                 </label>
                 <IconButton onClick={() => deleteEra(calendar.id, era.id)} title="Delete era" danger>
-                  x
+                  <span className="flex h-full w-full items-center justify-center"><XGlyph /></span>
                 </IconButton>
               </div>
             ))}
@@ -236,6 +251,9 @@ function CalendarEditor({
 
 // ─── Manage Calendars Dialog ──────────────────────────────────────────────
 
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
 function ManageCalendarsDialog({
   open,
   calendars,
@@ -254,9 +272,33 @@ function ManageCalendarsDialog({
     if (!open) return;
     previousFocus.current = (document.activeElement as HTMLElement) ?? null;
     const node = dialogRef.current;
-    node?.focus();
+    const firstFocusable = node?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (firstFocusable) firstFocusable.focus();
+    else node?.focus();
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab" || !node) return;
+      const focusables = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.hasAttribute("disabled"));
+      if (focusables.length === 0) {
+        e.preventDefault();
+        node.focus();
+        return;
+      }
+      const first = focusables[0]!;
+      const last = focusables[focusables.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener("keydown", onKey);
     return () => {
@@ -379,47 +421,42 @@ function FilterRail({
 
       <label className="flex flex-col gap-1.5">
         <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Calendar</span>
-        <select
+        <SelectInput
           value={calendarFilter}
-          onChange={(e) => {
-            onCalendarFilter(e.target.value);
+          dense
+          options={[
+            { value: "all", label: "All calendars" },
+            ...calendars.map((c) => ({ value: c.id, label: c.name })),
+          ]}
+          onCommit={(value) => {
+            onCalendarFilter(value);
             onEraFilter(null);
           }}
-          className="ornate-input min-h-9 rounded-[0.55rem] px-3 py-2 text-sm text-text-primary"
-        >
-          <option value="all">All calendars</option>
-          {calendars.map((c) => (
-            <option key={c.id} value={c.id}>{c.name}</option>
-          ))}
-        </select>
+        />
       </label>
 
       <label className="flex flex-col gap-1.5">
         <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Era</span>
-        <select
+        <SelectInput
           value={eraFilter ?? ""}
-          onChange={(e) => onEraFilter(e.target.value || null)}
-          className="ornate-input min-h-9 rounded-[0.55rem] px-3 py-2 text-sm text-text-primary"
-          disabled={erasForCalendar.length === 0}
-        >
-          <option value="">All eras</option>
-          {erasForCalendar.map((era) => (
-            <option key={era.id} value={era.id}>{era.name}</option>
-          ))}
-        </select>
+          dense
+          placeholder="All eras"
+          options={erasForCalendar.map((era) => ({ value: era.id, label: era.name }))}
+          onCommit={(value) => onEraFilter(value || null)}
+        />
       </label>
 
       <label className="flex flex-col gap-1.5">
         <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Importance</span>
-        <select
+        <SelectInput
           value={importanceFilter}
-          onChange={(e) => onImportanceFilter(e.target.value)}
-          className="ornate-input min-h-9 rounded-[0.55rem] px-3 py-2 text-sm text-text-primary"
-        >
-          {IMPORTANCE_FILTER_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>{option.label}</option>
-          ))}
-        </select>
+          dense
+          options={IMPORTANCE_FILTER_OPTIONS.map((option) => ({
+            value: String(option.value),
+            label: option.label,
+          }))}
+          onCommit={(value) => onImportanceFilter(value)}
+        />
       </label>
 
       <div className="flex flex-col gap-2">
@@ -445,7 +482,7 @@ function FilterRail({
         </div>
         <div className="flex flex-wrap gap-1.5">
           <RangeButton onClick={onFullRange}>Full Range</RangeButton>
-          <RangeButton onClick={onSelectedEra} active>Selected Era</RangeButton>
+          <RangeButton onClick={onSelectedEra} disabled={!eraFilter}>Selected Era</RangeButton>
           <RangeButton onClick={onThisEra} disabled={!hasSelected}>This Era</RangeButton>
         </div>
       </div>
@@ -567,7 +604,7 @@ function Chip({
       type="button"
       onClick={onClick}
       aria-pressed={selected}
-      className={`focus-ring rounded-[0.45rem] border px-2.5 py-1 text-2xs transition ${
+      className={`focus-ring inline-flex min-h-9 items-center rounded-[0.45rem] border px-3 py-1.5 text-2xs transition ${
         selected
           ? "border-[var(--border-accent-ring)] bg-[var(--bg-accent-subtle)] text-[var(--color-warm-pale)]"
           : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] text-text-muted hover:border-[var(--chrome-stroke-emphasis)] hover:text-text-primary"
@@ -594,7 +631,7 @@ function RangeButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`focus-ring rounded-[0.45rem] border px-2.5 py-1 text-2xs transition disabled:cursor-not-allowed disabled:opacity-40 ${
+      className={`focus-ring inline-flex min-h-9 items-center rounded-[0.45rem] border px-3 py-1.5 text-2xs transition disabled:cursor-not-allowed disabled:opacity-40 ${
         active
           ? "border-[var(--border-accent-ring)] bg-[var(--bg-active)] text-text-primary"
           : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] text-text-muted hover:border-[var(--chrome-stroke-emphasis)] hover:text-text-primary"
@@ -621,9 +658,11 @@ function CommitTextArea({
   const [draft, setDraft] = useState(value);
   const [focused, setFocused] = useState(false);
 
-  if (!focused && draft !== value) {
-    setDraft(value);
-  }
+  useEffect(() => {
+    if (!focused && draft !== value) {
+      setDraft(value);
+    }
+  }, [focused, value, draft]);
 
   const commit = () => {
     if (draft !== value) onCommit(draft);
@@ -738,9 +777,9 @@ function EventInspector({
           onClick={onClose}
           aria-label="Close inspector"
           title="Close inspector"
-          className="focus-ring rounded-[0.45rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-0.5 text-2xs text-text-muted transition hover:text-text-primary"
+          className="focus-ring inline-flex min-h-9 min-w-9 items-center justify-center rounded-[0.45rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] text-text-muted transition hover:text-text-primary"
         >
-          ✕
+          <XGlyph />
         </button>
       </div>
 
@@ -823,9 +862,9 @@ function EventInspector({
                 onClick={() => onUpdate({ articleId: undefined })}
                 title="Unlink article"
                 aria-label="Unlink article"
-                className="focus-ring rounded-[0.45rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-1 text-2xs text-text-muted transition hover:text-status-error"
+                className="focus-ring inline-flex min-h-9 min-w-9 items-center justify-center rounded-[0.45rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] text-text-muted transition hover:text-status-error"
               >
-                ✕
+                <XGlyph />
               </button>
             </>
           )}
@@ -914,7 +953,7 @@ const ChronicleEventRow = memo(function ChronicleEventRow({
         }
       }}
       aria-pressed={selected}
-      className={`focus-ring group relative grid w-full grid-cols-[0.8rem_5rem_minmax(0,1fr)] items-center gap-3 rounded-[0.45rem] border px-3 py-2 text-left transition md:grid-cols-[0.8rem_5rem_minmax(0,1fr)_7rem_10rem_1.5rem] ${
+      className={`focus-ring group relative grid w-full grid-cols-[0.8rem_5rem_minmax(0,1fr)] items-center gap-3 rounded-[0.45rem] border px-3 py-2 text-left transition md:grid-cols-[0.8rem_5rem_minmax(0,1fr)_7rem_10rem] ${
         selected
           ? "border-[var(--border-accent-ring)] bg-[linear-gradient(90deg,rgb(var(--accent-rgb)/0.12),rgb(var(--bg-rgb)/0.30))] shadow-[var(--shadow-glow)]"
           : "border-border-muted/18 bg-bg-abyss/18 hover:border-border-muted/45 hover:bg-bg-secondary/22"
@@ -932,9 +971,6 @@ const ChronicleEventRow = memo(function ChronicleEventRow({
       </span>
       <span className="hidden min-w-0 truncate text-xs text-text-muted md:block">
         {entry.calendar?.name ?? "Uncalendared"}
-      </span>
-      <span className="hidden justify-self-end text-lg leading-none text-text-muted md:block">
-        ...
       </span>
     </button>
   );
@@ -968,15 +1004,17 @@ function EventList({
         <div className="flex items-center gap-2">
           <label className="flex items-center gap-1.5 text-2xs text-text-muted">
             Sort by
-            <select
-              value={sortMode}
-              onChange={(e) => setSortMode(e.target.value as "year" | "importance")}
-              className="ornate-input min-h-7 rounded-md px-2 py-0.5 text-2xs text-text-primary"
-              aria-label="Sort chronicle events"
-            >
-              <option value="year">Year</option>
-              <option value="importance">Importance</option>
-            </select>
+            <span className="w-32">
+              <SelectInput
+                value={sortMode}
+                dense
+                options={[
+                  { value: "year", label: "Year" },
+                  { value: "importance", label: "Importance" },
+                ]}
+                onCommit={(value) => setSortMode(value as "year" | "importance")}
+              />
+            </span>
           </label>
         </div>
       </div>
@@ -1273,14 +1311,14 @@ export function TimelinePanel() {
       <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border-muted/45 bg-[radial-gradient(circle_at_top_left,rgb(var(--accent-rgb)/0.10),transparent_38%),linear-gradient(160deg,rgb(var(--bg-rgb)/0.96),rgb(var(--abyss-rgb)/0.94))] px-5 py-3">
         <div className="min-w-0">
           <p className="text-[0.6rem] uppercase tracking-[0.32em] text-[var(--color-warm)]/80">
-            Chronicle · Timeline Editor
+            {headerTitle === "Chronicle" ? "Timeline Editor" : "Chronicle · Timeline Editor"}
           </p>
           <h1 className="mt-1 truncate font-display text-2xl text-text-primary">
             {headerTitle}
           </h1>
         </div>
 
-        <div className="mr-44 flex flex-wrap items-center gap-2">
+        <div className="ml-auto flex flex-wrap items-center gap-2">
           <div className="flex items-center gap-0.5 rounded-[0.7rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] p-0.5">
             {(["timeline", "list"] as ViewMode[]).map((mode) => (
               <button
@@ -1305,7 +1343,7 @@ export function TimelinePanel() {
             variant={showSuggestions ? "secondary" : "ghost"}
             size="sm"
           >
-            {showSuggestions ? "Hide AI" : "AI Suggest"}
+            {showSuggestions ? "Hide Suggestions" : "AI Suggestions"}
           </ActionButton>
 
           <ActionButton onClick={handleAddEvent} variant="primary" disabled={calendars.length === 0}>

--- a/creator/src/components/lore/TimelinePanel.tsx
+++ b/creator/src/components/lore/TimelinePanel.tsx
@@ -29,10 +29,10 @@ type ViewMode = "timeline" | "list";
 const ERA_PALETTE = [
   "var(--color-status-warning)",
   "var(--color-stellar-blue)",
-  "#d4b66e",
+  "var(--color-aurum)",
   "var(--color-status-success)",
-  "#a897d2",
-  "#6ec0c2",
+  "var(--color-era-violet)",
+  "var(--color-era-teal)",
 ];
 
 function XGlyph() {
@@ -75,8 +75,8 @@ function parseYearInput(value: string): number | undefined {
 function importanceClasses(importance: TimelineEvent["importance"]) {
   if (importance === "legendary") {
     return {
-      dot: "bg-[#d4b66e] shadow-[0_0_18px_rgb(212_182_110/0.34)]",
-      pill: "border-[#d4b66e]/45 bg-[#d4b66e]/15 text-[#f4d98b]",
+      dot: "bg-[var(--color-aurum)] shadow-[0_0_18px_rgb(var(--aurum-rgb)/0.34)]",
+      pill: "border-[rgb(var(--aurum-rgb)/0.45)] bg-[rgb(var(--aurum-rgb)/0.15)] text-[var(--color-aurum-pale)]",
     };
   }
   if (importance === "major") {

--- a/creator/src/components/lore/TimelinePanel.tsx
+++ b/creator/src/components/lore/TimelinePanel.tsx
@@ -993,6 +993,7 @@ function EventList({
   onSelect,
   onMoveSelection,
   floatingInspector,
+  onCloseInspector,
 }: {
   groups: ReturnType<typeof buildChronicleGroups>;
   totalVisible: number;
@@ -1000,8 +1001,65 @@ function EventList({
   onSelect: (id: string) => void;
   onMoveSelection: (direction: "prev" | "next") => void;
   floatingInspector?: ReactNode;
+  onCloseInspector?: () => void;
 }) {
   const [sortMode, setSortMode] = useState<"year" | "importance">("year");
+  const [isXl, setIsXl] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia("(min-width: 1280px)").matches : true,
+  );
+  const slideOverRef = useRef<HTMLDivElement>(null);
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia("(min-width: 1280px)");
+    const onChange = (e: MediaQueryListEvent) => setIsXl(e.matches);
+    setIsXl(mql.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  const slideOverOpen = !isXl && !!floatingInspector && !!selectedEventId;
+
+  useEffect(() => {
+    if (!slideOverOpen) return;
+    previousFocus.current = (document.activeElement as HTMLElement) ?? null;
+    const node = slideOverRef.current;
+    const firstFocusable = node?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (firstFocusable) firstFocusable.focus();
+    else node?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCloseInspector?.();
+        return;
+      }
+      if (e.key !== "Tab" || !node) return;
+      const focusables = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => !el.hasAttribute("disabled"));
+      if (focusables.length === 0) {
+        e.preventDefault();
+        node.focus();
+        return;
+      }
+      const first = focusables[0]!;
+      const last = focusables[focusables.length - 1]!;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      previousFocus.current?.focus?.();
+    };
+  }, [slideOverOpen, onCloseInspector]);
 
   useEffect(() => {
     if (!selectedEventId) return;
@@ -1073,7 +1131,7 @@ function EventList({
         </div>
       </div>
 
-      <div className={`grid min-h-0 flex-1 overflow-hidden ${floatingInspector ? "xl:grid-cols-[minmax(0,1fr)_22rem]" : ""}`}>
+      <div className={`grid min-h-0 flex-1 overflow-hidden ${floatingInspector && isXl ? "xl:grid-cols-[minmax(0,1fr)_22rem]" : ""}`}>
         <div
           role="listbox"
           aria-label="Timeline events"
@@ -1115,12 +1173,35 @@ function EventList({
               }),
             )}
         </div>
-        {floatingInspector && (
-          <div className="hidden min-h-0 border-l border-border-muted/30 p-2 xl:block">
+        {floatingInspector && isXl && (
+          <div className="min-h-0 border-l border-border-muted/30 p-2">
             {floatingInspector}
           </div>
         )}
       </div>
+      {floatingInspector && !isXl && (
+        <>
+          <div
+            className={`fixed inset-0 z-30 bg-black/40 transition-opacity duration-200 ${
+              slideOverOpen ? "opacity-100" : "pointer-events-none opacity-0"
+            }`}
+            aria-hidden="true"
+            onClick={() => onCloseInspector?.()}
+          />
+          <div
+            ref={slideOverRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Event inspector"
+            tabIndex={-1}
+            className={`fixed inset-y-0 right-0 z-40 flex w-[22rem] max-w-[calc(100vw-2rem)] flex-col p-2 shadow-[var(--shadow-panel)] transition-transform duration-200 ${
+              slideOverOpen ? "translate-x-0" : "pointer-events-none translate-x-full"
+            }`}
+          >
+            {floatingInspector}
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -1233,10 +1314,15 @@ export function TimelinePanel() {
   }, [filteredEvents, selectedEventId]);
 
   const handleAddEvent = useCallback(() => {
-    const calendar = calendars.find((c) => c.id === (calendarFilter !== "all" ? calendarFilter : undefined)) ?? calendars[0];
+    const calendar =
+      calendarFilter !== "all"
+        ? calendars.find((c) => c.id === calendarFilter)
+        : eraFilter
+          ? calendars.find((c) => c.eras.some((e) => e.id === eraFilter)) ?? calendars[0]
+          : calendars[0];
     if (!calendar) return;
-    const era = eraFilter
-      ? calendar.eras.find((e) => e.id === eraFilter) ?? calendar.eras[0]
+    const era = eraFilter && calendar.eras.some((e) => e.id === eraFilter)
+      ? calendar.eras.find((e) => e.id === eraFilter)
       : calendar.eras[0];
     const event: TimelineEvent = {
       id: `evt_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
@@ -1362,6 +1448,7 @@ export function TimelinePanel() {
       onSelect={setSelectedEventId}
       onMoveSelection={handleMoveSelection}
       floatingInspector={inspector}
+      onCloseInspector={() => setSelectedEventId(null)}
     />
   );
 

--- a/creator/src/components/lore/TimelinePanel.tsx
+++ b/creator/src/components/lore/TimelinePanel.tsx
@@ -1,10 +1,9 @@
-import { useState, useCallback, useEffect, useMemo, memo } from "react";
+import { useState, useCallback, useEffect, useMemo, memo, useRef, type ReactNode } from "react";
 import { useLoreStore, selectArticles, selectCalendars, selectEvents } from "@/stores/loreStore";
 import type { CalendarSystem, CalendarEra, TimelineEvent } from "@/types/lore";
 import {
   buildChronicleGroups,
   filterResolvedTimelineEvents,
-  formatEventDate,
   getTimelineNeighbors,
   resolveTimelineEvents,
   timelineAbsoluteWindow,
@@ -12,6 +11,7 @@ import {
 } from "@/lib/loreCalendar";
 import {
   ActionButton,
+  DialogShell,
   FieldRow,
   TextInput,
   NumberInput,
@@ -23,6 +23,18 @@ import { getTimelineEventPrompt, getTimelineEventContext, getTimelineEventFramin
 import type { AssetContext } from "@/types/assets";
 import { TimelineView } from "./TimelineView";
 import { TimelineInferencePanel } from "./TimelineInferencePanel";
+
+type ViewMode = "timeline" | "list";
+
+// Solid era anchors — keep parity with TimelineView.tsx ERA_COLORS.
+const ERA_PALETTE = [
+  "#ff9d3d", // ember
+  "#35a1b0", // stellar blue
+  "#d4b66e", // soft gold
+  "#7cb66d", // moss green
+  "#a897d2", // lavender
+  "#6ec0c2", // pale teal
+];
 
 const IMPORTANCE_OPTIONS: Array<{ value: TimelineEvent["importance"]; label: string }> = [
   { value: "minor", label: "Minor" },
@@ -48,8 +60,8 @@ function parseYearInput(value: string): number | undefined {
 function importanceClasses(importance: TimelineEvent["importance"]) {
   if (importance === "legendary") {
     return {
-      dot: "bg-[var(--color-warm)] shadow-[0_0_18px_rgb(var(--accent-rgb)/0.32)]",
-      pill: "border-[rgb(var(--accent-rgb)/0.28)] bg-[rgb(var(--accent-rgb)/0.12)] text-[var(--color-warm-pale)]",
+      dot: "bg-[#d4b66e] shadow-[0_0_18px_rgb(212_182_110/0.34)]",
+      pill: "border-[#d4b66e]/45 bg-[#d4b66e]/15 text-[#f4d98b]",
     };
   }
   if (importance === "major") {
@@ -64,39 +76,28 @@ function importanceClasses(importance: TimelineEvent["importance"]) {
   };
 }
 
-function FilterPill({ label }: { label: string }) {
-  return (
-    <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-3 py-1 text-2xs text-text-muted">
-      {label}
-    </span>
-  );
+interface BoolFilters {
+  unlinked: boolean;
+  hasDescription: boolean;
+  hasImage: boolean;
 }
 
-function UtilityToggle({
-  title,
-  open,
-  onToggle,
-}: {
-  title: string;
-  open: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      aria-expanded={open}
-      className={`focus-ring flex min-h-11 items-center justify-between gap-3 rounded-[1.2rem] border px-4 py-3 text-left transition ${
-        open
-          ? "border-[var(--border-accent-ring)] bg-[var(--bg-active)] text-text-primary shadow-[var(--shadow-glow)]"
-          : "border-border-muted/40 bg-bg-secondary/35 text-text-secondary hover:border-[var(--chrome-stroke-emphasis)] hover:bg-bg-secondary/55"
-      }`}
-    >
-      <p className="min-w-0 font-display text-base text-text-primary">{title}</p>
-      <span className="shrink-0 text-xs text-text-muted">{open ? "Hide" : "Show"}</span>
-    </button>
-  );
+function applyBoolFilters(entries: ResolvedTimelineEvent[], filters: BoolFilters): ResolvedTimelineEvent[] {
+  if (!filters.unlinked && !filters.hasDescription && !filters.hasImage) return entries;
+  return entries.filter((entry) => {
+    if (filters.unlinked && entry.event.articleId) return false;
+    if (filters.hasDescription && !(entry.event.description && entry.event.description.trim().length > 0)) return false;
+    if (filters.hasImage && !(entry.event.image && entry.event.image.trim().length > 0)) return false;
+    return true;
+  });
 }
+
+function applyEraFilter(entries: ResolvedTimelineEvent[], eraId: string | null): ResolvedTimelineEvent[] {
+  if (!eraId) return entries;
+  return entries.filter((entry) => entry.event.eraId === eraId);
+}
+
+// ─── Calendar editor (used inside the manage dialog) ──────────────────────
 
 function CalendarEditor({
   calendars,
@@ -151,10 +152,6 @@ function CalendarEditor({
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="text-[0.65rem] uppercase tracking-[0.28em] text-[var(--color-warm)]/80">
-        Calendar Setup
-      </p>
-
       {calendars.length === 0 && (
         <div className="rounded-[1.4rem] border border-dashed border-border-muted/50 bg-bg-secondary/20 px-4 py-6 text-sm text-text-muted">
           No calendar systems exist yet. Add one below to begin placing dated events.
@@ -190,7 +187,7 @@ function CalendarEditor({
                 <input
                   type="color"
                   aria-label={`Color for ${era.name}`}
-                  value={era.color || "#ff7d00"} /* design-system: --color-accent */
+                  value={era.color || "#ff7d00"}
                   onChange={(e) => patchEra(calendar.id, era.id, { color: e.target.value })}
                   className="h-11 w-11 cursor-pointer rounded-full border border-[var(--chrome-stroke)] bg-transparent p-1"
                   title="Era color"
@@ -237,41 +234,476 @@ function CalendarEditor({
   );
 }
 
+// ─── Manage Calendars Dialog ──────────────────────────────────────────────
+
+function ManageCalendarsDialog({
+  open,
+  calendars,
+  onChange,
+  onClose,
+}: {
+  open: boolean;
+  calendars: CalendarSystem[];
+  onChange: (calendars: CalendarSystem[]) => void;
+  onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    previousFocus.current = (document.activeElement as HTMLElement) ?? null;
+    const node = dialogRef.current;
+    node?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      previousFocus.current?.focus?.();
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+  return (
+    <DialogShell
+      dialogRef={dialogRef}
+      titleId="manage-calendars-title"
+      title="Manage Calendars & Eras"
+      subtitle="Define the calendar systems and eras that anchor your timeline events."
+      onClose={onClose}
+      widthClassName="max-w-3xl"
+      footer={
+        <div className="flex justify-end">
+          <ActionButton variant="primary" onClick={onClose}>
+            Done
+          </ActionButton>
+        </div>
+      }
+    >
+      <CalendarEditor calendars={calendars} onChange={onChange} />
+    </DialogShell>
+  );
+}
+
+// ─── Filter Rail ─────────────────────────────────────────────────────────
+
+interface FilterRailProps {
+  search: string;
+  onSearch: (value: string) => void;
+  calendars: CalendarSystem[];
+  calendarFilter: string;
+  onCalendarFilter: (value: string) => void;
+  eraFilter: string | null;
+  onEraFilter: (value: string | null) => void;
+  importanceFilter: string;
+  onImportanceFilter: (value: string) => void;
+  windowStart: string;
+  windowEnd: string;
+  onWindowStart: (value: string) => void;
+  onWindowEnd: (value: string) => void;
+  onFullRange: () => void;
+  onSelectedEra: () => void;
+  onThisEra: () => void;
+  hasSelected: boolean;
+  boolFilters: BoolFilters;
+  onBoolFilters: (next: BoolFilters) => void;
+  visibleByCalendar: Map<string, number>;
+  onManageCalendars: () => void;
+  fullWindowMin?: number;
+  fullWindowMax?: number;
+}
+
+function FilterRail({
+  search,
+  onSearch,
+  calendars,
+  calendarFilter,
+  onCalendarFilter,
+  eraFilter,
+  onEraFilter,
+  importanceFilter,
+  onImportanceFilter,
+  windowStart,
+  windowEnd,
+  onWindowStart,
+  onWindowEnd,
+  onFullRange,
+  onSelectedEra,
+  onThisEra,
+  hasSelected,
+  boolFilters,
+  onBoolFilters,
+  visibleByCalendar,
+  onManageCalendars,
+  fullWindowMin,
+  fullWindowMax,
+}: FilterRailProps) {
+  const erasForCalendar = useMemo(() => {
+    if (calendarFilter !== "all") {
+      const cal = calendars.find((c) => c.id === calendarFilter);
+      return cal ? cal.eras : [];
+    }
+    return calendars.flatMap((cal) =>
+      cal.eras.map((era) => ({ ...era, calendarName: cal.name, calendarId: cal.id })),
+    );
+  }, [calendarFilter, calendars]);
+
+  const toggleImportance = (value: TimelineEvent["importance"]) => {
+    onImportanceFilter(importanceFilter === value ? "all" : value);
+  };
+
+  const toggleBool = (key: keyof BoolFilters) => {
+    onBoolFilters({ ...boolFilters, [key]: !boolFilters[key] });
+  };
+
+  return (
+    <aside className="flex min-h-0 flex-col gap-4 overflow-y-auto rounded-[0.9rem] border border-border-muted/45 bg-[linear-gradient(180deg,rgb(var(--bg-rgb)/0.94),rgb(var(--abyss-rgb)/0.98))] p-4 shadow-[var(--shadow-panel)]">
+      <div>
+        <p className="text-[0.62rem] uppercase tracking-[0.32em] text-[var(--color-warm)]/80">
+          Filter & Navigate
+        </p>
+      </div>
+
+      <label className="flex flex-col gap-1.5">
+        <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Search</span>
+        <input
+          value={search}
+          onChange={(e) => onSearch(e.target.value)}
+          placeholder="Search events, notes, eras…"
+          className="ornate-input min-h-9 rounded-[0.55rem] px-3 py-2 text-sm text-text-primary"
+          aria-label="Search timeline events"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1.5">
+        <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Calendar</span>
+        <select
+          value={calendarFilter}
+          onChange={(e) => {
+            onCalendarFilter(e.target.value);
+            onEraFilter(null);
+          }}
+          className="ornate-input min-h-9 rounded-[0.55rem] px-3 py-2 text-sm text-text-primary"
+        >
+          <option value="all">All calendars</option>
+          {calendars.map((c) => (
+            <option key={c.id} value={c.id}>{c.name}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1.5">
+        <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Era</span>
+        <select
+          value={eraFilter ?? ""}
+          onChange={(e) => onEraFilter(e.target.value || null)}
+          className="ornate-input min-h-9 rounded-[0.55rem] px-3 py-2 text-sm text-text-primary"
+          disabled={erasForCalendar.length === 0}
+        >
+          <option value="">All eras</option>
+          {erasForCalendar.map((era) => (
+            <option key={era.id} value={era.id}>{era.name}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1.5">
+        <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Importance</span>
+        <select
+          value={importanceFilter}
+          onChange={(e) => onImportanceFilter(e.target.value)}
+          className="ornate-input min-h-9 rounded-[0.55rem] px-3 py-2 text-sm text-text-primary"
+        >
+          {IMPORTANCE_FILTER_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>{option.label}</option>
+          ))}
+        </select>
+      </label>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Date Range</span>
+        <div className="flex items-center gap-2">
+          <input
+            value={windowStart}
+            onChange={(e) => onWindowStart(e.target.value)}
+            inputMode="numeric"
+            placeholder={fullWindowMin !== undefined ? String(fullWindowMin) : "0"}
+            aria-label="Range start year"
+            className="ornate-input min-h-9 w-full rounded-[0.55rem] px-3 py-2 text-sm text-text-primary"
+          />
+          <span className="text-text-muted">–</span>
+          <input
+            value={windowEnd}
+            onChange={(e) => onWindowEnd(e.target.value)}
+            inputMode="numeric"
+            placeholder={fullWindowMax !== undefined ? String(fullWindowMax) : ""}
+            aria-label="Range end year"
+            className="ornate-input min-h-9 w-full rounded-[0.55rem] px-3 py-2 text-sm text-text-primary"
+          />
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <RangeButton onClick={onFullRange}>Full Range</RangeButton>
+          <RangeButton onClick={onSelectedEra} active>Selected Era</RangeButton>
+          <RangeButton onClick={onThisEra} disabled={!hasSelected}>This Era</RangeButton>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Quick Filters</span>
+        <div className="flex flex-wrap gap-1.5">
+          <Chip selected={importanceFilter === "legendary"} onClick={() => toggleImportance("legendary")}>
+            Legendary
+          </Chip>
+          <Chip selected={importanceFilter === "major"} onClick={() => toggleImportance("major")}>
+            Major
+          </Chip>
+          <Chip selected={importanceFilter === "minor"} onClick={() => toggleImportance("minor")}>
+            Minor
+          </Chip>
+          <Chip selected={boolFilters.unlinked} onClick={() => toggleBool("unlinked")}>
+            Unlinked
+          </Chip>
+          <Chip selected={boolFilters.hasDescription} onClick={() => toggleBool("hasDescription")}>
+            Has Description
+          </Chip>
+          <Chip selected={boolFilters.hasImage} onClick={() => toggleBool("hasImage")}>
+            Has Image
+          </Chip>
+        </div>
+      </div>
+
+      {calendars.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Calendars</span>
+          <div className="flex flex-col gap-1">
+            {calendars.map((calendar, index) => {
+              const color = ERA_PALETTE[index % ERA_PALETTE.length];
+              const count = visibleByCalendar.get(calendar.id) ?? 0;
+              const active = calendarFilter === calendar.id;
+              return (
+                <button
+                  key={calendar.id}
+                  type="button"
+                  onClick={() => {
+                    onCalendarFilter(active ? "all" : calendar.id);
+                    onEraFilter(null);
+                  }}
+                  className={`focus-ring flex items-center justify-between gap-2 rounded-[0.45rem] border px-2.5 py-1.5 text-left transition ${
+                    active
+                      ? "border-[var(--border-accent-ring)] bg-[var(--bg-active)] text-text-primary"
+                      : "border-transparent text-text-secondary hover:border-border-muted/40 hover:bg-bg-secondary/30"
+                  }`}
+                >
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: color }} />
+                    <span className="truncate text-sm">{calendar.name}</span>
+                  </span>
+                  <span className="shrink-0 text-2xs tabular-nums text-text-muted">{count}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {erasForCalendar.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <span className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Eras</span>
+          <div className="flex flex-col gap-1">
+            {erasForCalendar.map((era) => {
+              const active = eraFilter === era.id;
+              return (
+                <button
+                  key={era.id}
+                  type="button"
+                  onClick={() => onEraFilter(active ? null : era.id)}
+                  className={`focus-ring flex items-center justify-between gap-2 rounded-[0.45rem] border px-2.5 py-1.5 text-left transition ${
+                    active
+                      ? "border-[var(--border-accent-ring)] bg-[var(--bg-active)] text-text-primary"
+                      : "border-transparent text-text-secondary hover:border-border-muted/40 hover:bg-bg-secondary/30"
+                  }`}
+                >
+                  <span className="truncate text-sm">{era.name}</span>
+                  <span className="shrink-0 text-2xs tabular-nums text-text-muted">
+                    {formatYear(era.startYear)}+
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <div className="mt-auto pt-2">
+        <button
+          type="button"
+          onClick={onManageCalendars}
+          className="focus-ring flex w-full items-center justify-between gap-2 rounded-[0.55rem] border border-border-muted/40 bg-bg-secondary/30 px-3 py-2.5 text-sm text-text-secondary transition hover:border-[var(--chrome-stroke-emphasis)] hover:bg-bg-secondary/55 hover:text-text-primary"
+        >
+          <span>Manage Calendars & Eras</span>
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden="true">
+            <circle cx="8" cy="8" r="2.5" />
+            <path d="M8 1.5v1.7M8 12.8v1.7M14.5 8h-1.7M3.2 8H1.5M12.6 3.4l-1.2 1.2M4.6 11.4l-1.2 1.2M12.6 12.6l-1.2-1.2M4.6 4.6L3.4 3.4" />
+          </svg>
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function Chip({
+  selected,
+  onClick,
+  children,
+}: {
+  selected: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={`focus-ring rounded-[0.45rem] border px-2.5 py-1 text-2xs transition ${
+        selected
+          ? "border-[var(--border-accent-ring)] bg-[var(--bg-accent-subtle)] text-[var(--color-warm-pale)]"
+          : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] text-text-muted hover:border-[var(--chrome-stroke-emphasis)] hover:text-text-primary"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function RangeButton({
+  onClick,
+  disabled,
+  active,
+  children,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  active?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`focus-ring rounded-[0.45rem] border px-2.5 py-1 text-2xs transition disabled:cursor-not-allowed disabled:opacity-40 ${
+        active
+          ? "border-[var(--border-accent-ring)] bg-[var(--bg-active)] text-text-primary"
+          : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] text-text-muted hover:border-[var(--chrome-stroke-emphasis)] hover:text-text-primary"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ─── Event Inspector ──────────────────────────────────────────────────────
+
+function CommitTextArea({
+  value,
+  onCommit,
+  placeholder,
+  maxLength,
+}: {
+  value: string;
+  onCommit: (value: string) => void;
+  placeholder?: string;
+  maxLength?: number;
+}) {
+  const [draft, setDraft] = useState(value);
+  const [focused, setFocused] = useState(false);
+
+  if (!focused && draft !== value) {
+    setDraft(value);
+  }
+
+  const commit = () => {
+    if (draft !== value) onCommit(draft);
+  };
+
+  return (
+    <div className="relative">
+      <textarea
+        value={draft}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        rows={4}
+        onChange={(e) => setDraft(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => {
+          setFocused(false);
+          commit();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            setDraft(value);
+            (e.target as HTMLTextAreaElement).blur();
+          }
+        }}
+        className="ornate-input min-h-20 w-full resize-none px-3 py-2 pr-16 text-xs leading-relaxed text-text-primary"
+      />
+      {maxLength !== undefined && (
+        <span className="pointer-events-none absolute bottom-2 right-3 text-[0.6rem] text-text-muted">
+          {draft.length} / {maxLength}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function EventInspector({
   resolvedEvent,
   calendars,
-  previous,
-  next,
-  onNavigate,
   onUpdate,
   onDelete,
+  onDuplicate,
+  onClose,
+  className = "",
 }: {
   resolvedEvent: ResolvedTimelineEvent | null;
   calendars: CalendarSystem[];
-  previous: ResolvedTimelineEvent | null;
-  next: ResolvedTimelineEvent | null;
-  onNavigate: (id: string) => void;
   onUpdate: (patch: Partial<TimelineEvent>) => void;
   onDelete: () => void;
+  onDuplicate: () => void;
+  onClose: () => void;
+  className?: string;
 }) {
   const articles = useLoreStore(selectArticles);
   const selectArticle = useLoreStore((s) => s.selectArticle);
 
   if (!resolvedEvent) {
     return (
-      <aside className="rounded-[2rem] border border-border-muted/40 bg-[var(--bg-deep-panel)] p-5 shadow-[var(--shadow-panel)]">
-        <p className="text-[0.65rem] uppercase tracking-[0.28em] text-[var(--color-warm)]/80">
-          Event Inspector
-        </p>
-        <h2 className="mt-3 font-display text-2xl text-[var(--color-warm-pale)]">
-          No event selected
-        </h2>
+      <aside className={`min-h-0 overflow-y-auto rounded-[0.9rem] border border-border-muted/45 bg-[linear-gradient(180deg,rgb(var(--bg-rgb)/0.94),rgb(var(--abyss-rgb)/0.98))] p-5 shadow-[var(--shadow-panel)] ${className}`}>
+        <div className="flex items-start justify-between gap-2">
+          <p className="text-[0.62rem] uppercase tracking-[0.28em] text-[var(--color-warm)]/80">
+            Event Inspector
+          </p>
+        </div>
+        <div className="mt-8 flex flex-col items-center gap-3 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full border border-border-muted/40 bg-bg-secondary/40 text-text-muted">
+            <svg width="20" height="20" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden="true">
+              <circle cx="8" cy="8" r="6" />
+              <path d="M8 5v3l2 2" />
+            </svg>
+          </div>
+          <p className="font-display text-base text-[var(--color-warm-pale)]">No event selected</p>
+          <p className="max-w-xs text-2xs leading-relaxed text-text-muted">
+            Click an event in the timeline or chronicle list to edit its details here.
+          </p>
+        </div>
       </aside>
     );
   }
 
-  const { event, absoluteYear, calendarName, eraName } = resolvedEvent;
-  const calendar = calendars.find((entry) => entry.id === event.calendarId);
+  const { event, absoluteYear, calendar, era } = resolvedEvent;
   const calendarOptions = [
     ...(calendar
       ? []
@@ -281,153 +713,143 @@ function EventInspector({
     ...calendars.map((entry) => ({ value: entry.id, label: entry.name })),
   ];
   const eraOptions = [
-    ...(calendar?.eras.some((era) => era.id === event.eraId) || !event.eraId
+    ...(calendar?.eras.some((e) => e.id === event.eraId) || !event.eraId
       ? []
       : [{ value: event.eraId, label: `Missing era (${event.eraId})` }]),
     { value: "", label: "No era" },
-    ...(calendar?.eras ?? []).map((era) => ({ value: era.id, label: era.name })),
+    ...(calendar?.eras ?? []).map((e) => ({ value: e.id, label: e.name })),
   ];
   const articleOptions = [
-    { value: "", label: "-- none --" },
+    { value: "", label: "— None —" },
     ...Object.values(articles)
       .sort((left, right) => left.title.localeCompare(right.title))
       .map((article) => ({ value: article.id, label: article.title })),
   ];
   const selectedArticle = event.articleId ? articles[event.articleId] : undefined;
-  const style = importanceClasses(event.importance);
 
   return (
-    <aside className="rounded-[2rem] border border-border-muted/40 bg-[var(--bg-deep-panel)] p-5 shadow-[var(--shadow-panel)] xl:sticky xl:top-5">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="text-[0.65rem] uppercase tracking-[0.28em] text-[var(--color-warm)]/80">
+    <aside className={`flex min-h-0 flex-col gap-4 overflow-y-auto rounded-[0.9rem] border border-border-muted/45 bg-[linear-gradient(180deg,rgb(var(--bg-rgb)/0.94),rgb(var(--abyss-rgb)/0.98))] p-5 shadow-[var(--shadow-panel)] ${className}`}>
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-[0.62rem] uppercase tracking-[0.28em] text-[var(--color-warm)]/80">
             Event Inspector
           </p>
-          <h2 className="mt-3 font-display text-2xl leading-tight text-[var(--color-warm-pale)]">
-            {event.title}
-          </h2>
-          <p className="mt-2 text-sm text-text-muted">
-            {formatEventDate(event, calendars)}
-          </p>
-        </div>
-        <span className={`rounded-full border px-3 py-1 text-2xs uppercase tracking-[0.2em] ${style.pill}`}>
-          {event.importance}
-        </span>
-      </div>
-
-      <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-1">
-        <div className="rounded-[1.2rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-4 py-3">
-          <p className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">Calendar</p>
-          <p className="mt-1 font-display text-lg text-text-primary">{calendarName}</p>
-        </div>
-        <div className="rounded-[1.2rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-4 py-3">
-          <p className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">Absolute Year</p>
-          <p className="mt-1 font-display text-lg text-text-primary">{formatYear(absoluteYear)}</p>
-          <p className="text-2xs text-text-muted">{eraName}</p>
-        </div>
-      </div>
-
-      <div className="mt-4 flex gap-2">
-        <ActionButton
-          onClick={() => previous && onNavigate(previous.event.id)}
-          disabled={!previous}
-          variant="ghost"
-          size="sm"
-          className="flex-1"
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close inspector"
+          title="Close inspector"
+          className="focus-ring rounded-[0.45rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-0.5 text-2xs text-text-muted transition hover:text-text-primary"
         >
-          Previous
-        </ActionButton>
-        <ActionButton
-          onClick={() => next && onNavigate(next.event.id)}
-          disabled={!next}
-          variant="ghost"
-          size="sm"
-          className="flex-1"
-        >
-          Next
-        </ActionButton>
+          ✕
+        </button>
       </div>
 
-      <div className="mt-5 flex flex-col gap-1.5">
-        <FieldRow label="Title">
-          <TextInput value={event.title} onCommit={(value) => onUpdate({ title: value })} />
-        </FieldRow>
-        <FieldRow label="Calendar">
-          <SelectInput
-            value={event.calendarId}
-            options={calendarOptions}
-            onCommit={(value) => {
-              const nextCalendar = calendars.find((entry) => entry.id === value);
-              const nextEraId = nextCalendar?.eras.some((era) => era.id === event.eraId)
-                ? event.eraId
-                : (nextCalendar?.eras[0]?.id ?? "");
-              onUpdate({ calendarId: value, eraId: nextEraId });
-            }}
-          />
-        </FieldRow>
-        <FieldRow label="Era">
-          <SelectInput
-            value={event.eraId}
-            options={eraOptions}
-            onCommit={(value) => onUpdate({ eraId: value })}
-          />
-        </FieldRow>
-        <FieldRow label="Year">
-          <NumberInput value={event.year} onCommit={(value) => onUpdate({ year: value ?? 0 })} />
-        </FieldRow>
-        <FieldRow label="Importance">
-          <SelectInput
-            value={event.importance}
-            options={IMPORTANCE_OPTIONS}
-            onCommit={(value) => onUpdate({ importance: value as TimelineEvent["importance"] })}
-          />
-        </FieldRow>
-        <FieldRow label="Article">
-          <SelectInput
-            value={event.articleId ?? ""}
-            options={articleOptions}
-            onCommit={(value) => onUpdate({ articleId: value || undefined })}
-          />
-        </FieldRow>
-        <FieldRow label="Description">
-          <TextInput
-            value={event.description ?? ""}
-            onCommit={(value) => onUpdate({ description: value || undefined })}
-            placeholder="Short chronicle note"
-            dense
-          />
-        </FieldRow>
+      <div>
+        <p className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Event Details</p>
       </div>
 
-      <div className="mt-5 rounded-[1.2rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-4 py-4">
-        <p className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">Linked Article</p>
-        {selectedArticle ? (
-          <>
-            <p className="mt-2 font-display text-lg text-text-primary">{selectedArticle.title}</p>
-            <button
-              type="button"
-              onClick={() => selectArticle(selectedArticle.id)}
-              className="focus-ring mt-3 rounded-full border border-[var(--border-accent-subtle)] px-3 py-1 text-2xs text-accent transition hover:bg-[var(--bg-accent-subtle)]"
-            >
-              Jump to article
-            </button>
-          </>
-        ) : (
-          <p className="mt-2 text-sm leading-6 text-text-muted">None</p>
-        )}
-      </div>
+      <FieldRow label="Title">
+        <TextInput value={event.title} onCommit={(value) => onUpdate({ title: value })} dense />
+      </FieldRow>
 
-      <div className="mt-5 rounded-[1.2rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-4 py-4">
-        <p className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">Event Image</p>
-        <p className="mt-1 text-2xs text-text-muted/80">
-          Renders as a transparent backdrop on the timeline. Independent of any linked article.
-        </p>
+      <FieldRow label="Calendar">
+        <SelectInput
+          value={event.calendarId}
+          options={calendarOptions}
+          dense
+          onCommit={(value) => {
+            const nextCalendar = calendars.find((entry) => entry.id === value);
+            const nextEraId = nextCalendar?.eras.some((era) => era.id === event.eraId)
+              ? event.eraId
+              : (nextCalendar?.eras[0]?.id ?? "");
+            onUpdate({ calendarId: value, eraId: nextEraId });
+          }}
+        />
+      </FieldRow>
+
+      <FieldRow label="Era">
+        <SelectInput
+          value={event.eraId}
+          options={eraOptions}
+          dense
+          onCommit={(value) => onUpdate({ eraId: value })}
+        />
+      </FieldRow>
+
+      <FieldRow label="Year">
+        <NumberInput value={event.year} onCommit={(value) => onUpdate({ year: value ?? 0 })} dense />
+      </FieldRow>
+
+      <FieldRow label="Absolute Year" hint={era ? `${era.name} starts at ${formatYear(era.startYear)}` : undefined}>
+        <div className="rounded-[0.55rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-3 py-2 text-xs tabular-nums text-text-primary">
+          {formatYear(absoluteYear)}
+        </div>
+      </FieldRow>
+
+      <FieldRow label="Importance">
+        <SelectInput
+          value={event.importance}
+          options={IMPORTANCE_OPTIONS}
+          dense
+          onCommit={(value) => onUpdate({ importance: value as TimelineEvent["importance"] })}
+        />
+      </FieldRow>
+
+      <FieldRow label="Linked Article">
+        <div className="flex items-center gap-1.5">
+          <div className="min-w-0 flex-1">
+            <SelectInput
+              value={event.articleId ?? ""}
+              options={articleOptions}
+              dense
+              onCommit={(value) => onUpdate({ articleId: value || undefined })}
+            />
+          </div>
+          {selectedArticle && (
+            <>
+              <button
+                type="button"
+                onClick={() => selectArticle(selectedArticle.id)}
+                title="Jump to article"
+                aria-label="Jump to article"
+                className="focus-ring rounded-[0.45rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-1 text-2xs text-accent transition hover:bg-[var(--bg-accent-subtle)]"
+              >
+                <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+                  <path d="M6 2H3v3M10 14h3v-3M3 13l10-10" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                onClick={() => onUpdate({ articleId: undefined })}
+                title="Unlink article"
+                aria-label="Unlink article"
+                className="focus-ring rounded-[0.45rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-1 text-2xs text-text-muted transition hover:text-status-error"
+              >
+                ✕
+              </button>
+            </>
+          )}
+        </div>
+      </FieldRow>
+
+      <FieldRow label="Description">
+        <CommitTextArea
+          value={event.description ?? ""}
+          onCommit={(value) => onUpdate({ description: value || undefined })}
+          placeholder="Short chronicle note"
+          maxLength={500}
+        />
+      </FieldRow>
+
+      <div className="border-t border-border-muted/30 pt-4">
+        <p className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">Event Image</p>
         <div className="mt-3">
           <FieldRow label="Filename">
             <TextInput
               value={event.image ?? ""}
               onCommit={(value) => onUpdate({ image: value || undefined })}
               placeholder="None"
+              dense
             />
           </FieldRow>
         </div>
@@ -447,16 +869,22 @@ function EventInspector({
             surface="lore"
           />
         </div>
+        <p className="mt-2 text-[0.6rem] text-text-muted">Recommended: 16:9, 1920×1080</p>
       </div>
 
-      <div className="mt-5">
-        <ActionButton onClick={onDelete} variant="danger" size="sm">
-          Delete Event
+      <div className="grid grid-cols-2 gap-2">
+        <ActionButton variant="secondary" onClick={onDuplicate}>
+          Duplicate
+        </ActionButton>
+        <ActionButton variant="danger" onClick={onDelete}>
+          Delete
         </ActionButton>
       </div>
     </aside>
   );
 }
+
+// ─── Event row ────────────────────────────────────────────────────────────
 
 const ChronicleEventRow = memo(function ChronicleEventRow({
   entry,
@@ -485,57 +913,142 @@ const ChronicleEventRow = memo(function ChronicleEventRow({
           onMoveSelection("prev");
         }
       }}
-      className={`focus-ring group relative grid w-full gap-4 rounded-[1.35rem] border px-4 py-4 text-left transition md:grid-cols-[9.5rem_minmax(0,1fr)] ${
-        selected
-          ? "border-[var(--border-accent-ring)] bg-[linear-gradient(145deg,rgb(var(--accent-rgb)/0.16),rgb(var(--bg-rgb)/0.92))] shadow-[var(--shadow-glow)]"
-          : "border-transparent bg-transparent hover:border-border-muted/40 hover:bg-bg-secondary/25"
-      }`}
       aria-pressed={selected}
+      className={`focus-ring group relative grid w-full grid-cols-[0.8rem_5rem_minmax(0,1fr)] items-center gap-3 rounded-[0.45rem] border px-3 py-2 text-left transition md:grid-cols-[0.8rem_5rem_minmax(0,1fr)_7rem_10rem_1.5rem] ${
+        selected
+          ? "border-[var(--border-accent-ring)] bg-[linear-gradient(90deg,rgb(var(--accent-rgb)/0.12),rgb(var(--bg-rgb)/0.30))] shadow-[var(--shadow-glow)]"
+          : "border-border-muted/18 bg-bg-abyss/18 hover:border-border-muted/45 hover:bg-bg-secondary/22"
+      }`}
     >
-      <span
-        className={`absolute left-[-0.68rem] top-8 h-3.5 w-3.5 rounded-full border border-bg-primary ${style.dot}`}
-        aria-hidden="true"
-      />
-
-      <div className="pl-4 md:pl-0">
-        <p className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">{entry.eraName}</p>
-        <p className="mt-2 font-display text-3xl leading-none text-[var(--color-warm-pale)]">
-          Y{formatYear(entry.event.year)}
-        </p>
-        <p className="mt-2 text-2xs uppercase tracking-[0.2em] text-text-muted">
-          Absolute {formatYear(entry.absoluteYear)}
-        </p>
-      </div>
-
-      <div className="min-w-0">
-        <div className="flex flex-wrap items-center gap-2">
-          <h4 className="break-words font-display text-2xl leading-tight text-text-primary">
-            {entry.event.title}
-          </h4>
-          <span className={`rounded-full border px-2.5 py-1 text-2xs uppercase tracking-[0.18em] ${style.pill}`}>
-            {entry.event.importance}
-          </span>
-        </div>
-
-        {entry.event.description && (
-          <p className="mt-3 break-words text-sm leading-7 text-text-secondary">
-            {entry.event.description}
-          </p>
-        )}
-
-        <div className="mt-3 flex flex-wrap items-center gap-2 text-2xs text-text-muted">
-          <span>{entry.calendarName}</span>
-          {entry.event.articleId && (
-            <>
-              <span className="text-text-muted/60">/</span>
-              <span>Linked article</span>
-            </>
-          )}
-        </div>
-      </div>
+      <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${style.dot}`} aria-hidden="true" />
+      <span className="shrink-0 font-display text-sm tabular-nums text-[var(--color-warm-pale)]">
+        Y{formatYear(entry.event.year)}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm text-text-primary">
+        {entry.event.title}
+      </span>
+      <span className={`hidden shrink-0 justify-self-start rounded-full border px-2 py-0.5 text-[0.6rem] uppercase tracking-[0.2em] md:inline-block ${style.pill}`}>
+        {entry.event.importance}
+      </span>
+      <span className="hidden min-w-0 truncate text-xs text-text-muted md:block">
+        {entry.calendar?.name ?? "Uncalendared"}
+      </span>
+      <span className="hidden justify-self-end text-lg leading-none text-text-muted md:block">
+        ...
+      </span>
     </button>
   );
 });
+
+// ─── Event List ──────────────────────────────────────────────────────────
+
+function EventList({
+  groups,
+  totalVisible,
+  selectedEventId,
+  onSelect,
+  onMoveSelection,
+  floatingInspector,
+}: {
+  groups: ReturnType<typeof buildChronicleGroups>;
+  totalVisible: number;
+  selectedEventId: string | null;
+  onSelect: (id: string) => void;
+  onMoveSelection: (direction: "prev" | "next") => void;
+  floatingInspector?: ReactNode;
+}) {
+  const [sortMode, setSortMode] = useState<"year" | "importance">("year");
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[0.9rem] border border-border-muted/40 bg-[linear-gradient(180deg,rgb(var(--bg-rgb)/0.88),rgb(var(--abyss-rgb)/0.94))] shadow-[var(--shadow-panel)]">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-border-muted/30 px-4 py-3">
+        <p className="font-display text-sm uppercase tracking-[0.28em] text-text-muted">
+          {totalVisible} {totalVisible === 1 ? "Event" : "Events"}
+        </p>
+        <div className="flex items-center gap-2">
+          <label className="flex items-center gap-1.5 text-2xs text-text-muted">
+            Sort by
+            <select
+              value={sortMode}
+              onChange={(e) => setSortMode(e.target.value as "year" | "importance")}
+              className="ornate-input min-h-7 rounded-md px-2 py-0.5 text-2xs text-text-primary"
+              aria-label="Sort chronicle events"
+            >
+              <option value="year">Year</option>
+              <option value="importance">Importance</option>
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div className={`grid min-h-0 flex-1 overflow-hidden ${floatingInspector ? "xl:grid-cols-[minmax(0,1fr)_22rem]" : ""}`}>
+        <div className="min-h-0 overflow-y-auto p-2">
+          {groups.map((calendarGroup) =>
+              calendarGroup.eras.map((eraGroup) => {
+            if (eraGroup.events.length === 0) return null;
+            const orderedEvents = sortMode === "importance"
+              ? [...eraGroup.events].sort((a, b) => importanceWeight(b.event.importance) - importanceWeight(a.event.importance))
+              : eraGroup.events;
+            return (
+              <section key={`${calendarGroup.id}:${eraGroup.id}`} className="border-b border-border-muted/25 last:border-b-0">
+                <div className="flex items-baseline gap-4 bg-[linear-gradient(90deg,rgb(var(--accent-rgb)/0.10),transparent_72%)] px-4 py-2">
+                  <p className="font-display text-2xs uppercase tracking-[0.28em] text-[var(--color-warm)]/85">
+                    {eraGroup.eraName}
+                  </p>
+                  {eraGroup.startYear !== null && (
+                    <p className="text-[0.6rem] uppercase tracking-[0.22em] text-text-muted">
+                      {formatYear(eraGroup.startYear)} – {formatYear(eraEndYear(calendarGroup, eraGroup))}
+                    </p>
+                  )}
+                </div>
+                <div className="flex flex-col gap-1 p-2">
+                  {orderedEvents.map((entry) => (
+                    <ChronicleEventRow
+                      key={entry.event.id}
+                      entry={entry}
+                      selected={entry.event.id === selectedEventId}
+                      onSelect={() => onSelect(entry.event.id)}
+                      onMoveSelection={onMoveSelection}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+              }),
+            )}
+        </div>
+        {floatingInspector && (
+          <div className="hidden min-h-0 border-l border-border-muted/30 p-2 xl:block">
+            {floatingInspector}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function importanceWeight(importance: TimelineEvent["importance"]) {
+  if (importance === "legendary") return 3;
+  if (importance === "major") return 2;
+  return 1;
+}
+
+function eraEndYear(
+  calendarGroup: ReturnType<typeof buildChronicleGroups>[number],
+  eraGroup: ReturnType<typeof buildChronicleGroups>[number]["eras"][number],
+): number {
+  if (eraGroup.startYear === null) return 0;
+  const sortedEras = [...calendarGroup.eras]
+    .filter((e) => e.startYear !== null)
+    .sort((a, b) => (a.startYear ?? 0) - (b.startYear ?? 0));
+  const idx = sortedEras.findIndex((e) => e.id === eraGroup.id);
+  const next = idx >= 0 ? sortedEras[idx + 1] : undefined;
+  if (next?.startYear !== undefined && next.startYear !== null) return next.startYear;
+  const lastEvent = eraGroup.events[eraGroup.events.length - 1];
+  return lastEvent ? Math.max(eraGroup.startYear, lastEvent.absoluteYear) : eraGroup.startYear;
+}
+
+// ─── Main Panel ──────────────────────────────────────────────────────────
 
 export function TimelinePanel() {
   const calendars = useLoreStore(selectCalendars);
@@ -544,29 +1057,37 @@ export function TimelinePanel() {
   const addEvent = useLoreStore((s) => s.addTimelineEvent);
   const updateEvent = useLoreStore((s) => s.updateTimelineEvent);
   const deleteEvent = useLoreStore((s) => s.deleteTimelineEvent);
+  const duplicateEvent = useLoreStore((s) => s.duplicateTimelineEvent);
 
+  const [viewMode, setViewMode] = useState<ViewMode>("timeline");
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [calendarFilter, setCalendarFilter] = useState("all");
+  const [eraFilter, setEraFilter] = useState<string | null>(null);
   const [importanceFilter, setImportanceFilter] = useState("all");
-  const [windowStart, setWindowStart] = useState<string>("");
-  const [windowEnd, setWindowEnd] = useState<string>("");
-  const [showCalendarSetup, setShowCalendarSetup] = useState(false);
+  const [windowStart, setWindowStart] = useState("");
+  const [windowEnd, setWindowEnd] = useState("");
+  const [boolFilters, setBoolFilters] = useState<BoolFilters>({
+    unlinked: false,
+    hasDescription: false,
+    hasImage: false,
+  });
+  const [showCalendarManager, setShowCalendarManager] = useState(false);
   const [showSuggestions, setShowSuggestions] = useState(false);
 
   const resolvedEvents = useMemo(() => resolveTimelineEvents(events, calendars), [events, calendars]);
-  const baseFilteredEvents = useMemo(
-    () =>
-      filterResolvedTimelineEvents(resolvedEvents, {
-        search,
-        calendarId: calendarFilter === "all" ? undefined : calendarFilter,
-        importance:
-          importanceFilter === "all"
-            ? undefined
-            : (importanceFilter as TimelineEvent["importance"]),
-      }),
-    [calendarFilter, importanceFilter, resolvedEvents, search],
-  );
+
+  const baseFilteredEvents = useMemo(() => {
+    const filtered = filterResolvedTimelineEvents(resolvedEvents, {
+      search,
+      calendarId: calendarFilter === "all" ? undefined : calendarFilter,
+      importance: importanceFilter === "all" ? undefined : (importanceFilter as TimelineEvent["importance"]),
+    });
+    return applyBoolFilters(applyEraFilter(filtered, eraFilter), boolFilters);
+  }, [calendarFilter, importanceFilter, eraFilter, resolvedEvents, search, boolFilters]);
+
+  const fullWindow = useMemo(() => timelineAbsoluteWindow(baseFilteredEvents), [baseFilteredEvents]);
+
   const activeWindow = useMemo(
     () =>
       timelineAbsoluteWindow(baseFilteredEvents, {
@@ -575,6 +1096,7 @@ export function TimelinePanel() {
       }),
     [baseFilteredEvents, windowEnd, windowStart],
   );
+
   const filteredEvents = useMemo(
     () =>
       filterResolvedTimelineEvents(baseFilteredEvents, {
@@ -583,10 +1105,23 @@ export function TimelinePanel() {
       }),
     [activeWindow?.max, activeWindow?.min, baseFilteredEvents],
   );
+
   const chronicleGroups = useMemo(
-    () => buildChronicleGroups(filteredEvents, calendars).filter((group) => group.visibleEventCount > 0),
+    () => buildChronicleGroups(filteredEvents, calendars).filter((g) => g.visibleEventCount > 0),
     [filteredEvents, calendars],
   );
+
+  const visibleByCalendar = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const cal of calendars) map.set(cal.id, 0);
+    for (const entry of resolvedEvents) {
+      if (entry.event.calendarId) {
+        map.set(entry.event.calendarId, (map.get(entry.event.calendarId) ?? 0) + 1);
+      }
+    }
+    return map;
+  }, [calendars, resolvedEvents]);
+
   const neighbors = useMemo(
     () => getTimelineNeighbors(filteredEvents, selectedEventId),
     [filteredEvents, selectedEventId],
@@ -600,11 +1135,13 @@ export function TimelinePanel() {
   }, [filteredEvents, selectedEventId]);
 
   const handleAddEvent = useCallback(() => {
-    const calendar = calendars[0];
+    const calendar = calendars.find((c) => c.id === (calendarFilter !== "all" ? calendarFilter : undefined)) ?? calendars[0];
     if (!calendar) return;
-    const era = calendar.eras[0];
+    const era = eraFilter
+      ? calendar.eras.find((e) => e.id === eraFilter) ?? calendar.eras[0]
+      : calendar.eras[0];
     const event: TimelineEvent = {
-      id: `evt_${Date.now()}`,
+      id: `evt_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
       calendarId: calendar.id,
       eraId: era?.id ?? "",
       year: 0,
@@ -613,35 +1150,36 @@ export function TimelinePanel() {
     };
     addEvent(event);
     setSelectedEventId(event.id);
-  }, [calendars, addEvent]);
+  }, [calendars, addEvent, calendarFilter, eraFilter]);
 
   const handleMoveSelection = useCallback(
     (direction: "prev" | "next") => {
       const target = direction === "prev" ? neighbors.previous : neighbors.next;
-      if (target) {
-        setSelectedEventId(target.event.id);
-      }
+      if (target) setSelectedEventId(target.event.id);
     },
     [neighbors.next, neighbors.previous],
   );
+
   const selectedResolved = neighbors.current;
 
-  const handleClearFilters = useCallback(() => {
-    setSearch("");
-    setCalendarFilter("all");
-    setImportanceFilter("all");
+  const handleFullRange = useCallback(() => {
     setWindowStart("");
     setWindowEnd("");
   }, []);
 
-  const fullWindow = useMemo(() => timelineAbsoluteWindow(baseFilteredEvents), [baseFilteredEvents]);
+  const handleSelectedEra = useCallback(() => {
+    if (!eraFilter) return;
+    const cal = calendars.find((c) => c.eras.some((e) => e.id === eraFilter));
+    const era = cal?.eras.find((e) => e.id === eraFilter);
+    if (!era || !cal) return;
+    const sorted = [...cal.eras].sort((a, b) => a.startYear - b.startYear);
+    const idx = sorted.findIndex((e) => e.id === era.id);
+    const next = idx >= 0 ? sorted[idx + 1] : undefined;
+    setWindowStart(String(era.startYear));
+    setWindowEnd(String(next ? next.startYear - 1 : era.startYear + 200));
+  }, [calendars, eraFilter]);
 
-  const handleResetWindow = useCallback(() => {
-    setWindowStart("");
-    setWindowEnd("");
-  }, []);
-
-  const handleFocusSelectedEra = useCallback(() => {
+  const handleThisEra = useCallback(() => {
     if (!selectedResolved) return;
     const era = selectedResolved.era;
     if (!era) {
@@ -650,304 +1188,251 @@ export function TimelinePanel() {
       return;
     }
     const sortedEras = [...(selectedResolved.calendar?.eras ?? [])].sort((a, b) => a.startYear - b.startYear);
-    const currentIndex = sortedEras.findIndex((entry) => entry.id === era.id);
-    const nextStart = currentIndex >= 0 ? sortedEras[currentIndex + 1]?.startYear : undefined;
+    const idx = sortedEras.findIndex((e) => e.id === era.id);
+    const nextStart = idx >= 0 ? sortedEras[idx + 1]?.startYear : undefined;
     const end = nextStart !== undefined ? nextStart - 1 : Math.max(selectedResolved.absoluteYear, era.startYear + 50);
     setWindowStart(String(era.startYear));
     setWindowEnd(String(end));
   }, [selectedResolved]);
 
-  const hasActiveFilters =
-    search.trim().length > 0 || calendarFilter !== "all" || importanceFilter !== "all" || windowStart.trim().length > 0 || windowEnd.trim().length > 0;
-  const visibleCalendarCount = new Set(filteredEvents.map((entry) => entry.event.calendarId)).size;
-  const calendarLabel =
-    calendarFilter === "all"
-      ? `${visibleCalendarCount || calendars.length || 0} calendar${(visibleCalendarCount || calendars.length || 0) === 1 ? "" : "s"}`
-      : (calendars.find((entry) => entry.id === calendarFilter)?.name ?? "Unknown calendar");
+  const handleWindowChange = useCallback(
+    (next: { min: number; max: number } | null) => {
+      if (!next || !fullWindow) {
+        setWindowStart("");
+        setWindowEnd("");
+        return;
+      }
+      setWindowStart(String(next.min));
+      setWindowEnd(String(next.max));
+    },
+    [fullWindow],
+  );
+
+  const handleDuplicate = useCallback(() => {
+    if (!selectedResolved) return;
+    const newId = duplicateEvent(selectedResolved.event.id);
+    if (newId) setSelectedEventId(newId);
+  }, [duplicateEvent, selectedResolved]);
+
+  const handleDeleteSelected = useCallback(() => {
+    if (!selectedResolved) return;
+    deleteEvent(selectedResolved.event.id);
+    setSelectedEventId(null);
+  }, [deleteEvent, selectedResolved]);
+
+  const headerTitle = useMemo(() => {
+    if (calendarFilter !== "all") {
+      const cal = calendars.find((c) => c.id === calendarFilter);
+      if (cal) return cal.name;
+    }
+    if (eraFilter) {
+      const era = calendars.flatMap((c) => c.eras).find((e) => e.id === eraFilter);
+      if (era) return era.name;
+    }
+    return "Chronicle";
+  }, [calendars, calendarFilter, eraFilter]);
+
+  const ribbon = (
+    <TimelineView
+      events={filteredEvents.map((entry) => entry.event)}
+      calendars={calendars}
+      selectedEventId={selectedEventId}
+      onSelectEvent={setSelectedEventId}
+      fullWindow={fullWindow}
+      activeWindow={activeWindow}
+      onWindowChange={handleWindowChange}
+    />
+  );
+
+  const inspector = (
+    <EventInspector
+      resolvedEvent={selectedResolved}
+      calendars={calendars}
+      onUpdate={(patch) => selectedResolved && updateEvent(selectedResolved.event.id, patch)}
+      onDelete={handleDeleteSelected}
+      onDuplicate={handleDuplicate}
+      onClose={() => setSelectedEventId(null)}
+      className="h-full"
+    />
+  );
+
+  const list = (
+    <EventList
+      groups={chronicleGroups}
+      totalVisible={filteredEvents.length}
+      selectedEventId={selectedEventId}
+      onSelect={setSelectedEventId}
+      onMoveSelection={handleMoveSelection}
+      floatingInspector={inspector}
+    />
+  );
 
   return (
-    <div className="flex flex-col gap-6">
-      <section className="rounded-[2rem] border border-border-muted/40 bg-[radial-gradient(circle_at_top_left,rgb(var(--accent-rgb)/0.12),transparent_36%),linear-gradient(155deg,rgb(var(--bg-rgb)/0.98),rgb(var(--abyss-rgb)/0.96))] p-6 shadow-[var(--shadow-panel)]">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <p className="text-[0.65rem] uppercase tracking-[0.32em] text-[var(--color-warm)]/80">
-              Chronicle Workspace
-            </p>
-            <h1 className="mt-3 max-w-3xl font-display text-3xl leading-tight text-[var(--color-warm-pale)] sm:text-4xl">
-              Timeline
-            </h1>
+    <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-[0.9rem] border border-border-muted/45 bg-[linear-gradient(180deg,rgb(var(--bg-rgb)/0.72),rgb(var(--abyss-rgb)/0.92))] shadow-[var(--shadow-panel)]">
+      {/* Header */}
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border-muted/45 bg-[radial-gradient(circle_at_top_left,rgb(var(--accent-rgb)/0.10),transparent_38%),linear-gradient(160deg,rgb(var(--bg-rgb)/0.96),rgb(var(--abyss-rgb)/0.94))] px-5 py-3">
+        <div className="min-w-0">
+          <p className="text-[0.6rem] uppercase tracking-[0.32em] text-[var(--color-warm)]/80">
+            Chronicle · Timeline Editor
+          </p>
+          <h1 className="mt-1 truncate font-display text-2xl text-text-primary">
+            {headerTitle}
+          </h1>
+        </div>
+
+        <div className="mr-44 flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-0.5 rounded-[0.7rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] p-0.5">
+            {(["timeline", "list"] as ViewMode[]).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setViewMode(mode)}
+                aria-pressed={viewMode === mode}
+                className={`focus-ring flex items-center gap-1.5 rounded-[0.55rem] px-3 py-1.5 text-2xs transition ${
+                  viewMode === mode
+                    ? "bg-[var(--bg-active-strong)] text-text-primary shadow-[var(--shadow-glow)]"
+                    : "text-text-muted hover:text-text-primary"
+                }`}
+              >
+                <ViewModeIcon mode={mode} />
+                {mode.charAt(0).toUpperCase() + mode.slice(1)}
+              </button>
+            ))}
           </div>
+
+          <ActionButton
+            onClick={() => setShowSuggestions((v) => !v)}
+            variant={showSuggestions ? "secondary" : "ghost"}
+            size="sm"
+          >
+            {showSuggestions ? "Hide AI" : "AI Suggest"}
+          </ActionButton>
+
           <ActionButton onClick={handleAddEvent} variant="primary" disabled={calendars.length === 0}>
-            Add Event
+            + Add Event
           </ActionButton>
         </div>
+      </header>
 
-        <div className="mt-6 grid gap-3 xl:grid-cols-[minmax(0,1.35fr)_minmax(12rem,0.7fr)_minmax(12rem,0.7fr)_minmax(10rem,0.55fr)_minmax(10rem,0.55fr)_auto]">
-          <label className="flex flex-col gap-2">
-            <span className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">Search</span>
-            <input
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search titles, notes, eras, or importance"
-              className="ornate-input min-h-11 rounded-2xl px-4 py-3 text-sm text-text-primary"
-              aria-label="Search timeline events"
-            />
-          </label>
-
-          <label className="flex flex-col gap-2">
-            <span className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">Calendar</span>
-            <select
-              value={calendarFilter}
-              onChange={(e) => setCalendarFilter(e.target.value)}
-              className="ornate-input min-h-11 rounded-2xl px-4 py-3 text-sm text-text-primary"
-              aria-label="Filter by calendar"
-            >
-              <option value="all">All calendars</option>
-              {calendars.map((calendar) => (
-                <option key={calendar.id} value={calendar.id}>
-                  {calendar.name}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="flex flex-col gap-2">
-            <span className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">Importance</span>
-            <select
-              value={importanceFilter}
-              onChange={(e) => setImportanceFilter(e.target.value)}
-              className="ornate-input min-h-11 rounded-2xl px-4 py-3 text-sm text-text-primary"
-              aria-label="Filter by importance"
-            >
-              {IMPORTANCE_FILTER_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="flex flex-col gap-2">
-            <span className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">From</span>
-            <input
-              value={windowStart}
-              onChange={(e) => setWindowStart(e.target.value)}
-              inputMode="numeric"
-              placeholder={fullWindow ? String(fullWindow.min) : ""}
-              className="ornate-input min-h-11 rounded-2xl px-4 py-3 text-sm text-text-primary"
-              aria-label="Timeline range start year"
-            />
-          </label>
-
-          <label className="flex flex-col gap-2">
-            <span className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">To</span>
-            <input
-              value={windowEnd}
-              onChange={(e) => setWindowEnd(e.target.value)}
-              inputMode="numeric"
-              placeholder={fullWindow ? String(fullWindow.max) : ""}
-              className="ornate-input min-h-11 rounded-2xl px-4 py-3 text-sm text-text-primary"
-              aria-label="Timeline range end year"
-            />
-          </label>
-
-          <div className="flex items-end">
-            <ActionButton
-              onClick={handleClearFilters}
-              variant="ghost"
-              disabled={!hasActiveFilters}
-              className="w-full xl:w-auto"
-            >
-              Clear Filters
-            </ActionButton>
-          </div>
+      {showSuggestions && (
+        <div className="border-b border-border-muted/35 bg-[var(--bg-deep-section)] p-4">
+          <TimelineInferencePanel />
         </div>
+      )}
 
-        <div className="mt-5 flex flex-wrap items-center gap-2">
-          <FilterPill label={`${filteredEvents.length} visible of ${events.length}`} />
-          <FilterPill label={calendarLabel} />
-          <FilterPill
-            label={
-              importanceFilter === "all"
-                ? "all importance"
-                : `${importanceFilter} only`
-            }
-          />
-          {activeWindow && fullWindow && (activeWindow.min !== fullWindow.min || activeWindow.max !== fullWindow.max) && (
-            <FilterPill label={`${formatYear(activeWindow.min)}-${formatYear(activeWindow.max)}`} />
-          )}
-          {search.trim() && <FilterPill label={`search: ${search.trim()}`} />}
-        </div>
-
-        <div className="mt-5 flex flex-wrap gap-2">
-          <ActionButton onClick={handleResetWindow} variant="ghost" size="sm" disabled={windowStart.trim() === "" && windowEnd.trim() === ""}>
-            Full Range
-          </ActionButton>
-          <ActionButton onClick={handleFocusSelectedEra} variant="ghost" size="sm" disabled={!selectedResolved}>
-            Selected Era
-          </ActionButton>
-        </div>
-
-        <div className="mt-5 grid gap-3 lg:grid-cols-2">
-          <UtilityToggle
-            title="AI Suggestions"
-            open={showSuggestions}
-            onToggle={() => setShowSuggestions((value) => !value)}
-          />
-          <UtilityToggle
-            title="Calendar Setup"
-            open={showCalendarSetup}
-            onToggle={() => setShowCalendarSetup((value) => !value)}
-          />
-        </div>
-      </section>
-
-      <div className="grid min-h-0 gap-6 xl:grid-cols-[minmax(0,1.65fr)_24rem]">
-        <section className="min-h-[44rem] rounded-[2rem] border border-border-muted/40 bg-[var(--bg-deep-panel)] p-5 shadow-[var(--shadow-panel)]">
-          {(showSuggestions || showCalendarSetup) && (
-            <div className="mb-5 flex flex-col gap-4">
-              {showSuggestions && (
-                <div className="rounded-[1.6rem] border border-border-muted/35 bg-[var(--bg-deep-section)] p-5">
-                  <TimelineInferencePanel />
-                </div>
-              )}
-              {showCalendarSetup && (
-                <div className="rounded-[1.6rem] border border-border-muted/35 bg-[var(--bg-deep-section)] p-5">
-                  <CalendarEditor calendars={calendars} onChange={setCalendars} />
-                </div>
-              )}
-            </div>
-          )}
-
-          {calendars.length === 0 ? (
-            <div className="flex min-h-[30rem] flex-col items-center justify-center gap-4 rounded-[1.6rem] border border-dashed border-border-muted/45 bg-bg-secondary/10 px-6 text-center">
-              <p className="font-display text-2xl text-[var(--color-warm-pale)]">No calendar systems yet</p>
-              <ActionButton onClick={() => setShowCalendarSetup(true)} variant="secondary">
-                Open Calendar Setup
-              </ActionButton>
-            </div>
-          ) : events.length === 0 ? (
-            <div className="flex min-h-[30rem] flex-col items-center justify-center gap-4 rounded-[1.6rem] border border-dashed border-border-muted/45 bg-bg-secondary/10 px-6 text-center">
-              <p className="font-display text-2xl text-[var(--color-warm-pale)]">The chronicle is still blank</p>
-              <div className="flex flex-wrap justify-center gap-2">
-                <ActionButton onClick={handleAddEvent} variant="primary">
-                  Add Event
-                </ActionButton>
-                <ActionButton onClick={() => setShowSuggestions(true)} variant="ghost">
-                  Open Suggestions
-                </ActionButton>
-              </div>
-            </div>
-          ) : filteredEvents.length === 0 ? (
-            <div className="flex min-h-[30rem] flex-col items-center justify-center gap-4 rounded-[1.6rem] border border-dashed border-border-muted/45 bg-bg-secondary/10 px-6 text-center">
-              <p className="font-display text-2xl text-[var(--color-warm-pale)]">No events match these filters</p>
-              <ActionButton onClick={handleClearFilters} variant="secondary">
-                Clear Filters
-              </ActionButton>
-            </div>
-          ) : (
-            <div className="flex flex-col gap-5">
-              <TimelineView
-                events={filteredEvents.map((entry) => entry.event)}
-                calendars={calendars}
-                selectedEventId={selectedEventId}
-                onSelectEvent={setSelectedEventId}
-                range={activeWindow}
-              />
-
-              <div className="rounded-[1.6rem] border border-border-muted/35 bg-[var(--bg-deep-panel)] p-5">
-                <div className="flex flex-wrap items-end justify-between gap-3 border-b border-border-muted/25 pb-4">
-                  <div>
-                    <p className="text-[0.65rem] uppercase tracking-[0.28em] text-[var(--color-warm)]/80">
-                      Chronicle
-                    </p>
-                    <h2 className="mt-2 font-display text-2xl text-text-primary">
-                      Ordered by time, grouped by era
-                    </h2>
-                  </div>
-                </div>
-
-                <div className="mt-6 space-y-8">
-                  {chronicleGroups.map((calendarGroup) => (
-                    <section key={calendarGroup.id}>
-                      <div className="flex flex-wrap items-end justify-between gap-3">
-                        <div>
-                          <p className="text-[0.65rem] uppercase tracking-[0.28em] text-text-muted">
-                            Calendar
-                          </p>
-                          <h3 className="mt-1 font-display text-3xl text-[var(--color-warm-pale)]">
-                            {calendarGroup.calendarName}
-                          </h3>
-                        </div>
-                        <p className="text-2xs uppercase tracking-[0.22em] text-text-muted">
-                          {calendarGroup.visibleEventCount} event{calendarGroup.visibleEventCount === 1 ? "" : "s"}
-                        </p>
-                      </div>
-
-                      <div className="mt-5 space-y-6">
-                        {calendarGroup.eras.map((eraGroup) => (
-                          <div key={eraGroup.id} className="rounded-[1.4rem] border border-border-muted/25 bg-bg-secondary/15 px-4 py-4">
-                            <div className="flex flex-wrap items-end justify-between gap-2">
-                              <div>
-                                <p className="text-[0.65rem] uppercase tracking-[0.24em] text-text-muted">
-                                  Era
-                                </p>
-                                <h4 className="mt-1 font-display text-xl text-text-primary">
-                                  {eraGroup.eraName}
-                                </h4>
-                              </div>
-                              {eraGroup.startYear !== null && (
-                                <p className="text-2xs uppercase tracking-[0.22em] text-text-muted">
-                                  Begins at {formatYear(eraGroup.startYear)}
-                                </p>
-                              )}
-                            </div>
-
-                            {eraGroup.events.length === 0 ? (
-                              <p className="mt-4 rounded-[1rem] border border-dashed border-border-muted/35 px-4 py-3 text-sm text-text-muted">
-                                No visible events are recorded in this era yet.
-                              </p>
-                            ) : (
-                              <div className="relative mt-5 pl-5">
-                                <div className="absolute bottom-3 left-[0.4rem] top-3 w-px bg-gradient-to-b from-[var(--color-warm)]/45 via-border-muted/40 to-transparent" />
-                                <div className="space-y-3">
-                                  {eraGroup.events.map((entry) => (
-                                    <ChronicleEventRow
-                                      key={entry.event.id}
-                                      entry={entry}
-                                      selected={entry.event.id === selectedEventId}
-                                      onSelect={() => setSelectedEventId(entry.event.id)}
-                                      onMoveSelection={handleMoveSelection}
-                                    />
-                                  ))}
-                                </div>
-                              </div>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    </section>
-                  ))}
-                </div>
-              </div>
-            </div>
-          )}
-        </section>
-
-        <EventInspector
-          resolvedEvent={selectedResolved}
+      {/* Body */}
+      <div className="grid min-h-0 flex-1 gap-4 overflow-hidden p-3 lg:grid-cols-[16rem_minmax(0,1fr)]">
+        <FilterRail
+          search={search}
+          onSearch={setSearch}
           calendars={calendars}
-          previous={neighbors.previous}
-          next={neighbors.next}
-          onNavigate={setSelectedEventId}
-          onUpdate={(patch) => selectedResolved && updateEvent(selectedResolved.event.id, patch)}
-          onDelete={() => {
-            if (!selectedResolved) return;
-            deleteEvent(selectedResolved.event.id);
-            setSelectedEventId(null);
-          }}
+          calendarFilter={calendarFilter}
+          onCalendarFilter={setCalendarFilter}
+          eraFilter={eraFilter}
+          onEraFilter={setEraFilter}
+          importanceFilter={importanceFilter}
+          onImportanceFilter={setImportanceFilter}
+          windowStart={windowStart}
+          windowEnd={windowEnd}
+          onWindowStart={setWindowStart}
+          onWindowEnd={setWindowEnd}
+          onFullRange={handleFullRange}
+          onSelectedEra={handleSelectedEra}
+          onThisEra={handleThisEra}
+          hasSelected={!!selectedResolved}
+          boolFilters={boolFilters}
+          onBoolFilters={setBoolFilters}
+          visibleByCalendar={visibleByCalendar}
+          onManageCalendars={() => setShowCalendarManager(true)}
+          fullWindowMin={fullWindow?.min}
+          fullWindowMax={fullWindow?.max}
         />
+
+        <main className="flex min-h-0 min-w-0 flex-col gap-3 overflow-hidden">
+          {calendars.length === 0 ? (
+            <EmptyState
+              title="No calendar systems yet"
+              body="Add a calendar to begin recording dated events on the timeline."
+              action={{
+                label: "Manage Calendars",
+                onClick: () => setShowCalendarManager(true),
+              }}
+            />
+          ) : events.length === 0 ? (
+            <EmptyState
+              title="The chronicle is still blank"
+              body="Add your first event to start building this world's history."
+              action={{ label: "+ Add Event", onClick: handleAddEvent }}
+            />
+          ) : filteredEvents.length === 0 ? (
+            <EmptyState
+              title="No events match these filters"
+              body="Adjust the filters in the sidebar, or clear them to see all events."
+            />
+          ) : (
+            <>
+              {viewMode === "timeline" && (
+                <>
+                  <div className="shrink-0">{ribbon}</div>
+                  {list}
+                </>
+              )}
+              {viewMode === "list" && list}
+            </>
+          )}
+        </main>
+
       </div>
+
+      <ManageCalendarsDialog
+        open={showCalendarManager}
+        calendars={calendars}
+        onChange={setCalendars}
+        onClose={() => setShowCalendarManager(false)}
+      />
     </div>
   );
+}
+
+function EmptyState({
+  title,
+  body,
+  action,
+}: {
+  title: string;
+  body: string;
+  action?: { label: string; onClick: () => void };
+}) {
+  return (
+    <div className="flex min-h-[24rem] flex-col items-center justify-center gap-3 rounded-[1.5rem] border border-dashed border-border-muted/45 bg-bg-secondary/15 px-6 text-center">
+      <p className="font-display text-2xl text-[var(--color-warm-pale)]">{title}</p>
+      <p className="max-w-md text-sm text-text-muted">{body}</p>
+      {action && (
+        <ActionButton onClick={action.onClick} variant="primary">
+          {action.label}
+        </ActionButton>
+      )}
+    </div>
+  );
+}
+
+function ViewModeIcon({ mode }: { mode: ViewMode }) {
+  if (mode === "timeline") {
+    return (
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+        <path d="M2 8h12" />
+        <circle cx="4" cy="8" r="1.4" fill="currentColor" />
+        <circle cx="8" cy="8" r="1.4" fill="currentColor" />
+        <circle cx="12" cy="8" r="1.4" fill="currentColor" />
+      </svg>
+    );
+  }
+  if (mode === "list") {
+    return (
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+        <path d="M3 4h10M3 8h10M3 12h10" />
+      </svg>
+    );
+  }
+  return null;
 }

--- a/creator/src/components/lore/TimelineView.tsx
+++ b/creator/src/components/lore/TimelineView.tsx
@@ -1,128 +1,303 @@
-import { useMemo, useState, useCallback } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CalendarSystem, TimelineEvent } from "@/types/lore";
-import { absoluteYear, buildEraBands, eventRange, sortEvents } from "@/lib/loreCalendar";
+import { absoluteYear, buildEraBands, sortEvents } from "@/lib/loreCalendar";
 
-const TRACK_HEIGHT = 148;
-const TRACK_Y = 94;
-const MARKER_Y = 62;
+const ZOOM_PRESETS = [0.75, 1, 1.5, 2] as const;
+const ZOOM_MIN = 0.5;
+const ZOOM_MAX = 4;
 
+const RIBBON_HEIGHT = 210;
+const TRACK_Y = 170;
+const LANE_BASE_Y = 76;
+const LANE_STEP = 22;
+const MAX_LANES = 4;
+const LABEL_PX_PER_CHAR = 6.4;
+const LABEL_MIN_GAP = 14;
+
+const SCRUBBER_HEIGHT = 60;
+const SCRUBBER_HANDLE = 14;
+const SCRUBBER_PAD = 12;
+
+// Solid era colors — avoid red/pink, align with Arcanum's ember + teal palette.
+// These are full-saturation anchors; tinted via color-mix at render time.
 const ERA_COLORS = [
-  "var(--color-era-1)",
-  "var(--color-era-2)",
-  "var(--color-era-3)",
-  "var(--color-era-4)",
-  "var(--color-era-5)",
-  "var(--color-era-6)",
+  "#ff9d3d", // ember
+  "#35a1b0", // stellar blue
+  "#d4b66e", // soft gold
+  "#7cb66d", // moss green
+  "#a897d2", // lavender
+  "#6ec0c2", // pale teal
 ];
+
+function eventColor(importance: TimelineEvent["importance"]) {
+  if (importance === "legendary") return "#d4b66e";
+  if (importance === "major") return "var(--color-accent)";
+  return "var(--color-stellar-blue)";
+}
+
+function eventRadius(importance: TimelineEvent["importance"]) {
+  if (importance === "legendary") return 7;
+  if (importance === "major") return 6;
+  return 4;
+}
+
+function formatYear(value: number) {
+  return new Intl.NumberFormat().format(Math.round(value));
+}
+
+function niceTickStep(span: number, target: number): number {
+  if (span <= 0) return 1;
+  const raw = span / Math.max(1, target);
+  const magnitude = Math.pow(10, Math.floor(Math.log10(raw)));
+  const candidates = [1, 2, 5, 10];
+  for (const c of candidates) {
+    const step = c * magnitude;
+    if (step >= raw) return step;
+  }
+  return 10 * magnitude;
+}
+
+interface LabeledEvent {
+  event: TimelineEvent;
+  absYear: number;
+  x: number;
+  laneY: number | null;
+}
+
+interface RibbonProps {
+  events: TimelineEvent[];
+  calendars: CalendarSystem[];
+  selectedEventId: string | null;
+  onSelectEvent: (id: string | null) => void;
+  fullWindow: { min: number; max: number } | null;
+  activeWindow: { min: number; max: number } | null;
+  onWindowChange: (window: { min: number; max: number } | null) => void;
+}
 
 export function TimelineView({
   events,
   calendars,
   selectedEventId,
   onSelectEvent,
-  range,
-}: {
-  events: TimelineEvent[];
-  calendars: CalendarSystem[];
-  selectedEventId: string | null;
-  onSelectEvent: (id: string | null) => void;
-  range?: { min: number; max: number } | null;
-}) {
+  fullWindow,
+  activeWindow,
+  onWindowChange,
+}: RibbonProps) {
   const [zoom, setZoom] = useState(1);
+  const [containerWidth, setContainerWidth] = useState(960);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
-  const computedRange = useMemo(() => range ?? eventRange(events, calendars), [range, events, calendars]);
-  const span = computedRange.max - computedRange.min || 100;
-  const svgWidth = Math.max(720, 1200 * zoom);
-  const pxPerYear = svgWidth / span;
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    const update = () => setContainerWidth(Math.max(640, node.clientWidth));
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(update);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  const window_ = activeWindow ?? fullWindow ?? { min: 0, max: 100 };
+  const span = Math.max(1, window_.max - window_.min);
+  const ribbonWidth = Math.max(containerWidth, containerWidth * zoom);
+  const innerWidth = ribbonWidth - SCRUBBER_PAD * 2;
+  const pxPerYear = innerWidth / span;
 
   const yearToX = useCallback(
-    (year: number) => (year - computedRange.min) * pxPerYear,
-    [computedRange.min, pxPerYear],
+    (year: number) => SCRUBBER_PAD + (year - window_.min) * pxPerYear,
+    [window_.min, pxPerYear],
   );
 
-  const eraBands = useMemo(() => buildEraBands(calendars, computedRange.max), [calendars, computedRange.max]);
+  const eraBands = useMemo(() => buildEraBands(calendars, window_.max), [calendars, window_.max]);
   const sortedEvents = useMemo(() => sortEvents(events, calendars), [events, calendars]);
 
+  const tickStep = useMemo(() => niceTickStep(span, Math.max(4, Math.round(ribbonWidth / 140))), [span, ribbonWidth]);
   const ticks = useMemo(() => {
-    const rawStep = span / 6;
-    const step = Math.max(1, Math.pow(10, Math.floor(Math.log10(rawStep || 1))));
-    const start = Math.ceil(computedRange.min / step) * step;
-    const result: number[] = [];
-    for (let y = start; y <= computedRange.max; y += step) {
-      result.push(y);
-    }
-    return result;
-  }, [computedRange.max, computedRange.min, span]);
+    const start = Math.ceil(window_.min / tickStep) * tickStep;
+    const out: number[] = [];
+    for (let y = start; y <= window_.max; y += tickStep) out.push(y);
+    return out;
+  }, [tickStep, window_.max, window_.min]);
+
+  // Greedy lane assignment for labeled (non-minor) events
+  const labeledEvents = useMemo<LabeledEvent[]>(() => {
+    const lanes: Array<{ end: number }> = [];
+    return sortedEvents.map((event) => {
+      const absY = absoluteYear(event, calendars);
+      const x = SCRUBBER_PAD + (absY - window_.min) * pxPerYear;
+      if (event.importance === "minor") {
+        return { event, absYear: absY, x, laneY: null };
+      }
+      const labelText = `Y${formatYear(event.year)} ${event.title}`;
+      const approxWidth = Math.min(220, Math.max(80, labelText.length * LABEL_PX_PER_CHAR));
+      const labelStart = x - 6;
+      const labelEnd = labelStart + approxWidth + LABEL_MIN_GAP;
+
+      for (let i = 0; i < MAX_LANES; i++) {
+        const lane = lanes[i];
+        if (!lane || lane.end <= labelStart) {
+          lanes[i] = { end: labelEnd };
+          return { event, absYear: absY, x, laneY: LANE_BASE_Y - i * LANE_STEP };
+        }
+      }
+      return { event, absYear: absY, x, laneY: null };
+    });
+  }, [calendars, pxPerYear, sortedEvents, window_.min]);
+
+  const handlePresetZoom = useCallback((value: number) => {
+    setZoom(Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, value)));
+  }, []);
+
+  const handleNudgeZoom = useCallback((direction: 1 | -1) => {
+    setZoom((z) => Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, +(z + direction * 0.25).toFixed(2))));
+  }, []);
+
+  const handleFocusSelected = useCallback(() => {
+    if (!selectedEventId || !fullWindow) return;
+    const ev = events.find((e) => e.id === selectedEventId);
+    if (!ev) return;
+    const center = absoluteYear(ev, calendars);
+    const fullSpan = fullWindow.max - fullWindow.min || 100;
+    const targetSpan = Math.max(40, fullSpan * 0.25);
+    const min = Math.max(fullWindow.min, Math.round(center - targetSpan / 2));
+    const max = Math.min(fullWindow.max, Math.round(center + targetSpan / 2));
+    onWindowChange({ min, max });
+  }, [calendars, events, fullWindow, onWindowChange, selectedEventId]);
+
+  const handleResetWindow = useCallback(() => {
+    onWindowChange(null);
+  }, [onWindowChange]);
 
   return (
-    <div className="rounded-[1.6rem] border border-border-muted/50 bg-[var(--bg-deep-section)] p-4 shadow-[var(--shadow-section)]">
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-        <p className="text-[0.65rem] uppercase tracking-[0.28em] text-[var(--color-warm)]/80">
-          Chronicle Overview
-        </p>
-        <div className="flex items-center gap-1 rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] p-1">
-          {[0.75, 1, 1.5, 2].map((value) => (
+    <div
+      ref={containerRef}
+      className="rounded-[0.8rem] border border-border-muted/40 bg-[radial-gradient(circle_at_50%_0%,rgb(var(--accent-rgb)/0.08),transparent_42%),linear-gradient(180deg,rgb(var(--bg-rgb)/0.90),rgb(var(--abyss-rgb)/0.95))] p-4 shadow-[var(--shadow-section)]"
+    >
+      {/* Toolbar */}
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-2xs uppercase tracking-[0.24em] text-text-muted">
+          <span>Zoom</span>
+          <div className="flex items-center gap-1 rounded-[0.7rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-1.5 py-1">
             <button
-              key={value}
               type="button"
-              onClick={() => setZoom(value)}
-              aria-label={`Zoom overview to ${value}x`}
-              aria-pressed={zoom === value}
-              className={`focus-ring rounded-full px-3 py-1 text-2xs transition ${
-                zoom === value
-                  ? "bg-[var(--bg-active-strong)] text-text-primary shadow-[var(--shadow-glow)]"
-                  : "text-text-muted hover:bg-[var(--chrome-highlight)] hover:text-text-primary"
-              }`}
+              onClick={() => handleNudgeZoom(-1)}
+              aria-label="Zoom out"
+              className="focus-ring rounded-full px-2 py-0.5 text-text-muted transition hover:text-text-primary"
             >
-              {value}x
+              −
             </button>
-          ))}
+            {ZOOM_PRESETS.map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => handlePresetZoom(value)}
+                aria-pressed={Math.abs(zoom - value) < 0.01}
+                className={`focus-ring rounded-md px-2.5 py-0.5 text-2xs transition ${
+                  Math.abs(zoom - value) < 0.01
+                    ? "bg-[var(--bg-active-strong)] text-text-primary shadow-[var(--shadow-glow)]"
+                    : "text-text-muted hover:text-text-primary"
+                }`}
+              >
+                {value}x
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => handleNudgeZoom(1)}
+              aria-label="Zoom in"
+              className="focus-ring rounded-full px-2 py-0.5 text-text-muted transition hover:text-text-primary"
+            >
+              +
+            </button>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-2xs uppercase tracking-[0.24em] text-text-muted">View</span>
+          <div className="rounded-[0.55rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-3 py-1 text-2xs text-text-primary">
+            Years
+          </div>
+          <button
+            type="button"
+            onClick={handleFocusSelected}
+            disabled={!selectedEventId}
+            aria-label="Focus selected event"
+            title="Focus selected event"
+            className="focus-ring rounded-[0.55rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-1 text-text-muted transition hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden="true">
+              <circle cx="8" cy="8" r="3" />
+              <line x1="8" y1="1.5" x2="8" y2="3.5" />
+              <line x1="8" y1="12.5" x2="8" y2="14.5" />
+              <line x1="1.5" y1="8" x2="3.5" y2="8" />
+              <line x1="12.5" y1="8" x2="14.5" y2="8" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={handleResetWindow}
+            aria-label="Reset to full range"
+            title="Reset to full range"
+            className="focus-ring rounded-[0.55rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-1 text-text-muted transition hover:text-text-primary"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden="true">
+              <path d="M2 6V2h4M14 6V2h-4M2 10v4h4M14 10v4h-4" />
+            </svg>
+          </button>
         </div>
       </div>
 
-      <div className="overflow-x-auto rounded-[1.25rem] border border-border-muted/35 bg-bg-abyss/70">
-        <svg
-          width={svgWidth}
-          height={TRACK_HEIGHT}
-          className="select-none"
-          role="img"
-          aria-label={`Overview timeline with ${events.length} visible events`}
-        >
-          {eraBands.map((band, index) => {
-            const x = yearToX(band.startYear);
-            const width = Math.max(1, yearToX(band.endYear) - x);
-            return (
-              <g key={`${band.calendarName}:${band.era.id}`}>
-                <rect
-                  x={x}
-                  y={16}
-                  width={width}
-                  height={52}
-                  fill={band.era.color || ERA_COLORS[index % ERA_COLORS.length]}
-                  rx={12}
-                />
-                {width > 96 && (
-                  <text
-                    x={x + 10}
-                    y={34}
-                    fill="var(--color-text-secondary)"
-                    fontSize={10}
-                    style={{ fontFamily: "var(--font-display), Palatino, serif" }}
+      <div className="overflow-x-auto rounded-[0.7rem] border border-border-muted/35 bg-[linear-gradient(180deg,rgb(var(--abyss-rgb)/0.58),rgb(var(--bg-rgb)/0.28))]">
+        <div className="relative" style={{ width: ribbonWidth, minWidth: "100%" }}>
+          {eraBands.length > 0 && (
+            <div className="relative h-14 border-b border-border-muted/25 bg-bg-abyss/25">
+            {eraBands.map((band, index) => {
+              const x = yearToX(band.startYear);
+              const width = Math.max(8, yearToX(band.endYear) - x);
+              const color = band.era.color || ERA_COLORS[index % ERA_COLORS.length]!;
+              return (
+                <div
+                  key={`${band.calendarName}:${band.era.id}`}
+                  className="absolute top-0 flex h-14 flex-col justify-center overflow-hidden border-r px-3"
+                  style={{
+                    left: x,
+                    width,
+                    background: `linear-gradient(180deg, color-mix(in srgb, ${color} 22%, transparent), color-mix(in srgb, ${color} 8%, transparent))`,
+                    borderColor: `color-mix(in srgb, ${color} 45%, transparent)`,
+                  }}
+                  title={`${band.era.name} · ${formatYear(band.startYear)} – ${formatYear(band.endYear)}`}
+                >
+                  <p
+                    className="truncate font-display text-2xs uppercase tracking-[0.22em]"
+                    style={{ color: `color-mix(in srgb, ${color} 88%, white)` }}
                   >
                     {band.era.name}
-                  </text>
-                )}
-              </g>
-            );
-          })}
+                  </p>
+                  <p className="truncate text-[0.65rem] text-text-secondary">
+                    {formatYear(band.startYear)} – {formatYear(band.endYear)}
+                  </p>
+                </div>
+              );
+            })}
+            </div>
+          )}
 
+          <svg
+            width={ribbonWidth}
+            height={RIBBON_HEIGHT}
+            className="block select-none"
+            role="img"
+            aria-label={`Timeline overview with ${events.length} events`}
+          >
           <line
             x1={0}
-            y1={MARKER_Y}
-            x2={svgWidth}
-            y2={MARKER_Y}
-            stroke="var(--color-border-muted)"
-            strokeWidth={1}
+            y1={TRACK_Y}
+            x2={ribbonWidth}
+            y2={TRACK_Y}
+            stroke="var(--color-warm)"
+            strokeOpacity={0.55}
+            strokeWidth={1.6}
           />
 
           {ticks.map((year) => {
@@ -131,74 +306,311 @@ export function TimelineView({
               <g key={year}>
                 <line
                   x1={x}
-                  y1={TRACK_Y}
+                  y1={TRACK_Y - 5}
                   x2={x}
-                  y2={MARKER_Y - 6}
-                  stroke="var(--color-border-muted)"
+                  y2={TRACK_Y + 5}
+                  stroke="var(--color-warm)"
+                  strokeOpacity={0.6}
                   strokeWidth={1}
-                  opacity={0.6}
                 />
                 <text
                   x={x}
-                  y={TRACK_Y + 18}
+                  y={TRACK_Y + 22}
                   textAnchor="middle"
-                  fill="var(--color-text-muted)"
-                  fontSize={9}
+                  fill="var(--color-text-secondary)"
+                  fontSize={11}
                   style={{ fontFamily: "var(--font-mono), Consolas, monospace" }}
                 >
-                  {Math.round(year)}
+                  {formatYear(year)}
                 </text>
               </g>
             );
           })}
 
-          {sortedEvents.map((event) => {
-            const x = yearToX(absoluteYear(event, calendars));
+          {labeledEvents.map((entry) => {
+            const { event, x, laneY } = entry;
             const isSelected = event.id === selectedEventId;
-            const fill =
-              event.importance === "legendary"
-                ? "var(--color-warm)"
-                : event.importance === "major"
-                  ? "var(--color-accent)"
-                  : "var(--color-stellar-blue)";
-            const radius = event.importance === "legendary" ? 8 : event.importance === "major" ? 6 : 4;
+            const fill = eventColor(event.importance);
+            const radius = eventRadius(event.importance);
+            const labelY = laneY;
+            const labelText = `Y${formatYear(event.year)}`;
+
             return (
               <g
                 key={event.id}
                 className="cursor-pointer"
                 onClick={() => onSelectEvent(event.id)}
+                tabIndex={0}
+                role="button"
+                aria-label={`${event.title} (year ${event.year})`}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onSelectEvent(event.id);
+                  }
+                }}
               >
-                {isSelected && (
-                  <circle
-                    cx={x}
-                    cy={MARKER_Y}
-                    r={radius + 5}
-                    fill={fill}
-                    opacity={0.18}
-                  />
+                {labelY !== null && labelY !== undefined && (
+                  <g>
+                    <text
+                      x={x}
+                      y={labelY}
+                      textAnchor="start"
+                      fill="var(--color-warm)"
+                      fontSize={12}
+                      style={{ fontFamily: "var(--font-display), Palatino, serif" }}
+                    >
+                      {labelText}
+                    </text>
+                    <text
+                      x={x}
+                      y={labelY + 14}
+                      textAnchor="start"
+                      fill={isSelected ? "var(--color-text-primary)" : "var(--color-text-secondary)"}
+                      fontSize={11}
+                      style={{ fontFamily: "var(--font-body), Palatino, serif" }}
+                    >
+                      {event.title.length > 36 ? `${event.title.slice(0, 34)}…` : event.title}
+                    </text>
+                  </g>
                 )}
+
                 <line
                   x1={x}
-                  y1={MARKER_Y}
+                  y1={TRACK_Y}
                   x2={x}
-                  y2={34}
+                  y2={labelY !== null ? (labelY ?? TRACK_Y) + 4 : TRACK_Y - 18}
                   stroke={fill}
-                  strokeWidth={isSelected ? 1.8 : 1}
-                  opacity={isSelected ? 0.9 : 0.35}
+                  strokeWidth={isSelected ? 1.6 : 1}
+                  opacity={isSelected ? 0.9 : 0.4}
                 />
+
+                {isSelected && (
+                  <circle cx={x} cy={TRACK_Y} r={radius + 6} fill={fill} opacity={0.18} />
+                )}
                 <circle
                   cx={x}
-                  cy={MARKER_Y}
+                  cy={TRACK_Y}
                   r={radius}
                   fill={fill}
-                  stroke={isSelected ? "var(--color-text-primary)" : "transparent"}
-                  strokeWidth={1.4}
+                  stroke={isSelected ? "var(--color-text-primary)" : "var(--color-bg-primary)"}
+                  strokeWidth={isSelected ? 2 : 1.2}
                 />
               </g>
             );
           })}
-        </svg>
+          </svg>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <Scrubber
+          fullWindow={fullWindow}
+          activeWindow={activeWindow}
+          onWindowChange={onWindowChange}
+          events={events}
+          calendars={calendars}
+        />
       </div>
     </div>
+  );
+}
+
+interface ScrubberProps {
+  fullWindow: { min: number; max: number } | null;
+  activeWindow: { min: number; max: number } | null;
+  onWindowChange: (window: { min: number; max: number } | null) => void;
+  events: TimelineEvent[];
+  calendars: CalendarSystem[];
+}
+
+function Scrubber({
+  fullWindow,
+  activeWindow,
+  onWindowChange,
+  events,
+  calendars,
+}: ScrubberProps) {
+  const [width, setWidth] = useState(900);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const dragRef = useRef<{ kind: "left" | "right" | "range"; startX: number; startMin: number; startMax: number } | null>(null);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    const update = () => setWidth(Math.max(320, node.clientWidth));
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(update);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  if (!fullWindow) return null;
+
+  const fullSpan = Math.max(1, fullWindow.max - fullWindow.min);
+  const innerWidth = width - SCRUBBER_PAD * 2;
+  const window_ = activeWindow ?? fullWindow;
+
+  const yearToX = (year: number) =>
+    SCRUBBER_PAD + ((year - fullWindow.min) / fullSpan) * innerWidth;
+
+  const leftX = yearToX(window_.min);
+  const rightX = yearToX(window_.max);
+
+  const startDrag = (kind: "left" | "right" | "range", e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    dragRef.current = {
+      kind,
+      startX: e.clientX,
+      startMin: window_.min,
+      startMax: window_.max,
+    };
+  };
+
+  const moveDrag = (e: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const deltaPx = e.clientX - drag.startX;
+    const deltaYears = (deltaPx / innerWidth) * fullSpan;
+    let nextMin = drag.startMin;
+    let nextMax = drag.startMax;
+    if (drag.kind === "left") {
+      nextMin = Math.max(fullWindow.min, Math.min(drag.startMax - 1, drag.startMin + deltaYears));
+    } else if (drag.kind === "right") {
+      nextMax = Math.max(drag.startMin + 1, Math.min(fullWindow.max, drag.startMax + deltaYears));
+    } else {
+      const span = drag.startMax - drag.startMin;
+      const lowerBound = fullWindow.min;
+      const upperBound = fullWindow.max - span;
+      nextMin = Math.max(lowerBound, Math.min(upperBound, drag.startMin + deltaYears));
+      nextMax = nextMin + span;
+    }
+    onWindowChange({ min: Math.round(nextMin), max: Math.round(nextMax) });
+  };
+
+  const endDrag = (e: React.PointerEvent) => {
+    if (!dragRef.current) return;
+    dragRef.current = null;
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      // ignore — capture may have been released
+    }
+  };
+
+  return (
+    <div ref={ref} className="select-none">
+      <svg width={width} height={SCRUBBER_HEIGHT} className="block">
+        <rect
+          x={SCRUBBER_PAD}
+          y={14}
+          width={innerWidth}
+          height={SCRUBBER_HEIGHT - 28}
+          rx={7}
+          fill="rgb(var(--highlight-rgb) / 0.06)"
+          stroke="var(--color-border-muted)"
+          strokeOpacity={0.4}
+        />
+
+        {events.map((event) => {
+          const x = yearToX(absoluteYear(event, calendars));
+          return (
+            <line
+              key={event.id}
+              x1={x}
+              y1={20}
+              x2={x}
+              y2={SCRUBBER_HEIGHT - 20}
+              stroke="var(--color-text-muted)"
+              strokeWidth={1}
+              opacity={event.importance === "minor" ? 0.35 : 0.6}
+            />
+          );
+        })}
+
+        <rect
+          x={leftX}
+          y={14}
+          width={Math.max(2, rightX - leftX)}
+          height={SCRUBBER_HEIGHT - 28}
+          rx={8}
+          fill="rgb(var(--highlight-rgb) / 0.08)"
+          stroke="var(--color-warm)"
+          strokeOpacity={0.7}
+          strokeWidth={1}
+          style={{ cursor: "grab" }}
+          onPointerDown={(e) => startDrag("range", e)}
+          onPointerMove={moveDrag}
+          onPointerUp={endDrag}
+          onPointerCancel={endDrag}
+        />
+
+        <ScrubberHandle
+          x={leftX}
+          onPointerDown={(e) => startDrag("left", e)}
+          onPointerMove={moveDrag}
+          onPointerUp={endDrag}
+          ariaLabel="Adjust window start year"
+        />
+        <ScrubberHandle
+          x={rightX}
+          onPointerDown={(e) => startDrag("right", e)}
+          onPointerMove={moveDrag}
+          onPointerUp={endDrag}
+          ariaLabel="Adjust window end year"
+        />
+      </svg>
+      <div className="mt-1 flex items-center justify-between text-[0.65rem] uppercase tracking-[0.22em] text-text-muted">
+        <span>{formatYear(fullWindow.min)}</span>
+        <span>
+          {formatYear(window_.min)} – {formatYear(window_.max)}
+        </span>
+        <span>{formatYear(fullWindow.max)}</span>
+      </div>
+    </div>
+  );
+}
+
+function ScrubberHandle({
+  x,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  ariaLabel,
+}: {
+  x: number;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <g style={{ cursor: "ew-resize" }} role="slider" aria-label={ariaLabel}>
+      <rect
+        x={x - SCRUBBER_HANDLE / 2}
+        y={8}
+        width={SCRUBBER_HANDLE}
+        height={SCRUBBER_HEIGHT - 16}
+        rx={6}
+        fill="var(--color-warm)"
+        opacity={0.85}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+      />
+      <line
+        x1={x}
+        y1={16}
+        x2={x}
+        y2={SCRUBBER_HEIGHT - 16}
+        stroke="var(--bg-primary)"
+        strokeWidth={1}
+        pointerEvents="none"
+      />
+    </g>
   );
 }

--- a/creator/src/components/lore/TimelineView.tsx
+++ b/creator/src/components/lore/TimelineView.tsx
@@ -18,19 +18,19 @@ const SCRUBBER_HEIGHT = 60;
 const SCRUBBER_HANDLE = 14;
 const SCRUBBER_PAD = 12;
 
-// Solid era colors — avoid red/pink, align with Arcanum's ember + teal palette.
-// These are full-saturation anchors; tinted via color-mix at render time.
+const LEGENDARY_GOLD = "#d4b66e";
+
 const ERA_COLORS = [
-  "#ff9d3d", // ember
-  "#35a1b0", // stellar blue
-  "#d4b66e", // soft gold
-  "#7cb66d", // moss green
-  "#a897d2", // lavender
-  "#6ec0c2", // pale teal
+  "var(--color-status-warning)",
+  "var(--color-stellar-blue)",
+  LEGENDARY_GOLD,
+  "var(--color-status-success)",
+  "#a897d2",
+  "#6ec0c2",
 ];
 
 function eventColor(importance: TimelineEvent["importance"]) {
-  if (importance === "legendary") return "#d4b66e";
+  if (importance === "legendary") return LEGENDARY_GOLD;
   if (importance === "major") return "var(--color-accent)";
   return "var(--color-stellar-blue)";
 }
@@ -41,8 +41,10 @@ function eventRadius(importance: TimelineEvent["importance"]) {
   return 4;
 }
 
+const YEAR_FORMATTER = new Intl.NumberFormat();
+
 function formatYear(value: number) {
-  return new Intl.NumberFormat().format(Math.round(value));
+  return YEAR_FORMATTER.format(Math.round(value));
 }
 
 function niceTickStep(span: number, target: number): number {
@@ -183,7 +185,7 @@ export function TimelineView({
               type="button"
               onClick={() => handleNudgeZoom(-1)}
               aria-label="Zoom out"
-              className="focus-ring rounded-full px-2 py-0.5 text-text-muted transition hover:text-text-primary"
+              className="focus-ring inline-flex min-h-9 min-w-9 items-center justify-center rounded-full px-2 py-1.5 text-text-muted transition hover:text-text-primary"
             >
               −
             </button>
@@ -193,7 +195,7 @@ export function TimelineView({
                 type="button"
                 onClick={() => handlePresetZoom(value)}
                 aria-pressed={Math.abs(zoom - value) < 0.01}
-                className={`focus-ring rounded-md px-2.5 py-0.5 text-2xs transition ${
+                className={`focus-ring inline-flex min-h-9 min-w-9 items-center justify-center rounded-md px-2.5 py-1.5 text-2xs transition ${
                   Math.abs(zoom - value) < 0.01
                     ? "bg-[var(--bg-active-strong)] text-text-primary shadow-[var(--shadow-glow)]"
                     : "text-text-muted hover:text-text-primary"
@@ -206,7 +208,7 @@ export function TimelineView({
               type="button"
               onClick={() => handleNudgeZoom(1)}
               aria-label="Zoom in"
-              className="focus-ring rounded-full px-2 py-0.5 text-text-muted transition hover:text-text-primary"
+              className="focus-ring inline-flex min-h-9 min-w-9 items-center justify-center rounded-full px-2 py-1.5 text-text-muted transition hover:text-text-primary"
             >
               +
             </button>
@@ -224,7 +226,7 @@ export function TimelineView({
             disabled={!selectedEventId}
             aria-label="Focus selected event"
             title="Focus selected event"
-            className="focus-ring rounded-[0.55rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-1 text-text-muted transition hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+            className="focus-ring inline-flex min-h-9 min-w-9 items-center justify-center rounded-[0.55rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-1.5 text-text-muted transition hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-40"
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden="true">
               <circle cx="8" cy="8" r="3" />
@@ -239,7 +241,7 @@ export function TimelineView({
             onClick={handleResetWindow}
             aria-label="Reset to full range"
             title="Reset to full range"
-            className="focus-ring rounded-[0.55rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-1 text-text-muted transition hover:text-text-primary"
+            className="focus-ring inline-flex min-h-9 min-w-9 items-center justify-center rounded-[0.55rem] border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2 py-1.5 text-text-muted transition hover:text-text-primary"
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden="true">
               <path d="M2 6V2h4M14 6V2h-4M2 10v4h4M14 10v4h-4" />
@@ -319,7 +321,7 @@ export function TimelineView({
                   textAnchor="middle"
                   fill="var(--color-text-secondary)"
                   fontSize={11}
-                  style={{ fontFamily: "var(--font-mono), Consolas, monospace" }}
+                  style={{ fontFamily: "var(--font-mono), Consolas, monospace", fontVariantNumeric: "tabular-nums" }}
                 >
                   {formatYear(year)}
                 </text>
@@ -340,7 +342,6 @@ export function TimelineView({
                 key={event.id}
                 className="cursor-pointer"
                 onClick={() => onSelectEvent(event.id)}
-                tabIndex={0}
                 role="button"
                 aria-label={`${event.title} (year ${event.year})`}
                 onKeyDown={(e) => {
@@ -434,6 +435,8 @@ function Scrubber({
   const [width, setWidth] = useState(900);
   const ref = useRef<HTMLDivElement | null>(null);
   const dragRef = useRef<{ kind: "left" | "right" | "range"; startX: number; startMin: number; startMax: number } | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const pendingWindowRef = useRef<{ min: number; max: number } | null>(null);
 
   useEffect(() => {
     const node = ref.current;
@@ -444,6 +447,15 @@ function Scrubber({
     const observer = new ResizeObserver(update);
     observer.observe(node);
     return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
   }, []);
 
   if (!fullWindow) return null;
@@ -457,6 +469,27 @@ function Scrubber({
 
   const leftX = yearToX(window_.min);
   const rightX = yearToX(window_.max);
+
+  const scheduleWindowChange = (next: { min: number; max: number }) => {
+    pendingWindowRef.current = next;
+    if (rafRef.current != null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const pending = pendingWindowRef.current;
+      pendingWindowRef.current = null;
+      if (pending) onWindowChange(pending);
+    });
+  };
+
+  const flushPending = () => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    const pending = pendingWindowRef.current;
+    pendingWindowRef.current = null;
+    if (pending) onWindowChange(pending);
+  };
 
   const startDrag = (kind: "left" | "right" | "range", e: React.PointerEvent) => {
     e.preventDefault();
@@ -488,17 +521,30 @@ function Scrubber({
       nextMin = Math.max(lowerBound, Math.min(upperBound, drag.startMin + deltaYears));
       nextMax = nextMin + span;
     }
-    onWindowChange({ min: Math.round(nextMin), max: Math.round(nextMax) });
+    scheduleWindowChange({ min: Math.round(nextMin), max: Math.round(nextMax) });
   };
 
   const endDrag = (e: React.PointerEvent) => {
     if (!dragRef.current) return;
     dragRef.current = null;
+    flushPending();
     try {
       (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
     } catch {
-      // ignore — capture may have been released
+      // intentionally empty
     }
+  };
+
+  const nudgeLeft = (delta: number) => {
+    const nextMin = Math.max(fullWindow.min, Math.min(window_.max - 1, window_.min + delta));
+    if (nextMin === window_.min) return;
+    onWindowChange({ min: Math.round(nextMin), max: window_.max });
+  };
+
+  const nudgeRight = (delta: number) => {
+    const nextMax = Math.max(window_.min + 1, Math.min(fullWindow.max, window_.max + delta));
+    if (nextMax === window_.max) return;
+    onWindowChange({ min: window_.min, max: Math.round(nextMax) });
   };
 
   return (
@@ -554,6 +600,14 @@ function Scrubber({
           onPointerMove={moveDrag}
           onPointerUp={endDrag}
           ariaLabel="Adjust window start year"
+          valueMin={fullWindow.min}
+          valueMax={window_.max - 1}
+          valueNow={window_.min}
+          onNudge={nudgeLeft}
+          onHomeEnd={(which) => {
+            if (which === "home") onWindowChange({ min: fullWindow.min, max: window_.max });
+            else onWindowChange({ min: window_.max - 1, max: window_.max });
+          }}
         />
         <ScrubberHandle
           x={rightX}
@@ -561,9 +615,17 @@ function Scrubber({
           onPointerMove={moveDrag}
           onPointerUp={endDrag}
           ariaLabel="Adjust window end year"
+          valueMin={window_.min + 1}
+          valueMax={fullWindow.max}
+          valueNow={window_.max}
+          onNudge={nudgeRight}
+          onHomeEnd={(which) => {
+            if (which === "home") onWindowChange({ min: window_.min, max: window_.min + 1 });
+            else onWindowChange({ min: window_.min, max: fullWindow.max });
+          }}
         />
       </svg>
-      <div className="mt-1 flex items-center justify-between text-[0.65rem] uppercase tracking-[0.22em] text-text-muted">
+      <div className="mt-1 flex items-center justify-between text-[0.65rem] uppercase tracking-[0.22em] text-text-muted tabular-nums">
         <span>{formatYear(fullWindow.min)}</span>
         <span>
           {formatYear(window_.min)} – {formatYear(window_.max)}
@@ -574,21 +636,78 @@ function Scrubber({
   );
 }
 
+interface ScrubberHandleProps {
+  x: number;
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerMove: (e: React.PointerEvent) => void;
+  onPointerUp: (e: React.PointerEvent) => void;
+  ariaLabel: string;
+  valueMin: number;
+  valueMax: number;
+  valueNow: number;
+  onNudge: (delta: number) => void;
+  onHomeEnd: (which: "home" | "end") => void;
+}
+
 function ScrubberHandle({
   x,
   onPointerDown,
   onPointerMove,
   onPointerUp,
   ariaLabel,
-}: {
-  x: number;
-  onPointerDown: (e: React.PointerEvent) => void;
-  onPointerMove: (e: React.PointerEvent) => void;
-  onPointerUp: (e: React.PointerEvent) => void;
-  ariaLabel: string;
-}) {
+  valueMin,
+  valueMax,
+  valueNow,
+  onNudge,
+  onHomeEnd,
+}: ScrubberHandleProps) {
+  const [focused, setFocused] = useState(false);
+
+  const handleKeyDown = (e: React.KeyboardEvent<SVGGElement>) => {
+    const step = e.shiftKey ? 10 : 1;
+    if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
+      e.preventDefault();
+      onNudge(-step);
+    } else if (e.key === "ArrowRight" || e.key === "ArrowUp") {
+      e.preventDefault();
+      onNudge(step);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      onHomeEnd("home");
+    } else if (e.key === "End") {
+      e.preventDefault();
+      onHomeEnd("end");
+    }
+  };
+
   return (
-    <g style={{ cursor: "ew-resize" }} role="slider" aria-label={ariaLabel}>
+    <g
+      style={{ cursor: "ew-resize", outline: "none" }}
+      tabIndex={0}
+      role="slider"
+      aria-label={ariaLabel}
+      aria-orientation="horizontal"
+      aria-valuemin={Math.round(valueMin)}
+      aria-valuemax={Math.round(valueMax)}
+      aria-valuenow={Math.round(valueNow)}
+      aria-valuetext={formatYear(valueNow)}
+      onKeyDown={handleKeyDown}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
+    >
+      {focused && (
+        <rect
+          x={x - SCRUBBER_HANDLE / 2 - 3}
+          y={5}
+          width={SCRUBBER_HANDLE + 6}
+          height={SCRUBBER_HEIGHT - 10}
+          rx={8}
+          fill="none"
+          stroke="var(--color-accent)"
+          strokeWidth={2}
+          pointerEvents="none"
+        />
+      )}
       <rect
         x={x - SCRUBBER_HANDLE / 2}
         y={8}
@@ -607,7 +726,7 @@ function ScrubberHandle({
         y1={16}
         x2={x}
         y2={SCRUBBER_HEIGHT - 16}
-        stroke="var(--bg-primary)"
+        stroke="var(--color-bg-primary)"
         strokeWidth={1}
         pointerEvents="none"
       />

--- a/creator/src/components/lore/TimelineView.tsx
+++ b/creator/src/components/lore/TimelineView.tsx
@@ -18,15 +18,15 @@ const SCRUBBER_HEIGHT = 60;
 const SCRUBBER_HANDLE = 14;
 const SCRUBBER_PAD = 12;
 
-const LEGENDARY_GOLD = "#d4b66e";
+const LEGENDARY_GOLD = "var(--color-aurum)";
 
 const ERA_COLORS = [
   "var(--color-status-warning)",
   "var(--color-stellar-blue)",
   LEGENDARY_GOLD,
   "var(--color-status-success)",
-  "#a897d2",
-  "#6ec0c2",
+  "var(--color-era-violet)",
+  "var(--color-era-teal)",
 ];
 
 function eventColor(importance: TimelineEvent["importance"]) {

--- a/creator/src/index.css
+++ b/creator/src/index.css
@@ -75,6 +75,7 @@
   --color-accent-muted:    #c96300;
   --color-accent-emphasis: #ffecd1;
   --color-aurum:           #e2bc6a;
+  --color-aurum-pale:      #f4d98b;
 
   /* ─── Warm Accent (primary creative actions) ─── */
   --color-warm:          #ff7d00;
@@ -85,6 +86,8 @@
   --color-violet:       #c0622a;
   --color-stellar-blue: #35a1b0;
   --color-arcane-teal:  #15616d;
+  --color-era-violet:   #a897d2;
+  --color-era-teal:     #6ec0c2;
 
   /* ─── Status Colors ─── */
   --color-status-success: #7cb66d;

--- a/creator/src/lib/loreTimelineInference.ts
+++ b/creator/src/lib/loreTimelineInference.ts
@@ -8,6 +8,7 @@ export interface TimelineSuggestion {
   year: number;
   eraId: string;
   eraName: string;
+  calendarId: string;
   importance: "minor" | "major" | "legendary";
   articleId: string;
   articleTitle: string;
@@ -19,7 +20,8 @@ const SYSTEM_PROMPT = `You are a timeline analyst for a fantasy world-building t
 For each temporal reference found, output a JSON array of objects with:
 - "title": short event title (max 60 chars)
 - "year": numeric year in the calendar
-- "eraId": which era this belongs to (from the provided era list)
+- "calendarId": which calendar this era belongs to (from the provided calendar list)
+- "eraId": which era this belongs to (from the provided era list, must belong to the named calendar)
 - "importance": "minor", "major", or "legendary"
 - "articleId": ID of the source article
 - "evidence": the exact quote or paraphrase that indicates this temporal reference (max 100 chars)
@@ -62,7 +64,7 @@ export async function inferTimelineEvents(
       ? calendars
           .map(
             (c) =>
-              `Calendar: ${c.name}\nEras: ${c.eras.map((e) => `${e.name} (id: ${e.id}, starts year ${e.startYear})`).join(", ")}`,
+              `Calendar: ${c.name} (id: ${c.id})\nEras: ${c.eras.map((e) => `${e.name} (id: ${e.id}, starts year ${e.startYear})`).join(", ")}`,
           )
           .join("\n\n")
       : "No calendar system defined. Use year numbers directly and eraId 'unknown'.";
@@ -108,14 +110,25 @@ export async function inferTimelineEvents(
       if (Array.isArray(parsed)) {
         for (const item of parsed) {
           const article = batch.find((a) => a.id === item.articleId);
+          const rawEraId = String(item.eraId ?? "");
+          const rawCalendarId = String(item.calendarId ?? "");
+          const proposedCalendar = calendars.find((c) => c.id === rawCalendarId);
+          const eraOwner = calendars.find((c) =>
+            c.eras.some((e) => e.id === rawEraId),
+          );
+          const resolvedCalendarId =
+            proposedCalendar && proposedCalendar.eras.some((e) => e.id === rawEraId)
+              ? proposedCalendar.id
+              : (eraOwner?.id ?? calendars[0]?.id ?? "");
           allSuggestions.push({
             title: String(item.title ?? ""),
             year: Number(item.year ?? 0),
-            eraId: String(item.eraId ?? ""),
+            eraId: rawEraId,
             eraName:
               calendars
                 .flatMap((c) => c.eras)
-                .find((e) => e.id === item.eraId)?.name ?? item.eraId,
+                .find((e) => e.id === rawEraId)?.name ?? rawEraId,
+            calendarId: resolvedCalendarId,
             importance: ["minor", "major", "legendary"].includes(
               item.importance,
             )

--- a/creator/src/stores/loreStore.ts
+++ b/creator/src/stores/loreStore.ts
@@ -96,6 +96,7 @@ interface LoreStore extends LoreState {
   addTimelineEvent: (event: TimelineEvent) => void;
   updateTimelineEvent: (id: string, patch: Partial<TimelineEvent>) => void;
   deleteTimelineEvent: (id: string) => void;
+  duplicateTimelineEvent: (id: string) => string | null;
 
   // Document operations
   createDocument: (doc: LoreDocument) => void;
@@ -630,6 +631,27 @@ export const useLoreStore = create<LoreStore>((set, get) => ({
         dirty: true,
       };
     }),
+
+  duplicateTimelineEvent: (id) => {
+    const state = get();
+    const source = state.lore?.timelineEvents?.find((e) => e.id === id);
+    if (!source || !state.lore) return null;
+    const newId = `evt_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+    const clone: TimelineEvent = {
+      ...source,
+      id: newId,
+      title: `${source.title} (copy)`,
+    };
+    set((s) => {
+      if (!s.lore) return s;
+      return {
+        ...snapshotLore(s),
+        lore: { ...s.lore, timelineEvents: [...(s.lore.timelineEvents ?? []), clone] },
+        dirty: true,
+      };
+    });
+    return newId;
+  },
 
   // ─── Document operations ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Redesigns the lore timeline editor to better match the visual spec and make the editing workflow usable while scrolling long event lists.

## Changes

- Tightens the app and lore panel spacing so the editor starts closer to the top-left workspace area.
- Rebuilds the timeline editor into a dense three-part layout with filter rail, fixed timeline/list workspace, and an editor inspector lane.
- Makes the chronicle event list independently scroll while the timeline ribbon and right-side inspector stay in place.
- Gives the inspector its own internal scroll so long edit forms do not move the event list.
- Adds timeline zoom/window controls, a scrubber, improved era bands, and synced horizontal scrolling between era labels and timeline markers.
- Removes the duplicate Split tab because it duplicated the Timeline view.
- Separates major and legendary event color coding.
- Includes the related duplicate timeline event store operation used by the refreshed editor actions.

## Validation

- `bunx tsc --noEmit`
- `bun run build`

Build passes. The existing Vite warning about `NewZoneDialog.tsx` being both dynamically and statically imported is still present and unrelated to this change.