### PR TITLE
Mirror AmbonMUD content-tuning sync (mob multipliers + item power budget)

### DIFF
--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useState, memo } from "react";
-import type { WorldFile, ItemFile, ItemOnUse, ItemType } from "@/types/world";
-import { ITEM_TYPES } from "@/types/world";
+import { useCallback, useMemo, useState, memo } from "react";
+import type { WorldFile, ItemFile, ItemOnUse, ItemRarity, ItemType } from "@/types/world";
+import { ITEM_RARITIES, ITEM_TYPES } from "@/types/world";
+import { evaluateItemBudget } from "@/lib/itemBudget";
 import { updateItem, deleteItem } from "@/lib/zoneEdits";
 import { useEntityEditor } from "@/lib/useEntityEditor";
 import { useConfigOptions } from "@/lib/useConfigOptions";
@@ -54,6 +55,7 @@ export function ItemEditor({
     onDelete,
   );
   const equipmentSlots = useConfigStore((s) => s.config?.equipmentSlots);
+  const itemBudgetConfig = useConfigStore((s) => s.config?.itemBudget);
   const slotOptions = useConfigOptions(equipmentSlots, [
     { value: "head", label: "Head" },
     { value: "body", label: "Body" },
@@ -63,6 +65,19 @@ export function ItemEditor({
     value: t,
     label: t.charAt(0).toUpperCase() + t.slice(1),
   }));
+  const rarityOptions = ITEM_RARITIES.map((r) => ({
+    value: r,
+    label: r.charAt(0).toUpperCase() + r.slice(1),
+  }));
+
+  const budgetReadout = useMemo(() => {
+    if (!item || !itemBudgetConfig) return null;
+    try {
+      return evaluateItemBudget(itemId, item, itemBudgetConfig);
+    } catch {
+      return null;
+    }
+  }, [item, itemBudgetConfig, itemId]);
 
   if (!item) return null;
 
@@ -278,6 +293,41 @@ export function ItemEditor({
                 onAdd={(statId) => handleStatChange(statId, 1)}
               />
             </div>
+          </Section>
+
+          <Section title="Power Budget">
+            <p className="mb-1 text-2xs text-text-muted">
+              Set level or rarity to opt this item into the server's power-budget
+              check. Leave blank to skip validation (legacy items).
+            </p>
+            <FieldGrid cols={2}>
+              <CompactField label="Level">
+                <NumberInput
+                  value={item.level}
+                  onCommit={(v) => patch({ level: v == null ? undefined : Math.max(1, Math.floor(v)) })}
+                  placeholder="—"
+                  min={1}
+                  dense
+                />
+              </CompactField>
+              <CompactField label="Rarity">
+                <SelectInput
+                  value={item.rarity ?? ""}
+                  options={rarityOptions}
+                  onCommit={(v) => patch({ rarity: (v || undefined) as ItemRarity | undefined })}
+                  allowEmpty
+                  placeholder="—"
+                  dense
+                />
+              </CompactField>
+            </FieldGrid>
+            {budgetReadout && (
+              <p className={`mt-1 text-2xs ${budgetReadout.overBudget ? "text-warm" : "text-text-muted"}`}>
+                Spent {budgetReadout.spent.toFixed(1)} / {budgetReadout.budget.toFixed(1)} pts
+                {budgetReadout.breakdown.length > 0 ? ` — ${budgetReadout.breakdown.join(", ")}` : ""}
+                {budgetReadout.overBudget ? " (over budget)" : ""}
+              </p>
+            )}
           </Section>
         </>
       )}

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -55,6 +55,12 @@ function fieldPlaceholder(stat: { tierDefault: number } | undefined): string {
   return stat ? String(stat.tierDefault) : "Auto";
 }
 
+function isInvalidMult(value: number | undefined): boolean {
+  if (value == null) return false;
+  if (!Number.isFinite(value)) return true;
+  return value <= 0 || value > 10;
+}
+
 const CATEGORY_OPTIONS = [
   { value: "humanoid", label: "Humanoid" },
   { value: "beast", label: "Beast" },
@@ -558,6 +564,66 @@ export function MobEditor({
                 onCommit={(v) => patch({ defaultAttack: v || undefined })}
               />
             </FieldRow>
+          </Section>
+
+          <Section
+            title="Stat Multipliers"
+            defaultExpanded={false}
+            titleTooltip="Scale the tier × level baseline before any absolute override below applies. Default 1.0. Absolute overrides still win for the fields they set."
+          >
+            <FieldGrid>
+              <CompactField label="HP Mult">
+                <NumberInput
+                  value={mob.hpMult}
+                  onCommit={(v) => patch({ hpMult: v })}
+                  placeholder="1.0"
+                  step={0.05}
+                  min={0}
+                />
+                {isInvalidMult(mob.hpMult) && (
+                  <p className="mt-1 text-2xs text-status-error">Must be &gt; 0 and ≤ 10</p>
+                )}
+              </CompactField>
+              <CompactField label="Damage Mult">
+                <NumberInput
+                  value={mob.dmgMult}
+                  onCommit={(v) => patch({ dmgMult: v })}
+                  placeholder="1.0"
+                  step={0.05}
+                  min={0}
+                />
+                {isInvalidMult(mob.dmgMult) && (
+                  <p className="mt-1 text-2xs text-status-error">Must be &gt; 0 and ≤ 10</p>
+                )}
+              </CompactField>
+              <CompactField label="XP Mult">
+                <NumberInput
+                  value={mob.xpMult}
+                  onCommit={(v) => patch({ xpMult: v })}
+                  placeholder="1.0"
+                  step={0.05}
+                  min={0}
+                />
+                {isInvalidMult(mob.xpMult) && (
+                  <p className="mt-1 text-2xs text-status-error">Must be &gt; 0 and ≤ 10</p>
+                )}
+              </CompactField>
+              <CompactField label="Gold Mult">
+                <NumberInput
+                  value={mob.goldMult}
+                  onCommit={(v) => patch({ goldMult: v })}
+                  placeholder="1.0"
+                  step={0.05}
+                  min={0}
+                />
+                {isInvalidMult(mob.goldMult) && (
+                  <p className="mt-1 text-2xs text-status-error">Must be &gt; 0 and ≤ 10</p>
+                )}
+              </CompactField>
+            </FieldGrid>
+            <p className="mt-1.5 text-2xs text-text-muted">
+              Multipliers scale the tier × level baseline. Absolute overrides below always win for the fields they set.
+            </p>
           </Section>
 
           <Section

--- a/creator/src/lib/__tests__/exportMud.test.ts
+++ b/creator/src/lib/__tests__/exportMud.test.ts
@@ -3,6 +3,7 @@ import { parse } from "yaml";
 import { buildMonolithicConfigObject } from "../exportMud";
 import { parseAppConfigYaml } from "../loader";
 import type { AppConfig } from "@/types/config";
+import { DEFAULT_ITEM_BUDGET } from "@/types/config";
 
 const BASE_CONFIG: AppConfig = {
   mode: "STANDALONE",
@@ -122,6 +123,7 @@ const BASE_CONFIG: AppConfig = {
   guildRanks: {},
   friends: { maxFriends: 50 },
   mobActionDelay: { minActionDelayMillis: 8000, maxActionDelayMillis: 20000 },
+  itemBudget: DEFAULT_ITEM_BUDGET,
   images: { baseUrl: "https://assets.ambon.dev" },
   globalAssets: {},
   skillPoints: {

--- a/creator/src/lib/__tests__/itemBudget.test.ts
+++ b/creator/src/lib/__tests__/itemBudget.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { evaluateItemBudget } from "../itemBudget";
+import type { ItemFile } from "@/types/world";
+import { DEFAULT_ITEM_BUDGET } from "@/types/config";
+
+function weapon(overrides: Partial<ItemFile> = {}): ItemFile {
+  return { displayName: "Test Weapon", slot: "weapon", ...overrides };
+}
+
+describe("evaluateItemBudget", () => {
+  it("skips when item has neither level nor rarity", () => {
+    const result = evaluateItemBudget("sword", weapon({ damage: 4 }), DEFAULT_ITEM_BUDGET);
+    expect(result).toBeNull();
+  });
+
+  it("skips when config is disabled", () => {
+    const config = { ...DEFAULT_ITEM_BUDGET, enabled: false };
+    const result = evaluateItemBudget("sword", weapon({ damage: 4, level: 5 }), config);
+    expect(result).toBeNull();
+  });
+
+  it("skips when item has no slot", () => {
+    const result = evaluateItemBudget(
+      "trinket",
+      { displayName: "X", level: 5, damage: 4 },
+      DEFAULT_ITEM_BUDGET,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("flags a level-1 common weapon with damage 4 as over budget", () => {
+    const result = evaluateItemBudget(
+      "sword",
+      weapon({ damage: 4, level: 1 }),
+      DEFAULT_ITEM_BUDGET,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.spent).toBeCloseTo(20, 5);
+    expect(result!.budget).toBeCloseTo(8, 5);
+    expect(result!.overBudget).toBe(true);
+    expect(result!.rarity).toBe("common");
+    expect(result!.level).toBe(1);
+  });
+
+  it("passes a level-5 rare weapon with damage 4", () => {
+    const result = evaluateItemBudget(
+      "sword",
+      weapon({ damage: 4, level: 5, rarity: "rare" }),
+      DEFAULT_ITEM_BUDGET,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.spent).toBeCloseTo(20, 5);
+    expect(result!.budget).toBeCloseTo(24, 5);
+    expect(result!.overBudget).toBe(false);
+  });
+
+  it("breakdown lists all non-zero contributions", () => {
+    const result = evaluateItemBudget(
+      "armor",
+      {
+        displayName: "Ringmail",
+        slot: "body",
+        level: 5,
+        rarity: "common",
+        armor: 2,
+        stats: { STR: 2, DEX: 1 },
+      },
+      DEFAULT_ITEM_BUDGET,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.breakdown).toEqual(["armor 2=4.0pt", "stats 3=3.0pt"]);
+  });
+
+  it("defaults rarity to config.defaultRarity when only level set", () => {
+    const result = evaluateItemBudget(
+      "sword",
+      weapon({ damage: 1, level: 3 }),
+      DEFAULT_ITEM_BUDGET,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.rarity).toBe(DEFAULT_ITEM_BUDGET.defaultRarity);
+  });
+
+  it("coerces level below 1 up to 1", () => {
+    const result = evaluateItemBudget(
+      "sword",
+      weapon({ damage: 1, level: 0, rarity: "common" }),
+      DEFAULT_ITEM_BUDGET,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.level).toBe(1);
+  });
+
+  it("throws when rarity is unknown", () => {
+    expect(() =>
+      evaluateItemBudget(
+        "sword",
+        weapon({ damage: 1, level: 1, rarity: "mythic" as unknown as ItemFile["rarity"] }),
+        DEFAULT_ITEM_BUDGET,
+      ),
+    ).toThrow(/mythic/);
+  });
+
+  it("throws when slot is unknown", () => {
+    expect(() =>
+      evaluateItemBudget(
+        "sword",
+        { displayName: "X", slot: "tail", level: 1 },
+        DEFAULT_ITEM_BUDGET,
+      ),
+    ).toThrow(/tail/);
+  });
+
+  it("tolerance band: borderline weapon flagged at 5%, allowed at 20%", () => {
+    // weapon at level 1 common: budget = (6 + 1*2) * 1.0 = 8.
+    // damage 2 → spent = 10. 10 / 8 = 1.25 = 25% over.
+    const item = weapon({ damage: 2, level: 1, rarity: "common" });
+
+    const tight = evaluateItemBudget("sword", item, { ...DEFAULT_ITEM_BUDGET, tolerance: 0.05 });
+    expect(tight!.overBudget).toBe(true);
+
+    const lax = evaluateItemBudget("sword", item, { ...DEFAULT_ITEM_BUDGET, tolerance: 0.5 });
+    expect(lax!.overBudget).toBe(false);
+  });
+});

--- a/creator/src/lib/__tests__/resolveMobStats.test.ts
+++ b/creator/src/lib/__tests__/resolveMobStats.test.ts
@@ -111,4 +111,66 @@ describe("resolveMobStats", () => {
     const stats = resolveMobStats(mob({ tier: undefined, level: 1 }), MOB_TIERS)!;
     expect(stats.hp.tierDefault).toBe(20);
   });
+
+  it("hpMult scales tier-derived hp at level 5", () => {
+    const stats = resolveMobStats(
+      mob({ tier: "standard", level: 5, hpMult: 1.5 }),
+      MOB_TIERS,
+    )!;
+    // baseline at level 5 = 20 + 5*4 = 40, * 1.5 = 60
+    expect(stats.hp.tierDefault).toBe(60);
+    expect(stats.hp.effective).toBe(60);
+    expect(stats.hp.overridden).toBe(false);
+  });
+
+  it("dmgMult scales both min and max damage", () => {
+    const stats = resolveMobStats(
+      mob({ tier: "standard", level: 5, dmgMult: 2 }),
+      MOB_TIERS,
+    )!;
+    // min at level 5 = 2 + 2*4 = 10, * 2 = 20
+    expect(stats.minDamage.tierDefault).toBe(20);
+    // max at level 5 = 4 + 2*4 = 12, * 2 = 24
+    expect(stats.maxDamage.tierDefault).toBe(24);
+  });
+
+  it("xpMult and goldMult scale rewards", () => {
+    const stats = resolveMobStats(
+      mob({ tier: "standard", level: 3, xpMult: 2.5, goldMult: 0.5 }),
+      MOB_TIERS,
+    )!;
+    // xp at level 3 = 30 + 10*2 = 50, * 2.5 = 125
+    expect(stats.xpReward.tierDefault).toBe(125);
+    // goldMin at level 3 = 3 + 2*2 = 7, * 0.5 = 3.5 -> 4
+    expect(stats.goldMin.tierDefault).toBe(4);
+    // goldMax at level 3 = 8 + 2*2 = 12, * 0.5 = 6
+    expect(stats.goldMax.tierDefault).toBe(6);
+  });
+
+  it("absolute override beats multiplier", () => {
+    const stats = resolveMobStats(
+      mob({ tier: "standard", level: 1, hp: 100, hpMult: 5 }),
+      MOB_TIERS,
+    )!;
+    expect(stats.hp.overridden).toBe(true);
+    expect(stats.hp.effective).toBe(100);
+  });
+
+  it("hpMult clamps to at least 1 on a small mob", () => {
+    const stats = resolveMobStats(
+      mob({ tier: "weak", level: 1, hpMult: 0.01 }),
+      MOB_TIERS,
+    )!;
+    expect(stats.hp.tierDefault).toBe(1);
+  });
+
+  it("maxDamage stays at least the multiplier-applied minDamage", () => {
+    const stats = resolveMobStats(
+      mob({ tier: "weak", level: 1, dmgMult: 0.01 }),
+      MOB_TIERS,
+    )!;
+    // both clamp to 1; max must not fall below min
+    expect(stats.minDamage.tierDefault).toBe(1);
+    expect(stats.maxDamage.tierDefault).toBeGreaterThanOrEqual(stats.minDamage.tierDefault);
+  });
 });

--- a/creator/src/lib/__tests__/validateConfig.test.ts
+++ b/creator/src/lib/__tests__/validateConfig.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { validateConfig } from "../validateConfig";
 import type { AppConfig } from "@/types/config";
+import { DEFAULT_ITEM_BUDGET } from "@/types/config";
 
 /** Minimal valid config for tests to spread over */
 const BASE_CONFIG: AppConfig = {
@@ -126,6 +127,7 @@ const BASE_CONFIG: AppConfig = {
   multiclass: { minLevel: 10, goldCost: 500 },
   guildRanks: {},
   mobActionDelay: { minActionDelayMillis: 8000, maxActionDelayMillis: 20000 },
+  itemBudget: DEFAULT_ITEM_BUDGET,
   characterCreation: { startingGold: 0 },
   images: { baseUrl: "/images/" },
   globalAssets: {

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { validateZone, type ValidationIssue } from "../validateZone";
 import type { WorldFile } from "@/types/world";
+import { DEFAULT_ITEM_BUDGET } from "@/types/config";
 
 const TEST_MOB_TIERS = {
   weak: { baseHp: 8, hpPerLevel: 3, baseMinDamage: 1, baseMaxDamage: 3, damagePerLevel: 1, baseArmor: 0, baseXpReward: 10, xpRewardPerLevel: 3, baseGoldMin: 0, baseGoldMax: 2, goldPerLevel: 1 },
@@ -661,6 +662,27 @@ describe("validateZone", () => {
       const issues = validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS);
 
       expect(issues).toHaveLength(0);
+    });
+  });
+
+  describe("item power budget", () => {
+    it("warns when a level-1 common weapon with damage 4 exceeds its slot+level budget", () => {
+      const world = makeValidWorld();
+      world.items!.sword = { displayName: "Sword", slot: "weapon", room: "room1", damage: 4, level: 1 };
+      const issues = validateZone(
+        world,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        DEFAULT_ITEM_BUDGET,
+      );
+      const overBudget = issues.filter(
+        (i) => i.entity === "item:sword" && i.severity === "warning" && i.message.includes("over power budget"),
+      );
+      expect(overBudget).toHaveLength(1);
     });
   });
 });

--- a/creator/src/lib/itemBudget.ts
+++ b/creator/src/lib/itemBudget.ts
@@ -1,0 +1,80 @@
+import type { ItemFile } from "@/types/world";
+import type { ItemBudgetConfig } from "@/types/config";
+
+export interface ItemBudgetEvaluation {
+  itemId: string;
+  slot: string;
+  level: number;
+  rarity: string;
+  spent: number;
+  budget: number;
+  tolerance: number;
+  overBudget: boolean;
+  breakdown: string[];
+}
+
+/**
+ * Port of `dev.ambon.domain.world.ItemBudgetEvaluation.evaluate` from AmbonMUD.
+ * Returns null when the item opts out (no level/rarity, no slot, or config disabled).
+ * Throws when the item declares an unknown slot or rarity — callers should catch
+ * and surface as a validation error rather than crashing.
+ */
+export function evaluateItemBudget(
+  itemId: string,
+  item: ItemFile,
+  config: ItemBudgetConfig,
+): ItemBudgetEvaluation | null {
+  if (!config.enabled) return null;
+  if (item.level == null && item.rarity == null) return null;
+  if (!item.slot) return null;
+
+  const slotKey = item.slot.toLowerCase();
+  const slotBase = config.slotBaseBudget[slotKey];
+  if (slotBase == null) {
+    throw new Error(`Unknown slot "${item.slot}" — not in itemBudget.slotBaseBudget`);
+  }
+
+  const rarityKey = (item.rarity ?? config.defaultRarity).toLowerCase();
+  const rarityMult = config.rarityMultiplier[rarityKey];
+  if (rarityMult == null) {
+    throw new Error(`Unknown rarity "${rarityKey}" — not in itemBudget.rarityMultiplier`);
+  }
+
+  const level = Math.max(1, item.level ?? 1);
+  const budget = (slotBase + level * config.pointsPerLevel) * rarityMult;
+
+  const damage = item.damage ?? 0;
+  const armor = item.armor ?? 0;
+  const statSum = Object.values(item.stats ?? {}).reduce((a, b) => a + b, 0);
+
+  const damagePoints = damage * config.damagePointCost;
+  const armorPoints = armor * config.armorPointCost;
+  const statPoints = statSum * config.statPointCost;
+  const spent = damagePoints + armorPoints + statPoints;
+
+  const breakdown: string[] = [];
+  if (damagePoints > 0) breakdown.push(`damage ${damage}=${damagePoints.toFixed(1)}pt`);
+  if (armorPoints > 0) breakdown.push(`armor ${armor}=${armorPoints.toFixed(1)}pt`);
+  if (statPoints > 0) breakdown.push(`stats ${statSum}=${statPoints.toFixed(1)}pt`);
+
+  const overBudget = spent > budget * (1 + config.tolerance);
+
+  return {
+    itemId,
+    slot: slotKey,
+    level,
+    rarity: rarityKey,
+    spent,
+    budget,
+    tolerance: config.tolerance,
+    overBudget,
+    breakdown,
+  };
+}
+
+/** One-line summary suitable for a validation issue message. */
+export function summarizeItemBudget(evaluation: ItemBudgetEvaluation): string {
+  const pct = evaluation.budget > 0 ? Math.round((evaluation.spent / evaluation.budget) * 100) : 0;
+  const breakdown = evaluation.breakdown.length > 0 ? evaluation.breakdown.join(", ") : "no contributions";
+  return `Item over power budget: spent ${evaluation.spent.toFixed(1)} / ${evaluation.budget.toFixed(1)} points (${pct}%), breakdown: ${breakdown}`;
+}

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -2,7 +2,8 @@ import { readDir, readTextFile } from "@tauri-apps/plugin-fs";
 import { exists } from "@tauri-apps/plugin-fs";
 import { parseDocument } from "yaml";
 import type { WorldFile } from "@/types/world";
-import type { AppConfig } from "@/types/config";
+import type { AppConfig, ItemBudgetConfig } from "@/types/config";
+import { DEFAULT_ITEM_BUDGET } from "@/types/config";
 import type { Project } from "@/types/project";
 import { normalizeExitDirections, normalizeMobSpawns } from "@/lib/zoneEdits";
 import {
@@ -86,6 +87,7 @@ export function parseAppConfigYaml(content: string): AppConfig {
     combat: parseCombatConfig(engine.combat),
     mobTiers: parseMobTiersConfig(engine.mob),
     mobActionDelay: parseMobActionDelayConfig(engine.mob),
+    itemBudget: parseItemBudgetConfig(engine.items),
     progression: parseProgressionConfig(progression),
     economy: parseSimpleSection(engine.economy, { buyMultiplier: 1.0, sellMultiplier: 0.5 }),
     regen: parseRegenConfig(engine.regen),
@@ -508,6 +510,45 @@ function parseMobTiersConfig(raw: unknown): AppConfig["mobTiers"] {
     standard: parseTier(tiers.standard, { baseHp: 10, hpPerLevel: 3, baseMinDamage: 1, baseMaxDamage: 4, damagePerLevel: 1, baseArmor: 0, baseXpReward: 30, xpRewardPerLevel: 10, baseGoldMin: 2, baseGoldMax: 8, goldPerLevel: 2 }),
     elite: parseTier(tiers.elite, { baseHp: 20, hpPerLevel: 5, baseMinDamage: 2, baseMaxDamage: 6, damagePerLevel: 1, baseArmor: 1, baseXpReward: 75, xpRewardPerLevel: 20, baseGoldMin: 10, baseGoldMax: 25, goldPerLevel: 5 }),
     boss: parseTier(tiers.boss, { baseHp: 50, hpPerLevel: 10, baseMinDamage: 3, baseMaxDamage: 8, damagePerLevel: 2, baseArmor: 3, baseXpReward: 200, xpRewardPerLevel: 50, baseGoldMin: 50, baseGoldMax: 100, goldPerLevel: 15 }),
+  };
+}
+
+function parseItemBudgetConfig(raw: unknown): ItemBudgetConfig {
+  const items = (raw ?? {}) as Record<string, unknown>;
+  const budgetRaw = items.budget;
+  if (!budgetRaw || typeof budgetRaw !== "object") {
+    return {
+      ...DEFAULT_ITEM_BUDGET,
+      slotBaseBudget: { ...DEFAULT_ITEM_BUDGET.slotBaseBudget },
+      rarityMultiplier: { ...DEFAULT_ITEM_BUDGET.rarityMultiplier },
+    };
+  }
+  const b = budgetRaw as Record<string, unknown>;
+  const mergeNumberMap = (
+    overlay: unknown,
+    defaults: Record<string, number>,
+  ): Record<string, number> => {
+    const out: Record<string, number> = { ...defaults };
+    if (overlay && typeof overlay === "object") {
+      for (const [k, v] of Object.entries(overlay)) {
+        if (typeof v === "number" && Number.isFinite(v)) out[k] = v;
+      }
+    }
+    return out;
+  };
+  const num = (val: unknown, fallback: number): number =>
+    typeof val === "number" && Number.isFinite(val) ? val : fallback;
+  return {
+    enabled: asBool(b.enabled, DEFAULT_ITEM_BUDGET.enabled),
+    warnOnly: asBool(b.warnOnly, DEFAULT_ITEM_BUDGET.warnOnly),
+    tolerance: num(b.tolerance, DEFAULT_ITEM_BUDGET.tolerance),
+    pointsPerLevel: num(b.pointsPerLevel, DEFAULT_ITEM_BUDGET.pointsPerLevel),
+    damagePointCost: num(b.damagePointCost, DEFAULT_ITEM_BUDGET.damagePointCost),
+    armorPointCost: num(b.armorPointCost, DEFAULT_ITEM_BUDGET.armorPointCost),
+    statPointCost: num(b.statPointCost, DEFAULT_ITEM_BUDGET.statPointCost),
+    slotBaseBudget: mergeNumberMap(b.slotBaseBudget, DEFAULT_ITEM_BUDGET.slotBaseBudget),
+    rarityMultiplier: mergeNumberMap(b.rarityMultiplier, DEFAULT_ITEM_BUDGET.rarityMultiplier),
+    defaultRarity: asString(b.defaultRarity, DEFAULT_ITEM_BUDGET.defaultRarity),
   };
 }
 
@@ -1439,6 +1480,7 @@ async function loadSplitConfig(projectDir: string): Promise<AppConfig | null> {
       combat: parseCombatConfig(combatRaw.combat ?? combatRaw),
       mobTiers: parseMobTiersConfig(combatRaw.mob ?? combatRaw),
       mobActionDelay: parseMobActionDelayConfig(combatRaw.mob ?? combatRaw),
+      itemBudget: parseItemBudgetConfig(combatRaw.items ?? worldRaw.items),
 
       // classes.yaml
       classes: asRecord(classesRaw.definitions ?? classesRaw),

--- a/creator/src/lib/resolveMobStats.ts
+++ b/creator/src/lib/resolveMobStats.ts
@@ -22,9 +22,9 @@ import {
 export interface MobStatValue {
   /** Effective value the engine will use (override when set, else tier default). */
   effective: number;
-  /** What the tier+level would produce if the author removed the override. */
+  /** What the tier+level (with any multiplier applied) would produce if the author removed the override. */
   tierDefault: number;
-  /** True when the author set an explicit value overriding the tier default. */
+  /** True when the author set an explicit absolute value overriding the tier default. */
   overridden: boolean;
 }
 
@@ -46,10 +46,25 @@ function tierFor(mob: MobFile, mobTiers: MobTiersConfig | undefined): MobTierCon
   return (mobTiers as unknown as Record<string, MobTierConfig>)[id];
 }
 
+function multOrDefault(value: number | undefined): number {
+  if (value == null || !Number.isFinite(value) || value <= 0) return 1;
+  return value;
+}
+
 /**
  * Resolve every combat stat for a mob using the tier + level math the MUD
- * engine runs at load time. Returns both the effective value and the tier
- * default so the editor can show one alongside the other.
+ * engine runs at load time, then applies the per-mob multipliers
+ * (`hpMult`, `dmgMult`, `xpMult`, `goldMult`) before falling back to any
+ * absolute author override.
+ *
+ * Resolution order (matches `ResolvedMobStats.resolveMobStats` in the
+ * AmbonMUD Kotlin source — `src/main/kotlin/dev/ambon/domain/world/
+ * ResolvedMobStats.kt` — which is the source of truth):
+ *   1. tier × level baseline
+ *   2. multiplier (default 1.0; clamp resulting hp/min/max damage to ≥ 1,
+ *      xp/gold to ≥ 0, and maxDamage to ≥ multiplier-applied minDamage)
+ *   3. absolute override (`mob.hp`, `mob.minDamage`, …) — always wins,
+ *      multiplier is ignored for that specific field.
  *
  * Returns undefined if the tier lookup fails (no mobTiers config, or the
  * mob references an unknown tier). Callers should treat that as "can't
@@ -63,6 +78,18 @@ export function resolveMobStats(
   if (!tier) return undefined;
   const level = mob.level ?? 1;
 
+  const hpMult = multOrDefault(mob.hpMult);
+  const dmgMult = multOrDefault(mob.dmgMult);
+  const xpMult = multOrDefault(mob.xpMult);
+  const goldMult = multOrDefault(mob.goldMult);
+
+  const baseHp = Math.max(1, Math.round(mobHpAtLevel(tier, level) * hpMult));
+  const baseMin = Math.max(1, Math.round(mobMinDamageAtLevel(tier, level) * dmgMult));
+  const baseMax = Math.max(baseMin, Math.round(mobMaxDamageAtLevel(tier, level) * dmgMult));
+  const baseXp = Math.max(0, Math.round(mobXpRewardAtLevel(tier, level) * xpMult));
+  const baseGoldMin = Math.max(0, Math.round(mobGoldMinAtLevel(tier, level) * goldMult));
+  const baseGoldMax = Math.max(baseGoldMin, Math.round(mobGoldMaxAtLevel(tier, level) * goldMult));
+
   const make = (authored: number | undefined, tierDefault: number): MobStatValue => ({
     effective: authored ?? tierDefault,
     tierDefault,
@@ -70,13 +97,13 @@ export function resolveMobStats(
   });
 
   const stats: ResolvedMobStats = {
-    hp: make(mob.hp, mobHpAtLevel(tier, level)),
-    minDamage: make(mob.minDamage, mobMinDamageAtLevel(tier, level)),
-    maxDamage: make(mob.maxDamage, mobMaxDamageAtLevel(tier, level)),
+    hp: make(mob.hp, baseHp),
+    minDamage: make(mob.minDamage, baseMin),
+    maxDamage: make(mob.maxDamage, baseMax),
     armor: make(mob.armor, tier.baseArmor),
-    xpReward: make(mob.xpReward, mobXpRewardAtLevel(tier, level)),
-    goldMin: make(mob.goldMin, mobGoldMinAtLevel(tier, level)),
-    goldMax: make(mob.goldMax, mobGoldMaxAtLevel(tier, level)),
+    xpReward: make(mob.xpReward, baseXp),
+    goldMin: make(mob.goldMin, baseGoldMin),
+    goldMax: make(mob.goldMax, baseGoldMax),
     anyOverridden: false,
   };
   stats.anyOverridden =

--- a/creator/src/lib/runtimeHandoff.ts
+++ b/creator/src/lib/runtimeHandoff.ts
@@ -102,6 +102,7 @@ export function runWorkspaceValidation(): ValidationSummary {
     knownAchievements,
     config?.mobTiers,
     config?.progression.quests,
+    config?.itemBudget,
   );
 
   if (config) {

--- a/creator/src/lib/saveZone.ts
+++ b/creator/src/lib/saveZone.ts
@@ -31,6 +31,7 @@ export function serializeZone(zoneId: string): string {
     knownAchievements,
     config?.mobTiers,
     config?.progression.quests,
+    config?.itemBudget,
   );
   const errors = issues.filter((issue) => issue.severity === "error");
   if (errors.length > 0) {

--- a/creator/src/lib/tuning/__tests__/presets.test.ts
+++ b/creator/src/lib/tuning/__tests__/presets.test.ts
@@ -7,6 +7,7 @@ import { applyTemplate } from "@/lib/templates";
 import { validateConfig } from "@/lib/validateConfig";
 import { computeMetrics } from "@/lib/tuning/formulas";
 import type { AppConfig } from "@/types/config";
+import { DEFAULT_ITEM_BUDGET } from "@/types/config";
 
 // ─── Full Mock Config ───────────────────────────────────────────────
 // A complete AppConfig that passes validateConfig with zero errors.
@@ -49,6 +50,7 @@ const FULL_MOCK_CONFIG: AppConfig = {
     boss: { baseHp: 50, hpPerLevel: 10, baseMinDamage: 3, baseMaxDamage: 8, damagePerLevel: 2, baseArmor: 3, baseXpReward: 200, xpRewardPerLevel: 50, baseGoldMin: 50, baseGoldMax: 100, goldPerLevel: 15 },
   },
   mobActionDelay: { minActionDelayMillis: 2000, maxActionDelayMillis: 5000 },
+  itemBudget: DEFAULT_ITEM_BUDGET,
   progression: {
     maxLevel: 50,
     xp: { baseXp: 100, exponent: 2.0, linearXp: 0, multiplier: 1.0, defaultKillXp: 10 },
@@ -193,6 +195,10 @@ describe("preset structure", () => {
     expect(BALANCED_PRESET.config.dailyQuests?.enabled).toBe(true);
     expect(BALANCED_PRESET.config.globalQuests?.enabled).toBe(true);
     expect(BALANCED_PRESET.config.guild?.maxSize).toBe(30);
+  });
+
+  it("Balanced itemBudget overlay mirrors DEFAULT_ITEM_BUDGET exactly", () => {
+    expect(BALANCED_PRESET.config.itemBudget).toEqual(DEFAULT_ITEM_BUDGET);
   });
 });
 

--- a/creator/src/lib/tuning/presets.ts
+++ b/creator/src/lib/tuning/presets.ts
@@ -423,6 +423,38 @@ export const BALANCED_PRESET: TuningPreset = {
       maxActionDelayMillis: 8000,
     },
 
+    // ─── Item Budget ─────────────────────────────────────────────────
+    // Must match DEFAULT_ITEM_BUDGET in @/types/config — keep in sync.
+    itemBudget: {
+      enabled: true,
+      warnOnly: true,
+      tolerance: 0.05,
+      pointsPerLevel: 2.0,
+      damagePointCost: 5.0,
+      armorPointCost: 2.0,
+      statPointCost: 1.0,
+      slotBaseBudget: {
+        weapon: 6,
+        head: 3,
+        body: 5,
+        hand: 3,
+        feet: 3,
+        neck: 3,
+        wrist: 2,
+        finger: 2,
+        ranged: 5,
+        shield: 4,
+      },
+      rarityMultiplier: {
+        common: 1.0,
+        uncommon: 1.25,
+        rare: 1.5,
+        epic: 2.0,
+        legendary: 2.5,
+      },
+      defaultRarity: "common",
+    },
+
     // ─── Stat Bindings ───────────────────────────────────────────────
     stats: {
       bindings: {

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -9,7 +9,7 @@ import type {
   RecipeFile,
 } from "@/types/world";
 import { ITEM_TYPES } from "@/types/world";
-import type { EquipmentSlotDefinition, MobTiersConfig } from "@/types/config";
+import type { EquipmentSlotDefinition, ItemBudgetConfig, MobTiersConfig } from "@/types/config";
 import { resolveDoorKeyId, resolveDoorState } from "./doorHelpers";
 import { mobMaxDamageAtLevel, mobMinDamageAtLevel } from "./tuning/formulas";
 import { computeZoneRebalance } from "./zoneRebalance";
@@ -17,6 +17,7 @@ import { exitTarget } from "./zoneEdits";
 import { getTrainerClasses } from "./trainers";
 import { resolveMobStats } from "./resolveMobStats";
 import { resolveQuestXp } from "./resolveQuestXp";
+import { evaluateItemBudget, summarizeItemBudget } from "./itemBudget";
 import type { QuestXpConfig } from "@/types/config";
 
 /**
@@ -424,6 +425,7 @@ export function validateZone(
   knownAchievements?: ReadonlySet<string>,
   mobTiers?: MobTiersConfig,
   questXpConfig?: QuestXpConfig,
+  itemBudget?: ItemBudgetConfig,
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const roomIds = new Set(Object.keys(world.rooms));
@@ -650,6 +652,17 @@ export function validateZone(
         }
       }
     }
+
+    const multCheck = (label: "hpMult" | "dmgMult" | "xpMult" | "goldMult", value: number | undefined) => {
+      if (value == null) return;
+      if (!Number.isFinite(value) || value <= 0 || value > 10) {
+        addIssue(issues, "error", entity, `${label} must be a finite number in (0, 10] — got ${value}`);
+      }
+    };
+    multCheck("hpMult", mob.hpMult);
+    multCheck("dmgMult", mob.dmgMult);
+    multCheck("xpMult", mob.xpMult);
+    multCheck("goldMult", mob.goldMult);
   }
 
   if (
@@ -691,6 +704,16 @@ export function validateZone(
         entity,
         `itemType "${item.itemType}" is not a known type. Valid: ${ITEM_TYPES.join(", ")}`,
       );
+    }
+    if (itemBudget) {
+      try {
+        const evaluation = evaluateItemBudget(itemId, item, itemBudget);
+        if (evaluation && evaluation.overBudget) {
+          addIssue(issues, "warning", entity, summarizeItemBudget(evaluation));
+        }
+      } catch (err) {
+        addIssue(issues, "error", entity, err instanceof Error ? err.message : String(err));
+      }
     }
   }
 
@@ -891,10 +914,11 @@ export function validateAllZones(
   knownAchievements?: ReadonlySet<string>,
   mobTiers?: MobTiersConfig,
   questXpConfig?: QuestXpConfig,
+  itemBudget?: ItemBudgetConfig,
 ): Map<string, ValidationIssue[]> {
   const results = new Map<string, ValidationIssue[]>();
   for (const [zoneId, zone] of zones) {
-    const issues = validateZone(zone.data, equipmentSlots, validClasses, knownFactions, knownAchievements, mobTiers, questXpConfig);
+    const issues = validateZone(zone.data, equipmentSlots, validClasses, knownFactions, knownAchievements, mobTiers, questXpConfig, itemBudget);
     if (issues.length > 0) {
       results.set(zoneId, issues);
     }

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -217,6 +217,68 @@ export interface MobActionDelayConfig {
   maxActionDelayMillis: number;
 }
 
+// ─── Item Power Budget ──────────────────────────────────────────────
+
+/**
+ * Power-budget rules for equippable items. Mirrors `dev.ambon.config.ItemBudgetConfig`
+ * on the AmbonMUD server. Validation is opt-in per item: items without a `level:`
+ * or `rarity:` are treated as legacy and skipped.
+ *
+ * Budget formula:
+ *   `budget = (slotBaseBudget[slot] + level * pointsPerLevel) * rarityMultiplier[rarity]`
+ *
+ * Spent points:
+ *   `spent = damage * damagePointCost + armor * armorPointCost + sum(stats.values) * statPointCost`
+ *
+ * An item is flagged when `spent > budget * (1 + tolerance)`.
+ */
+export interface ItemBudgetConfig {
+  enabled: boolean;
+  /** When true, over-budget items log a warning. When false, they fail the world load. */
+  warnOnly: boolean;
+  /** Tolerance above budget before a violation is reported (0.05 = 5% slack). */
+  tolerance: number;
+  pointsPerLevel: number;
+  damagePointCost: number;
+  armorPointCost: number;
+  statPointCost: number;
+  slotBaseBudget: Record<string, number>;
+  rarityMultiplier: Record<string, number>;
+  /** Rarity assumed when an item declares a level but no rarity. */
+  defaultRarity: string;
+}
+
+/** Built-in defaults, matched to the Kotlin `ItemBudgetConfig` defaults. */
+export const DEFAULT_ITEM_BUDGET: ItemBudgetConfig = {
+  enabled: true,
+  warnOnly: true,
+  tolerance: 0.05,
+  pointsPerLevel: 2.0,
+  damagePointCost: 5.0,
+  armorPointCost: 2.0,
+  statPointCost: 1.0,
+  slotBaseBudget: {
+    weapon: 6,
+    head: 3,
+    body: 5,
+    hand: 3,
+    feet: 3,
+    neck: 3,
+    wrist: 2,
+    finger: 2,
+    ranged: 5,
+    shield: 4,
+  },
+  rarityMultiplier: {
+    common: 1.0,
+    uncommon: 1.25,
+    rare: 1.5,
+    epic: 2.0,
+    legendary: 2.5,
+  },
+  defaultRarity: "common",
+};
+
 // ─── Progression ────────────────────────────────────────────────────
 
 export interface DiminishingXpThreshold {
@@ -1194,6 +1256,13 @@ export interface AppConfig {
   globalQuests?: GlobalQuestsConfig;
   guildHalls?: GuildHallsConfig;
   leaderboard?: LeaderboardConfig;
+  /**
+   * Power-budget rules for equippable items. Mirrors `engine.items.budget` on
+   * the AmbonMUD server — when an authored item declares `level:` or `rarity:`,
+   * the validator compares its stat/damage/armor cost to the slot+level+rarity
+   * budget and warns when over.
+   */
+  itemBudget: ItemBudgetConfig;
   globalAssets: Record<string, string>;
   defaultAssets: Record<string, string>;
   persistence: PersistenceConfig;

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -183,6 +183,16 @@ export interface MobFile {
   tier?: string;
   level?: number;
   category?: string;
+  /**
+   * Multiplicative tuning knobs applied to tier×level baselines *before* any
+   * absolute override below. Use to express relative tuning ("hits ~20% harder
+   * than baseline") without typing raw numbers. Each must be in (0, 10]; the
+   * server rejects values outside that range. Default 1.0 (no change).
+   */
+  hpMult?: number;
+  dmgMult?: number;
+  xpMult?: number;
+  goldMult?: number;
   hp?: number;
   minDamage?: number;
   maxDamage?: number;
@@ -271,6 +281,20 @@ export const ITEM_TYPES: readonly ItemType[] = [
   "misc",
 ] as const;
 
+/**
+ * Rarity tier for item power-budget tuning. Multiplies the slot+level budget;
+ * see {@link ItemBudgetConfig} for the default scale.
+ */
+export type ItemRarity = "common" | "uncommon" | "rare" | "epic" | "legendary";
+
+export const ITEM_RARITIES: readonly ItemRarity[] = [
+  "common",
+  "uncommon",
+  "rare",
+  "epic",
+  "legendary",
+] as const;
+
 export interface ItemFile {
   displayName: string;
   description?: string;
@@ -298,6 +322,17 @@ export interface ItemFile {
    * stored in containers. Always resolves to the "quest" category server-side.
    */
   questItem?: boolean;
+  /**
+   * Intended item level. Setting this (or {@link rarity}) opts the item into
+   * the server's power-budget validator (see {@link ItemBudgetConfig}). Items
+   * without a level are treated as legacy and skipped by the validator.
+   */
+  level?: number;
+  /**
+   * Rarity tier. Multiplies the slot+level budget. Defaults to `common` on the
+   * server when only {@link level} is set.
+   */
+  rarity?: ItemRarity;
 }
 
 export interface ItemOnUse {


### PR DESCRIPTION
## Summary

Mirrors the new AmbonMUD content-tuning surfaces (per [`docs/ARCANUM_TUNING_SYNC.md`](https://github.com/anthropics/ambonmud/blob/main/docs/ARCANUM_TUNING_SYNC.md) on the MUD side) in Arcanum's authoring UI and config plumbing.

### Mob stat multipliers
- `MobFile.hpMult / dmgMult / xpMult / goldMult` (optional, in (0, 10]) scale tier × level baselines before any absolute override.
- Mob editor gains a **Stat Multipliers** section (collapsed by default) with four `NumberInput`s and inline range validation.
- `resolveMobStats` applies the same `baseline → multiplier → absolute override` order as the server's [`ResolvedMobStats.kt`](https://github.com/anthropics/ambonmud/blob/main/src/main/kotlin/dev/ambon/domain/world/ResolvedMobStats.kt). The existing tier-default hints in the override section automatically pick up the multiplied value.
- `validateZone` flags non-finite or out-of-range multipliers as errors (blocks save).

### Item power budget
- `ItemFile.level` + `ItemFile.rarity` opt items into the new check.
- New `lib/itemBudget.ts` ports `evaluateItemBudget` from Kotlin: skip when legacy, throw on unknown slot/rarity, return `{spent, budget, overBudget, breakdown[]}`.
- `validateZone` surfaces over-budget items as warnings and unknown slot/rarity as errors. `saveZone` + `runtimeHandoff` thread `config.itemBudget` into the validator.
- Item editor gains a **Power Budget** section (level + rarity inputs) with a live spent/budget readout that turns warm-colored when over.

### Config + tuning preset
- `AppConfig` gains a required `itemBudget: ItemBudgetConfig` field; `DEFAULT_ITEM_BUDGET` matches the Kotlin defaults verbatim.
- Loader parses `engine.items.budget` from both the monolithic and standalone formats, with shallow-merge for `slotBaseBudget` / `rarityMultiplier`.
- `BALANCED_PRESET` gains a matching `itemBudget` overlay — the doc names Balanced as the cross-repo anchor.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun run test` — 1889 / 1889 tests pass (12 new across `itemBudget`, `resolveMobStats`, `validateZone`, `presets`)
- [ ] Manual: load a mob in an open project, set `hpMult: 2.0` at level 5, confirm Stat Overrides shows the doubled HP placeholder
- [ ] Manual: load an item with `slot: weapon, damage: 4, level: 1, rarity: common`, confirm the Power Budget readout shows over-budget + the validator emits a warning