### PR TITLE
Bring image library along when importing a zone from another project

### DIFF
--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -1064,3 +1064,135 @@ pub async fn flip_image(app: AppHandle, image_ref: String) -> Result<String, Str
 
     Ok(file_name)
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportZoneAssetsResult {
+    pub imported: u32,
+    pub skipped: u32,
+    pub missing_blobs: Vec<String>,
+    pub source_manifest_found: bool,
+}
+
+/// Walk up from `zone_file` looking for `.arcanum/manifest.json`.
+fn find_sibling_manifest(zone_file: &std::path::Path) -> Option<PathBuf> {
+    let mut cursor = zone_file.parent().map(|p| p.to_path_buf());
+    while let Some(dir) = cursor {
+        let candidate = dir.join(".arcanum").join("manifest.json");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        cursor = dir.parent().map(|p| p.to_path_buf());
+    }
+    None
+}
+
+async fn read_external_manifest(path: &std::path::Path) -> Result<Manifest, String> {
+    let data = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|e| format!("Failed to read source manifest: {e}"))?;
+    serde_json::from_str(&data).map_err(|e| format!("Failed to parse source manifest: {e}"))
+}
+
+/// Preview: how many active manifest entries the source project has for a given zone.
+/// Returns 0 if no sibling `.arcanum/manifest.json` is found.
+#[tauri::command]
+pub async fn count_zone_assets(
+    source_zone_file: String,
+    source_zone_id: String,
+) -> Result<u32, String> {
+    let zone_path = PathBuf::from(&source_zone_file);
+    let Some(manifest_path) = find_sibling_manifest(&zone_path) else {
+        return Ok(0);
+    };
+    let manifest = read_external_manifest(&manifest_path).await?;
+    let count = manifest
+        .assets
+        .iter()
+        .filter(|a| a.context.zone == source_zone_id)
+        .count() as u32;
+    Ok(count)
+}
+
+/// Copy a zone's manifest entries from another Arcanum project's `.arcanum/manifest.json`
+/// into the active project's manifest. Blob files live globally in the app data dir and
+/// are already shared between projects on the same machine, so no file copying is needed
+/// for local imports. Entries whose blob is missing locally are reported as `missing_blobs`
+/// (they're still added to the manifest — the user can re-sync from R2 or regenerate).
+///
+/// `target_zone_id` rewrites `context.zone` on the imported entries so they group under
+/// the (possibly renamed) zone in the target project. Existing entries with the same
+/// content hash are skipped to avoid duplicates.
+#[tauri::command]
+pub async fn import_zone_assets(
+    app: AppHandle,
+    source_zone_file: String,
+    source_zone_id: String,
+    target_zone_id: String,
+) -> Result<ImportZoneAssetsResult, String> {
+    let zone_path = PathBuf::from(&source_zone_file);
+    let Some(src_manifest_path) = find_sibling_manifest(&zone_path) else {
+        return Ok(ImportZoneAssetsResult {
+            imported: 0,
+            skipped: 0,
+            missing_blobs: Vec::new(),
+            source_manifest_found: false,
+        });
+    };
+
+    let src_manifest = read_external_manifest(&src_manifest_path).await?;
+    let candidates: Vec<AssetEntry> = src_manifest
+        .assets
+        .into_iter()
+        .filter(|a| a.context.zone == source_zone_id)
+        .collect();
+
+    if candidates.is_empty() {
+        return Ok(ImportZoneAssetsResult {
+            imported: 0,
+            skipped: 0,
+            missing_blobs: Vec::new(),
+            source_manifest_found: true,
+        });
+    }
+
+    let blob_base = assets_dir(&app)?;
+    let mut missing_blobs = Vec::new();
+
+    let _lock = MANIFEST_LOCK.lock().await;
+    let mut target_manifest = load_manifest(&app).await?;
+    let existing_hashes: std::collections::HashSet<String> = target_manifest
+        .assets
+        .iter()
+        .map(|a| a.hash.clone())
+        .collect();
+
+    let mut imported = 0u32;
+    let mut skipped = 0u32;
+
+    for entry in candidates {
+        let blob_present = ["images", "video", "audio"]
+            .iter()
+            .any(|sub| blob_base.join(sub).join(&entry.file_name).exists());
+        if !blob_present {
+            missing_blobs.push(entry.file_name.clone());
+        }
+        if existing_hashes.contains(&entry.hash) {
+            skipped += 1;
+            continue;
+        }
+        let mut new_entry = entry;
+        new_entry.context.zone = target_zone_id.clone();
+        new_entry.sync_status = "local".to_string();
+        target_manifest.assets.push(new_entry);
+        imported += 1;
+    }
+
+    save_manifest(&app, &target_manifest).await?;
+
+    Ok(ImportZoneAssetsResult {
+        imported,
+        skipped,
+        missing_blobs,
+        source_manifest_found: true,
+    })
+}

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -88,6 +88,8 @@ macro_rules! base_handler {
             assets::import_player_sprites,
             assets::bulk_import_images,
             assets::export_assets_to_dir,
+            assets::count_zone_assets,
+            assets::import_zone_assets,
             assets::migrate_sprite_tier,
             assets::expand_base_sprites,
             assets::flip_image,

--- a/creator/src/components/ImportZoneDialog.tsx
+++ b/creator/src/components/ImportZoneDialog.tsx
@@ -6,6 +6,7 @@ import { parseDocument } from "yaml";
 import { stringify } from "yaml";
 import { useProjectStore } from "@/stores/projectStore";
 import { useZoneStore } from "@/stores/zoneStore";
+import { useAssetStore } from "@/stores/assetStore";
 import { zoneFilePath } from "@/lib/projectPaths";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 import { DialogShell, ActionButton, Spinner } from "./ui/FormWidgets";
@@ -30,6 +31,8 @@ interface ParsedZone {
   roomCount: number;
   /** Whether a zone with this ID already exists. */
   collision: boolean;
+  /** Count of image-library entries detected in the source project for this zone. */
+  assetCount: number;
   /** Error message if file failed to parse. */
   error?: string;
 }
@@ -40,6 +43,15 @@ interface ImportResult {
   zoneId: string;
   status: "imported" | "skipped" | "renamed" | "overwritten" | "error";
   message: string;
+  /** Counts from the asset-library copy step (omitted when nothing was imported). */
+  assets?: { imported: number; skipped: number; missingBlobs: number };
+}
+
+interface ImportZoneAssetsResult {
+  imported: number;
+  skipped: number;
+  missing_blobs: string[];
+  source_manifest_found: boolean;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────
@@ -71,10 +83,12 @@ export function ImportZoneDialog({ onClose }: { onClose: () => void }) {
   const openTab = useProjectStore((s) => s.openTab);
   const loadZone = useZoneStore((s) => s.loadZone);
   const zones = useZoneStore((s) => s.zones);
+  const loadAssets = useAssetStore((s) => s.loadAssets);
 
   const [step, setStep] = useState<"select" | "review" | "importing" | "done">("select");
   const [parsed, setParsed] = useState<ParsedZone[]>([]);
   const [conflictStrategy, setConflictStrategy] = useState<ConflictStrategy>("rename");
+  const [importImages, setImportImages] = useState(true);
   const [results, setResults] = useState<ImportResult[]>([]);
   const [selectError, setSelectError] = useState<string | null>(null);
 
@@ -112,6 +126,7 @@ export function ImportZoneDialog({ onClose }: { onClose: () => void }) {
             data: data as WorldFile,
             roomCount: 0,
             collision: false,
+            assetCount: 0,
             error: "Not a valid zone file (missing 'zone' or 'rooms' field)",
           });
           continue;
@@ -121,6 +136,16 @@ export function ImportZoneDialog({ onClose }: { onClose: () => void }) {
           ? data.zone
           : sanitizeZoneId(data.zone);
 
+        let assetCount = 0;
+        try {
+          assetCount = await invoke<number>("count_zone_assets", {
+            sourceZoneFile: filePath,
+            sourceZoneId: data.zone,
+          });
+        } catch {
+          // Source project has no manifest, or it's unreadable — treat as 0.
+        }
+
         results.push({
           filePath,
           fileName,
@@ -128,6 +153,7 @@ export function ImportZoneDialog({ onClose }: { onClose: () => void }) {
           data,
           roomCount: Object.keys(data.rooms).length,
           collision: existingIds.has(zoneId),
+          assetCount,
         });
       } catch (err) {
         results.push({
@@ -137,6 +163,7 @@ export function ImportZoneDialog({ onClose }: { onClose: () => void }) {
           data: {} as WorldFile,
           roomCount: 0,
           collision: false,
+          assetCount: 0,
           error: `Parse error: ${String(err)}`,
         });
       }
@@ -210,6 +237,37 @@ export function ImportZoneDialog({ onClose }: { onClose: () => void }) {
         loadZone(finalId, filePath, data);
         existingIds.add(finalId);
 
+        let assetSummary: ImportResult["assets"] | undefined;
+        if (importImages && entry.assetCount > 0) {
+          try {
+            const r = await invoke<ImportZoneAssetsResult>("import_zone_assets", {
+              sourceZoneFile: entry.filePath,
+              sourceZoneId: entry.data.zone,
+              targetZoneId: finalId,
+            });
+            if (r.source_manifest_found) {
+              assetSummary = {
+                imported: r.imported,
+                skipped: r.skipped,
+                missingBlobs: r.missing_blobs.length,
+              };
+            }
+          } catch (err) {
+            console.error(`Asset import failed for zone "${finalId}":`, err);
+          }
+        }
+
+        const baseMessage = entry.collision && conflictStrategy === "rename"
+          ? `Imported as "${finalId}" (renamed from "${entry.zoneId}").`
+          : `Imported with ${Object.keys(data.rooms).length} rooms.`;
+        const assetTail = assetSummary
+          ? ` Image library: ${assetSummary.imported} new, ${assetSummary.skipped} duplicate${
+              assetSummary.missingBlobs > 0
+                ? `, ${assetSummary.missingBlobs} blob${assetSummary.missingBlobs === 1 ? "" : "s"} missing locally`
+                : ""
+            }.`
+          : "";
+
         importResults.push({
           zoneId: finalId,
           status: entry.collision
@@ -217,9 +275,8 @@ export function ImportZoneDialog({ onClose }: { onClose: () => void }) {
               ? "renamed"
               : "overwritten"
             : "imported",
-          message: entry.collision && conflictStrategy === "rename"
-            ? `Imported as "${finalId}" (renamed from "${entry.zoneId}").`
-            : `Imported with ${Object.keys(data.rooms).length} rooms.`,
+          message: baseMessage + assetTail,
+          assets: assetSummary,
         });
       } catch (err) {
         importResults.push({
@@ -232,7 +289,12 @@ export function ImportZoneDialog({ onClose }: { onClose: () => void }) {
 
     setResults(importResults);
     setStep("done");
-  }, [project, parsed, conflictStrategy, zones, loadZone]);
+
+    // Refresh the asset library so newly imported entries show up immediately.
+    if (importImages && importResults.some((r) => r.assets && r.assets.imported > 0)) {
+      loadAssets().catch(() => {});
+    }
+  }, [project, parsed, conflictStrategy, importImages, zones, loadZone, loadAssets]);
 
   // ── Open imported zones ────────────────────────────────────────
 
@@ -249,6 +311,7 @@ export function ImportZoneDialog({ onClose }: { onClose: () => void }) {
 
   const validCount = parsed.filter((p) => !p.error).length;
   const collisionCount = parsed.filter((p) => p.collision && !p.error).length;
+  const totalAssetCount = parsed.reduce((sum, p) => sum + (p.error ? 0 : p.assetCount), 0);
   const successCount = results.filter(
     (r) => r.status === "imported" || r.status === "renamed" || r.status === "overwritten",
   ).length;
@@ -349,11 +412,31 @@ export function ImportZoneDialog({ onClose }: { onClose: () => void }) {
                     {entry.roomCount} room{entry.roomCount === 1 ? "" : "s"}
                     {entry.data.mobs ? ` \u00b7 ${Object.keys(entry.data.mobs).length} mobs` : ""}
                     {entry.data.items ? ` \u00b7 ${Object.keys(entry.data.items).length} items` : ""}
+                    {entry.assetCount > 0 ? ` \u00b7 ${entry.assetCount} image${entry.assetCount === 1 ? "" : "s"}` : ""}
                   </p>
                 )}
               </li>
             ))}
           </ul>
+
+          {/* Image library opt-in */}
+          {totalAssetCount > 0 && (
+            <label className="flex items-start gap-2 rounded-lg border border-border-default bg-bg-secondary px-3 py-2.5 text-xs text-text-secondary">
+              <input
+                type="checkbox"
+                checked={importImages}
+                onChange={(e) => setImportImages(e.target.checked)}
+                className="mt-0.5 accent-accent"
+              />
+              <span>
+                Also import the image library
+                {" "}
+                <span className="text-text-muted">
+                  ({totalAssetCount} generated image{totalAssetCount === 1 ? "" : "s"} detected across the selected zone{validCount === 1 ? "" : "s"})
+                </span>
+              </span>
+            </label>
+          )}
 
           {/* Conflict strategy */}
           {collisionCount > 0 && (


### PR DESCRIPTION
## Summary
- `ImportZoneDialog` can now copy a zone's image-library entries from the source project's `.arcanum/manifest.json` into the active project, alongside the YAML import.
- Asset blobs are content-addressed under `app_data_dir/assets/`, shared across projects on the same machine, so no file copying is needed locally — only the manifest is merged. Entries whose blob is missing locally are reported per zone so the user knows to re-sync from R2 or regenerate.
- Two new Tauri commands in `assets.rs`: `count_zone_assets` (preview) and `import_zone_assets` (merge). Both walk up from the picked zone file looking for a sibling `.arcanum/manifest.json`, so the dialog doesn't have to know the source project's layout.
- The review step now shows the image count per zone, and a default-on **Also import the image library** toggle appears whenever at least one zone has assets to bring over. `context.zone` is rewritten to the (possibly renamed) target zone ID, `sync_status` resets to `local`, and dupes are deduped by content hash.

## Test plan
- [ ] Import a standalone-format zone from a sibling project on the same machine — verify the image-count badge appears on the review row and that the toggle defaults to on.
- [ ] Confirm the asset library refreshes after import and the new entries are filed under the (possibly renamed) target zone.
- [ ] Import the same zone twice — second pass should report `0 new, N duplicate`.
- [ ] Import a zone whose source project has no `.arcanum/manifest.json` — toggle should not appear and the zone should still import normally.
- [ ] Rename a colliding zone on import — confirm `context.zone` on the new manifest entries matches the renamed ID, not the original.