### PR TITLE
Adaptive item stats (PRIMARY/SECONDARY/TERTIARY)

### DIFF
--- a/creator/src/components/config/classes/ClassEditor.tsx
+++ b/creator/src/components/config/classes/ClassEditor.tsx
@@ -377,19 +377,84 @@ function RoleIdentityCard({
   statOptions: { value: string; label: string }[];
   onPatch: (p: Partial<ClassDefinitionConfig>) => void;
 }) {
+  // Source of truth for the three priority slots: prefer the new
+  // `statPriorities` array, fall back to legacy `primaryStat` for slot 0.
+  const priorities = cls.statPriorities ?? [];
+  const primary = priorities[0] ?? cls.primaryStat ?? "";
+  const secondary = priorities[1] ?? "";
+  const tertiary = priorities[2] ?? "";
+
+  function setPriority(index: 0 | 1 | 2, value: string) {
+    const next = [primary, secondary, tertiary];
+    next[index] = value;
+    // Clearing primary clears everything below it — keeps the array
+    // contiguous so the server-side resolve doesn't see a hole at [0].
+    if (index === 0 && !value) {
+      next[1] = "";
+      next[2] = "";
+    } else if (index === 1 && !value) {
+      next[2] = "";
+    }
+    // Trim trailing empties and drop the array entirely when empty.
+    const trimmed: string[] = [];
+    for (const slot of next) {
+      if (slot) trimmed.push(slot);
+      else break;
+    }
+    const patch: Partial<ClassDefinitionConfig> = {
+      statPriorities: trimmed.length > 0 ? trimmed : undefined,
+    };
+    if (index === 0) {
+      // Keep legacy primaryStat in sync with statPriorities[0] so older
+      // call sites (article scaffolding, etc.) stay coherent.
+      patch.primaryStat = value || undefined;
+    }
+    onPatch(patch);
+  }
+
   return (
     <SectionCard title="Role Identity">
       <div className="grid grid-cols-1 gap-3">
         <FieldLabel
           label="Primary Stat"
-          hint="Influences UI hints and may scale class abilities."
+          hint="Resolves PRIMARY on adaptive items and drives ability scaling."
         >
           <SelectInput
-            value={cls.primaryStat ?? ""}
+            value={primary}
             options={statOptions}
-            onCommit={(v) => onPatch({ primaryStat: v || undefined })}
+            onCommit={(v) => setPriority(0, v)}
             allowEmpty
             placeholder="— none —"
+            dense
+          />
+        </FieldLabel>
+
+        <FieldLabel
+          label="Secondary Stat"
+          hint="Resolves SECONDARY on adaptive items. Disabled until Primary is set."
+        >
+          <SelectInput
+            value={secondary}
+            options={statOptions}
+            onCommit={(v) => setPriority(1, v)}
+            allowEmpty
+            placeholder={primary ? "— none —" : "set Primary first"}
+            disabled={!primary}
+            dense
+          />
+        </FieldLabel>
+
+        <FieldLabel
+          label="Tertiary Stat"
+          hint="Resolves TERTIARY on adaptive items. Disabled until Secondary is set."
+        >
+          <SelectInput
+            value={tertiary}
+            options={statOptions}
+            onCommit={(v) => setPriority(2, v)}
+            allowEmpty
+            placeholder={secondary ? "— none —" : "set Secondary first"}
+            disabled={!secondary}
             dense
           />
         </FieldLabel>

--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -117,6 +117,7 @@ export function ItemEditor({
       primaryStat: item.primaryStat,
       secondaryStat: item.secondaryStat,
       tertiaryStat: item.tertiaryStat,
+      disableTertiary: item.disableTertiary,
     });
   }, [item]);
 
@@ -297,9 +298,18 @@ export function ItemEditor({
                 </CompactField>
                 <CompactField label="Tertiary Override" span>
                   <SelectInput
-                    value={item.tertiaryStat ?? ""}
-                    options={statOptions}
-                    onCommit={(v) => patch({ tertiaryStat: v || undefined })}
+                    value={item.disableTertiary ? "__none__" : (item.tertiaryStat ?? "")}
+                    options={[
+                      { value: "__none__", label: "— skip tertiary (60/40 split) —" },
+                      ...statOptions,
+                    ]}
+                    onCommit={(v) => {
+                      if (v === "__none__") {
+                        patch({ tertiaryStat: undefined, disableTertiary: true });
+                      } else {
+                        patch({ tertiaryStat: v || undefined, disableTertiary: undefined });
+                      }
+                    }}
                     allowEmpty
                     placeholder="TERTIARY (adaptive)"
                     dense

--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -175,6 +175,18 @@ export function ItemEditor({
     [onUse, patch],
   );
 
+  const [justApplied, setJustApplied] = useState(false);
+  const handleApplyDerivation = useCallback(() => {
+    if (!derivation) return;
+    patch({
+      damage: derivation.damage > 0 ? derivation.damage : undefined,
+      armor: derivation.armor > 0 ? derivation.armor : undefined,
+      stats: Object.keys(derivation.stats).length > 0 ? derivation.stats : undefined,
+    });
+    setJustApplied(true);
+    setTimeout(() => setJustApplied(false), 1500);
+  }, [derivation, patch]);
+
   return (
     <>
       <EntityHeader type="Item">
@@ -218,10 +230,20 @@ export function ItemEditor({
         <>
           <Section title="Power">
             <p className="mb-1 text-2xs text-text-muted">
-              Pick the item's level, rarity, and role. Arcanum derives damage, armor, and stat values from these — edit a derived field below to mark it as an override.
+              Set slot, level, rarity, and role. The calculator suggests damage, armor, and stat bonuses below — click <strong>Apply</strong> to write them onto the item. Override dropdowns left blank produce adaptive stats (PRIMARY/SECONDARY/TERTIARY) that resolve per class at equip time.
             </p>
             <div className="flex flex-col gap-1.5">
               <FieldGrid cols={2}>
+                <CompactField label="Slot" span>
+                  <SelectInput
+                    value={item.slot ?? ""}
+                    options={slotOptions}
+                    onCommit={(v) => patch({ slot: v || undefined })}
+                    allowEmpty
+                    placeholder="— none —"
+                    dense
+                  />
+                </CompactField>
                 <CompactField label="Level">
                   <NumberInput
                     value={item.level}
@@ -253,62 +275,79 @@ export function ItemEditor({
                     dense
                   />
                 </CompactField>
-                <CompactField label="Primary Stat">
+                <CompactField label="Primary Override">
                   <SelectInput
                     value={item.primaryStat ?? ""}
                     options={statOptions}
                     onCommit={(v) => patch({ primaryStat: v || undefined })}
                     allowEmpty
-                    placeholder="—"
+                    placeholder="PRIMARY (adaptive)"
                     dense
                   />
                 </CompactField>
-                <CompactField label="Secondary Stat">
+                <CompactField label="Secondary Override">
                   <SelectInput
                     value={item.secondaryStat ?? ""}
                     options={statOptions}
                     onCommit={(v) => patch({ secondaryStat: v || undefined })}
                     allowEmpty
-                    placeholder="—"
+                    placeholder="SECONDARY (adaptive)"
                     dense
                   />
                 </CompactField>
-                <CompactField label="Tertiary Stat" span>
+                <CompactField label="Tertiary Override" span>
                   <SelectInput
                     value={item.tertiaryStat ?? ""}
                     options={statOptions}
                     onCommit={(v) => patch({ tertiaryStat: v || undefined })}
                     allowEmpty
-                    placeholder="—"
+                    placeholder="TERTIARY (adaptive)"
                     dense
                   />
                 </CompactField>
               </FieldGrid>
               {derivation && (
                 <div className="rounded border border-border-default bg-bg-tertiary px-2 py-1.5 text-2xs">
-                  <div className="font-medium text-text-primary">
-                    Budget: {Math.round(derivation.budget.totalBudget)}
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium text-text-primary">
+                      Budget: {Math.round(derivation.budget.totalBudget)} pts
+                    </span>
+                    <div className="flex items-center gap-2">
+                      {justApplied && (
+                        <span className="text-2xs text-status-success">Applied ✓</span>
+                      )}
+                      <button
+                        type="button"
+                        onClick={handleApplyDerivation}
+                        className="rounded border border-accent/40 bg-accent/10 px-2 py-0.5 text-2xs font-medium text-accent transition-colors hover:bg-accent/20"
+                        title="Overwrites Damage, Armor, and Stat Bonuses with the values shown below."
+                      >
+                        Apply
+                      </button>
+                    </div>
                   </div>
-                  <div className="text-text-muted">
-                    {derivation.budget.damageBudget > 0 && (
-                      <span>{Math.round(derivation.budget.damageBudget)} dmg</span>
+                  <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5 text-text-muted">
+                    {derivation.damage > 0 && (
+                      <span>
+                        <span className="text-text-primary">+{derivation.damage}</span> damage
+                      </span>
                     )}
-                    {derivation.budget.damageBudget > 0 && derivation.budget.armorBudget > 0 && " · "}
-                    {derivation.budget.armorBudget > 0 && (
-                      <span>{Math.round(derivation.budget.armorBudget)} armor</span>
+                    {derivation.armor > 0 && (
+                      <span>
+                        <span className="text-text-primary">+{derivation.armor}</span> armor
+                      </span>
                     )}
-                    {(derivation.budget.damageBudget > 0 || derivation.budget.armorBudget > 0) &&
-                      derivation.budget.statBudget > 0 &&
-                      " · "}
-                    {derivation.budget.statBudget > 0 && (
-                      <span>{Math.round(derivation.budget.statBudget)} stat</span>
-                    )}
+                    {Object.entries(derivation.stats).map(([id, v]) => (
+                      <span key={id}>
+                        <span className="text-text-primary">+{v}</span> {id}
+                      </span>
+                    ))}
                   </div>
                 </div>
               )}
               {!derivation && (item.slot || item.level != null || item.tier || item.archetype) && (
                 <div className="rounded border border-dashed border-border-default bg-bg-tertiary px-2 py-1 text-2xs text-text-muted">
-                  Set slot, level, tier, and archetype to enable derivation.
+                  Set slot, level, tier, and archetype to enable the calculator.
                 </div>
               )}
             </div>
@@ -356,47 +395,13 @@ export function ItemEditor({
                   label="Soulbound — cannot be dropped, sold, traded, or given"
                 />
               </FieldRow>
-            </div>
-          </Section>
-
-          <Section title="Properties">
-            <div className="flex flex-col gap-1.5">
-              <FieldGrid cols={2}>
-                <CompactField label="Slot" span>
-                  <SelectInput
-                    value={item.slot ?? ""}
-                    options={slotOptions}
-                    onCommit={(v) => patch({ slot: v || undefined })}
-                    allowEmpty
-                    placeholder="— none —"
-                    dense
-                  />
-                </CompactField>
-                <CompactField label={renderOverrideLabel("Damage", item.damage, derivation?.damage)}>
-                  <NumberInput
-                    value={item.damage}
-                    onCommit={(v) => patch({ damage: v })}
-                    placeholder={derivation ? String(derivation.damage) : "0"}
-                    min={0}
-                    dense
-                  />
-                </CompactField>
-                <CompactField label={renderOverrideLabel("Armor", item.armor, derivation?.armor)}>
-                  <NumberInput
-                    value={item.armor}
-                    onCommit={(v) => patch({ armor: v })}
-                    placeholder={derivation ? String(derivation.armor) : "0"}
-                    min={0}
-                    dense
-                  />
-                </CompactField>
-              </FieldGrid>
-              <hr className="my-2 border-border-muted" />
-              <CheckboxInput
-                checked={item.consumable ?? false}
-                onCommit={(v) => patch({ consumable: v || undefined })}
-                label="Is consumable"
-              />
+              <FieldRow label="Consumable">
+                <CheckboxInput
+                  checked={item.consumable ?? false}
+                  onCommit={(v) => patch({ consumable: v || undefined })}
+                  label="Used up on use (potion, scroll, food)"
+                />
+              </FieldRow>
               {item.consumable && (
                 <FieldGrid cols={2}>
                   <CompactField label="Charges" span>
@@ -437,6 +442,34 @@ export function ItemEditor({
                   </CompactField>
                 </FieldGrid>
               )}
+            </div>
+          </Section>
+
+          <Section title="Properties">
+            <p className="mb-1 text-2xs text-text-muted">
+              The actual numbers the server reads. Use Power's Apply button to populate from the calculator, or edit directly to author by hand.
+            </p>
+            <div className="flex flex-col gap-1.5">
+              <FieldGrid cols={2}>
+                <CompactField label={renderOverrideLabel("Damage", item.damage, derivation?.damage)}>
+                  <NumberInput
+                    value={item.damage}
+                    onCommit={(v) => patch({ damage: v })}
+                    placeholder={derivation ? String(derivation.damage) : "0"}
+                    min={0}
+                    dense
+                  />
+                </CompactField>
+                <CompactField label={renderOverrideLabel("Armor", item.armor, derivation?.armor)}>
+                  <NumberInput
+                    value={item.armor}
+                    onCommit={(v) => patch({ armor: v })}
+                    placeholder={derivation ? String(derivation.armor) : "0"}
+                    min={0}
+                    dense
+                  />
+                </CompactField>
+              </FieldGrid>
             </div>
           </Section>
 

--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState, useMemo, memo } from "react";
 import type { WorldFile, ItemFile, ItemOnUse, ItemType } from "@/types/world";
-import { ITEM_TYPES } from "@/types/world";
+import { ITEM_TYPES, ARCHETYPAL_STATS } from "@/types/world";
 import { updateItem, deleteItem } from "@/lib/zoneEdits";
 import { useEntityEditor } from "@/lib/useEntityEditor";
 import { useConfigOptions } from "@/lib/useConfigOptions";
@@ -489,6 +489,7 @@ export function ItemEditor({
               })()}
               <AddStatRow
                 existingStats={Object.keys(stats)}
+                statOptions={statOptions}
                 onAdd={(statId) => handleStatChange(statId, 1)}
               />
             </div>
@@ -517,58 +518,78 @@ export function ItemEditor({
 
 const AddStatRow = memo(function AddStatRow({
   existingStats,
+  statOptions,
   onAdd,
 }: {
   existingStats: string[];
+  statOptions: { value: string; label: string }[];
   onAdd: (statId: string) => void;
 }) {
   const [editing, setEditing] = useState(false);
-  const [value, setValue] = useState("");
-
-  const handleSubmit = () => {
-    const id = value.trim().toUpperCase();
-    if (id && !existingStats.includes(id)) {
-      onAdd(id);
-    }
-    setValue("");
-    setEditing(false);
-  };
+  const existingSet = useMemo(() => new Set(existingStats), [existingStats]);
+  const archetypalAvailable = useMemo(
+    () => ARCHETYPAL_STATS.filter((s) => !existingSet.has(s)),
+    [existingSet],
+  );
+  const concreteAvailable = useMemo(
+    () => statOptions.filter((o) => !existingSet.has(o.value)),
+    [statOptions, existingSet],
+  );
+  const hasOptions = archetypalAvailable.length > 0 || concreteAvailable.length > 0;
 
   if (editing) {
     return (
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          handleSubmit();
-        }}
-        className="mt-1 flex items-center gap-1"
-      >
-        <input
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          placeholder="e.g. STR, DEX"
+      <div className="mt-1 flex items-center gap-1">
+        <select
           autoFocus
-          className="h-5 flex-1 rounded border border-border-default bg-bg-primary px-1.5 text-2xs text-text-primary outline-none focus:border-accent focus-visible:ring-2 focus-visible:ring-border-active"
-          onBlur={handleSubmit}
-        />
-        <button
-          type="button"
-          onClick={() => {
-            setValue("");
+          defaultValue=""
+          onChange={(e) => {
+            const id = e.target.value;
+            if (id) onAdd(id);
             setEditing(false);
           }}
+          onBlur={() => setEditing(false)}
+          className="h-6 flex-1 rounded border border-border-default bg-bg-primary px-1.5 text-2xs text-text-primary outline-none focus:border-accent focus-visible:ring-2 focus-visible:ring-border-active"
+        >
+          <option value="" disabled>
+            Pick a stat…
+          </option>
+          {archetypalAvailable.length > 0 && (
+            <optgroup label="Adaptive (resolves per class)">
+              {archetypalAvailable.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </optgroup>
+          )}
+          {concreteAvailable.length > 0 && (
+            <optgroup label="Concrete">
+              {concreteAvailable.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </optgroup>
+          )}
+        </select>
+        <button
+          type="button"
+          onClick={() => setEditing(false)}
           className="text-2xs text-text-muted hover:text-text-primary"
         >
           &times;
         </button>
-      </form>
+      </div>
     );
   }
 
   return (
     <button
+      type="button"
       onClick={() => setEditing(true)}
-      className="mt-1 rounded border border-border-default px-2 py-0.5 text-2xs text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text-primary"
+      disabled={!hasOptions}
+      className="mt-1 rounded border border-border-default px-2 py-0.5 text-2xs text-text-muted transition-colors hover:bg-bg-tertiary hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-text-muted"
     >
       + Add Stat Bonus
     </button>

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -777,6 +777,9 @@ export function classToPlain(cls: AppConfig["classes"][string]): Record<string, 
   if (cls.description) obj.description = cls.description;
   if (cls.backstory) obj.backstory = cls.backstory;
   if (cls.primaryStat) obj.primaryStat = cls.primaryStat;
+  if (cls.statPriorities && cls.statPriorities.length > 0) {
+    obj.statPriorities = cls.statPriorities;
+  }
   if (cls.selectable != null) obj.selectable = cls.selectable;
   if (cls.startRoom) obj.startRoom = cls.startRoom;
   if (cls.threatMultiplier != null) obj.threatMultiplier = cls.threatMultiplier;

--- a/creator/src/lib/runtimeHandoff.ts
+++ b/creator/src/lib/runtimeHandoff.ts
@@ -94,6 +94,13 @@ export function runWorkspaceValidation(): ValidationSummary {
   const knownAchievements = config?.achievementDefs
     ? new Set(Object.keys(config.achievementDefs))
     : undefined;
+  const classStatPriorities = config?.classes
+    ? Object.fromEntries(
+        Object.entries(config.classes)
+          .filter(([, cls]) => cls.statPriorities && cls.statPriorities.length > 0)
+          .map(([id, cls]) => [id, cls.statPriorities!]),
+      )
+    : undefined;
   const results = validateAllZones(
     zones,
     config?.equipmentSlots,
@@ -102,6 +109,7 @@ export function runWorkspaceValidation(): ValidationSummary {
     knownAchievements,
     config?.mobTiers,
     config?.progression.quests,
+    classStatPriorities,
   );
 
   if (config) {

--- a/creator/src/lib/saveZone.ts
+++ b/creator/src/lib/saveZone.ts
@@ -23,6 +23,13 @@ export function serializeZone(zoneId: string): string {
   const knownAchievements = config?.achievementDefs
     ? new Set(Object.keys(config.achievementDefs))
     : undefined;
+  const classStatPriorities = config?.classes
+    ? Object.fromEntries(
+        Object.entries(config.classes)
+          .filter(([, cls]) => cls.statPriorities && cls.statPriorities.length > 0)
+          .map(([id, cls]) => [id, cls.statPriorities!]),
+      )
+    : undefined;
   const issues = validateZone(
     sanitized,
     config?.equipmentSlots,
@@ -31,6 +38,7 @@ export function serializeZone(zoneId: string): string {
     knownAchievements,
     config?.mobTiers,
     config?.progression.quests,
+    classStatPriorities,
   );
   const errors = issues.filter((issue) => issue.severity === "error");
   if (errors.length > 0) {

--- a/creator/src/lib/tuning/__tests__/itemBudget.test.ts
+++ b/creator/src/lib/tuning/__tests__/itemBudget.test.ts
@@ -179,6 +179,22 @@ describe("distributeStats", () => {
     // All three slots → same key: (50 + 30 + 20) / 5 = 20
     expect(out.STR).toBe(20);
   });
+
+  it("disableTertiary drops tertiary and uses a 60/40 split", () => {
+    const out = distributeStats(100, undefined, undefined, undefined, undefined, true);
+    expect(out.PRIMARY).toBe(Math.round(60 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.SECONDARY).toBe(Math.round(40 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.TERTIARY).toBeUndefined();
+  });
+
+  it("disableTertiary respects primary/secondary overrides", () => {
+    const out = distributeStats(100, "STR", "DEX", "ignored", undefined, true);
+    expect(out.STR).toBe(Math.round(60 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.DEX).toBe(Math.round(40 / DEFAULT_POINT_COSTS.statPointCost));
+    // tertiary slot is dropped — the "ignored" override has no effect.
+    expect(out.ignored).toBeUndefined();
+    expect(out.TERTIARY).toBeUndefined();
+  });
 });
 
 describe("deriveItemStats", () => {

--- a/creator/src/lib/tuning/__tests__/itemBudget.test.ts
+++ b/creator/src/lib/tuning/__tests__/itemBudget.test.ts
@@ -122,26 +122,43 @@ describe("splitItemBudget", () => {
 });
 
 describe("distributeStats", () => {
-  it("returns empty map when no stats picked", () => {
-    expect(distributeStats(100)).toEqual({});
+  it("defaults all three slots to archetypal keys when no overrides given", () => {
+    const out = distributeStats(100);
+    expect(out.PRIMARY).toBe(Math.round(50 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.SECONDARY).toBe(Math.round(30 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.TERTIARY).toBe(Math.round(20 / DEFAULT_POINT_COSTS.statPointCost));
   });
 
-  it("puts 100% into primary when only one stat is picked", () => {
+  it("primary override pins slot 0 to a concrete stat, leaves others adaptive", () => {
     const out = distributeStats(100, "STR");
-    expect(out).toEqual({ STR: Math.round(100 / DEFAULT_POINT_COSTS.statPointCost) });
+    expect(out.STR).toBe(Math.round(50 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.SECONDARY).toBe(Math.round(30 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.TERTIARY).toBe(Math.round(20 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.PRIMARY).toBeUndefined();
   });
 
-  it("splits 60/40 across primary/secondary", () => {
+  it("two overrides leave only tertiary adaptive", () => {
     const out = distributeStats(100, "STR", "DEX");
-    expect(out.STR).toBe(Math.round(60 / DEFAULT_POINT_COSTS.statPointCost));
-    expect(out.DEX).toBe(Math.round(40 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.STR).toBe(Math.round(50 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.DEX).toBe(Math.round(30 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.TERTIARY).toBe(Math.round(20 / DEFAULT_POINT_COSTS.statPointCost));
   });
 
-  it("splits 50/30/20 across all three", () => {
+  it("all three overrides produce a fully concrete distribution", () => {
     const out = distributeStats(100, "STR", "DEX", "CON");
     expect(out.STR).toBe(Math.round(50 / DEFAULT_POINT_COSTS.statPointCost));
     expect(out.DEX).toBe(Math.round(30 / DEFAULT_POINT_COSTS.statPointCost));
     expect(out.CON).toBe(Math.round(20 / DEFAULT_POINT_COSTS.statPointCost));
+    expect(out.PRIMARY).toBeUndefined();
+    expect(out.SECONDARY).toBeUndefined();
+    expect(out.TERTIARY).toBeUndefined();
+  });
+
+  it("weights are fixed regardless of override count", () => {
+    // 1 override: same primary weight as 3 overrides.
+    const one = distributeStats(100, "STR");
+    const three = distributeStats(100, "STR", "DEX", "CON");
+    expect(one.STR).toBe(three.STR);
   });
 
   it("returns empty when statBudget is zero", () => {
@@ -150,7 +167,17 @@ describe("distributeStats", () => {
 
   it("respects custom statPointCost", () => {
     const out = distributeStats(100, "STR", undefined, undefined, 10);
-    expect(out).toEqual({ STR: 10 });
+    // 50% * 100 / 10 = 5 for the primary override
+    expect(out.STR).toBe(5);
+    // SECONDARY / TERTIARY also recomputed against the custom cost
+    expect(out.SECONDARY).toBe(3);
+    expect(out.TERTIARY).toBe(2);
+  });
+
+  it("stacks when the same stat ID is used in multiple slots", () => {
+    const out = distributeStats(100, "STR", "STR", "STR");
+    // All three slots → same key: (50 + 30 + 20) / 5 = 20
+    expect(out.STR).toBe(20);
   });
 });
 
@@ -189,8 +216,13 @@ describe("deriveItemStats", () => {
     expect(out.effectiveArchetype).toBe("stat");
     expect(out.damage).toBe(0);
     expect(out.armor).toBe(0);
-    // Ring common: base 40 × 1 = 40, all stat → INT = 40/5 = 8
-    expect(out.stats.INT).toBe(8);
+    // Ring common: base 40 × 1 = 40, all stat
+    //   INT = 50% × 40 / 5 = 4 (primary override)
+    //   SECONDARY = 30% × 40 / 5 ≈ 2
+    //   TERTIARY  = 20% × 40 / 5 ≈ 2
+    expect(out.stats.INT).toBe(4);
+    expect(out.stats.SECONDARY).toBe(2);
+    expect(out.stats.TERTIARY).toBe(2);
   });
 
   it("balanced shield writes both damage and armor", () => {
@@ -203,20 +235,31 @@ describe("deriveItemStats", () => {
     // Shield base 70 × 1 = 70
     // Damage 30% × 70 / 20 = 1.05 → 1
     // Armor  30% × 70 / 10 = 2.1 → 2
-    // Stats  40% × 70 / 5  = 5.6 → 6 (single stat = 100%)
+    // Stats  40% × 70 = 28 stat budget:
+    //   CON       = 50% × 28 / 5 ≈ 3 (primary override)
+    //   SECONDARY = 30% × 28 / 5 ≈ 2
+    //   TERTIARY  = 20% × 28 / 5 ≈ 1
     expect(out.damage).toBe(1);
     expect(out.armor).toBe(2);
-    expect(out.stats.CON).toBe(6);
+    expect(out.stats.CON).toBe(3);
+    expect(out.stats.SECONDARY).toBe(2);
+    expect(out.stats.TERTIARY).toBe(1);
   });
 
-  it("no stats picked yields empty stat map", () => {
+  it("no overrides given yields fully adaptive stat map", () => {
     const out = deriveItemStats({
       slot: "weapon",
       tier: "common",
       archetype: "damage",
     });
-    expect(out.damage).toBe(3); // 60/20 = 3
-    expect(out.stats).toEqual({});
+    // Damage = 60/20 = 3, stat budget = 40
+    //   PRIMARY   = 50% × 40 / 5 = 4
+    //   SECONDARY = 30% × 40 / 5 ≈ 2
+    //   TERTIARY  = 20% × 40 / 5 ≈ 2
+    expect(out.damage).toBe(3);
+    expect(out.stats.PRIMARY).toBe(4);
+    expect(out.stats.SECONDARY).toBe(2);
+    expect(out.stats.TERTIARY).toBe(2);
   });
 
   it("respects custom point costs", () => {
@@ -227,8 +270,15 @@ describe("deriveItemStats", () => {
       primaryStat: "STR",
       pointCosts: { damagePointCost: 10, statPointCost: 2 },
     });
-    expect(out.damage).toBe(6); // 60/10 = 6
-    expect(out.stats.STR).toBe(20); // 40/2 = 20
+    // Damage budget = 60, divided by 10 → 6
+    // Stat budget = 40 with statPointCost=2:
+    //   STR       = 50% × 40 / 2 = 10
+    //   SECONDARY = 30% × 40 / 2 = 6
+    //   TERTIARY  = 20% × 40 / 2 = 4
+    expect(out.damage).toBe(6);
+    expect(out.stats.STR).toBe(10);
+    expect(out.stats.SECONDARY).toBe(6);
+    expect(out.stats.TERTIARY).toBe(4);
   });
 });
 

--- a/creator/src/lib/tuning/itemBudget.ts
+++ b/creator/src/lib/tuning/itemBudget.ts
@@ -208,13 +208,17 @@ export function splitItemBudget(
   };
 }
 
-/** Distribute a stat-budget across 1–3 stat IDs.
+/** Distribute a stat-budget across the three priority slots.
  *
- *  Returns an empty map if no stats are picked or statBudget is 0.
- *  Distribution:
- *    1 stat  → 100% primary
- *    2 stats → 60% primary / 40% secondary
- *    3 stats → 50% primary / 30% secondary / 20% tertiary
+ *  Each slot defaults to its archetypal key (PRIMARY / SECONDARY / TERTIARY)
+ *  which the server resolves per-class at equip time. A builder can override
+ *  any slot with a concrete stat ID to pin that portion of the budget to a
+ *  specific stat (e.g. flavor a "boots of speed" with literal DEX in the
+ *  primary slot while keeping SECONDARY / TERTIARY adaptive).
+ *
+ *  Weights are fixed at 50% primary / 30% secondary / 20% tertiary regardless
+ *  of how many slots are overridden — overrides change *what* a slot resolves
+ *  to, not *how much* of the budget it gets.
  */
 export function distributeStats(
   statBudget: number,
@@ -225,23 +229,17 @@ export function distributeStats(
 ): StatMap {
   if (statBudget <= 0 || statPointCost <= 0) return {};
 
-  const picks: string[] = [];
-  if (primary) picks.push(primary);
-  if (secondary) picks.push(secondary);
-  if (tertiary) picks.push(tertiary);
-  if (picks.length === 0) return {};
-
-  let weights: number[];
-  if (picks.length === 1) weights = [1.0];
-  else if (picks.length === 2) weights = [0.6, 0.4];
-  else weights = [0.5, 0.3, 0.2];
+  const slots: [string, number][] = [
+    [primary || "PRIMARY", 0.5],
+    [secondary || "SECONDARY", 0.3],
+    [tertiary || "TERTIARY", 0.2],
+  ];
 
   const out: StatMap = {};
-  for (let i = 0; i < picks.length; i++) {
-    const id = picks[i]!;
-    const points = Math.round((statBudget * weights[i]!) / statPointCost);
+  for (const [id, weight] of slots) {
+    const points = Math.round((statBudget * weight) / statPointCost);
     if (points > 0) {
-      // Stack if author picked the same stat twice (defensive; UI should prevent).
+      // Stack if the same concrete stat is used for more than one slot.
       out[id] = (out[id] ?? 0) + points;
     }
   }

--- a/creator/src/lib/tuning/itemBudget.ts
+++ b/creator/src/lib/tuning/itemBudget.ts
@@ -137,6 +137,8 @@ export interface ItemDerivationInput {
   primaryStat?: string;
   secondaryStat?: string;
   tertiaryStat?: string;
+  /** When true, drop the tertiary slot — split 60/40 across primary/secondary. */
+  disableTertiary?: boolean;
   /** Optional per-world override map. Falls back to DEFAULT_SLOT_BASE_BUDGETS. */
   slotBudgets?: Record<string, number>;
   /** Optional point-cost overrides. Falls back to DEFAULT_POINT_COSTS. */
@@ -216,9 +218,12 @@ export function splitItemBudget(
  *  specific stat (e.g. flavor a "boots of speed" with literal DEX in the
  *  primary slot while keeping SECONDARY / TERTIARY adaptive).
  *
- *  Weights are fixed at 50% primary / 30% secondary / 20% tertiary regardless
- *  of how many slots are overridden — overrides change *what* a slot resolves
- *  to, not *how much* of the budget it gets.
+ *  Weights are fixed at 50% / 30% / 20% regardless of how many slots are
+ *  overridden — overrides change *what* a slot resolves to, not *how much*
+ *  of the budget it gets.
+ *
+ *  Setting `disableTertiary` drops the tertiary slot and splits the budget
+ *  60/40 across primary/secondary, matching the historical two-stat layout.
  */
 export function distributeStats(
   statBudget: number,
@@ -226,14 +231,20 @@ export function distributeStats(
   secondary?: string,
   tertiary?: string,
   statPointCost: number = DEFAULT_POINT_COSTS.statPointCost,
+  disableTertiary: boolean = false,
 ): StatMap {
   if (statBudget <= 0 || statPointCost <= 0) return {};
 
-  const slots: [string, number][] = [
-    [primary || "PRIMARY", 0.5],
-    [secondary || "SECONDARY", 0.3],
-    [tertiary || "TERTIARY", 0.2],
-  ];
+  const slots: [string, number][] = disableTertiary
+    ? [
+        [primary || "PRIMARY", 0.6],
+        [secondary || "SECONDARY", 0.4],
+      ]
+    : [
+        [primary || "PRIMARY", 0.5],
+        [secondary || "SECONDARY", 0.3],
+        [tertiary || "TERTIARY", 0.2],
+      ];
 
   const out: StatMap = {};
   for (const [id, weight] of slots) {
@@ -268,6 +279,7 @@ export function deriveItemStats(input: ItemDerivationInput): ItemDerivationOutpu
     input.secondaryStat,
     input.tertiaryStat,
     costs.statPointCost,
+    input.disableTertiary ?? false,
   );
 
   return {

--- a/creator/src/lib/validateConfig.ts
+++ b/creator/src/lib/validateConfig.ts
@@ -332,6 +332,30 @@ export function validateConfig(config: AppConfig): ValidationIssue[] {
         message: `Primary stat "${cls.primaryStat}" is not defined`,
       });
     }
+    if (cls.statPriorities && cls.statPriorities.length > 0) {
+      // Every entry must reference a known stat — drops would be silent at
+      // equip time, so prefer a hard error here.
+      if (statIds.size > 0) {
+        for (const statId of cls.statPriorities) {
+          if (!statIds.has(statId)) {
+            issues.push({
+              severity: "error",
+              entity: `class:${id}`,
+              message: `statPriorities references unknown stat "${statId}"`,
+            });
+          }
+        }
+      }
+      // primaryStat is the legacy single-stat field. Disagreement between it
+      // and statPriorities[0] usually means the legacy field is stale.
+      if (cls.primaryStat && cls.statPriorities[0] && cls.statPriorities[0] !== cls.primaryStat) {
+        issues.push({
+          severity: "warning",
+          entity: `class:${id}`,
+          message: `primaryStat "${cls.primaryStat}" disagrees with statPriorities[0] "${cls.statPriorities[0]}" — these should match`,
+        });
+      }
+    }
     if (cls.threatMultiplier != null && cls.threatMultiplier < 0) {
       issues.push({
         severity: "error",

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -8,7 +8,7 @@ import type {
   RareYieldFile,
   RecipeFile,
 } from "@/types/world";
-import { ITEM_TYPES } from "@/types/world";
+import { ITEM_TYPES, ARCHETYPAL_STATS, isArchetypalStat } from "@/types/world";
 import type { EquipmentSlotDefinition, MobTiersConfig } from "@/types/config";
 import { resolveDoorKeyId, resolveDoorState } from "./doorHelpers";
 import { mobMaxDamageAtLevel, mobMinDamageAtLevel } from "./tuning/formulas";
@@ -402,6 +402,9 @@ export function validateZone(
   knownAchievements?: ReadonlySet<string>,
   mobTiers?: MobTiersConfig,
   questXpConfig?: QuestXpConfig,
+  /** Class id -> ordered statPriorities. Used to warn when an item uses an
+   *  archetypal stat slot that no class fills (the bonus would silently drop). */
+  classStatPriorities?: Record<string, string[]>,
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const roomIds = new Set(Object.keys(world.rooms));
@@ -677,6 +680,26 @@ export function validateZone(
         }
       }
     }
+    // Archetypal stats (PRIMARY/SECONDARY/TERTIARY) silently drop for classes
+    // whose statPriorities is too shallow. Surface the gap so authors don't
+    // ship an item that gives a hidden Mage no bonus.
+    if (item.stats && classStatPriorities && Object.keys(classStatPriorities).length > 0) {
+      const usedArchetypal = Object.keys(item.stats).filter(isArchetypalStat);
+      for (const key of usedArchetypal) {
+        const depthNeeded = ARCHETYPAL_STATS.indexOf(key) + 1;
+        const shallow = Object.entries(classStatPriorities)
+          .filter(([, prio]) => prio.length < depthNeeded)
+          .map(([id]) => id);
+        if (shallow.length > 0) {
+          addIssue(
+            issues,
+            "warning",
+            entity,
+            `Stat "${key}" has no resolution for class${shallow.length > 1 ? "es" : ""} ${shallow.join(", ")} — extend their statPriorities or remove this bonus`,
+          );
+        }
+      }
+    }
   }
 
   for (const [shopId, shop] of Object.entries(world.shops ?? {})) {
@@ -876,10 +899,11 @@ export function validateAllZones(
   knownAchievements?: ReadonlySet<string>,
   mobTiers?: MobTiersConfig,
   questXpConfig?: QuestXpConfig,
+  classStatPriorities?: Record<string, string[]>,
 ): Map<string, ValidationIssue[]> {
   const results = new Map<string, ValidationIssue[]>();
   for (const [zoneId, zone] of zones) {
-    const issues = validateZone(zone.data, equipmentSlots, validClasses, knownFactions, knownAchievements, mobTiers, questXpConfig);
+    const issues = validateZone(zone.data, equipmentSlots, validClasses, knownFactions, knownAchievements, mobTiers, questXpConfig, classStatPriorities);
     if (issues.length > 0) {
       results.set(zoneId, issues);
     }

--- a/creator/src/lib/zoneRebalance.ts
+++ b/creator/src/lib/zoneRebalance.ts
@@ -299,6 +299,7 @@ export function restatItem(
     primaryStat: item.primaryStat,
     secondaryStat: item.secondaryStat,
     tertiaryStat: item.tertiaryStat,
+    disableTertiary: item.disableTertiary,
     slotBudgets,
   });
 

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -832,6 +832,22 @@ export interface ClassDefinitionConfig {
   /** Per-level multiplicative growth rate this class contributes to max mana. */
   manaScalingRate: number;
   primaryStat?: string;
+  /**
+   * Ordered stat IDs from most to least valued for this class. Used to resolve
+   * archetypal item stats (`PRIMARY`/`SECONDARY`/`TERTIARY` in a StatMap) at
+   * equip time:
+   *   PRIMARY   → statPriorities[0]
+   *   SECONDARY → statPriorities[1]
+   *   TERTIARY  → statPriorities[2]
+   *
+   * Provide at least three entries to fully support adaptive items. When this
+   * field is empty or missing, the server falls back to `[primaryStat]` —
+   * which leaves SECONDARY/TERTIARY unresolvable (items using them silently
+   * drop those bonuses for this class).
+   *
+   * Example for a Wizard: `["intelligence", "wisdom", "constitution"]`.
+   */
+  statPriorities?: string[];
   selectable?: boolean;
   startRoom?: string;
   threatMultiplier?: number;

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -1,5 +1,34 @@
-/** Dynamic stat map: stat ID -> numeric value */
+/**
+ * Dynamic stat map: stat ID -> numeric value.
+ *
+ * Two flavors of key are accepted:
+ *
+ * - **Concrete** stat IDs (lowercase by convention, e.g. `strength`,
+ *   `dexterity`) must be defined in `application.yaml::stats.definitions`.
+ *   These apply uniformly to anyone wearing the item.
+ *
+ * - **Archetypal** stat IDs ({@link ARCHETYPAL_STATS}) are uppercase placeholders
+ *   that resolve at equip time against the wearer's active class
+ *   `statPriorities`:
+ *     PRIMARY   → statPriorities[0]
+ *     SECONDARY → statPriorities[1]
+ *     TERTIARY  → statPriorities[2]
+ *
+ *   Items can mix both — `{ PRIMARY: 3, dexterity: 1 }` gives flat DEX to
+ *   everyone plus 3 to the wearer's primary stat. When the active class has
+ *   no priority slot for the archetypal key, the server silently drops it.
+ */
 export type StatMap = Record<string, number>;
+
+/** Archetypal stat keys that resolve to a concrete stat at equip time
+ *  via the wearer's class `statPriorities`. */
+export const ARCHETYPAL_STATS = ["PRIMARY", "SECONDARY", "TERTIARY"] as const;
+export type ArchetypalStat = (typeof ARCHETYPAL_STATS)[number];
+
+/** True if `key` is one of `PRIMARY`/`SECONDARY`/`TERTIARY`. */
+export function isArchetypalStat(key: string): key is ArchetypalStat {
+  return (ARCHETYPAL_STATS as readonly string[]).includes(key);
+}
 
 // ─── Zone-level types (mirror world-yaml-dtos) ──────────────────────
 

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -365,6 +365,12 @@ export interface ItemFile {
   /** Tertiary stat: receives the smallest share of the stat-budget. */
   tertiaryStat?: string;
   /**
+   * When true, the tertiary slot is dropped entirely and the stat budget is
+   * split 60/40 between primary and secondary instead of the default 50/30/20.
+   * Use for items that should only carry two stat bonuses.
+   */
+  disableTertiary?: boolean;
+  /**
    * Class restriction. When non-empty, only players whose `playerClass` matches
    * one of these IDs can equip the item. Null/absent = unrestricted. Mirrors
    * AmbonMUD's `ItemFile.classes` field; the server's equip handler enforces


### PR DESCRIPTION
## Summary
- Lets items grant adaptive stat bonuses that resolve at equip time against the wearer's class `statPriorities`.
- A single \"auringold boots\" drop becomes useful for every class, fixing loot-dilution for the single-player case.
- Editor-side only — server-side mirror is a separate AmbonMUD PR.

## Why

With 6 classes, drop tables are vying against both a percentage roll *and* a class-fit roll on top — fine for end-game MMOs, painful for the single-player and early-population paths we want Arcanum worlds to handle. Adaptive stats fold the class-fit step into authoring: one base item, stats follow the wielder.

## Schema

### `StatMap` (creator/src/types/world.ts)

Now accepts two key flavors:

- **Concrete** (lowercase, e.g. `strength`) — must be defined in `application.yaml::stats.definitions`. Applies uniformly.
- **Archetypal** (uppercase: `PRIMARY` / `SECONDARY` / `TERTIARY`) — resolves at equip time against the active class's `statPriorities`. New `ARCHETYPAL_STATS` const + `isArchetypalStat()` guard are exported for the server to mirror.

Mixing is allowed: `stats: { PRIMARY: 3, dexterity: 1 }` gives flat DEX to everyone plus 3 to the wearer's primary stat.

### `ClassDefinitionConfig` (creator/src/types/config.ts)

```ts
statPriorities?: string[];   // [0]=PRIMARY, [1]=SECONDARY, [2]=TERTIARY
```

Legacy `primaryStat` is kept as a fallback so old class YAMLs keep working. When `statPriorities` is missing, the server falls back to `[primaryStat]` — which leaves SECONDARY/TERTIARY unresolvable (bonuses silently drop for that class).

### YAML examples

\`\`\`yaml
classes:
  definitions:
    WARRIOR:
      primaryStat: strength
      statPriorities: [strength, constitution, dexterity]
    WIZARD:
      primaryStat: intelligence
      statPriorities: [intelligence, wisdom, constitution]
\`\`\`

\`\`\`yaml
items:
  auringold_boots:
    displayName: a pair of auringold boots
    slot: feet
    armor: 2
    stats:
      PRIMARY: 3
      SECONDARY: 1
  boots_of_speed:
    displayName: boots of speed
    slot: feet
    armor: 1
    stats:
      dexterity: 4      # concrete — doesn't adapt
      PRIMARY: 1        # small adaptive bonus on a flavored item
\`\`\`

## Server-side resolution (for the AmbonMUD PR)

The frontend produces YAML; the server is responsible for actually applying the bonuses. Sketch of the equip-time resolution:

\`\`\`kotlin
fun resolveItemStats(
    rawStats: Map<String, Int>,
    activeClass: ClassDefinitionConfig,
): Map<String, Int> {
    val priorities = activeClass.statPriorities.ifEmpty {
        listOfNotNull(activeClass.primaryStat.takeIf { it.isNotBlank() })
    }
    val resolved = mutableMapOf<String, Int>()
    for ((key, value) in rawStats) {
        val concrete = when (key) {
            \"PRIMARY\"   -> priorities.getOrNull(0)
            \"SECONDARY\" -> priorities.getOrNull(1)
            \"TERTIARY\"  -> priorities.getOrNull(2)
            else          -> key   // concrete stat ID — pass through
        } ?: continue              // archetypal slot has no priority → drop
        resolved.merge(concrete, value, Int::plus)
    }
    return resolved
}
\`\`\`

Open question still to settle with the server: **multiclassing.** Active-class-wins (above) is the boring-correct default; snapshot-on-equip would store a per-item resolution map for build identity. Let's pick one.

## Validation added

- `validateConfig`
  - **error** when `statPriorities` references an unknown stat.
  - **warn** when `primaryStat` disagrees with `statPriorities[0]`.
- `validateZone`
  - **warn** when an item uses an archetypal stat that any class can't resolve (lists the offending classes).

## UI

\`ItemEditor\` → Stat Bonuses → \"Add Stat Bonus\" is now a grouped select:

- **Adaptive (resolves per class)** — PRIMARY / SECONDARY / TERTIARY
- **Concrete** — the project's `stats.definitions` entries

Already-used keys are filtered; button disables when nothing's left. (Also fixed an existing bug where the input uppercased everything — meant `strength` would have been stored as `STRENGTH`.)

## Test plan

- [ ] Open an existing project, edit an item, confirm Add Stat Bonus shows Adaptive + Concrete groups
- [ ] Add PRIMARY=3 to an item, save, verify YAML round-trips as `PRIMARY: 3`
- [ ] Add `statPriorities: [intelligence, wisdom, constitution]` to a class, save config, verify it persists
- [ ] Class with `statPriorities` referencing a fake stat → validation error
- [ ] Class with `primaryStat: x` and `statPriorities: [y, ...]` → validation warning
- [ ] Item with SECONDARY=1 in a project where some class has only one statPriority → zone warning naming that class