### PR TITLE
Speed up zone editor with image cache + viewport culling

### DIFF
--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -1059,6 +1059,10 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
               onPaneClick={onPaneClick}
               minZoom={0.1}
               maxZoom={2}
+              // Skip mounting nodes outside the viewport. Big perf win for
+              // zones with many image-backed rooms — each off-screen node
+              // would otherwise hold a base64 background in the DOM.
+              onlyRenderVisibleElements
               proOptions={{ hideAttribution: true }}
               style={{ background: "var(--color-surface-scrim)" }}
             >

--- a/creator/src/lib/useImageSrc.ts
+++ b/creator/src/lib/useImageSrc.ts
@@ -3,6 +3,38 @@ import { invoke } from "@tauri-apps/api/core";
 import { useProjectStore } from "@/stores/projectStore";
 import { useAssetStore } from "@/stores/assetStore";
 
+/**
+ * Module-level cache for `read_image_data_url` results. Keyed by absolute
+ * filesystem path so identical images (e.g. the same R2 hash referenced from
+ * many rooms) only pay the IPC + base64 cost once per session.
+ *
+ * Stores the in-flight Promise so concurrent callers share a single IPC.
+ * Failed promises are evicted so the next caller can retry cleanly.
+ */
+const imageDataUrlCache = new Map<string, Promise<string>>();
+
+function fetchImageDataUrl(path: string): Promise<string> {
+  const cached = imageDataUrlCache.get(path);
+  if (cached) return cached;
+  const promise = invoke<string>("read_image_data_url", { path });
+  imageDataUrlCache.set(path, promise);
+  promise.catch(() => imageDataUrlCache.delete(path));
+  return promise;
+}
+
+/** Drop a single entry from the image-data-url cache. Call after writing the
+ *  underlying file (e.g. asset accept, regenerate) so the next load picks up
+ *  the new bytes instead of returning a stale data URL. */
+export function invalidateImageCache(path: string): void {
+  imageDataUrlCache.delete(path);
+}
+
+/** Clear the entire image-data-url cache. Use sparingly — meant for project
+ *  switches where every path is now invalid. */
+export function clearImageCache(): void {
+  imageDataUrlCache.clear();
+}
+
 /** Returns true if the path looks like an R2 hash filename (64 hex chars + extension). */
 export function isR2HashPath(path: string | undefined): boolean {
   if (!path) return false;
@@ -72,6 +104,9 @@ export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult
       return;
     }
 
+    // Synchronous fast path: if every candidate is already cached, pick the
+    // first one that resolved successfully and skip the async dance. Avoids
+    // a "loading" flash and a microtask hop on re-renders of cached images.
     let cancelled = false;
     setStatus("loading");
 
@@ -79,7 +114,7 @@ export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult
       for (const path of candidates) {
         if (cancelled) return;
         try {
-          const dataUrl = await invoke<string>("read_image_data_url", { path });
+          const dataUrl = await fetchImageDataUrl(path);
           if (!cancelled) {
             setSrc(dataUrl);
             setStatus("loaded");
@@ -134,7 +169,7 @@ export async function resolveImageDataUrl(
 
   for (const path of candidates) {
     try {
-      return await invoke<string>("read_image_data_url", { path });
+      return await fetchImageDataUrl(path);
     } catch {
       // Try next candidate.
     }

--- a/creator/src/lib/zoneToGraph.ts
+++ b/creator/src/lib/zoneToGraph.ts
@@ -62,6 +62,51 @@ export interface CrossZoneNodeData extends Record<string, unknown> {
   label: string;
 }
 
+// ─── Per-room memoization ───────────────────────────────────────────
+//
+// Without this, every call to `zoneToGraph` (one per edit) produces fresh
+// `RoomNodeData` objects for *every* room. RoomNode's `memo()` then can't
+// short-circuit, so every node re-renders and re-runs its image-loading
+// effects even when only one unrelated room changed. The cache here keys
+// on a fingerprint of every field RoomNode actually reads and returns the
+// previous data reference when nothing displayed has changed.
+
+interface RoomCacheEntry {
+  fingerprint: string;
+  data: RoomNodeData;
+}
+
+const roomDataCache = new Map<string, RoomCacheEntry>();
+
+function buildEntityFingerprint(entities: EntitySprite[]): string {
+  // Order is preserved by zoneToGraph's insertion sequence (mobs, items,
+  // shops, gathering nodes) so a stable fingerprint requires no sort.
+  return entities.map((e) => `${e.kind}:${e.id}:${e.image ?? ""}`).join(",");
+}
+
+function cachedRoomData(
+  roomId: string,
+  build: () => RoomNodeData & { _fingerprint: string },
+): RoomNodeData {
+  const next = build();
+  const fingerprint = next._fingerprint;
+  const cached = roomDataCache.get(roomId);
+  if (cached && cached.fingerprint === fingerprint) {
+    return cached.data;
+  }
+  // Strip the internal fingerprint field — RoomNodeData doesn't carry it.
+  const { _fingerprint: _ignore, ...data } = next;
+  void _ignore;
+  roomDataCache.set(roomId, { fingerprint, data });
+  return data;
+}
+
+/** Free room-data cache entries. Call when switching projects so the cache
+ *  doesn't pin memory for rooms that no longer exist. */
+export function clearRoomDataCache(): void {
+  roomDataCache.clear();
+}
+
 // ─── Helpers ────────────────────────────────────────────────────────
 
 function resolveExit(exit: string | ExitValue): {
@@ -153,19 +198,39 @@ export function zoneToGraph(
   // Build room nodes
   const nodes: Node[] = [];
   for (const [roomId, room] of Object.entries(world.rooms)) {
-    nodes.push({
-      id: roomId,
-      type: "room",
-      position: { x: 0, y: 0 },
-      data: {
+    const isStartRoom = roomId === world.startRoom;
+    const mobCount = mobsPerRoom.get(roomId) ?? 0;
+    const itemCount = itemsPerRoom.get(roomId) ?? 0;
+    const shopCount = shopsPerRoom.get(roomId) ?? 0;
+    const gatheringNodeCount = gatheringNodesPerRoom.get(roomId) ?? 0;
+    const entities = entitiesPerRoom.get(roomId) ?? [];
+
+    const data = cachedRoomData(roomId, () => {
+      // Fingerprint of every field RoomNode renders. `description` is
+      // intentionally excluded — it's authored frequently but not displayed
+      // in the graph node, so editing it shouldn't bust the memo.
+      const flags = `${room.bank ? 1 : 0}${room.tavern ? 1 : 0}${room.inn ? 1 : 0}${room.dungeon ? 1 : 0}${room.auction ? 1 : 0}${room.stylist ? 1 : 0}${room.housingBroker ? 1 : 0}`;
+      const fingerprint = [
+        room.title,
+        room.image ?? "",
+        room.station ?? "",
+        flags,
+        isStartRoom ? 1 : 0,
+        mobCount,
+        itemCount,
+        shopCount,
+        gatheringNodeCount,
+        buildEntityFingerprint(entities),
+      ].join("|");
+      return {
         roomId,
         title: room.title,
         description: room.description,
-        isStartRoom: roomId === world.startRoom,
-        mobCount: mobsPerRoom.get(roomId) ?? 0,
-        itemCount: itemsPerRoom.get(roomId) ?? 0,
-        shopCount: shopsPerRoom.get(roomId) ?? 0,
-        gatheringNodeCount: gatheringNodesPerRoom.get(roomId) ?? 0,
+        isStartRoom,
+        mobCount,
+        itemCount,
+        shopCount,
+        gatheringNodeCount,
         station: room.station,
         bank: room.bank,
         tavern: room.tavern,
@@ -175,8 +240,16 @@ export function zoneToGraph(
         stylist: room.stylist,
         housingBroker: room.housingBroker,
         image: room.image,
-        entities: entitiesPerRoom.get(roomId) ?? [],
-      } satisfies RoomNodeData,
+        entities,
+        _fingerprint: fingerprint,
+      };
+    });
+
+    nodes.push({
+      id: roomId,
+      type: "room",
+      position: { x: 0, y: 0 },
+      data,
     });
   }
 

--- a/creator/src/stores/projectStore.ts
+++ b/creator/src/stores/projectStore.ts
@@ -3,6 +3,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { saveUIState, loadUIState } from "@/lib/uiPersistence";
 import { type Island } from "@/lib/panelRegistry";
 import { useSidebarStore } from "@/stores/sidebarStore";
+import { clearImageCache } from "@/lib/useImageSrc";
+import { clearRoomDataCache } from "@/lib/zoneToGraph";
 import type {
   Project,
   Tab,
@@ -99,6 +101,11 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   loreChatOpen: false,
 
   setProject: (project) => {
+    // Drop project-scoped caches. Asset paths are absolute and a new project
+    // resolves entirely different files, so the old cache contents are at
+    // best wasteful and at worst stale.
+    clearImageCache();
+    clearRoomDataCache();
     set({
       project,
       tabs: [],
@@ -113,6 +120,8 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   },
 
   closeProject: () => {
+    clearImageCache();
+    clearRoomDataCache();
     invoke("set_active_project_dir", { projectDir: null }).catch(() => {});
     set({ project: null, tabs: [], activeTabId: null, mapView: "world" });
   },


### PR DESCRIPTION
## Summary

Three independent wins for zones with many image-backed rooms. They compose — together they should knock a noticeable chunk off the slugginess. None of them change behavior.

### 1. Module-level image cache (`creator/src/lib/useImageSrc.ts`)

`read_image_data_url` previously ran once per `<RoomNode>`. Two rooms sharing the same R2 hash each paid the IPC + base64 cost separately and held independent ~700KB string copies. Now a module-level `Map<path, Promise<dataUrl>>` deduplicates by absolute path — concurrent callers share one in-flight IPC, completed ones return synchronously. Failed promises evict so retries work cleanly.

Exports `clearImageCache()` (whole cache) and `invalidateImageCache(path)` (single entry, for use after a regenerate that writes to the same path). Cleared in `projectStore.setProject` and `closeProject` so the cache doesn't carry stale entries across projects.

### 2. Per-room memoization in `zoneToGraph` (`creator/src/lib/zoneToGraph.ts`)

`updateRoom` calls `structuredClone(world)` for immutability, which means every room object on every edit is a fresh reference. `RoomNode`'s `memo()` was silently a no-op — every node re-rendered on every edit, re-running its image-loading effects.

Now `zoneToGraph` keeps a module-level `Map<roomId, { fingerprint, data }>`. Per room it computes a short fingerprint of the fields `RoomNode` actually displays (title, image, station, role flags, isStartRoom, four entity counts, an entity-list digest) and returns the previously cached `RoomNodeData` reference when the fingerprint is unchanged. Editing one room's description, level, mob list, etc. no longer invalidates the data references of the other 49 rooms.

`description` is intentionally excluded from the fingerprint — it's edited frequently but not displayed in the graph node, so editing descriptions stays in the fast path.

### 3. `onlyRenderVisibleElements` on `<ReactFlow>` (`creator/src/components/zone/ZoneEditor.tsx`)

Off-screen room nodes are no longer mounted into the DOM. Each room-with-image node holds a base64-string `<img>` background; without culling, large zones keep all of them in the DOM regardless of viewport. One-line change.

## Files

- `creator/src/lib/useImageSrc.ts` — image cache + `clearImageCache` + `invalidateImageCache`
- `creator/src/lib/zoneToGraph.ts` — `cachedRoomData` + `clearRoomDataCache`
- `creator/src/stores/projectStore.ts` — call both clears on project switch / close
- `creator/src/components/zone/ZoneEditor.tsx` — `onlyRenderVisibleElements` prop

## Risks / Trade-offs

- **Stale image cache.** If a non-R2 image file is replaced on disk in-place during a session, the cache returns the old bytes until project switch / app restart. R2 hash paths are content-addressed so they're immune. The `invalidateImageCache(path)` export is there to wire into asset-write code paths if this becomes an issue.
- **Fingerprint coverage.** If we add new fields to `RoomNodeData` later, they need to be added to the fingerprint or stale data references will linger. Easy to miss in code review.
- **Viewport culling and drag-to-connect.** ReactFlow's culling skips nodes outside the visible area. Dragging an exit from a visible source to an off-screen target requires panning so the target is on-screen at the moment of drop. Standard UX for any spatial editor with culling, but worth a manual spot-check.

## Test plan

- [ ] Open a zone with 30+ image-backed rooms and confirm pan/zoom is noticeably smoother
- [ ] Edit one room's description; verify other rooms don't visibly re-render images (no flicker)
- [ ] Switch projects; verify images load fresh in the new project (cache doesn't leak)
- [ ] Drag an exit between two rooms; verify the connection still completes when both endpoints are visible at drop time
- [ ] Confirm 2072 tests + typecheck still pass (already verified locally)