### PR TITLE
Lore RAG infrastructure (#227)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ All public functions exposed to the frontend are `#[tauri::command]` and return 
   - `DB` — D1 `arcanum-hub` (users, worlds, AI quotas, verification_codes, signup_attempts)
   - `BUCKET` — R2 `arcanum-hub` (`worlds/<slug>/showcase.json` + `worlds/<slug>/images/<hash>.webp`)
   - `ASSETS` — showcase `dist/` ships alongside the Worker; `not_found_handling = "single-page-application"` + `run_worker_first = true` so API paths aren't absorbed by SPA fallback
-  - Secrets: `HUB_ADMIN_KEY`, `RESEND_API_KEY`, `TURNSTILE_SECRET_KEY`, `RUNWARE_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`
+  - Secrets: `HUB_ADMIN_KEY`, `RESEND_API_KEY`, `TURNSTILE_SECRET_KEY`, `RUNWARE_API_KEY`, `OPENROUTER_API_KEY`, `ANTHROPIC_API_KEY`, `VOYAGE_API_KEY`
   - Vars: `FROM_EMAIL` (sender for verification codes, must be on a Resend-verified domain), `TURNSTILE_SITE_KEY` (public, paired with the secret)
 - **Self-registration** (public, `api.<root>`):
   - Three tiers: `demo` (self-signup, 10 images/20 prompts, no publish), `full` (email-verified, 500 images/5000 prompts, publish), `publish` (admin-issued BYOK, publish-only).
@@ -156,7 +156,8 @@ All public functions exposed to the frontend are `#[tauri::command]` and return 
   - `POST /ai/image/generate` → Runware (`runware:400@2` FLUX.2, `openai:gpt-image@2` GPT Image 2)
   - `POST /ai/llm/complete` → OpenRouter DeepSeek V3.2 (`deepseek/deepseek-v3.2-20251201`)
   - `POST /ai/llm/vision` → Claude Sonnet 4.6
-  - Vision calls bill against `prompts_used`. Model allowlist + guardrails (steps ≤ 32, dimensions ≤ 1024, GPT quality forced to `"low"`) enforced server-side.
+  - `POST /ai/embed` → Voyage AI (`voyage-3-lite`), bills one prompt per input string, batch capped at 128
+  - Vision and embedding calls bill against `prompts_used`. Model allowlist + guardrails (steps ≤ 32, dimensions ≤ 1024, GPT quality forced to `"low"`, embedding inputs ≤ 8000 chars) enforced server-side.
 - **Admin API** (X-Admin-Key header): `GET/POST /admin/users`, `DELETE /admin/users/<id>`, `POST /admin/users/<id>/regenerate-key` (zeros usage counters), `POST /admin/users/<id>/tier`, `POST /admin/users/<id>/quotas`, `GET /admin/worlds`, `DELETE /admin/worlds/<slug>`. Admin-minted users default to `email_verified=1`.
 - **Reserved subdomains** — `admin`, `www`, `hub`, `mail`, `ftp`, `ns1`, `ns2` are refused by `isValidSlug()` so nobody can claim them as world slugs. The Worker's `handleReservedSubdomain` proxies `admin.` to the Pages deployment and 301s `www.` to the apex.
 - **Hub AI mode on the client** — flipped via `settings.use_hub_ai` (user-level boolean in `~/.tauri/settings.json`). When on, the existing image/LLM/vision Tauri commands check `hub_ai::is_enabled(&settings)` at the top and short-circuit to `hub_ai::generate_image` / `hub_ai::complete` / `hub_ai::complete_with_vision` before touching direct-provider code. The frontend doesn't know about hub mode at all — same command names, same response shapes.

--- a/creator/src-tauri/Cargo.lock
+++ b/creator/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +81,7 @@ dependencies = [
  "imagesize",
  "regex",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -756,6 +769,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,6 +1334,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1321,6 +1355,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1908,6 +1951,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3147,6 +3201,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/creator/src-tauri/Cargo.toml
+++ b/creator/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ ffmpeg-sidecar = "2"
 which = "6"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 walkdir = "2"
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading"] }

--- a/creator/src-tauri/src/embeddings.rs
+++ b/creator/src-tauri/src/embeddings.rs
@@ -1,0 +1,128 @@
+// ─── Embedding dispatcher ────────────────────────────────────────────
+//
+// Mirrors the hub_ai short-circuit pattern used by the existing AI
+// provider modules: when settings.use_hub_ai is on, requests go to the
+// Arcanum Hub's /ai/embed endpoint. Otherwise we call Voyage AI's API
+// directly using the user's voyage_api_key.
+//
+// Model: voyage-3-lite (512 dimensions). Voyage caps each request at
+// 128 inputs, so larger batches are chunked transparently.
+
+use serde::{Deserialize, Serialize};
+
+use crate::settings::Settings;
+
+pub const EMBEDDING_MODEL: &str = "voyage-3-lite";
+pub const EMBEDDING_DIM: u32 = 512;
+const VOYAGE_BATCH_LIMIT: usize = 128;
+const VOYAGE_URL: &str = "https://api.voyageai.com/v1/embeddings";
+
+#[derive(Debug, Serialize)]
+struct EmbedRequest<'a> {
+    model: &'a str,
+    input: &'a [String],
+}
+
+#[derive(Debug, Deserialize)]
+struct VoyageResponse {
+    data: Vec<VoyageItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VoyageItem {
+    embedding: Vec<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HubEmbedResponse {
+    embeddings: Vec<Vec<f32>>,
+    #[allow(dead_code)]
+    model: Option<String>,
+}
+
+/// Embed a batch of input strings. Returns one vector per input, in
+/// the same order. Chunks the request to respect provider batch caps.
+pub async fn embed(s: &Settings, inputs: &[String]) -> Result<Vec<Vec<f32>>, String> {
+    if inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut out: Vec<Vec<f32>> = Vec::with_capacity(inputs.len());
+    for chunk in inputs.chunks(VOYAGE_BATCH_LIMIT) {
+        let mut batch = embed_batch(s, chunk).await?;
+        out.append(&mut batch);
+    }
+    Ok(out)
+}
+
+async fn embed_batch(s: &Settings, inputs: &[String]) -> Result<Vec<Vec<f32>>, String> {
+    if crate::hub_ai::is_enabled(s) {
+        return embed_via_hub(s, inputs).await;
+    }
+    embed_via_voyage(s, inputs).await
+}
+
+async fn embed_via_hub(s: &Settings, inputs: &[String]) -> Result<Vec<Vec<f32>>, String> {
+    let url = format!("{}/ai/embed", s.hub_api_url.trim_end_matches('/'));
+    let body = EmbedRequest {
+        model: EMBEDDING_MODEL,
+        input: inputs,
+    };
+    let client = crate::http::shared_client();
+    let response = client
+        .post(&url)
+        .bearer_auth(&s.hub_api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Hub embed request failed: {e}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!(
+            "Hub embed error ({status}): {}",
+            text.chars().take(500).collect::<String>()
+        ));
+    }
+    let parsed: HubEmbedResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse hub embed response: {e}"))?;
+    Ok(parsed.embeddings)
+}
+
+async fn embed_via_voyage(s: &Settings, inputs: &[String]) -> Result<Vec<Vec<f32>>, String> {
+    if s.voyage_api_key.is_empty() {
+        return Err(
+            "Voyage AI API key not configured. Set it in Settings, or enable Arcanum Hub AI."
+                .to_string(),
+        );
+    }
+    let body = EmbedRequest {
+        model: EMBEDDING_MODEL,
+        input: inputs,
+    };
+    let client = crate::http::shared_client();
+    let response = client
+        .post(VOYAGE_URL)
+        .bearer_auth(&s.voyage_api_key)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Voyage embed request failed: {e}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!(
+            "Voyage embed error ({status}): {}",
+            text.chars().take(500).collect::<String>()
+        ));
+    }
+    let parsed: VoyageResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Voyage embed response: {e}"))?;
+    Ok(parsed.data.into_iter().map(|d| d.embedding).collect())
+}

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -8,6 +8,10 @@ mod cancellation;
 mod captions;
 #[cfg(feature = "ai")]
 mod deepinfra;
+#[cfg(feature = "ai")]
+mod embeddings;
+#[cfg(feature = "ai")]
+mod rag;
 mod ffmpeg;
 mod ffmpeg_progress;
 mod fs_utils;
@@ -175,6 +179,10 @@ pub fn run() {
                     openai_images::openai_generate_image,
                     openai_tts::openai_tts_generate,
                     sketch::analyze_sketch,
+                    rag::rag_upsert_chunks,
+                    rag::rag_retrieve,
+                    rag::rag_index_stats,
+                    rag::rag_clear_index,
                 ]
             }
             #[cfg(not(feature = "ai"))]

--- a/creator/src-tauri/src/rag.rs
+++ b/creator/src-tauri/src/rag.rs
@@ -1,0 +1,506 @@
+// ─── Lore RAG index ──────────────────────────────────────────────────
+//
+// Local-first embedding store backed by SQLite at
+// <project>/.arcanum/rag.sqlite. Retrieval is a brute-force cosine
+// over a BLOB column — a lore corpus is at most a few thousand chunks,
+// so this is sub-millisecond in practice and avoids the ANN
+// dependency footprint.
+//
+// Embedding model and dimension are recorded in `index_meta`. If a
+// caller's configured model/dim diverges from what's stored, every
+// operation refuses and asks the user to clear+rebuild — silently
+// mixing dim-512 and dim-1024 vectors would yield nonsense ranks.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tauri::AppHandle;
+
+use crate::embeddings::{self, EMBEDDING_DIM, EMBEDDING_MODEL};
+use crate::settings;
+
+const SCHEMA_VERSION: &str = "1";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RagChunk {
+    pub id: String,
+    pub kind: String,
+    pub source_id: String,
+    pub section: Option<String>,
+    pub title: String,
+    pub body: String,
+    pub metadata: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetrievedChunk {
+    pub id: String,
+    pub kind: String,
+    pub source_id: String,
+    pub section: Option<String>,
+    pub title: String,
+    pub body: String,
+    pub metadata: serde_json::Value,
+    pub score: f32,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RetrievalFilters {
+    pub include_kinds: Option<Vec<String>>,
+    pub must_include_source_ids: Option<Vec<String>>,
+    pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IndexStats {
+    pub total_chunks: u32,
+    pub by_kind: HashMap<String, u32>,
+    pub embedding_model: String,
+    pub embedding_dim: u32,
+    pub last_embedded_at: Option<i64>,
+}
+
+// ─── Path resolution ─────────────────────────────────────────────────
+
+fn db_path(project_path: &str) -> PathBuf {
+    PathBuf::from(project_path).join(".arcanum").join("rag.sqlite")
+}
+
+fn ensure_parent(path: &PathBuf) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create rag dir: {e}"))?;
+    }
+    Ok(())
+}
+
+// ─── Connection helpers ──────────────────────────────────────────────
+
+fn open_conn(project_path: &str) -> Result<Connection, String> {
+    let path = db_path(project_path);
+    ensure_parent(&path)?;
+    let conn = Connection::open(&path).map_err(|e| format!("Failed to open rag.sqlite: {e}"))?;
+    init_schema(&conn)?;
+    Ok(conn)
+}
+
+fn init_schema(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS chunks (
+            id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            section TEXT,
+            title TEXT NOT NULL,
+            body TEXT NOT NULL,
+            metadata TEXT NOT NULL,
+            content_hash TEXT NOT NULL,
+            embedding BLOB NOT NULL,
+            embedded_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks(source_id);
+        CREATE INDEX IF NOT EXISTS idx_chunks_kind ON chunks(kind);
+        CREATE TABLE IF NOT EXISTS index_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        "#,
+    )
+    .map_err(|e| format!("Failed to init rag schema: {e}"))
+}
+
+fn get_meta(conn: &Connection, key: &str) -> Result<Option<String>, String> {
+    conn.query_row(
+        "SELECT value FROM index_meta WHERE key = ?1",
+        params![key],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .map_err(|e| format!("Failed to read index_meta: {e}"))
+}
+
+fn set_meta(conn: &Connection, key: &str, value: &str) -> Result<(), String> {
+    conn.execute(
+        "INSERT INTO index_meta (key, value) VALUES (?1, ?2) \
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![key, value],
+    )
+    .map_err(|e| format!("Failed to write index_meta: {e}"))?;
+    Ok(())
+}
+
+/// Verify that the stored embedding model/dim match what this build
+/// would produce. On a fresh DB, write the meta. On a mismatch, return
+/// an error directing the user to clear+rebuild — mixing vectors from
+/// different models produces meaningless rankings.
+fn verify_or_seed_meta(conn: &Connection) -> Result<(), String> {
+    let model = get_meta(conn, "embedding_model")?;
+    let dim = get_meta(conn, "embedding_dim")?;
+    let schema = get_meta(conn, "schema_version")?;
+    match (model.as_deref(), dim.as_deref()) {
+        (Some(m), Some(d)) => {
+            if m != EMBEDDING_MODEL {
+                return Err(format!(
+                    "RAG index was built with embedding model '{m}', \
+                     but the current build uses '{EMBEDDING_MODEL}'. \
+                     Clear the index from Settings → Lore RAG and rebuild."
+                ));
+            }
+            let stored_dim: u32 = d
+                .parse()
+                .map_err(|_| format!("RAG index has invalid embedding_dim '{d}'"))?;
+            if stored_dim != EMBEDDING_DIM {
+                return Err(format!(
+                    "RAG index dimension {stored_dim} does not match \
+                     current embedding dim {EMBEDDING_DIM}. Clear and rebuild."
+                ));
+            }
+            if schema.as_deref() != Some(SCHEMA_VERSION) {
+                set_meta(conn, "schema_version", SCHEMA_VERSION)?;
+            }
+        }
+        _ => {
+            set_meta(conn, "schema_version", SCHEMA_VERSION)?;
+            set_meta(conn, "embedding_model", EMBEDDING_MODEL)?;
+            set_meta(conn, "embedding_dim", &EMBEDDING_DIM.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+// ─── Encoding helpers ────────────────────────────────────────────────
+
+fn embedding_to_bytes(embedding: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(embedding.len() * 4);
+    for f in embedding {
+        out.extend_from_slice(&f.to_le_bytes());
+    }
+    out
+}
+
+fn bytes_to_embedding(bytes: &[u8]) -> Vec<f32> {
+    let mut out = Vec::with_capacity(bytes.len() / 4);
+    let mut chunk = [0u8; 4];
+    for c in bytes.chunks_exact(4) {
+        chunk.copy_from_slice(c);
+        out.push(f32::from_le_bytes(chunk));
+    }
+    out
+}
+
+fn content_hash(body: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    let denom = na.sqrt() * nb.sqrt();
+    if denom == 0.0 {
+        0.0
+    } else {
+        dot / denom
+    }
+}
+
+// ─── Stats ───────────────────────────────────────────────────────────
+
+fn compute_stats(conn: &Connection) -> Result<IndexStats, String> {
+    let total: u32 = conn
+        .query_row("SELECT COUNT(*) FROM chunks", [], |row| row.get(0))
+        .map_err(|e| format!("Failed to count chunks: {e}"))?;
+
+    let mut by_kind: HashMap<String, u32> = HashMap::new();
+    let mut stmt = conn
+        .prepare("SELECT kind, COUNT(*) FROM chunks GROUP BY kind")
+        .map_err(|e| format!("Failed to prepare kind stats: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+        })
+        .map_err(|e| format!("Failed to read kind stats: {e}"))?;
+    for r in rows {
+        let (k, c) = r.map_err(|e| format!("Failed to decode kind stats: {e}"))?;
+        by_kind.insert(k, c);
+    }
+
+    let last_embedded_at: Option<i64> = conn
+        .query_row("SELECT MAX(embedded_at) FROM chunks", [], |row| row.get(0))
+        .optional()
+        .map_err(|e| format!("Failed to read last embedded_at: {e}"))?
+        .flatten();
+
+    let model = get_meta(conn, "embedding_model")?.unwrap_or_else(|| EMBEDDING_MODEL.to_string());
+    let dim: u32 = get_meta(conn, "embedding_dim")?
+        .and_then(|d| d.parse().ok())
+        .unwrap_or(EMBEDDING_DIM);
+
+    Ok(IndexStats {
+        total_chunks: total,
+        by_kind,
+        embedding_model: model,
+        embedding_dim: dim,
+        last_embedded_at,
+    })
+}
+
+// ─── Tauri commands ──────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn rag_upsert_chunks(
+    app: AppHandle,
+    project_path: String,
+    chunks: Vec<RagChunk>,
+) -> Result<IndexStats, String> {
+    let settings = settings::get_settings(app).await?;
+
+    // Phase 1: figure out which chunks need (re)embedding by reading
+    // existing hashes from SQLite. spawn_blocking keeps the async
+    // runtime free.
+    let project_for_scan = project_path.clone();
+    let chunks_for_scan = chunks.clone();
+    let needs_embed: Vec<(usize, String)> = tokio::task::spawn_blocking(move || {
+        let conn = open_conn(&project_for_scan)?;
+        verify_or_seed_meta(&conn)?;
+        let mut stmt = conn
+            .prepare("SELECT content_hash FROM chunks WHERE id = ?1")
+            .map_err(|e| format!("Failed to prepare lookup: {e}"))?;
+        let mut to_embed = Vec::new();
+        for (idx, chunk) in chunks_for_scan.iter().enumerate() {
+            let hash = content_hash(&chunk.body);
+            let existing: Option<String> = stmt
+                .query_row(params![chunk.id], |row| row.get::<_, String>(0))
+                .optional()
+                .map_err(|e| format!("Failed to read existing hash: {e}"))?;
+            if existing.as_deref() != Some(hash.as_str()) {
+                to_embed.push((idx, hash));
+            }
+        }
+        Ok::<_, String>(to_embed)
+    })
+    .await
+    .map_err(|e| format!("rag scan task failed: {e}"))??;
+
+    // Phase 2: embed the changed bodies (batched inside embeddings::embed).
+    let embed_inputs: Vec<String> = needs_embed
+        .iter()
+        .map(|(idx, _)| chunks[*idx].body.clone())
+        .collect();
+    let vectors = embeddings::embed(&settings, &embed_inputs).await?;
+    if vectors.len() != embed_inputs.len() {
+        return Err(format!(
+            "Embedding provider returned {} vectors for {} inputs",
+            vectors.len(),
+            embed_inputs.len()
+        ));
+    }
+    for v in &vectors {
+        if v.len() as u32 != EMBEDDING_DIM {
+            return Err(format!(
+                "Embedding dimension mismatch: expected {EMBEDDING_DIM}, got {}",
+                v.len()
+            ));
+        }
+    }
+
+    // Phase 3: write back atomically inside a transaction.
+    let project_for_write = project_path;
+    let stats = tokio::task::spawn_blocking(move || {
+        let mut conn = open_conn(&project_for_write)?;
+        verify_or_seed_meta(&conn)?;
+        let now_ms: i64 = chrono::Utc::now().timestamp_millis();
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Failed to open transaction: {e}"))?;
+        for (vec_idx, (chunk_idx, hash)) in needs_embed.iter().enumerate() {
+            let chunk = &chunks[*chunk_idx];
+            let embedding = &vectors[vec_idx];
+            let metadata_text = serde_json::to_string(&chunk.metadata)
+                .map_err(|e| format!("Failed to serialize metadata: {e}"))?;
+            let blob = embedding_to_bytes(embedding);
+            tx.execute(
+                "INSERT INTO chunks (id, kind, source_id, section, title, body, metadata, content_hash, embedding, embedded_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10) \
+                 ON CONFLICT(id) DO UPDATE SET \
+                   kind = excluded.kind, \
+                   source_id = excluded.source_id, \
+                   section = excluded.section, \
+                   title = excluded.title, \
+                   body = excluded.body, \
+                   metadata = excluded.metadata, \
+                   content_hash = excluded.content_hash, \
+                   embedding = excluded.embedding, \
+                   embedded_at = excluded.embedded_at",
+                params![
+                    chunk.id,
+                    chunk.kind,
+                    chunk.source_id,
+                    chunk.section,
+                    chunk.title,
+                    chunk.body,
+                    metadata_text,
+                    hash,
+                    blob,
+                    now_ms,
+                ],
+            )
+            .map_err(|e| format!("Failed to upsert chunk {}: {e}", chunk.id))?;
+        }
+        tx.commit()
+            .map_err(|e| format!("Failed to commit transaction: {e}"))?;
+        compute_stats(&conn)
+    })
+    .await
+    .map_err(|e| format!("rag write task failed: {e}"))??;
+
+    Ok(stats)
+}
+
+#[tauri::command]
+pub async fn rag_retrieve(
+    app: AppHandle,
+    project_path: String,
+    query: String,
+    k: usize,
+    filters: RetrievalFilters,
+) -> Result<Vec<RetrievedChunk>, String> {
+    let settings = settings::get_settings(app).await?;
+    let query_vec = {
+        let vs = embeddings::embed(&settings, &[query]).await?;
+        vs.into_iter()
+            .next()
+            .ok_or_else(|| "Embedding provider returned no vector for query".to_string())?
+    };
+    if query_vec.len() as u32 != EMBEDDING_DIM {
+        return Err(format!(
+            "Query embedding dim {} does not match expected {EMBEDDING_DIM}",
+            query_vec.len()
+        ));
+    }
+
+    tokio::task::spawn_blocking(move || {
+        let conn = open_conn(&project_path)?;
+        verify_or_seed_meta(&conn)?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, kind, source_id, section, title, body, metadata, embedding FROM chunks",
+            )
+            .map_err(|e| format!("Failed to prepare retrieval query: {e}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, Vec<u8>>(7)?,
+                ))
+            })
+            .map_err(|e| format!("Failed to scan chunks: {e}"))?;
+
+        let include_kinds = filters.include_kinds.as_ref();
+        let source_filter = filters.must_include_source_ids.as_ref();
+        let tag_filter = filters.tags.as_ref();
+
+        let mut scored: Vec<RetrievedChunk> = Vec::new();
+        for row in rows {
+            let (id, kind, source_id, section, title, body, metadata_text, blob) =
+                row.map_err(|e| format!("Failed to decode chunk row: {e}"))?;
+            if let Some(kinds) = include_kinds {
+                if !kinds.is_empty() && !kinds.contains(&kind) {
+                    continue;
+                }
+            }
+            if let Some(sources) = source_filter {
+                if !sources.is_empty() && !sources.contains(&source_id) {
+                    continue;
+                }
+            }
+            let metadata: serde_json::Value =
+                serde_json::from_str(&metadata_text).unwrap_or(serde_json::Value::Null);
+            if let Some(tags) = tag_filter {
+                if !tags.is_empty() {
+                    let matched = metadata
+                        .get("tags")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter().any(|t| {
+                                t.as_str()
+                                    .map(|s| tags.iter().any(|f| f == s))
+                                    .unwrap_or(false)
+                            })
+                        })
+                        .unwrap_or(false);
+                    if !matched {
+                        continue;
+                    }
+                }
+            }
+            let embedding = bytes_to_embedding(&blob);
+            let score = cosine_similarity(&query_vec, &embedding);
+            scored.push(RetrievedChunk {
+                id,
+                kind,
+                source_id,
+                section,
+                title,
+                body,
+                metadata,
+                score,
+            });
+        }
+
+        scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(k);
+        Ok::<_, String>(scored)
+    })
+    .await
+    .map_err(|e| format!("rag retrieve task failed: {e}"))?
+}
+
+#[tauri::command]
+pub async fn rag_index_stats(project_path: String) -> Result<IndexStats, String> {
+    tokio::task::spawn_blocking(move || {
+        let conn = open_conn(&project_path)?;
+        verify_or_seed_meta(&conn)?;
+        compute_stats(&conn)
+    })
+    .await
+    .map_err(|e| format!("rag stats task failed: {e}"))?
+}
+
+#[tauri::command]
+pub async fn rag_clear_index(project_path: String) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || {
+        let conn = open_conn(&project_path)?;
+        conn.execute("DELETE FROM chunks", [])
+            .map_err(|e| format!("Failed to clear chunks: {e}"))?;
+        conn.execute("DELETE FROM index_meta", [])
+            .map_err(|e| format!("Failed to clear index_meta: {e}"))?;
+        // Reseed meta so future writes don't trip the version check.
+        set_meta(&conn, "schema_version", SCHEMA_VERSION)?;
+        set_meta(&conn, "embedding_model", EMBEDDING_MODEL)?;
+        set_meta(&conn, "embedding_dim", &EMBEDDING_DIM.to_string())?;
+        Ok::<_, String>(())
+    })
+    .await
+    .map_err(|e| format!("rag clear task failed: {e}"))?
+}

--- a/creator/src-tauri/src/settings.rs
+++ b/creator/src-tauri/src/settings.rs
@@ -38,6 +38,8 @@ pub struct Settings {
     pub openrouter_api_key: String,
     #[serde(default)]
     pub openai_api_key: String,
+    #[serde(default)]
+    pub voyage_api_key: String,
     #[serde(default = "default_image_model")]
     pub image_model: String,
     #[serde(default = "default_enhance_model")]
@@ -119,6 +121,7 @@ impl Default for Settings {
             anthropic_api_key: String::new(),
             openrouter_api_key: String::new(),
             openai_api_key: String::new(),
+            voyage_api_key: String::new(),
             image_model: default_image_model(),
             enhance_model: default_enhance_model(),
             prompt_llm_provider: default_prompt_llm_provider(),
@@ -199,6 +202,7 @@ pub async fn get_settings(app: AppHandle) -> Result<Settings, String> {
                 anthropic_api_key: user.anthropic_api_key,
                 openrouter_api_key: user.openrouter_api_key,
                 openai_api_key: user.openai_api_key,
+                voyage_api_key: user.voyage_api_key,
                 github_pat: user.github_pat,
                 hub_api_url: user.hub_api_url,
                 hub_api_key: user.hub_api_key,
@@ -261,6 +265,7 @@ pub async fn get_merged_settings(
             anthropic_api_key: user.anthropic_api_key,
             openrouter_api_key: user.openrouter_api_key,
             openai_api_key: user.openai_api_key,
+            voyage_api_key: user.voyage_api_key,
             github_pat: user.github_pat,
             hub_api_url: user.hub_api_url,
             hub_api_key: user.hub_api_key,

--- a/creator/src/components/config/ConfigPanelHost.tsx
+++ b/creator/src/components/config/ConfigPanelHost.tsx
@@ -46,6 +46,7 @@ import { RuntimeHandoffStudio } from "./RuntimeHandoffStudio";
 import { RawYamlPanel } from "./panels/RawYamlPanel";
 import { VersionControlPanel } from "./panels/VersionControlPanel";
 import { InfrastructurePanel } from "./panels/InfrastructurePanel";
+import { LoreIndexPanel } from "./panels/LoreIndexPanel";
 
 type ConfigPanelProps = { config: AppConfig; onChange: (patch: Partial<AppConfig>) => void };
 
@@ -126,6 +127,8 @@ function renderPanel(panelId: string, props: ConfigPanelProps): ReactNode {
       return <RawYamlPanel config={config} onChange={onChange} />;
     case "versionControl":
       return <VersionControlPanel />;
+    case "loreIndex":
+      return <LoreIndexPanel />;
 
     default:
       return <div className="px-6 py-8 text-sm text-text-muted/60">Panel not found: {panelId}</div>;

--- a/creator/src/components/config/QuestsAuthoringPanel.tsx
+++ b/creator/src/components/config/QuestsAuthoringPanel.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useMemo, useState } from "react";
+import { useZoneStore } from "@/stores/zoneStore";
+import { useProjectStore } from "@/stores/projectStore";
+import { useQuestAuthoringStore } from "@/stores/questAuthoringStore";
+import { addQuest, generateEntityId } from "@/lib/zoneEdits";
+import type { QuestFile, WorldFile } from "@/types/world";
+import { QuestEditor } from "@/components/editors/QuestEditor";
+import { PlusIcon, SearchIcon } from "./achievements/icons";
+
+interface QuestRow {
+  zoneId: string;
+  questId: string;
+  name: string;
+}
+
+interface Selection {
+  zoneId: string;
+  questId: string;
+}
+
+function cx(...c: Array<string | false | null | undefined>) {
+  return c.filter(Boolean).join(" ");
+}
+
+function getActiveZoneId(): string | null {
+  const { tabs, activeTabId } = useProjectStore.getState();
+  const tab = tabs.find((t) => t.id === activeTabId);
+  if (tab?.kind === "zone") return tab.id.replace(/^zone:/, "");
+  return null;
+}
+
+/**
+ * Top-level cross-zone quest authoring surface. Lists every quest in the
+ * project grouped by zone, with a reusable QuestEditor on the right.
+ * Reachable via the Living World → Quests panel (the default tab).
+ */
+export function QuestsAuthoringPanel() {
+  const zones = useZoneStore((s) => s.zones);
+  const updateZone = useZoneStore((s) => s.updateZone);
+
+  const pendingFocus = useQuestAuthoringStore((s) => s.pendingFocus);
+  const pendingCreate = useQuestAuthoringStore((s) => s.pendingCreate);
+  const consumePendingFocus = useQuestAuthoringStore((s) => s.consumePendingFocus);
+  const consumePendingCreate = useQuestAuthoringStore((s) => s.consumePendingCreate);
+
+  const [selection, setSelection] = useState<Selection | null>(null);
+  const [query, setQuery] = useState("");
+  const [newQuestZone, setNewQuestZone] = useState<string>(() => getActiveZoneId() ?? "");
+
+  // Flat list of every quest across loaded zones, alphabetised by zone then name.
+  const allQuests: QuestRow[] = useMemo(() => {
+    const rows: QuestRow[] = [];
+    for (const [zoneId, zoneState] of zones) {
+      const quests = zoneState.data.quests ?? {};
+      for (const [questId, quest] of Object.entries(quests)) {
+        rows.push({ zoneId, questId, name: quest.name || questId });
+      }
+    }
+    rows.sort((a, b) => {
+      if (a.zoneId !== b.zoneId) return a.zoneId.localeCompare(b.zoneId);
+      return a.name.localeCompare(b.name);
+    });
+    return rows;
+  }, [zones]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return allQuests;
+    return allQuests.filter(
+      (r) =>
+        r.questId.toLowerCase().includes(q) ||
+        r.name.toLowerCase().includes(q) ||
+        r.zoneId.toLowerCase().includes(q),
+    );
+  }, [allQuests, query]);
+
+  // Group filtered rows by zone for display.
+  const grouped = useMemo(() => {
+    const map = new Map<string, QuestRow[]>();
+    for (const row of filtered) {
+      const list = map.get(row.zoneId) ?? [];
+      list.push(row);
+      map.set(row.zoneId, list);
+    }
+    return Array.from(map.entries());
+  }, [filtered]);
+
+  const zoneOptions = useMemo(() => {
+    return Array.from(zones.keys()).sort();
+  }, [zones]);
+
+  // Keep newQuestZone valid: default to active zone, otherwise first available.
+  useEffect(() => {
+    if (newQuestZone && zones.has(newQuestZone)) return;
+    const active = getActiveZoneId();
+    setNewQuestZone(active && zones.has(active) ? active : (zoneOptions[0] ?? ""));
+  }, [zones, zoneOptions, newQuestZone]);
+
+  // Default selection: first quest in the list, if nothing selected.
+  useEffect(() => {
+    if (selection) {
+      const stillExists = zones.get(selection.zoneId)?.data.quests?.[selection.questId];
+      if (stillExists) return;
+    }
+    setSelection(allQuests[0] ? { zoneId: allQuests[0].zoneId, questId: allQuests[0].questId } : null);
+  }, [allQuests, selection, zones]);
+
+  // Consume incoming focus intent.
+  useEffect(() => {
+    if (!pendingFocus) return;
+    const focus = consumePendingFocus();
+    if (!focus) return;
+    if (zones.get(focus.zoneId)?.data.quests?.[focus.questId]) {
+      setSelection({ zoneId: focus.zoneId, questId: focus.questId });
+    }
+  }, [pendingFocus, consumePendingFocus, zones]);
+
+  // Consume incoming create-new intent.
+  useEffect(() => {
+    if (!pendingCreate) return;
+    const req = consumePendingCreate();
+    if (!req) return;
+    handleCreate(req.zoneId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingCreate]);
+
+  const handleCreate = (zoneId: string) => {
+    const zone = zones.get(zoneId);
+    if (!zone) return;
+    const id = generateEntityId(zone.data, "quests");
+    const next = addQuest(zone.data, id, { name: id, giver: "" } as QuestFile);
+    updateZone(zoneId, next);
+    setSelection({ zoneId, questId: id });
+  };
+
+  const handleWorldChange = (zoneId: string) => (world: WorldFile) => {
+    updateZone(zoneId, world);
+  };
+
+  const handleDelete = () => {
+    setSelection(null);
+  };
+
+  const selectedWorld = selection ? zones.get(selection.zoneId)?.data : undefined;
+  const selectedExists =
+    selection && selectedWorld?.quests?.[selection.questId] !== undefined;
+
+  if (zones.size === 0) {
+    return (
+      <div className="panel-surface flex min-h-[24rem] flex-col items-center justify-center gap-2 rounded-2xl px-6 py-12 text-center shadow-section">
+        <p className="font-display text-base text-text-primary">No zones loaded</p>
+        <p className="max-w-xs text-2xs text-text-muted/80">
+          Open a project with at least one zone to start authoring quests.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+      <aside className="panel-surface flex max-h-[calc(100vh-2rem)] flex-col gap-3 rounded-2xl p-4 shadow-section xl:sticky xl:top-3 xl:col-span-4 xl:self-start">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="font-display text-xs font-semibold uppercase tracking-[0.18em] text-text-secondary">
+            Quests
+          </h3>
+          <span className="font-mono text-2xs text-text-muted/70">{allQuests.length}</span>
+        </div>
+
+        <div className="ornate-input flex items-center gap-2 px-2.5 py-1.5">
+          <SearchIcon className="text-text-muted/70" />
+          <input
+            className="min-w-0 flex-1 bg-transparent text-xs text-text-primary outline-none placeholder:text-text-muted/60"
+            placeholder="Search quests, ids, or zones…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <select
+            aria-label="Target zone for new quest"
+            value={newQuestZone}
+            onChange={(e) => setNewQuestZone(e.target.value)}
+            className="ornate-input min-w-0 flex-1 px-2.5 py-1.5 text-xs text-text-primary"
+          >
+            {zoneOptions.length === 0 ? (
+              <option value="">— no zones —</option>
+            ) : (
+              zoneOptions.map((z) => (
+                <option key={z} value={z}>
+                  {z}
+                </option>
+              ))
+            )}
+          </select>
+          <button
+            type="button"
+            onClick={() => newQuestZone && handleCreate(newQuestZone)}
+            disabled={!newQuestZone}
+            title={
+              newQuestZone
+                ? `Add a new quest in ${newQuestZone}`
+                : "Open a zone before creating a quest"
+            }
+            className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-lg border border-accent/40 bg-accent/10 px-3 py-1.5 text-xs font-medium text-accent transition hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <PlusIcon />
+            New
+          </button>
+        </div>
+
+        <ul className="-mx-1 flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-1 pb-1">
+          {grouped.length === 0 ? (
+            <li>
+              <div className="rounded-xl border border-dashed border-[var(--chrome-stroke-strong)] bg-[var(--chrome-fill-soft)] px-3 py-6 text-center text-2xs italic text-text-muted/70">
+                {allQuests.length === 0
+                  ? "No quests yet — pick a zone above and click New."
+                  : `No matches for "${query}".`}
+              </div>
+            </li>
+          ) : (
+            grouped.map(([zoneId, rows]) => (
+              <li key={zoneId} className="flex flex-col gap-1">
+                <div className="flex items-center justify-between gap-2 px-1">
+                  <span className="font-display text-2xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+                    {zoneId}
+                  </span>
+                  <span className="font-mono text-2xs text-text-muted/60">{rows.length}</span>
+                </div>
+                <ul className="flex flex-col gap-1">
+                  {rows.map((row) => {
+                    const isSelected =
+                      selection?.zoneId === row.zoneId && selection?.questId === row.questId;
+                    return (
+                      <li key={`${row.zoneId}/${row.questId}`}>
+                        <button
+                          type="button"
+                          onClick={() => setSelection({ zoneId: row.zoneId, questId: row.questId })}
+                          aria-pressed={isSelected}
+                          className={cx(
+                            "focus-ring flex w-full flex-col gap-0.5 rounded-xl border p-2.5 text-left transition",
+                            isSelected
+                              ? "selected-card"
+                              : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] hover:border-accent/30 hover:bg-[var(--chrome-fill)]",
+                          )}
+                        >
+                          <span className="truncate font-display text-sm font-semibold text-text-primary">
+                            {row.name}
+                          </span>
+                          <span className="truncate font-mono text-2xs text-text-muted/70">
+                            {row.questId}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </li>
+            ))
+          )}
+        </ul>
+      </aside>
+
+      <section className="xl:col-span-8">
+        {selection && selectedExists && selectedWorld ? (
+          <div className="panel-surface flex min-h-[34rem] flex-col gap-4 rounded-2xl p-4 shadow-section">
+            <header className="flex flex-wrap items-start justify-between gap-3 border-b border-[var(--chrome-stroke)] pb-3">
+              <div className="min-w-0 flex-1">
+                <p className="font-display text-2xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+                  Quest · {selection.zoneId}
+                </p>
+                <h3 className="mt-1 truncate font-display text-xl font-semibold text-text-primary">
+                  {selectedWorld.quests?.[selection.questId]?.name || selection.questId}
+                </h3>
+                <p className="mt-0.5 font-mono text-2xs text-text-muted/70">{selection.questId}</p>
+              </div>
+            </header>
+            <QuestEditor
+              key={`${selection.zoneId}/${selection.questId}`}
+              questId={selection.questId}
+              world={selectedWorld}
+              onWorldChange={handleWorldChange(selection.zoneId)}
+              onDelete={handleDelete}
+            />
+          </div>
+        ) : (
+          <div className="panel-surface flex min-h-[34rem] flex-col items-center justify-center gap-2 rounded-2xl px-6 py-12 text-center shadow-section">
+            <p className="font-display text-base text-text-primary">No quest selected</p>
+            <p className="max-w-xs text-2xs text-text-muted/80">
+              Pick a quest from the list, or create a new one in the zone of your choice.
+            </p>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/creator/src/components/config/QuestsStudio.tsx
+++ b/creator/src/components/config/QuestsStudio.tsx
@@ -24,18 +24,21 @@ import { useArrayField } from "@/lib/useArrayField";
 import { useConfigOptions } from "@/lib/useConfigOptions";
 import { AutoQuestsPanel } from "./panels/AutoQuestsPanel";
 import { TaxonomyWorkbench } from "./achievements/TaxonomyWorkbench";
+import { QuestsAuthoringPanel } from "./QuestsAuthoringPanel";
+import { useZoneStore } from "@/stores/zoneStore";
 
 interface Props {
   config: AppConfig;
   onChange: (patch: Partial<AppConfig>) => void;
 }
 
-type TabId = "config" | "objectiveTypes" | "completionTypes";
+type TabId = "quests" | "objectiveTypes" | "completionTypes" | "config";
 
 const TABS: Array<{ id: TabId; label: string }> = [
-  { id: "config", label: "Config" },
+  { id: "quests", label: "Quests" },
   { id: "objectiveTypes", label: "Objective Types" },
   { id: "completionTypes", label: "Completion Types" },
+  { id: "config", label: "Config" },
 ];
 
 const DEFAULT_DAILY_QUESTS: DailyQuestsConfig = {
@@ -91,11 +94,19 @@ function defaultCompletionType(raw: string): QuestCompletionTypeDefinition {
  * (taxonomy), and Completion Types (taxonomy).
  */
 export function QuestsStudio({ config, onChange }: Props) {
-  const [active, setActive] = useState<TabId>("config");
+  const [active, setActive] = useState<TabId>("quests");
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   const objectiveCount = Object.keys(config.questObjectiveTypes).length;
   const completionCount = Object.keys(config.questCompletionTypes).length;
+  const zones = useZoneStore((s) => s.zones);
+  const questCount = (() => {
+    let total = 0;
+    for (const zone of zones.values()) {
+      total += Object.keys(zone.data.quests ?? {}).length;
+    }
+    return total;
+  })();
 
   return (
     <div className="flex flex-col gap-5">
@@ -107,11 +118,13 @@ export function QuestsStudio({ config, onChange }: Props) {
         >
           {TABS.map((tab, index) => {
             const count =
-              tab.id === "objectiveTypes"
-                ? objectiveCount
-                : tab.id === "completionTypes"
-                  ? completionCount
-                  : null;
+              tab.id === "quests"
+                ? questCount
+                : tab.id === "objectiveTypes"
+                  ? objectiveCount
+                  : tab.id === "completionTypes"
+                    ? completionCount
+                    : null;
             return (
               <button
                 key={tab.id}
@@ -154,6 +167,8 @@ export function QuestsStudio({ config, onChange }: Props) {
         role="tabpanel"
         aria-labelledby={`quest-tab-${active}`}
       >
+        {active === "quests" && <QuestsAuthoringPanel />}
+
         {active === "config" && <QuestsConfigPanel config={config} onChange={onChange} />}
 
         {active === "objectiveTypes" && (

--- a/creator/src/components/config/panels/FactionPanel.tsx
+++ b/creator/src/components/config/panels/FactionPanel.tsx
@@ -36,7 +36,6 @@ export function FactionPanel() {
   const updateConfig = useConfigStore((s) => s.updateConfig);
   const zones = useZoneStore((s) => s.zones);
   const [selected, setSelected] = useState<string | null>(null);
-  const [newQuestId, setNewQuestId] = useState("");
 
   const rawFactions = config?.factions;
   const factions: FactionConfig = {
@@ -202,14 +201,16 @@ export function FactionPanel() {
     [factions.definitions, factions.questRewards, patch, selected],
   );
 
-  const addQuestReward = useCallback(() => {
-    const qid = newQuestId.trim();
-    if (!qid) return;
-    const existing = factions.questRewards ?? {};
-    if (existing[qid]) return;
-    patch({ questRewards: { ...existing, [qid]: {} } });
-    setNewQuestId("");
-  }, [newQuestId, factions.questRewards, patch]);
+  const addQuestReward = useCallback(
+    (questId: string) => {
+      const qid = questId.trim();
+      if (!qid) return;
+      const existing = factions.questRewards ?? {};
+      if (existing[qid]) return;
+      patch({ questRewards: { ...existing, [qid]: {} } });
+    },
+    [factions.questRewards, patch],
+  );
 
   const patchQuestReward = useCallback(
     (questId: string, factionId: string, amount: number | undefined) => {
@@ -218,21 +219,6 @@ export function FactionPanel() {
       if (amount == null || amount === 0) delete entry[factionId];
       else entry[factionId] = amount;
       patch({ questRewards: { ...existing, [questId]: entry } });
-    },
-    [factions.questRewards, patch],
-  );
-
-  const renameQuestReward = useCallback(
-    (oldQid: string, newQid: string) => {
-      const trimmed = newQid.trim();
-      if (!trimmed || oldQid === trimmed) return;
-      const existing = factions.questRewards ?? {};
-      if (existing[trimmed]) return;
-      const next: Record<string, Record<string, number>> = {};
-      for (const [qid, rewards] of Object.entries(existing)) {
-        next[qid === oldQid ? trimmed : qid] = rewards;
-      }
-      patch({ questRewards: next });
     },
     [factions.questRewards, patch],
   );
@@ -364,11 +350,8 @@ export function FactionPanel() {
         <QuestRewards
           questRewards={factions.questRewards}
           factionOptions={factionOptions}
-          newQuestId={newQuestId}
-          onNewQuestIdChange={setNewQuestId}
           onAddQuest={addQuestReward}
           onPatchPair={patchQuestReward}
-          onRenameQuest={renameQuestReward}
           onDeleteQuest={deleteQuestReward}
         />
       </div>

--- a/creator/src/components/config/panels/LoreIndexPanel.tsx
+++ b/creator/src/components/config/panels/LoreIndexPanel.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useState } from "react";
+import { useAssetStore } from "@/stores/assetStore";
+import { useConfigStore } from "@/stores/configStore";
+import { useLoreStore } from "@/stores/loreStore";
+import { useProjectStore } from "@/stores/projectStore";
+import { useZoneStore } from "@/stores/zoneStore";
+import {
+  clearIndex,
+  getIndexStats,
+  rebuildIndex,
+  type ChunkerInput,
+  type IndexStats,
+} from "@/lib/rag";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import type { Settings } from "@/types/assets";
+
+function formatRelative(ts: number | null): string {
+  if (!ts) return "never";
+  const ms = Date.now() - ts;
+  if (ms < 0) return "just now";
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  return `${days}d ago`;
+}
+
+export function LoreIndexPanel() {
+  const settings = useAssetStore((s) => s.settings);
+  const loadSettings = useAssetStore((s) => s.loadSettings);
+  const saveSettings = useAssetStore((s) => s.saveSettings);
+  const projectDir = useProjectStore((s) => s.project?.mudDir);
+
+  const [stats, setStats] = useState<IndexStats | null>(null);
+  const [statsLoading, setStatsLoading] = useState(true);
+  const [rebuilding, setRebuilding] = useState(false);
+  const [progressLine, setProgressLine] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [confirmClearOpen, setConfirmClearOpen] = useState(false);
+  const [draft, setDraft] = useState<Settings | null>(null);
+  const [savingKey, setSavingKey] = useState(false);
+  const [keySaved, setKeySaved] = useState(false);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  useEffect(() => {
+    if (settings) setDraft({ ...settings });
+  }, [settings]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setStatsLoading(true);
+      const next = await getIndexStats();
+      if (!cancelled) {
+        setStats(next);
+        setStatsLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectDir]);
+
+  function gatherInput(): ChunkerInput {
+    const lore = useLoreStore.getState().lore;
+    const config = useConfigStore.getState().config;
+    const zones = Array.from(useZoneStore.getState().zones.entries()).map(
+      ([zoneId, z]) => ({ zoneId, data: z.data }),
+    );
+    return { lore, config, zones };
+  }
+
+  async function handleRebuild() {
+    if (rebuilding) return;
+    setError(null);
+    setRebuilding(true);
+    setProgressLine("Chunking…");
+    try {
+      const next = await rebuildIndex(gatherInput(), (stage) => setProgressLine(stage));
+      setStats(next);
+      setProgressLine("Done");
+      setTimeout(() => setProgressLine(""), 1500);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setProgressLine("");
+    } finally {
+      setRebuilding(false);
+    }
+  }
+
+  async function handleClearConfirmed() {
+    setConfirmClearOpen(false);
+    setError(null);
+    try {
+      await clearIndex();
+      const next = await getIndexStats();
+      setStats(next);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  async function handleSaveKey() {
+    if (!draft) return;
+    setSavingKey(true);
+    setError(null);
+    try {
+      await saveSettings(draft);
+      setKeySaved(true);
+      setTimeout(() => setKeySaved(false), 2000);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingKey(false);
+    }
+  }
+
+  const keyDirty =
+    !!settings && !!draft && (draft.voyage_api_key ?? "") !== (settings.voyage_api_key ?? "");
+
+  const byKind = stats?.by_kind ?? {};
+  const byKindEntries = Object.entries(byKind).sort(([a], [b]) => a.localeCompare(b));
+
+  return (
+    <div className="flex flex-col gap-8">
+      {/* ─── Status ──────────────────────────────────────────── */}
+      <section>
+        <h3 className="mb-1 font-display text-sm uppercase tracking-widest text-text-primary">
+          Status
+        </h3>
+        <p className="mb-4 text-2xs text-text-muted">
+          Embedded chunks power retrieval-augmented lookups across articles, timelines, maps, and
+          entity descriptions. Rebuild after major lore edits.
+        </p>
+
+        {!projectDir ? (
+          <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-5 py-4 text-xs text-text-muted">
+            Open a world project to manage its lore index.
+          </div>
+        ) : statsLoading ? (
+          <div className="text-xs text-text-muted">Loading index status…</div>
+        ) : (
+          <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-5 py-4">
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <Stat label="Total chunks" value={stats ? String(stats.total_chunks) : "0"} />
+              <Stat
+                label="Last embedded"
+                value={stats ? formatRelative(stats.last_embedded_at) : "never"}
+              />
+              <Stat
+                label="Model"
+                value={stats?.embedding_model || "—"}
+                mono
+              />
+              <Stat
+                label="Dim"
+                value={stats?.embedding_dim ? String(stats.embedding_dim) : "—"}
+                mono
+              />
+            </div>
+            {byKindEntries.length > 0 && (
+              <div className="mt-4 border-t border-border-muted pt-3">
+                <div className="text-3xs uppercase tracking-wider text-text-muted">By kind</div>
+                <ul className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1 text-2xs text-text-secondary">
+                  {byKindEntries.map(([kind, count]) => (
+                    <li key={kind} className="flex items-center gap-1.5">
+                      <span className="font-mono text-accent/80">{count}</span>
+                      <span>{kind}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        {projectDir && (
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleRebuild}
+              disabled={rebuilding}
+              className="action-button action-button-primary action-button-md focus-ring"
+            >
+              {rebuilding ? "Rebuilding…" : "Rebuild Index"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmClearOpen(true)}
+              disabled={rebuilding || !stats || stats.total_chunks === 0}
+              className="focus-ring rounded-full border border-status-error/40 px-3 py-1 text-2xs text-status-error transition hover:bg-status-error/10 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Clear index
+            </button>
+            {progressLine && (
+              <span className="text-2xs text-text-muted">{progressLine}</span>
+            )}
+            {error && <span className="text-2xs text-status-error">{error}</span>}
+          </div>
+        )}
+      </section>
+
+      {/* ─── Voyage API key ──────────────────────────────────── */}
+      <section className="border-t border-border-default pt-6">
+        <h3 className="mb-1 font-display text-sm uppercase tracking-widest text-text-primary">
+          Voyage AI API key
+        </h3>
+        <p className="mb-4 text-2xs text-text-muted">
+          Used for embedding text chunks when not routing through the Arcanum Hub. Stored on this
+          machine only.
+        </p>
+        {draft ? (
+          <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-3">
+            <div className="flex items-center justify-between gap-2">
+              <label
+                htmlFor="voyage-api-key"
+                className="font-display text-xs uppercase tracking-wide-ui text-text-primary"
+              >
+                Voyage
+              </label>
+              <span
+                className={`rounded-full px-2 py-0.5 text-3xs uppercase tracking-ui ${
+                  draft.voyage_api_key
+                    ? "bg-status-success/15 text-status-success"
+                    : "bg-[var(--chrome-highlight)] text-text-muted"
+                }`}
+              >
+                {draft.voyage_api_key ? "set" : "empty"}
+              </span>
+            </div>
+            <input
+              id="voyage-api-key"
+              type="password"
+              value={draft.voyage_api_key ?? ""}
+              onChange={(e) => setDraft({ ...draft, voyage_api_key: e.target.value })}
+              placeholder="Enter your Voyage AI API key"
+              className="mt-2 w-full rounded border border-border-default bg-bg-primary px-3 py-1.5 text-xs text-text-primary placeholder:text-text-muted outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+            />
+            <p className="mt-2 text-3xs text-text-muted/60">
+              Get your key at <code className="font-mono text-accent/70">dash.voyageai.com</code>
+            </p>
+            <div className="mt-3 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleSaveKey}
+                disabled={!keyDirty || savingKey}
+                className="action-button action-button-primary action-button-sm focus-ring"
+              >
+                {savingKey ? "Saving…" : "Save"}
+              </button>
+              {keySaved && <span className="text-2xs text-status-success">Saved</span>}
+              {keyDirty && !savingKey && (
+                <span className="text-2xs text-accent">modified</span>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="text-xs text-text-muted">Loading…</div>
+        )}
+      </section>
+
+      {confirmClearOpen && (
+        <ConfirmDialog
+          title="Clear lore index?"
+          message="This removes every embedded chunk for this project. You will need to rebuild before retrieval works again."
+          confirmLabel="Clear index"
+          cancelLabel="Cancel"
+          destructive
+          onConfirm={handleClearConfirmed}
+          onCancel={() => setConfirmClearOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <div className="text-3xs uppercase tracking-wider text-text-muted">{label}</div>
+      <div
+        className={`mt-1 text-base text-text-primary ${
+          mono ? "font-mono text-sm" : "font-display"
+        }`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/creator/src/components/config/panels/QuestPicker.tsx
+++ b/creator/src/components/config/panels/QuestPicker.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useZoneStore } from "@/stores/zoneStore";
+import { useProjectStore } from "@/stores/projectStore";
+import { useQuestAuthoringStore } from "@/stores/questAuthoringStore";
+import { panelTab } from "@/lib/panelRegistry";
+
+interface QuestOption {
+  zoneId: string;
+  questId: string;
+  name: string;
+}
+
+interface QuestPickerProps {
+  value: string;
+  onChange: (questId: string) => void;
+  /** Hide quests already chosen (e.g. existing keys in a Record map). */
+  excludeIds?: string[];
+  placeholder?: string;
+  /** Show a '+ New Quest' footer that opens the Quests authoring panel. */
+  allowCreate?: boolean;
+  /** When the picker's value points to a quest that doesn't exist, render a warning. */
+  warnOnMissing?: boolean;
+  className?: string;
+}
+
+function getActiveZoneId(): string | null {
+  const { tabs, activeTabId } = useProjectStore.getState();
+  const tab = tabs.find((t) => t.id === activeTabId);
+  if (tab?.kind === "zone") return tab.id.replace(/^zone:/, "");
+  return null;
+}
+
+/**
+ * Cross-zone quest picker. Lists every quest in the project grouped by zone,
+ * with search. Optional '+ New Quest' footer routes to the Living World →
+ * Quests authoring panel with create intent.
+ */
+export function QuestPicker({
+  value,
+  onChange,
+  excludeIds,
+  placeholder,
+  allowCreate,
+  warnOnMissing = true,
+  className,
+}: QuestPickerProps) {
+  const zones = useZoneStore((s) => s.zones);
+  const openTab = useProjectStore((s) => s.openTab);
+  const setPendingCreate = useQuestAuthoringStore((s) => s.setPendingCreate);
+
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const allQuests = useMemo<QuestOption[]>(() => {
+    const rows: QuestOption[] = [];
+    for (const [zoneId, zoneState] of zones) {
+      const quests = zoneState.data.quests ?? {};
+      for (const [questId, quest] of Object.entries(quests)) {
+        rows.push({ zoneId, questId, name: quest.name || questId });
+      }
+    }
+    rows.sort((a, b) => {
+      if (a.zoneId !== b.zoneId) return a.zoneId.localeCompare(b.zoneId);
+      return a.name.localeCompare(b.name);
+    });
+    return rows;
+  }, [zones]);
+
+  const excludeSet = useMemo(() => new Set(excludeIds ?? []), [excludeIds]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return allQuests.filter((row) => {
+      if (excludeSet.has(row.questId)) return false;
+      if (!q) return true;
+      return (
+        row.questId.toLowerCase().includes(q) ||
+        row.name.toLowerCase().includes(q) ||
+        row.zoneId.toLowerCase().includes(q)
+      );
+    });
+  }, [allQuests, query, excludeSet]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setQuery("");
+      }
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  const selected = useMemo(
+    () => (value ? allQuests.find((q) => q.questId === value) : undefined),
+    [allQuests, value],
+  );
+  const hasUnknownValue = !!value && !selected;
+
+  const handleCreate = () => {
+    const activeZone = getActiveZoneId();
+    const firstZone = Array.from(zones.keys()).sort()[0];
+    const targetZone = (activeZone && zones.has(activeZone) ? activeZone : firstZone) ?? null;
+    if (targetZone) setPendingCreate({ zoneId: targetZone });
+    openTab(panelTab("quests"));
+    setOpen(false);
+    setQuery("");
+  };
+
+  return (
+    <div ref={rootRef} className={`relative ${className ?? ""}`}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="ornate-input flex min-h-9 w-full items-center px-2.5 py-1.5 text-left text-xs text-text-primary"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        {selected ? (
+          <span className="flex min-w-0 flex-1 items-baseline gap-2">
+            <span className="truncate font-semibold">{selected.name}</span>
+            <span className="shrink-0 rounded bg-bg-tertiary px-1.5 py-px font-mono text-2xs text-text-muted">
+              {selected.zoneId}
+            </span>
+          </span>
+        ) : hasUnknownValue ? (
+          <span className="flex min-w-0 flex-1 items-baseline gap-2">
+            <span className={`truncate italic ${warnOnMissing ? "text-status-warning" : "text-text-muted"}`}>
+              {warnOnMissing ? "Missing quest" : "Unknown quest"}
+            </span>
+            <span className="truncate font-mono text-2xs text-text-muted">{value}</span>
+          </span>
+        ) : (
+          <span className="flex-1 text-text-muted">{placeholder ?? "Select quest…"}</span>
+        )}
+        <span
+          className={`ml-2 text-[9px] text-text-muted transition-transform ${open ? "rotate-90" : ""}`}
+          aria-hidden="true"
+        >
+          &#x25B6;
+        </span>
+      </button>
+
+      {open && (
+        <div className="absolute left-0 right-0 z-30 mt-1 overflow-hidden rounded border border-border-default bg-bg-elevated shadow-lg">
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={`Search ${allQuests.length} quest${allQuests.length === 1 ? "" : "s"}…`}
+            className="w-full border-b border-border-muted bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50"
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                setOpen(false);
+                setQuery("");
+              }
+            }}
+          />
+          <div className="max-h-60 overflow-y-auto">
+            {allQuests.length === 0 ? (
+              <p className="px-2 py-2 text-2xs text-text-muted">
+                No quests authored yet. Open the Quests panel to create one.
+              </p>
+            ) : filtered.length === 0 ? (
+              <p className="px-2 py-2 text-2xs text-text-muted">
+                {query ? `No quests match "${query}".` : "All quests are already selected."}
+              </p>
+            ) : (
+              filtered.map((row) => {
+                const isActive = row.questId === value;
+                return (
+                  <button
+                    key={`${row.zoneId}/${row.questId}`}
+                    type="button"
+                    onClick={() => {
+                      onChange(row.questId);
+                      setOpen(false);
+                      setQuery("");
+                    }}
+                    className={`flex w-full items-center gap-2 border-b border-border-muted/30 px-2 py-1.5 text-left transition-colors hover:bg-bg-hover ${isActive ? "bg-accent/10" : ""}`}
+                  >
+                    <span className="flex min-w-0 flex-1 flex-col">
+                      <span className="truncate text-xs text-text-primary">{row.name}</span>
+                      <span className="truncate font-mono text-2xs text-text-muted">{row.questId}</span>
+                    </span>
+                    <span className="shrink-0 rounded bg-bg-tertiary px-1.5 py-px font-mono text-2xs text-text-muted">
+                      {row.zoneId}
+                    </span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+          {allowCreate && (
+            <button
+              type="button"
+              onClick={handleCreate}
+              className="w-full border-t border-border-muted bg-bg-primary/50 px-2 py-1.5 text-left text-2xs font-medium text-accent transition hover:bg-accent/10"
+            >
+              + New quest in the Quests panel…
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Read-only display of a quest reference: shows the quest name + zone badge,
+ * or a missing-quest warning. Clicking jumps to the Quests authoring panel
+ * with that quest focused.
+ */
+export function QuestRefBadge({ questId }: { questId: string }) {
+  const zones = useZoneStore((s) => s.zones);
+  const openTab = useProjectStore((s) => s.openTab);
+  const setPendingFocus = useQuestAuthoringStore((s) => s.setPendingFocus);
+
+  const found = useMemo(() => {
+    for (const [zoneId, zoneState] of zones) {
+      const quest = zoneState.data.quests?.[questId];
+      if (quest) return { zoneId, name: quest.name || questId };
+    }
+    return null;
+  }, [zones, questId]);
+
+  const handleJump = () => {
+    if (found) setPendingFocus({ zoneId: found.zoneId, questId });
+    openTab(panelTab("quests"));
+  };
+
+  if (!found) {
+    return (
+      <button
+        type="button"
+        onClick={handleJump}
+        className="focus-ring inline-flex items-center gap-1.5 rounded border border-status-warning/40 bg-status-warning/5 px-1.5 py-0.5 text-2xs text-status-warning transition hover:bg-status-warning/10"
+        title="This quest is not defined in any loaded zone — click to open the Quests panel"
+      >
+        <span aria-hidden>⚠</span>
+        <span className="font-mono">{questId}</span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleJump}
+      className="focus-ring inline-flex items-center gap-1.5 rounded border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-1.5 py-0.5 text-2xs text-text-primary transition hover:border-accent/40 hover:bg-[var(--chrome-fill)]"
+      title="Open this quest in the Quests panel"
+    >
+      <span className="truncate">{found.name}</span>
+      <span className="shrink-0 rounded bg-bg-tertiary px-1 font-mono text-text-muted">{found.zoneId}</span>
+    </button>
+  );
+}

--- a/creator/src/components/config/panels/factions/QuestRewards.tsx
+++ b/creator/src/components/config/panels/factions/QuestRewards.tsx
@@ -1,30 +1,26 @@
-﻿import { memo, useState } from "react";
-import { ActionButton, TextInput, NumberInput, SelectInput } from "@/components/ui/FormWidgets";
+import { memo, useState } from "react";
+import { ActionButton, NumberInput, SelectInput } from "@/components/ui/FormWidgets";
 import { SectionCard } from "@/components/ui/SectionCard";
+import { QuestPicker, QuestRefBadge } from "@/components/config/panels/QuestPicker";
 import { PlusIcon, TrashIcon, XIcon, CompassRoseIcon } from "./icons";
 
 interface QuestRewardsProps {
   questRewards: Record<string, Record<string, number>> | undefined;
   factionOptions: { value: string; label: string }[];
-  newQuestId: string;
-  onNewQuestIdChange: (v: string) => void;
-  onAddQuest: () => void;
+  onAddQuest: (questId: string) => void;
   onPatchPair: (questId: string, factionId: string, amount: number | undefined) => void;
-  onRenameQuest: (oldId: string, newId: string) => void;
   onDeleteQuest: (questId: string) => void;
 }
 
 export function QuestRewards({
   questRewards,
   factionOptions,
-  newQuestId,
-  onNewQuestIdChange,
   onAddQuest,
   onPatchPair,
-  onRenameQuest,
   onDeleteQuest,
 }: QuestRewardsProps) {
   const entries = Object.entries(questRewards ?? {});
+  const existingIds = entries.map(([qid]) => qid);
 
   return (
     <SectionCard
@@ -32,32 +28,22 @@ export function QuestRewards({
       description="What a finished quest does to a player's standing. Use it to court allies — or burn bridges — based on the work they take."
     >
       <div className="mb-3 flex items-center gap-2">
-        <input
-          className="ornate-input min-w-0 flex-1 px-2.5 py-1.5 text-xs text-text-primary"
-          placeholder="quest_id"
-          value={newQuestId}
-          onChange={(e) => onNewQuestIdChange(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") onAddQuest();
-          }}
-        />
-        <ActionButton
-          variant="primary"
-          size="sm"
-          onClick={onAddQuest}
-          disabled={!newQuestId.trim()}
-          className="shrink-0"
-        >
-          <PlusIcon />
-          Add Quest
-        </ActionButton>
+        <div className="min-w-0 flex-1">
+          <QuestPicker
+            value=""
+            onChange={(qid) => qid && onAddQuest(qid)}
+            excludeIds={existingIds}
+            placeholder="Pick a quest to bind…"
+            allowCreate
+          />
+        </div>
       </div>
 
       {entries.length === 0 ? (
         <div className="px-2 py-6 text-center">
           <CompassRoseIcon className="mx-auto mb-2 h-6 w-6 text-text-muted/40" />
           <p className="font-body text-2xs italic leading-snug text-text-muted/80">
-            No quests bound to reputation yet. Name a quest above, then tie it to the factions it pleases or offends.
+            No quests bound to reputation yet. Pick one above, then tie it to the factions it pleases or offends.
           </p>
         </div>
       ) : (
@@ -68,7 +54,6 @@ export function QuestRewards({
               questId={qid}
               rewards={rewards}
               factionOptions={factionOptions}
-              onRename={(v) => onRenameQuest(qid, v)}
               onPatch={(fid, amount) => onPatchPair(qid, fid, amount)}
               onDelete={() => onDeleteQuest(qid)}
             />
@@ -83,7 +68,6 @@ interface QuestRewardRowProps {
   questId: string;
   rewards: Record<string, number>;
   factionOptions: { value: string; label: string }[];
-  onRename: (v: string) => void;
   onPatch: (factionId: string, amount: number | undefined) => void;
   onDelete: () => void;
 }
@@ -92,7 +76,6 @@ const QuestRewardRow = memo(function QuestRewardRow({
   questId,
   rewards,
   factionOptions,
-  onRename,
   onPatch,
   onDelete,
 }: QuestRewardRowProps) {
@@ -114,8 +97,8 @@ const QuestRewardRow = memo(function QuestRewardRow({
         <span className="font-display text-2xs uppercase tracking-wider text-text-muted">
           Quest
         </span>
-        <div className="min-w-0 flex-1 font-mono">
-          <TextInput value={questId} onCommit={onRename} placeholder="quest_id" dense />
+        <div className="min-w-0 flex-1">
+          <QuestRefBadge questId={questId} />
         </div>
         <button
           type="button"

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -563,10 +563,10 @@ export function MobEditor({
           <Section
             title={stats?.anyOverridden ? "Stat Overrides ●" : "Stat Overrides"}
             defaultExpanded={false}
-            description={
+            titleTooltip={
               stats
-                ? "Every field below follows tier × level by default. Only set a value when you need to break from the curve — the engine uses whatever you type instead of the computed value."
-                : "Set this mob's tier and level to preview the computed stats. Any value you type below becomes an override."
+                ? "Fields follow tier × level by default. Type a value to override the curve."
+                : "Set tier and level first to preview computed stats. Any value typed here overrides the curve."
             }
             actions={
               stats?.anyOverridden ? (

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -24,6 +24,7 @@ import { useVibeStore } from "@/stores/vibeStore";
 import { useConfigStore } from "@/stores/configStore";
 import { resolveMobStats } from "@/lib/resolveMobStats";
 import { CATEGORY_ICONS } from "@/assets/ui";
+import { QuestPicker, QuestRefBadge } from "@/components/config/panels/QuestPicker";
 
 interface MobEditorProps {
   mobId: string;
@@ -159,11 +160,6 @@ export function MobEditor({
     });
   }, [patch]);
 
-  const zoneQuests = Object.entries(world.quests ?? {}).map(([id, q]) => ({
-    id,
-    name: q.name,
-  }));
-
   const {
     add: handleAddDrop,
     update: handleUpdateDrop,
@@ -186,13 +182,21 @@ export function MobEditor({
     [mob.behavior, patch],
   );
 
-  const handleToggleQuest = useCallback(
+  const handleAddQuest = useCallback(
+    (questId: string) => {
+      if (!questId) return;
+      const current = mob.quests ?? [];
+      if (current.includes(questId)) return;
+      patch({ quests: [...current, questId] });
+    },
+    [mob.quests, patch],
+  );
+
+  const handleRemoveQuest = useCallback(
     (questId: string) => {
       const current = mob.quests ?? [];
-      const quests = current.includes(questId)
-        ? current.filter((q) => q !== questId)
-        : [...current, questId];
-      patch({ quests: quests.length > 0 ? quests : undefined });
+      const next = current.filter((q) => q !== questId);
+      patch({ quests: next.length > 0 ? next : undefined });
     },
     [mob.quests, patch],
   );
@@ -682,26 +686,32 @@ export function MobEditor({
           </Section>
 
           <Section title={`Quests (${mob.quests?.length ?? 0})`}>
-            {zoneQuests.length === 0 ? (
-              <p className="text-xs text-text-muted">No quests defined in this zone</p>
-            ) : (
-              <div className="flex flex-col gap-0.5">
-                {zoneQuests.map((q) => (
-                  <label
-                    key={q.id}
-                    className="flex items-center gap-1.5 rounded px-1 py-0.5 text-xs text-text-secondary hover:bg-bg-tertiary"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={(mob.quests ?? []).includes(q.id)}
-                      onChange={() => handleToggleQuest(q.id)}
-                      className="accent-accent"
-                    />
-                    {q.name || q.id}
-                  </label>
-                ))}
-              </div>
-            )}
+            <div className="flex flex-col gap-2">
+              {(mob.quests ?? []).length > 0 && (
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {(mob.quests ?? []).map((qid) => (
+                    <div key={qid} className="inline-flex items-center gap-1">
+                      <QuestRefBadge questId={qid} />
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveQuest(qid)}
+                        aria-label={`Remove ${qid}`}
+                        className="focus-ring inline-flex h-5 w-5 items-center justify-center rounded text-text-muted/70 transition hover:bg-status-error/15 hover:text-status-error"
+                      >
+                        &times;
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <QuestPicker
+                value=""
+                onChange={handleAddQuest}
+                excludeIds={mob.quests}
+                placeholder="Pick a quest this mob gives or turns in…"
+                allowCreate
+              />
+            </div>
           </Section>
         </>
       )}

--- a/creator/src/components/sidebar/ZonesPanel.tsx
+++ b/creator/src/components/sidebar/ZonesPanel.tsx
@@ -16,7 +16,6 @@ import {
   addItem,
   addShop,
   addTrainer,
-  addQuest,
   addGatheringNode,
   addRecipe,
   setDungeon,
@@ -28,7 +27,6 @@ import type {
   ItemFile,
   ShopFile,
   TrainerFile,
-  QuestFile,
   GatheringNodeFile,
   RecipeFile,
 } from "@/types/world";
@@ -123,16 +121,6 @@ const CATEGORIES: CategoryDef[] = [
         yields: [],
         room: firstRoom,
       } as GatheringNodeFile);
-    },
-  },
-  {
-    key: "quest",
-    label: "Quests",
-    collection: "quests",
-    nameField: "name",
-    addFn: (world) => {
-      const id = generateEntityId(world, "quests");
-      return addQuest(world, id, { name: id, giver: "" } as QuestFile);
     },
   },
   {

--- a/creator/src/components/ui/CommandPalette.tsx
+++ b/creator/src/components/ui/CommandPalette.tsx
@@ -4,6 +4,7 @@ import { useLoreStore, selectArticles } from "@/stores/loreStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useAssetStore } from "@/stores/assetStore";
 import { ALL_PANELS, panelTab } from "@/lib/panelRegistry";
+import { useQuestAuthoringStore } from "@/stores/questAuthoringStore";
 import { AI_ENABLED } from "@/lib/featureFlags";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 
@@ -220,7 +221,10 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
           title: quest.name || questId,
           subtitle: zoneName,
           searchText: questId,
-          action: () => navigateTo({ zoneId, entityKind: "quest", entityId: questId }),
+          action: () => {
+            useQuestAuthoringStore.getState().setPendingFocus({ zoneId, questId });
+            openTab(panelTab("quests"));
+          },
         });
       }
       for (const [nodeId, node] of Object.entries(zone.gatheringNodes ?? {})) {

--- a/creator/src/components/ui/FormWidgets.tsx
+++ b/creator/src/components/ui/FormWidgets.tsx
@@ -272,12 +272,14 @@ export function EditableTextArea({
 /** Collapsible section with a header label. Click header to toggle. */
 export function Section({
   title,
+  titleTooltip,
   description,
   children,
   actions,
   defaultExpanded = true,
 }: {
   title: string;
+  titleTooltip?: string;
   description?: string;
   children: ReactNode;
   actions?: ReactNode;
@@ -306,10 +308,14 @@ export function Section({
           >
             &#x25B6;
           </span>
-          <h4 className={cx(
-            "font-display font-semibold text-2xs uppercase tracking-widest [transition:color_200ms_var(--ease-unfurl)]",
-            expanded ? "text-text-secondary" : "text-text-muted"
-          )}>
+          <h4
+            title={titleTooltip}
+            className={cx(
+              "font-display font-semibold text-2xs uppercase tracking-widest [transition:color_200ms_var(--ease-unfurl)]",
+              expanded ? "text-text-secondary" : "text-text-muted",
+              titleTooltip ? "cursor-help decoration-text-muted/40 decoration-dotted underline-offset-2 hover:underline" : undefined,
+            )}
+          >
             {title}
           </h4>
         </button>
@@ -331,16 +337,26 @@ export function Section({
 export function FieldRow({
   label,
   hint,
+  labelTooltip,
   children,
 }: {
   label: string;
   hint?: string;
+  labelTooltip?: string;
   children: ReactNode;
 }) {
   return (
     <div className="py-0.5">
       <label className="flex items-center gap-2 text-xs">
-        <span className="w-24 shrink-0 text-text-muted">{label}</span>
+        <span
+          title={labelTooltip}
+          className={cx(
+            "w-24 shrink-0 text-text-muted",
+            labelTooltip && "cursor-help decoration-text-muted/40 decoration-dotted underline-offset-2 hover:underline",
+          )}
+        >
+          {label}
+        </span>
         <div className="min-w-0 flex-1">{children}</div>
       </label>
       {hint && (

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -543,10 +543,7 @@ export function RoomPanel({
       </Section>
 
       {/* Exits */}
-      <Section
-        title={`Exits (${exits.length})`}
-        description="Edit room links here. Cross-zone targets use the `zone:room` format and stay one-way from this zone."
-      >
+      <Section title={`Exits (${exits.length})`}>
         <div className="flex flex-col gap-2">
           {exitError && (
             <p className="rounded border border-status-error/30 bg-status-error/10 px-3 py-2 text-2xs text-status-error">
@@ -677,15 +674,7 @@ export function RoomPanel({
           )}
 
           <div className="rounded-xl border border-accent/25 bg-[linear-gradient(180deg,rgba(var(--accent-rgb),0.12),rgba(var(--accent-rgb),0.04))] p-3 shadow-[inset_0_1px_0_rgb(var(--text-rgb)/0.03)]">
-            <div className="flex items-center gap-2">
-              <span className="rounded-full border border-accent/35 bg-accent/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-accent">
-                New
-              </span>
-              <p className="text-2xs uppercase tracking-widest text-text-secondary">Create Exit</p>
-            </div>
-            <p className="mt-1 text-2xs leading-relaxed text-text-muted">
-              Start with a direction, then target a local room or type a loaded foreign zone like <span className="font-mono text-accent">otherzone:</span>.
-            </p>
+            <p className="text-2xs uppercase tracking-widest text-text-secondary">Create Exit</p>
             <div className="mt-2 grid grid-cols-[5.5rem_minmax(0,1fr)] gap-2">
               <label className="text-2xs text-text-muted">
                 Direction
@@ -767,7 +756,6 @@ export function RoomPanel({
       {/* Room features */}
       <Section
         title={`Features (${Object.keys(room.features ?? {}).length})`}
-        description="Containers, levers, and signs players can interact with in this room. Sequence puzzles below can reference these same feature keys."
         defaultExpanded={Object.keys(room.features ?? {}).length > 0}
       >
         <RoomFeaturesEditor
@@ -781,13 +769,10 @@ export function RoomPanel({
       {/* Terrain override */}
       <Section
         title="Terrain"
-        description="Override the zone-level terrain for this room. Leave blank to inherit the zone default."
+        titleTooltip="Drives weather effects and the default room background. Sheltered terrains (inside, underground, underwater) suppress weather particles. Leave blank to inherit the zone default."
         defaultExpanded={!!room.terrain}
       >
-        <FieldRow
-          label="Terrain"
-          hint="Determines weather effects and default room background. Sheltered terrains (inside, underground, underwater) suppress weather particles."
-        >
+        <FieldRow label="Terrain">
           <div className="flex items-center gap-2">
             {room.terrain && TERRAIN_ICONS[room.terrain] && (
               <img src={TERRAIN_ICONS[room.terrain]} alt="" className="h-5 w-5 rounded" />
@@ -947,7 +932,6 @@ export function RoomPanel({
       <Section
         title={`Services (${shops.length + trainers.length + gatheringNodes.length})`}
         defaultExpanded={false}
-        description="Room-scoped services and interactables that players use here."
         actions={
           <div className="flex items-center gap-1">
             <button
@@ -1092,7 +1076,6 @@ export function RoomPanel({
       {/* Puzzles */}
       <Section
         title={`Puzzles (${puzzles.length})`}
-        description="Sequence puzzles usually target room features like levers and containers defined above."
         defaultExpanded={puzzles.length > 0}
         actions={
           <div className="flex items-center gap-1">

--- a/creator/src/components/zone/ZoneLayoutDoctor.tsx
+++ b/creator/src/components/zone/ZoneLayoutDoctor.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/zoneLayoutDoctorLlm";
 import type { WorldFile } from "@/types/world";
 import { ActionButton, Spinner } from "@/components/ui/FormWidgets";
+import sidebarBg from "@/assets/sidebar-bg.png";
 
 interface ZoneLayoutDoctorProps {
   zoneId: string;
@@ -135,6 +136,57 @@ export function ZoneLayoutDoctor({ world, onWorldChange }: ZoneLayoutDoctorProps
 
   const roomCount = Object.keys(world.rooms).length;
 
+  if (!analyzed) {
+    return (
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        <img
+          src={sidebarBg}
+          alt=""
+          className="pointer-events-none absolute inset-0 h-full w-full object-cover opacity-[0.12]"
+        />
+        <div className="relative z-10 flex min-h-0 flex-1 items-center justify-center overflow-y-auto p-8">
+          <div className="flex max-w-md flex-col items-center gap-4 text-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full border border-border-muted bg-[var(--chrome-fill-soft)] text-accent shadow-[0_1px_0_var(--chrome-highlight)_inset]">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-8 w-8"
+              >
+                <circle cx="11" cy="11" r="7" />
+                <path d="m20 20-3.5-3.5" />
+                <path d="M11 8v6" />
+                <path d="M8 11h6" />
+              </svg>
+            </div>
+            <div>
+              <h2 className="font-display text-xl uppercase tracking-widest text-accent">
+                No Analysis Yet
+              </h2>
+              <p className="mt-1 text-xs uppercase tracking-wider text-text-muted">
+                Zone Structural Audit
+              </p>
+            </div>
+            <p className="text-sm leading-relaxed text-text-secondary">
+              Scan this zone's {roomCount} room{roomCount === 1 ? "" : "s"} for structural problems
+              and directional references in room descriptions that no longer match the layout.
+            </p>
+            <button
+              onClick={handleAnalyze}
+              disabled={roomCount === 0}
+              className="rounded-full border border-[rgb(var(--accent-rgb)/0.35)] bg-gradient-active-strong px-5 py-2 text-xs uppercase tracking-widest text-text-primary transition hover:shadow-glow disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Analyze Zone
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
       {/* Header */}
@@ -151,22 +203,9 @@ export function ZoneLayoutDoctor({ world, onWorldChange }: ZoneLayoutDoctorProps
           onClick={handleAnalyze}
           disabled={roomCount === 0}
         >
-          {analyzed ? "Re-analyze" : "Analyze Zone"}
+          Re-analyze
         </ActionButton>
       </div>
-
-      {/* Empty state */}
-      {!analyzed && (
-        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border-muted bg-bg-elevated/50 px-8 py-16">
-          <div className="font-display text-base uppercase tracking-widest text-text-muted">
-            No Analysis Yet
-          </div>
-          <p className="mt-2 max-w-md text-center text-2xs text-text-secondary">
-            Run the Layout Doctor to scan this zone's {roomCount} rooms for structural issues
-            and text/exit mismatches.
-          </p>
-        </div>
-      )}
 
       {/* Results summary */}
       {analyzed && (

--- a/creator/src/components/zone/ZoneMapPanel.tsx
+++ b/creator/src/components/zone/ZoneMapPanel.tsx
@@ -14,6 +14,7 @@ import { zoneToGraph } from "@/lib/zoneToGraph";
 import type { WorldFile } from "@/types/world";
 import type { LoreMap, MapPin } from "@/types/lore";
 import { ActionButton } from "@/components/ui/FormWidgets";
+import sidebarBg from "@/assets/sidebar-bg.png";
 
 interface ZoneMapPanelProps {
   zoneId: string;
@@ -191,117 +192,161 @@ export function ZoneMapPanel({ zoneId, world, onWorldChange }: ZoneMapPanelProps
   );
 
   const roomCount = Object.keys(world.rooms).length;
+  const showEmptyState = !previewSrc && !currentMapSrc && !generating;
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="font-display text-sm uppercase tracking-widest text-accent">
-            Zone Map
-          </h2>
-          <p className="mt-1 text-2xs text-text-muted">
-            Generate an illustrated fantasy map from this zone's rooms and connections.
-          </p>
-        </div>
-      </div>
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <img
+        src={sidebarBg}
+        alt=""
+        className="pointer-events-none absolute inset-0 h-full w-full object-cover opacity-[0.12]"
+      />
 
-      {/* Current map display */}
-      {(previewSrc || currentMapSrc) && (
-        <div className="relative shrink-0 overflow-hidden rounded-xl border border-border-default bg-bg-abyss">
-          <img
-            src={previewSrc ?? currentMapSrc!}
-            alt={`${world.zone} zone map`}
-            className="block w-full"
-          />
-          {previewSrc && (
-            <div className="absolute inset-x-0 bottom-0 flex items-center justify-center gap-2 bg-gradient-to-t from-[var(--bg-scrim-heavy)] to-transparent px-4 pb-4 pt-10">
-              <span className="mr-2 text-2xs uppercase tracking-widest text-text-muted">
-                Preview
-              </span>
-              <ActionButton onClick={handleAccept} size="sm">
-                Accept
-              </ActionButton>
-              <ActionButton onClick={() => setPreview(null)} variant="secondary" size="sm">
-                Discard
-              </ActionButton>
+      {showEmptyState ? (
+        <div className="relative z-10 flex min-h-0 flex-1 items-center justify-center overflow-y-auto p-8">
+          <div className="flex max-w-md flex-col items-center gap-4 text-center">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full border border-border-muted bg-[var(--chrome-fill-soft)] text-accent shadow-[0_1px_0_var(--chrome-highlight)_inset]">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-8 w-8"
+              >
+                <path d="M9 4 3 6v14l6-2 6 2 6-2V4l-6 2-6-2Z" />
+                <path d="M9 4v14" />
+                <path d="M15 6v14" />
+              </svg>
+            </div>
+            <div>
+              <h2 className="font-display text-xl uppercase tracking-widest text-accent">
+                No Zone Map
+              </h2>
+              <p className="mt-1 text-xs uppercase tracking-wider text-text-muted">
+                Illustrated Zone Atlas
+              </p>
+            </div>
+            <p className="text-sm leading-relaxed text-text-secondary">
+              Generate an illustrated map showing the geography and landmarks of this zone, built
+              from your {roomCount} room{roomCount === 1 ? "" : "s"}, their descriptions, exits, and
+              the zone vibe.
+            </p>
+            {AI_ENABLED && (
+              <button
+                onClick={handleGenerate}
+                disabled={!hasImageKey || roomCount === 0}
+                className="rounded-full border border-[rgb(var(--accent-rgb)/0.35)] bg-gradient-active-strong px-5 py-2 text-xs uppercase tracking-widest text-text-primary transition hover:shadow-glow disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Generate Zone Map
+              </button>
+            )}
+            {!hasImageKey && AI_ENABLED && (
+              <p className="text-2xs italic text-text-muted">
+                Configure an image provider API key in Settings to generate maps.
+              </p>
+            )}
+            {!vibe && AI_ENABLED && hasImageKey && (
+              <p className="text-2xs italic text-text-muted">
+                Tip: Generate a zone vibe first (in the Map view sidebar) for richer results.
+              </p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="relative z-10 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="font-display text-sm uppercase tracking-widest text-accent">
+                Zone Map
+              </h2>
+              <p className="mt-1 text-2xs text-text-muted">
+                Illustrated atlas built from this zone's rooms, exits, and vibe.
+              </p>
+            </div>
+          </div>
+
+          {(previewSrc || currentMapSrc) && (
+            <div className="relative shrink-0 overflow-hidden rounded-xl border border-border-default bg-bg-abyss">
+              <img
+                src={previewSrc ?? currentMapSrc!}
+                alt={`${world.zone} zone map`}
+                className="block w-full"
+              />
+              {previewSrc && (
+                <div className="absolute inset-x-0 bottom-0 flex items-center justify-center gap-2 bg-gradient-to-t from-[var(--bg-scrim-heavy)] to-transparent px-4 pb-4 pt-10">
+                  <span className="mr-2 text-2xs uppercase tracking-widest text-text-muted">
+                    Preview
+                  </span>
+                  <ActionButton onClick={handleAccept} size="sm">
+                    Accept
+                  </ActionButton>
+                  <ActionButton onClick={() => setPreview(null)} variant="secondary" size="sm">
+                    Discard
+                  </ActionButton>
+                </div>
+              )}
             </div>
           )}
-        </div>
-      )}
 
-      {/* Empty state */}
-      {!previewSrc && !currentMapSrc && !generating && (
-        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border-muted bg-bg-elevated/50 px-8 py-16">
-          <div className="font-display text-base uppercase tracking-widest text-text-muted">
-            No Zone Map
+          {generating && (
+            <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-border-muted bg-bg-elevated/50 px-8 py-16">
+              <div className="h-8 w-8 rounded-full border-2 border-accent border-t-transparent animate-spin" />
+              <span className="text-2xs uppercase tracking-widest text-text-muted">
+                Generating zone map...
+              </span>
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2">
+            {AI_ENABLED && (
+              <ActionButton
+                onClick={handleGenerate}
+                disabled={generating || !hasImageKey || roomCount === 0}
+              >
+                {generating
+                  ? "Generating..."
+                  : currentMapFile
+                    ? "Regenerate Map"
+                    : "Generate Zone Map"}
+              </ActionButton>
+            )}
+
+            {currentMapFile && !existingLoreMap && !createdLoreMap && (
+              <ActionButton onClick={handleCreateLoreMap} variant="secondary">
+                Create Lore Map with Pins
+              </ActionButton>
+            )}
+
+            {createdLoreMap && (
+              <span className="text-2xs text-status-success">
+                Lore map created with {Object.keys(world.rooms).length} room pins
+              </span>
+            )}
+
+            {existingLoreMap && (
+              <span className="text-2xs text-text-muted">
+                Lore map exists: "{existingLoreMap.title}"
+              </span>
+            )}
           </div>
-          <p className="mt-2 max-w-md text-center text-2xs text-text-secondary">
-            Generate an illustrated map showing the geography and landmarks of this zone.
-            The map is built from your {roomCount} rooms, their descriptions, exits, and the zone vibe.
-          </p>
+
+          {!hasImageKey && AI_ENABLED && (
+            <p className="text-2xs italic text-text-muted">
+              Configure an image provider API key in Settings to generate maps.
+            </p>
+          )}
+
+          {!vibe && AI_ENABLED && (
+            <p className="text-2xs italic text-text-muted">
+              Tip: Generate a zone vibe first (in the Map view sidebar) for better results.
+            </p>
+          )}
+
+          {error && <p className="text-2xs italic text-status-error">{error}</p>}
         </div>
       )}
-
-      {/* Generation spinner */}
-      {generating && (
-        <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-border-muted bg-bg-elevated/50 px-8 py-16">
-          <div className="h-8 w-8 rounded-full border-2 border-accent border-t-transparent animate-spin" />
-          <span className="text-2xs uppercase tracking-widest text-text-muted">
-            Generating zone map...
-          </span>
-        </div>
-      )}
-
-      {/* Actions */}
-      <div className="flex flex-wrap items-center gap-2">
-        {AI_ENABLED && (
-          <ActionButton
-            onClick={handleGenerate}
-            disabled={generating || !hasImageKey || roomCount === 0}
-          >
-            {generating
-              ? "Generating..."
-              : currentMapFile
-                ? "Regenerate Map"
-                : "Generate Zone Map"}
-          </ActionButton>
-        )}
-
-        {currentMapFile && !existingLoreMap && !createdLoreMap && (
-          <ActionButton onClick={handleCreateLoreMap} variant="secondary">
-            Create Lore Map with Pins
-          </ActionButton>
-        )}
-
-        {createdLoreMap && (
-          <span className="text-2xs text-status-success">
-            Lore map created with {Object.keys(world.rooms).length} room pins
-          </span>
-        )}
-
-        {existingLoreMap && (
-          <span className="text-2xs text-text-muted">
-            Lore map exists: "{existingLoreMap.title}"
-          </span>
-        )}
-      </div>
-
-      {/* Info */}
-      {!hasImageKey && AI_ENABLED && (
-        <p className="text-2xs italic text-text-muted">
-          Configure an image provider API key in Settings to generate maps.
-        </p>
-      )}
-
-      {!vibe && AI_ENABLED && (
-        <p className="text-2xs italic text-text-muted">
-          Tip: Generate a zone vibe first (in the Map view sidebar) for better results.
-          The vibe text is injected into the map generation prompt.
-        </p>
-      )}
-
-      {error && <p className="text-2xs italic text-status-error">{error}</p>}
     </div>
   );
 }

--- a/creator/src/lib/panelRegistry.ts
+++ b/creator/src/lib/panelRegistry.ts
@@ -132,6 +132,7 @@ const OPERATIONS_PANELS: PanelDef[] = [
   { id: "rawYaml", label: "Raw YAML", host: "config", kicker: "Advanced", title: "Raw configuration", description: "Inspect or edit the exact serialized YAML when the structured editors are not enough.", maxWidth: "max-w-6xl", island: "settings", glyph: "\u{1F4DD}" },
   { id: "versionControl", label: "Version Control", host: "config", kicker: "Operations", title: "Version control", description: "Git status, commits, push/pull, and conflict resolution for standalone projects.", maxWidth: "max-w-5xl", island: "settings", glyph: "\u{1F33F}" },
   { id: "backup", label: "Backups", host: "command", kicker: "Operations", title: "Backups & Snapshots", description: "Autosave, periodic snapshots, and zip archives. A safety net beyond git.", maxWidth: "max-w-5xl", island: "settings", glyph: "\u{1F5C4}\uFE0F" },
+  { id: "loreIndex", label: "Lore Index", host: "config", kicker: "Operations", title: "Lore index", description: "Searchable embedding index over lore, timelines, maps, and entity descriptions. Rebuild manually after major edits.", maxWidth: "max-w-5xl", island: "settings", glyph: "\u{1F50D}" },
 ];
 
 // ─── Command panels ─────────────────────────────────────────────────

--- a/creator/src/lib/rag/__tests__/chunker.test.ts
+++ b/creator/src/lib/rag/__tests__/chunker.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from "vitest";
+import { chunkLore } from "../chunker";
+import type { Article, WorldLore } from "@/types/lore";
+
+function makeArticle(overrides: Partial<Article>): Article {
+  return {
+    id: "a1",
+    template: "freeform",
+    title: "Untitled",
+    fields: {},
+    content: "",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function loreWith(articles: Record<string, Article>, extra: Partial<WorldLore> = {}): WorldLore {
+  return {
+    version: 2,
+    articles,
+    ...extra,
+  };
+}
+
+const tipTapDoc = (nodes: unknown[]) => JSON.stringify({ type: "doc", content: nodes });
+const heading = (level: number, text: string) => ({
+  type: "heading",
+  attrs: { level },
+  content: [{ type: "text", text }],
+});
+const paragraph = (text: string) => ({
+  type: "paragraph",
+  content: [{ type: "text", text }],
+});
+
+describe("chunkLore", () => {
+  it("splits article body on H2 sections", () => {
+    const article = makeArticle({
+      id: "ar_one",
+      title: "Ar One",
+      sections: [
+        {
+          id: "s1",
+          type: "richtext",
+          title: "Overview",
+          body: tipTapDoc([
+            heading(2, "Origins"),
+            paragraph("Born in fire."),
+            heading(2, "Legacy"),
+            paragraph("Remembered in song."),
+          ]),
+        },
+      ],
+    });
+    const chunks = chunkLore({
+      lore: loreWith({ ar_one: article }),
+      config: null,
+      zones: [],
+    });
+    const articleChunks = chunks.filter((c) => c.kind === "article");
+    expect(articleChunks.length).toBeGreaterThanOrEqual(2);
+    const sections = articleChunks.map((c) => c.section);
+    expect(sections).toContain("Origins");
+    expect(sections).toContain("Legacy");
+    const origins = articleChunks.find((c) => c.section === "Origins")!;
+    expect(origins.body).toContain("Born in fire.");
+    expect(origins.source_id).toBe("ar_one");
+    expect(origins.id).toMatch(/^article:ar_one:section:/);
+  });
+
+  it("produces a single chunk for an article with no H2 headings", () => {
+    const article = makeArticle({
+      id: "ar_two",
+      title: "Plain",
+      sections: [
+        {
+          id: "s1",
+          type: "richtext",
+          title: "Overview",
+          body: tipTapDoc([paragraph("Just a paragraph.")]),
+        },
+      ],
+    });
+    const chunks = chunkLore({
+      lore: loreWith({ ar_two: article }),
+      config: null,
+      zones: [],
+    });
+    const articleChunks = chunks.filter((c) => c.kind === "article");
+    expect(articleChunks).toHaveLength(1);
+    expect(articleChunks[0]!.body).toContain("Just a paragraph.");
+  });
+
+  it("skips articles with empty bodies", () => {
+    const article = makeArticle({ id: "empty", title: "Empty", content: "" });
+    const chunks = chunkLore({
+      lore: loreWith({ empty: article }),
+      config: null,
+      zones: [],
+    });
+    expect(chunks.filter((c) => c.kind === "article")).toHaveLength(0);
+  });
+
+  it("tags draft articles in metadata", () => {
+    const article = makeArticle({
+      id: "draft_one",
+      title: "Draft",
+      draft: true,
+      sections: [
+        {
+          id: "s1",
+          type: "richtext",
+          title: "Body",
+          body: tipTapDoc([paragraph("WIP content.")]),
+        },
+      ],
+    });
+    const chunks = chunkLore({
+      lore: loreWith({ draft_one: article }),
+      config: null,
+      zones: [],
+    });
+    const draftChunk = chunks.find((c) => c.source_id === "draft_one");
+    expect(draftChunk).toBeDefined();
+    expect(draftChunk!.metadata.draft).toBe(true);
+  });
+
+  it("shapes timeline event chunks with date + era + description", () => {
+    const lore = loreWith(
+      {},
+      {
+        calendarSystems: [
+          {
+            id: "cal1",
+            name: "Reckoning",
+            eras: [{ id: "first", name: "First Age", startYear: 0 }],
+          },
+        ],
+        timelineEvents: [
+          {
+            id: "ev1",
+            calendarId: "cal1",
+            eraId: "first",
+            year: 142,
+            title: "The Founding",
+            description: "Walls rise.",
+            importance: "major",
+          },
+        ],
+      },
+    );
+    const chunks = chunkLore({ lore, config: null, zones: [] });
+    const event = chunks.find((c) => c.kind === "event")!;
+    expect(event.id).toBe("event:ev1");
+    expect(event.title).toBe("The Founding");
+    expect(event.body).toContain("142");
+    expect(event.body).toContain("First Age");
+    expect(event.body).toContain("Walls rise.");
+    expect(event.metadata.era).toBe("First Age");
+  });
+
+  it("humanizes relationship types and skips trivial mentions", () => {
+    const articles: Record<string, Article> = {
+      a1: makeArticle({
+        id: "a1",
+        title: "Aria",
+        relations: [
+          { targetId: "a2", type: "child_of" },
+          { targetId: "a3", type: "mentions" },
+        ],
+      }),
+      a2: makeArticle({ id: "a2", title: "Mira" }),
+      a3: makeArticle({ id: "a3", title: "Other" }),
+    };
+    const chunks = chunkLore({
+      lore: loreWith(articles),
+      config: null,
+      zones: [],
+    });
+    const rels = chunks.filter((c) => c.kind === "relationship");
+    expect(rels).toHaveLength(1);
+    expect(rels[0]!.body).toContain("child of");
+    expect(rels[0]!.body).toContain("Aria");
+    expect(rels[0]!.body).toContain("Mira");
+    expect(rels[0]!.id).toBe("rel:a1:a2:child_of");
+  });
+
+  it("produces entity chunks from config races/classes/abilities and zone mobs/items", () => {
+    const chunks = chunkLore({
+      lore: null,
+      config: {
+        races: {
+          elf: {
+            displayName: "Elf",
+            backstory: "Ancient kin.",
+            bodyDescription: "Tall and lithe.",
+          },
+        },
+        classes: {
+          mage: { displayName: "Mage", description: "Wields arcane fire.", hpPerLevel: 5, manaPerLevel: 10 },
+        },
+        abilities: {
+          firebolt: {
+            displayName: "Firebolt",
+            description: "Hurls flame.",
+            manaCost: 5,
+            cooldownMs: 1000,
+            levelRequired: 1,
+            targetType: "single",
+            effect: { type: "damage" },
+          },
+        },
+      } as never,
+      zones: [
+        {
+          zoneId: "ashfen",
+          data: {
+            zone: "ashfen",
+            rooms: {},
+            mobs: { goblin: { name: "Goblin", description: "Mean little thing." } },
+            items: { sword: { displayName: "Sword", description: "Sharp." } },
+          } as never,
+        },
+      ],
+    });
+    const kinds = chunks.map((c) => `${c.kind}:${c.metadata.entityKind}:${c.metadata.fieldName}`);
+    expect(kinds).toContain("entity:race:backstory");
+    expect(kinds).toContain("entity:race:bodyDescription");
+    expect(kinds).toContain("entity:class:description");
+    expect(kinds).toContain("entity:ability:description");
+    expect(kinds).toContain("entity:mob:description");
+    expect(kinds).toContain("entity:item:description");
+    const mob = chunks.find((c) => c.metadata.entityKind === "mob")!;
+    expect(mob.id).toBe("entity:mob:ashfen:goblin:description");
+    expect(mob.metadata.zoneId).toBe("ashfen");
+  });
+});

--- a/creator/src/lib/rag/chunker.ts
+++ b/creator/src/lib/rag/chunker.ts
@@ -1,0 +1,412 @@
+import type {
+  Article,
+  ArticleRelation,
+  CalendarSystem,
+  LoreMap,
+  RichTextSection,
+  TimelineEvent,
+  WorldLore,
+} from "@/types/lore";
+import type {
+  AbilityDefinitionConfig,
+  AppConfig,
+  ClassDefinitionConfig,
+  RaceDefinitionConfig,
+} from "@/types/config";
+import type { ItemFile, MobFile, WorldFile } from "@/types/world";
+import { getEffectiveSections } from "@/lib/loreSections";
+import type { RagChunk } from "./types";
+
+export interface ChunkerZone {
+  zoneId: string;
+  data: WorldFile;
+}
+
+export interface ChunkerInput {
+  lore: WorldLore | null;
+  config: AppConfig | null;
+  zones: ChunkerZone[];
+}
+
+/** Heading + body slice extracted from a rich-text TipTap doc. */
+interface SectionSlice {
+  heading: string | null;
+  body: string;
+}
+
+/** Walk a TipTap JSON node and emit slices keyed by H2 headings. */
+function splitTipTapByH2(content: string): SectionSlice[] {
+  if (!content) return [];
+  let doc: unknown;
+  if (content.startsWith("{")) {
+    try {
+      doc = JSON.parse(content);
+    } catch {
+      return [{ heading: null, body: content }];
+    }
+  } else {
+    return splitMarkdownByH2(content);
+  }
+
+  const top = doc as { content?: unknown[] };
+  if (!Array.isArray(top.content)) return [];
+
+  const slices: SectionSlice[] = [];
+  let current: SectionSlice = { heading: null, body: "" };
+
+  for (const node of top.content) {
+    if (!node || typeof node !== "object") continue;
+    const n = node as Record<string, unknown>;
+    const type = n.type as string | undefined;
+    if (type === "heading") {
+      const level = Number((n.attrs as Record<string, unknown> | undefined)?.level ?? 1);
+      const text = nodeToPlainText(n);
+      if (level <= 2) {
+        if (current.body.trim() || current.heading) slices.push(current);
+        current = { heading: text || null, body: "" };
+        continue;
+      }
+      current.body += text ? `${text}\n` : "";
+      continue;
+    }
+    const text = nodeToPlainText(n);
+    if (text) current.body += `${text}\n`;
+  }
+  if (current.body.trim() || current.heading) slices.push(current);
+  return slices;
+}
+
+function nodeToPlainText(node: unknown): string {
+  if (!node || typeof node !== "object") return "";
+  const n = node as Record<string, unknown>;
+  if (n.type === "text" && typeof n.text === "string") return n.text;
+  if (n.type === "mention") {
+    const label = (n.attrs as Record<string, unknown> | undefined)?.label;
+    return typeof label === "string" ? label : "";
+  }
+  const parts: string[] = [];
+  if (Array.isArray(n.content)) {
+    for (const child of n.content) parts.push(nodeToPlainText(child));
+  }
+  const joined = parts.join("");
+  if (n.type === "listItem") return `- ${joined}`;
+  if (n.type === "paragraph" || n.type === "heading") return joined;
+  return joined;
+}
+
+function splitMarkdownByH2(content: string): SectionSlice[] {
+  const lines = content.split(/\r?\n/);
+  const slices: SectionSlice[] = [];
+  let current: SectionSlice = { heading: null, body: "" };
+  for (const line of lines) {
+    const m = line.match(/^##\s+(.+)$/);
+    if (m) {
+      if (current.body.trim() || current.heading) slices.push(current);
+      current = { heading: m[1]!.trim(), body: "" };
+    } else {
+      current.body += `${line}\n`;
+    }
+  }
+  if (current.body.trim() || current.heading) slices.push(current);
+  return slices;
+}
+
+function articleSectionBody(section: { type: string }): string {
+  if (section.type === "richtext") {
+    const rich = section as RichTextSection;
+    return rich.body ?? "";
+  }
+  return "";
+}
+
+function articleSliceSet(article: Article): SectionSlice[] {
+  const sections = getEffectiveSections(article);
+  const slices: SectionSlice[] = [];
+  let producedAny = false;
+  for (const s of sections) {
+    if (s.private) continue;
+    if (s.type !== "richtext") continue;
+    const body = articleSectionBody(s);
+    if (!body || !body.trim()) continue;
+    producedAny = true;
+    const sub = splitTipTapByH2(body).filter((sl) => sl.body.trim().length > 0 || sl.heading);
+    if (sub.length === 0) {
+      slices.push({ heading: s.title ?? null, body });
+      continue;
+    }
+    sub.forEach((sl, i) => {
+      const heading = sl.heading ?? (i === 0 ? s.title ?? null : null);
+      slices.push({ heading, body: sl.body });
+    });
+  }
+  if (!producedAny && article.content && article.content.trim()) {
+    const sub = splitTipTapByH2(article.content).filter(
+      (sl) => sl.body.trim().length > 0 || sl.heading,
+    );
+    if (sub.length === 0) slices.push({ heading: null, body: article.content });
+    else slices.push(...sub);
+  }
+  return slices;
+}
+
+function chunkArticles(lore: WorldLore | null): RagChunk[] {
+  if (!lore) return [];
+  const out: RagChunk[] = [];
+  for (const [articleId, article] of Object.entries(lore.articles)) {
+    const slices = articleSliceSet(article);
+    const baseMeta: Record<string, unknown> = {
+      templateId: article.template,
+      tags: article.tags ?? [],
+      fields: article.fields ?? {},
+    };
+    if (article.draft) baseMeta.draft = true;
+
+    if (slices.length === 0) continue;
+
+    slices.forEach((slice, idx) => {
+      const body = slice.body.trim();
+      if (!body && !slice.heading) return;
+      out.push({
+        id: `article:${articleId}:section:${idx}`,
+        kind: "article",
+        source_id: articleId,
+        section: slice.heading ?? undefined,
+        title: article.title,
+        body: body || slice.heading || "",
+        metadata: baseMeta,
+      });
+    });
+  }
+  return out;
+}
+
+function chunkEvents(lore: WorldLore | null): RagChunk[] {
+  if (!lore?.timelineEvents) return [];
+  const out: RagChunk[] = [];
+  const erasByCal = new Map<string, Map<string, string>>();
+  for (const cal of (lore.calendarSystems ?? []) as CalendarSystem[]) {
+    const eras = new Map<string, string>();
+    for (const era of cal.eras) eras.set(era.id, era.name);
+    erasByCal.set(cal.id, eras);
+  }
+
+  for (const event of lore.timelineEvents as TimelineEvent[]) {
+    const eraName = erasByCal.get(event.calendarId)?.get(event.eraId) ?? event.eraId;
+    const description = event.description?.trim() ?? "";
+    const date = `Year ${event.year}`;
+    const body = `${date} (${eraName}): ${description || event.title}`;
+    out.push({
+      id: `event:${event.id}`,
+      kind: "event",
+      source_id: event.id,
+      title: event.title,
+      body,
+      metadata: {
+        date,
+        year: event.year,
+        era: eraName,
+        eraId: event.eraId,
+        calendarId: event.calendarId,
+        importance: event.importance,
+        articleId: event.articleId,
+      },
+    });
+  }
+  return out;
+}
+
+function chunkPins(lore: WorldLore | null): RagChunk[] {
+  if (!lore?.maps) return [];
+  const articleTitleById = new Map<string, string>();
+  for (const [id, a] of Object.entries(lore.articles)) articleTitleById.set(id, a.title);
+
+  const out: RagChunk[] = [];
+  for (const map of lore.maps as LoreMap[]) {
+    map.pins.forEach((pin, idx) => {
+      const label = pin.label?.trim();
+      const linkedTitle = pin.articleId ? articleTitleById.get(pin.articleId) : undefined;
+      const display = label || linkedTitle;
+      if (!display) return;
+      const body = linkedTitle && label && linkedTitle !== label
+        ? `${label} on ${map.title}: linked to ${linkedTitle}`
+        : `${display} on ${map.title}`;
+      out.push({
+        id: `pin:${map.id}:${idx}`,
+        kind: "pin",
+        source_id: pin.id,
+        title: display,
+        body,
+        metadata: {
+          mapId: map.id,
+          mapName: map.title,
+          articleRef: pin.articleId,
+          position: pin.position,
+        },
+      });
+    });
+  }
+  return out;
+}
+
+const TRIVIAL_RELATION_TYPES = new Set(["mentions", "mention"]);
+
+function humanizeRelationType(type: string): string {
+  return type.replace(/[_-]+/g, " ").trim();
+}
+
+function chunkRelationships(lore: WorldLore | null): RagChunk[] {
+  if (!lore) return [];
+  const out: RagChunk[] = [];
+  const titleById = new Map<string, string>();
+  for (const [id, a] of Object.entries(lore.articles)) titleById.set(id, a.title);
+
+  const seen = new Set<string>();
+  for (const [fromId, article] of Object.entries(lore.articles)) {
+    const relations = (article.relations ?? []) as ArticleRelation[];
+    for (const rel of relations) {
+      const type = (rel.type ?? "").toLowerCase();
+      if (!type || TRIVIAL_RELATION_TYPES.has(type)) continue;
+      const id = `rel:${fromId}:${rel.targetId}:${type}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+
+      const fromTitle = titleById.get(fromId) ?? fromId;
+      const toTitle = titleById.get(rel.targetId) ?? rel.targetId;
+      const verb = humanizeRelationType(rel.type);
+      const note = rel.label?.trim();
+      const body = note
+        ? `${fromTitle} ${verb} ${toTitle}: ${note}`
+        : `${fromTitle} ${verb} ${toTitle}`;
+      out.push({
+        id,
+        kind: "relationship",
+        source_id: fromId,
+        title: `${fromTitle} ⇄ ${toTitle}`,
+        body,
+        metadata: {
+          type: rel.type,
+          fromId,
+          toId: rel.targetId,
+          label: rel.label,
+        },
+      });
+    }
+  }
+  return out;
+}
+
+interface EntityBlurbSpec {
+  entityKind: "race" | "class" | "ability" | "mob" | "item";
+  entityId: string;
+  display: string;
+  fields: { fieldName: string; value: string | undefined }[];
+  extraMeta?: Record<string, unknown>;
+}
+
+function entitySpecToChunks(spec: EntityBlurbSpec): RagChunk[] {
+  const out: RagChunk[] = [];
+  for (const { fieldName, value } of spec.fields) {
+    if (!value || !value.trim()) continue;
+    out.push({
+      id: `entity:${spec.entityKind}:${spec.entityId}:${fieldName}`,
+      kind: "entity",
+      source_id: spec.entityId,
+      section: fieldName,
+      title: spec.display,
+      body: value.trim(),
+      metadata: {
+        entityKind: spec.entityKind,
+        entityId: spec.entityId,
+        fieldName,
+        ...(spec.extraMeta ?? {}),
+      },
+    });
+  }
+  return out;
+}
+
+function chunkEntities(config: AppConfig | null, zones: ChunkerZone[]): RagChunk[] {
+  const out: RagChunk[] = [];
+
+  if (config?.races) {
+    for (const [id, race] of Object.entries(config.races) as [string, RaceDefinitionConfig][]) {
+      out.push(
+        ...entitySpecToChunks({
+          entityKind: "race",
+          entityId: id,
+          display: race.displayName || id,
+          fields: [
+            { fieldName: "backstory", value: race.backstory },
+            { fieldName: "bodyDescription", value: race.bodyDescription },
+            { fieldName: "description", value: race.description },
+          ],
+        }),
+      );
+    }
+  }
+  if (config?.classes) {
+    for (const [id, klass] of Object.entries(config.classes) as [string, ClassDefinitionConfig][]) {
+      out.push(
+        ...entitySpecToChunks({
+          entityKind: "class",
+          entityId: id,
+          display: klass.displayName || id,
+          fields: [
+            { fieldName: "description", value: klass.description },
+            { fieldName: "backstory", value: klass.backstory },
+          ],
+        }),
+      );
+    }
+  }
+  if (config?.abilities) {
+    for (const [id, ability] of Object.entries(config.abilities) as [string, AbilityDefinitionConfig][]) {
+      out.push(
+        ...entitySpecToChunks({
+          entityKind: "ability",
+          entityId: id,
+          display: ability.displayName || id,
+          fields: [{ fieldName: "description", value: ability.description }],
+        }),
+      );
+    }
+  }
+
+  for (const { zoneId, data } of zones) {
+    for (const [id, mob] of Object.entries(data.mobs ?? {}) as [string, MobFile][]) {
+      out.push(
+        ...entitySpecToChunks({
+          entityKind: "mob",
+          entityId: `${zoneId}:${id}`,
+          display: mob.name || id,
+          fields: [{ fieldName: "description", value: mob.description }],
+          extraMeta: { zoneId },
+        }),
+      );
+    }
+    for (const [id, item] of Object.entries(data.items ?? {}) as [string, ItemFile][]) {
+      out.push(
+        ...entitySpecToChunks({
+          entityKind: "item",
+          entityId: `${zoneId}:${id}`,
+          display: item.displayName || id,
+          fields: [{ fieldName: "description", value: item.description }],
+          extraMeta: { zoneId },
+        }),
+      );
+    }
+  }
+
+  return out;
+}
+
+/** Pure: input snapshots → flat RagChunk[] ready for the backend. */
+export function chunkLore(input: ChunkerInput): RagChunk[] {
+  return [
+    ...chunkArticles(input.lore),
+    ...chunkEvents(input.lore),
+    ...chunkPins(input.lore),
+    ...chunkRelationships(input.lore),
+    ...chunkEntities(input.config, input.zones),
+  ];
+}

--- a/creator/src/lib/rag/index.ts
+++ b/creator/src/lib/rag/index.ts
@@ -1,0 +1,66 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useProjectStore } from "@/stores/projectStore";
+import { chunkLore, type ChunkerInput } from "./chunker";
+import type { IndexStats, RetrievalFilters, RetrievedChunk } from "./types";
+
+function activeProjectPath(): string | null {
+  return useProjectStore.getState().project?.mudDir ?? null;
+}
+
+export async function retrieveLoreContext(params: {
+  query: string;
+  k?: number;
+  filters?: RetrievalFilters;
+}): Promise<RetrievedChunk[]> {
+  const projectPath = activeProjectPath();
+  if (!projectPath) return [];
+  const k = params.k ?? 8;
+  const filters = params.filters ?? {};
+  return invoke<RetrievedChunk[]>("rag_retrieve", {
+    projectPath,
+    query: params.query,
+    k,
+    filters,
+  });
+}
+
+export async function rebuildIndex(
+  input: ChunkerInput,
+  onProgress?: (stage: string) => void,
+): Promise<IndexStats> {
+  const projectPath = activeProjectPath();
+  if (!projectPath) throw new Error("No active project");
+  onProgress?.("Chunking…");
+  const chunks = chunkLore(input);
+  onProgress?.(`Embedding ${chunks.length} chunks…`);
+  const stats = await invoke<IndexStats>("rag_upsert_chunks", {
+    projectPath,
+    chunks,
+  });
+  onProgress?.("Done");
+  return stats;
+}
+
+export async function getIndexStats(): Promise<IndexStats | null> {
+  const projectPath = activeProjectPath();
+  if (!projectPath) return null;
+  try {
+    return await invoke<IndexStats>("rag_index_stats", { projectPath });
+  } catch {
+    return null;
+  }
+}
+
+export async function clearIndex(): Promise<void> {
+  const projectPath = activeProjectPath();
+  if (!projectPath) return;
+  await invoke("rag_clear_index", { projectPath });
+}
+
+export type { ChunkerInput } from "./chunker";
+export type {
+  IndexStats,
+  RagChunk,
+  RetrievalFilters,
+  RetrievedChunk,
+} from "./types";

--- a/creator/src/lib/rag/promptAssembly.ts
+++ b/creator/src/lib/rag/promptAssembly.ts
@@ -1,0 +1,65 @@
+import type { RetrievedChunk } from "./types";
+
+interface GroupedArtefact {
+  source_id: string;
+  kind: RetrievedChunk["kind"];
+  title: string;
+  sections: { section?: string; body: string; id: string }[];
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+function groupBySource(chunks: RetrievedChunk[]): GroupedArtefact[] {
+  const order: string[] = [];
+  const groups = new Map<string, GroupedArtefact>();
+  for (const c of chunks) {
+    const key = `${c.kind}:${c.source_id}`;
+    let g = groups.get(key);
+    if (!g) {
+      g = { source_id: c.source_id, kind: c.kind, title: c.title, sections: [] };
+      groups.set(key, g);
+      order.push(key);
+    }
+    g.sections.push({ section: c.section, body: c.body, id: c.id });
+  }
+  return order.map((k) => groups.get(k)!);
+}
+
+function renderArtefact(g: GroupedArtefact): string {
+  const titleAttr = escapeAttr(g.title);
+  const idAttr = escapeAttr(g.sections[0]?.id ?? `${g.kind}:${g.source_id}`);
+  const sectionLabels = g.sections
+    .map((s) => s.section)
+    .filter((s): s is string => !!s);
+  const sectionAttr = sectionLabels.length > 0 ? ` section="${escapeAttr(sectionLabels.join(", "))}"` : "";
+  const body = g.sections
+    .map((s) => (s.section && g.sections.length > 1 ? `## ${s.section}\n${s.body}` : s.body))
+    .join("\n\n")
+    .trim();
+  return `<artefact id="${idAttr}" kind="${g.kind}" title="${titleAttr}"${sectionAttr}>\n${body}\n</artefact>`;
+}
+
+/**
+ * Render retrieved chunks as a structured `<lore-context>` block suitable for
+ * inclusion in an LLM system prompt. Chunks from the same source are collapsed
+ * into a single `<artefact>` with concatenated sections. Total output is capped
+ * at `maxChars` (default 12000) — overflow artefacts are dropped from the tail.
+ */
+export function formatContextForPrompt(
+  chunks: RetrievedChunk[],
+  maxChars: number = 12000,
+): string {
+  if (chunks.length === 0) return "<lore-context></lore-context>";
+  const grouped = groupBySource(chunks);
+  const parts: string[] = [];
+  let total = "<lore-context>\n</lore-context>".length;
+  for (const g of grouped) {
+    const rendered = renderArtefact(g);
+    if (total + rendered.length + 1 > maxChars) break;
+    parts.push(rendered);
+    total += rendered.length + 1;
+  }
+  return `<lore-context>\n${parts.join("\n")}\n</lore-context>`;
+}

--- a/creator/src/lib/rag/types.ts
+++ b/creator/src/lib/rag/types.ts
@@ -1,0 +1,28 @@
+export interface RagChunk {
+  id: string;
+  kind: "article" | "event" | "pin" | "region" | "relationship" | "entity";
+  source_id: string;
+  section?: string;
+  title: string;
+  body: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface RetrievedChunk extends RagChunk {
+  score: number;
+}
+
+export interface RetrievalFilters {
+  include_kinds?: RagChunk["kind"][];
+  must_include_source_ids?: string[];
+  /** OR-match against metadata.tags */
+  tags?: string[];
+}
+
+export interface IndexStats {
+  total_chunks: number;
+  by_kind: Record<string, number>;
+  embedding_model: string;
+  embedding_dim: number;
+  last_embedded_at: number | null;
+}

--- a/creator/src/stores/questAuthoringStore.ts
+++ b/creator/src/stores/questAuthoringStore.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+
+export interface QuestAuthoringStore {
+  /** When set, the Quests panel should select this quest on mount/change. */
+  pendingFocus: { zoneId: string; questId: string } | null;
+  /** When set, the Quests panel should create a fresh quest in this zone and focus it. */
+  pendingCreate: { zoneId: string } | null;
+
+  setPendingFocus: (focus: { zoneId: string; questId: string } | null) => void;
+  setPendingCreate: (create: { zoneId: string } | null) => void;
+  consumePendingFocus: () => { zoneId: string; questId: string } | null;
+  consumePendingCreate: () => { zoneId: string } | null;
+}
+
+export const useQuestAuthoringStore = create<QuestAuthoringStore>((set, get) => ({
+  pendingFocus: null,
+  pendingCreate: null,
+
+  setPendingFocus: (pendingFocus) => set({ pendingFocus }),
+  setPendingCreate: (pendingCreate) => set({ pendingCreate }),
+
+  consumePendingFocus: () => {
+    const focus = get().pendingFocus;
+    if (focus) set({ pendingFocus: null });
+    return focus;
+  },
+  consumePendingCreate: () => {
+    const create = get().pendingCreate;
+    if (create) set({ pendingCreate: null });
+    return create;
+  },
+}));

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -101,6 +101,7 @@ export interface Settings {
   hub_api_url: string;
   hub_api_key: string;
   use_hub_ai: boolean;
+  voyage_api_key?: string;
 }
 
 /** Project-level settings stored in <project_dir>/.arcanum/settings.json */

--- a/hub-worker/README.md
+++ b/hub-worker/README.md
@@ -37,6 +37,7 @@ wrangler secret put TURNSTILE_SECRET_KEY  # CF Turnstile (pair with TURNSTILE_SI
 wrangler secret put RUNWARE_API_KEY       # image generation
 wrangler secret put OPENROUTER_API_KEY    # text LLM
 wrangler secret put ANTHROPIC_API_KEY     # vision LLM
+wrangler secret put VOYAGE_API_KEY        # embeddings (/ai/embed, lore RAG)
 
 # Dev server on http://127.0.0.1:8787:
 npm run dev

--- a/hub-worker/src/db.ts
+++ b/hub-worker/src/db.ts
@@ -204,6 +204,17 @@ export async function incrementPromptUsage(env: Env, userId: string): Promise<vo
     .run();
 }
 
+export async function incrementPromptUsageBy(
+  env: Env,
+  userId: string,
+  amount: number,
+): Promise<void> {
+  if (!Number.isFinite(amount) || amount <= 0) return;
+  await env.DB.prepare("UPDATE users SET prompts_used = prompts_used + ? WHERE id = ?")
+    .bind(Math.floor(amount), userId)
+    .run();
+}
+
 export async function setUserQuotas(
   env: Env,
   userId: string,

--- a/hub-worker/src/env.ts
+++ b/hub-worker/src/env.ts
@@ -10,6 +10,8 @@ export interface Env {
   RUNWARE_API_KEY: string;
   OPENROUTER_API_KEY: string;
   ANTHROPIC_API_KEY: string;
+  /** Voyage AI embeddings, used by /ai/embed for lore RAG indexing. */
+  VOYAGE_API_KEY: string;
   // ─── Self-registration ──────────────────────────────────────────────
   // Resend transactional email for verification codes. Domain must be
   // verified in the Resend console and FROM_EMAIL must be on that domain.

--- a/hub-worker/src/handlers/ai.ts
+++ b/hub-worker/src/handlers/ai.ts
@@ -9,16 +9,18 @@
 //   POST /ai/image/remove-background   → Runware Bria RMBG v2.0
 //   POST /ai/llm/complete              → OpenRouter → DeepSeek V3.2
 //   POST /ai/llm/vision                → Anthropic Claude Sonnet 4.6
+//   POST /ai/embed                     → Voyage AI (voyage-3-lite)
 //
-// Vision calls bill against the same `prompts_used` counter as
-// completions — they're bucketed together as "LLM calls" per the
-// spec. Image calls use `images_used`. Counters are decoupled from
+// Vision and embedding calls bill against the same `prompts_used`
+// counter as completions — they're bucketed together as "LLM calls"
+// per the spec. Embeddings count one prompt per input string in the
+// batch. Image calls use `images_used`. Counters are decoupled from
 // key rotation; an admin resets them explicitly via
 // POST /admin/users/<id>/reset-usage.
 
 import type { Env } from "../env";
 import type { UserRow } from "../db";
-import { incrementImageUsage, incrementPromptUsage } from "../db";
+import { incrementImageUsage, incrementPromptUsage, incrementPromptUsageBy } from "../db";
 import { error, json, preflight } from "../util";
 
 const CORS = { origin: "*" as const };
@@ -48,6 +50,18 @@ const LLM_MODEL = "claude-haiku-4-5-20251001";
 
 // Claude Sonnet 4.6 for vision.
 const VISION_MODEL = "claude-sonnet-4-6";
+
+// Voyage AI embedding models. voyage-3-lite is the small/fast tier
+// used by lore RAG; it's the only model exposed via the hub.
+const EMBEDDING_MODELS = new Set(["voyage-3-lite"]);
+const DEFAULT_EMBEDDING_MODEL = "voyage-3-lite";
+
+// Voyage caps batch size at 128 inputs per call. Clients chunk on
+// their side; the hub just rejects oversize batches.
+const MAX_EMBEDDING_BATCH = 128;
+// voyage-3-lite handles ~32k token contexts, but we don't need to
+// allow runaway inputs through the proxy.
+const MAX_EMBEDDING_INPUT_CHARS = 8000;
 
 // ─── Guardrails ──────────────────────────────────────────────────────
 
@@ -95,6 +109,9 @@ export async function handleAi(
   }
   if (pathname === "/ai/llm/vision" && req.method === "POST") {
     return await llmVision(req, env, user);
+  }
+  if (pathname === "/ai/embed" && req.method === "POST") {
+    return await embed(req, env, user);
   }
   return error(404, "Not found", CORS);
 }
@@ -582,6 +599,145 @@ async function llmVision(req: Request, env: Env, user: UserRow): Promise<Respons
         prompts_quota: user.prompts_quota,
         input_tokens: raw.usage?.input_tokens,
         output_tokens: raw.usage?.output_tokens,
+      },
+    },
+    {},
+    CORS,
+  );
+}
+
+// ─── Embeddings (Voyage AI) ──────────────────────────────────────────
+//
+// Bills against the same `prompts_used` lifetime counter as LLM
+// completions and vision calls — one prompt per input string in the
+// batch. Voyage caps batch size at 128; we reject anything larger
+// with a clear error so the client can chunk.
+
+interface EmbedBody {
+  model?: string;
+  input?: unknown;
+}
+
+interface VoyageEmbedItem {
+  object?: string;
+  embedding?: number[];
+  index?: number;
+}
+
+interface VoyageEmbedResponse {
+  data?: VoyageEmbedItem[];
+  model?: string;
+  usage?: { total_tokens?: number };
+}
+
+async function embed(req: Request, env: Env, user: UserRow): Promise<Response> {
+  if (user.prompts_used >= user.prompts_quota) {
+    return quotaExceeded("prompts", user.prompts_used, user.prompts_quota);
+  }
+
+  let body: EmbedBody;
+  try {
+    body = (await req.json()) as EmbedBody;
+  } catch {
+    return error(400, "Invalid JSON body", CORS);
+  }
+
+  const model = (body.model ?? DEFAULT_EMBEDDING_MODEL).trim();
+  if (!EMBEDDING_MODELS.has(model)) {
+    return error(
+      400,
+      `Unsupported embedding model "${model}". Allowed: ${[...EMBEDDING_MODELS].join(", ")}`,
+      CORS,
+    );
+  }
+
+  if (!Array.isArray(body.input) || body.input.length === 0) {
+    return error(400, "input must be a non-empty array of strings", CORS);
+  }
+  if (body.input.length > MAX_EMBEDDING_BATCH) {
+    return json(
+      {
+        error: "batch_too_large",
+        message: `Maximum ${MAX_EMBEDDING_BATCH} inputs per embedding call`,
+      },
+      { status: 400 },
+      CORS,
+    );
+  }
+
+  const inputs: string[] = [];
+  for (let i = 0; i < body.input.length; i++) {
+    const item = body.input[i];
+    if (typeof item !== "string") {
+      return error(400, `input[${i}] must be a string`, CORS);
+    }
+    if (item.length === 0) {
+      return error(400, `input[${i}] must be non-empty`, CORS);
+    }
+    if (item.length > MAX_EMBEDDING_INPUT_CHARS) {
+      return error(
+        400,
+        `input[${i}] exceeds ${MAX_EMBEDDING_INPUT_CHARS} character cap`,
+        CORS,
+      );
+    }
+    inputs.push(item);
+  }
+
+  // Quota check on the full batch — refuse rather than partially
+  // billing if the call would push the user over their quota.
+  if (user.prompts_used + inputs.length > user.prompts_quota) {
+    return quotaExceeded("prompts", user.prompts_used, user.prompts_quota);
+  }
+
+  const upstream = await fetch("https://api.voyageai.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${env.VOYAGE_API_KEY}`,
+    },
+    body: JSON.stringify({ model, input: inputs }),
+  });
+
+  if (!upstream.ok) {
+    const text = await upstream.text().catch(() => "");
+    return error(upstream.status, `Voyage error (${upstream.status}): ${text.slice(0, 500)}`, CORS);
+  }
+
+  const raw = (await upstream.json()) as VoyageEmbedResponse;
+  if (!raw.data || raw.data.length !== inputs.length) {
+    return error(502, "Voyage returned mismatched embedding count", CORS);
+  }
+
+  // Preserve the request order using the `index` field — Voyage may
+  // not guarantee ordered output. Fall back to array position if
+  // index is missing.
+  const embeddings: number[][] = new Array(inputs.length);
+  for (let i = 0; i < raw.data.length; i++) {
+    const entry: VoyageEmbedItem | undefined = raw.data[i];
+    if (!entry || !Array.isArray(entry.embedding)) {
+      return error(502, "Voyage returned a malformed embedding", CORS);
+    }
+    const idx = typeof entry.index === "number" ? entry.index : i;
+    if (idx < 0 || idx >= inputs.length) {
+      return error(502, "Voyage returned an out-of-range embedding index", CORS);
+    }
+    embeddings[idx] = entry.embedding;
+  }
+  for (let i = 0; i < embeddings.length; i++) {
+    if (!embeddings[i]) return error(502, "Voyage returned an incomplete embedding set", CORS);
+  }
+
+  await incrementPromptUsageBy(env, user.id, inputs.length);
+
+  return json(
+    {
+      embeddings,
+      model,
+      usage: {
+        prompts_used: user.prompts_used + inputs.length,
+        prompts_quota: user.prompts_quota,
+        total_tokens: raw.usage?.total_tokens,
       },
     },
     {},

--- a/hub-worker/wrangler.toml
+++ b/hub-worker/wrangler.toml
@@ -79,3 +79,7 @@ TURNSTILE_SITE_KEY = "0x4AAAAAAC-tx5qpomJo9lmk"
 #   TURNSTILE_SECRET_KEY   — CF Turnstile secret; pair with the public
 #                            site key in [vars]. Leave unset to skip
 #                            Turnstile verification.
+#   RUNWARE_API_KEY        — image generation
+#   OPENROUTER_API_KEY     — text LLM (currently unused; Claude via Anthropic)
+#   ANTHROPIC_API_KEY      — text + vision LLM
+#   VOYAGE_API_KEY         — embeddings for /ai/embed (lore RAG)


### PR DESCRIPTION
Foundation for #227. Local-first embedding index that future LLM features will call via a single `retrieveLoreContext()` helper. No existing call sites are migrated in this PR — substrate only, per the scope decision in planning.

## Summary

- **Storage**: `<project>/.arcanum/rag.sqlite` via `rusqlite` (bundled). Single `chunks` table (id, kind, source_id, section, title, body, metadata JSON, content_hash, embedding BLOB, embedded_at) plus an `index_meta` k/v for schema version + model + dim. Content-hash dedupe so unchanged chunks skip re-embedding.
- **Retrieval**: brute-force cosine in Rust over the BLOB column. Fast at lore-corpus scale (thousands of vectors). Swappable for sqlite-vec later without changing the public surface.
- **Embedding dispatch**: new `embeddings.rs` mirrors the existing `hub_ai::is_enabled(&settings)` short-circuit pattern. Hub path posts to `/ai/embed`; direct path hits Voyage `voyage-3-lite` (512-dim). Auto-chunks inputs > 128 per request.
- **Chunker** (`creator/src/lib/rag/chunker.ts`): articles split by H2 section, plus one chunk each for timeline events, map pins, non-trivial relationships, and entity descriptions from `races` / `classes` / `abilities` / `mobs` / `items`. Drafts pass through tagged so retrieval can filter. Pure function — no I/O.
- **Public surface** (`creator/src/lib/rag/index.ts`): `retrieveLoreContext`, `rebuildIndex`, `getIndexStats`, `clearIndex`.
- **Prompt-assembly formatter**: dedupes by source, collapses same-source chunks into one `<artefact>` block, caps total chars (default 12k).
- **Hub `/ai/embed`**: model allowlist (`voyage-3-lite` only), batch cap 128, per-input length cap 8k chars, billed against `prompts_used` only on 2xx upstream — same pattern as `/ai/llm/vision`.
- **UI**: new `LoreIndexPanel` on the settings island of the World Map (Ctrl+M → Settings, or Ctrl+K → "Lore Index"). Shows total chunks, by-kind breakdown, embedding model + dim, last update; has Rebuild Index, Clear Index (confirm-dialog), and Voyage API key field.

## Wire contract

`RagChunk` / `RetrievedChunk` / `RetrievalFilters` / `IndexStats` are shared by Rust, TypeScript, and the hub. See `creator/src/lib/rag/types.ts` and `creator/src-tauri/src/rag.rs`.

## Hub deploy follow-up (not in this PR)

Before the hub can serve embeddings:

```
cd hub-worker
npx wrangler secret put VOYAGE_API_KEY
npm run deploy
```

## Out of scope (deliberate)

- No migration of existing LLM call sites (gap analysis, consistency auditor, mention suggestions, timeline inference, relation inference, rewrite, enhance). Each becomes its own follow-up PR.
- No auto re-index on lore save. Manual rebuild only for now.
- No debug surface to view retrieved context.

## Test plan

- [x] `cd creator && bunx tsc --noEmit` — green
- [x] `cd creator && bun run test` — 1862/1862 (7 new chunker tests)
- [x] `cd creator/src-tauri && cargo check` — green
- [x] `cd creator/src-tauri && cargo check --no-default-features` — green (verifies AI gating)
- [x] `cd hub-worker && npx tsc --noEmit` — green
- [ ] Manual: open a project, open the Lore Index panel, Rebuild, verify chunk counts and last-update timestamp
- [ ] Manual: call `retrieveLoreContext({ query: "..." })` from the dev console; verify top-k results are relevant
- [ ] Manual (hub mode): toggle `use_hub_ai`, rebuild index, verify embeddings come back via `/ai/embed` and `prompts_used` increments