### PR TITLE
feat: dialogue voice-over generation (Arcanum side)

### DIFF
--- a/creator/src-tauri/src/elevenlabs.rs
+++ b/creator/src-tauri/src/elevenlabs.rs
@@ -1,0 +1,273 @@
+// ─── ElevenLabs Text-to-Speech ──────────────────────────────────
+// Dialogue voice-over synthesis. Arcanum owns the ElevenLabs API key,
+// the templateKey → voiceId mapping, and licensing; the AmbonMUD engine
+// only ever sees a fully-resolved clip URL (see docs/VOICE_OVER_CONTRACT.md
+// in the AmbonMUD repo).
+//
+// Synthesized clips are content-addressed by SHA256(text + voiceId + modelId)
+// so identical lines don't re-synthesize. Cached MP3s live under
+// `app_data_dir/assets/voices/<hash>.mp3`.
+//
+// `text_sha8` — first 8 hex chars of SHA-256 over the *raw* node text — is the
+// cross-repo agreed hash baked into the R2 path. The engine recomputes the
+// identical value from the same `node.text`, so an edited line lands at a new
+// path and never serves stale audio.
+
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Manager};
+
+use crate::settings;
+
+const API_BASE: &str = "https://api.elevenlabs.io/v1";
+
+/// ElevenLabs MP3 default for the standard TTS endpoint. Web Audio's
+/// `decodeAudioData` decodes MP3 natively, so the web client needs no
+/// transcoding.
+const OUTPUT_FORMAT: &str = "mp3_44100_128";
+
+const DEFAULT_MODEL: &str = "eleven_multilingual_v2";
+
+// ─── Types ───────────────────────────────────────────────────────
+
+/// A voice available on the account, surfaced to the voice picker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElevenLabsVoice {
+    pub voice_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub category: String,
+    #[serde(default)]
+    pub preview_url: String,
+}
+
+/// A synthesized (or cached) dialogue clip returned to the frontend.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceClip {
+    /// Absolute filesystem path to the cached MP3.
+    pub file_path: String,
+    /// Content hash of (text + voice + model) — the cache filename stem.
+    pub cache_hash: String,
+    /// First 8 hex chars of SHA-256(raw text). Baked into the R2 path; the
+    /// AmbonMUD engine recomputes the same value.
+    pub text_sha8: String,
+    /// `data:audio/mpeg;base64,...` for immediate in-app preview playback.
+    pub data_url: String,
+    pub size_bytes: u64,
+    /// Whether the clip came from cache (true) or was freshly synthesized.
+    pub cached: bool,
+}
+
+// ─── Hashing ─────────────────────────────────────────────────────
+
+fn cache_hash(text: &str, voice_id: &str, model_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    hasher.update(b"|");
+    hasher.update(voice_id.as_bytes());
+    hasher.update(b"|");
+    hasher.update(model_id.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// First 8 hex chars of SHA-256 over the exact raw node text. This is the
+/// contract hash — see module docs. Must match the engine's computation
+/// byte-for-byte, so it hashes `text` verbatim with no trimming.
+pub fn text_sha8(text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    let full = format!("{:x}", hasher.finalize());
+    full[..8].to_string()
+}
+
+async fn voices_cache_dir(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+        .join("assets")
+        .join("voices");
+    tokio::fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| format!("Failed to create voices dir: {e}"))?;
+    Ok(dir)
+}
+
+// ─── Commands ────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct ListVoicesResponse {
+    voices: Vec<ElevenLabsVoice>,
+}
+
+/// List the voices available on the configured ElevenLabs account.
+#[tauri::command]
+pub async fn elevenlabs_list_voices(app: AppHandle) -> Result<Vec<ElevenLabsVoice>, String> {
+    let settings = settings::get_settings(app).await?;
+    if settings.elevenlabs_api_key.is_empty() {
+        return Err("ElevenLabs API key not configured. Set it in Settings.".to_string());
+    }
+
+    let client = crate::http::shared_client();
+    let response = client
+        .get(format!("{API_BASE}/voices"))
+        .header("xi-api-key", &settings.elevenlabs_api_key)
+        .send()
+        .await
+        .map_err(|e| format!("ElevenLabs voices request failed: {e}"))?;
+
+    let response = crate::http::check_response(response).await?;
+    let parsed: ListVoicesResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse ElevenLabs voices response: {e}"))?;
+    Ok(parsed.voices)
+}
+
+#[derive(Debug, Serialize)]
+struct TtsRequest {
+    text: String,
+    model_id: String,
+}
+
+/// Synthesize a dialogue line into an MP3 clip via ElevenLabs.
+///
+/// Returns a cached clip when the same (text, voice, model) was generated
+/// before. Otherwise calls the API and caches the result under
+/// `app_data_dir/assets/voices/<cache_hash>.mp3`.
+#[tauri::command]
+pub async fn elevenlabs_synthesize(
+    app: AppHandle,
+    text: String,
+    voice_id: String,
+    model_id: Option<String>,
+) -> Result<VoiceClip, String> {
+    if text.trim().is_empty() {
+        return Err("Voice-over text is empty.".to_string());
+    }
+    if voice_id.trim().is_empty() {
+        return Err("No voice selected for this line.".to_string());
+    }
+
+    let model_id = model_id
+        .map(|m| m.trim().to_string())
+        .filter(|m| !m.is_empty())
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+
+    let cache_hash = cache_hash(&text, &voice_id, &model_id);
+    let text_sha8 = text_sha8(&text);
+    let dir = voices_cache_dir(&app).await?;
+    let file_path = dir.join(format!("{cache_hash}.mp3"));
+
+    // ─── Cache lookup ────────────────────────────────────────
+    if let Ok(metadata) = tokio::fs::metadata(&file_path).await {
+        if metadata.is_file() && metadata.len() > 0 {
+            let bytes = tokio::fs::read(&file_path)
+                .await
+                .map_err(|e| format!("Failed to read cached voice clip: {e}"))?;
+            return Ok(VoiceClip {
+                file_path: file_path.to_string_lossy().to_string(),
+                cache_hash,
+                text_sha8,
+                data_url: to_data_url(&bytes),
+                size_bytes: metadata.len(),
+                cached: true,
+            });
+        }
+    }
+
+    // ─── Request ─────────────────────────────────────────────
+    let settings = settings::get_settings(app.clone()).await?;
+    if settings.elevenlabs_api_key.is_empty() {
+        return Err("ElevenLabs API key not configured. Set it in Settings.".to_string());
+    }
+
+    let body = TtsRequest {
+        text: text.clone(),
+        model_id: model_id.clone(),
+    };
+
+    let client = crate::http::shared_client();
+    let response = client
+        .post(format!(
+            "{API_BASE}/text-to-speech/{voice_id}?output_format={OUTPUT_FORMAT}"
+        ))
+        .header("xi-api-key", &settings.elevenlabs_api_key)
+        .header("Accept", "audio/mpeg")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("ElevenLabs TTS request failed: {e}"))?;
+
+    let response = crate::http::check_response(response).await?;
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read TTS response bytes: {e}"))?;
+
+    if bytes.is_empty() {
+        return Err("ElevenLabs returned an empty audio body.".to_string());
+    }
+
+    tokio::fs::write(&file_path, &bytes)
+        .await
+        .map_err(|e| format!("Failed to write voice clip: {e}"))?;
+
+    Ok(VoiceClip {
+        file_path: file_path.to_string_lossy().to_string(),
+        cache_hash,
+        text_sha8,
+        data_url: to_data_url(&bytes),
+        size_bytes: bytes.len() as u64,
+        cached: false,
+    })
+}
+
+fn to_data_url(bytes: &[u8]) -> String {
+    let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+    format!("data:audio/mpeg;base64,{b64}")
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_hash_is_deterministic() {
+        let a = cache_hash("Greetings, traveler.", "voiceA", "eleven_multilingual_v2");
+        let b = cache_hash("Greetings, traveler.", "voiceA", "eleven_multilingual_v2");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn cache_hash_varies_with_text_voice_and_model() {
+        let base = cache_hash("hello", "voiceA", "model1");
+        assert_ne!(base, cache_hash("world", "voiceA", "model1"));
+        assert_ne!(base, cache_hash("hello", "voiceB", "model1"));
+        assert_ne!(base, cache_hash("hello", "voiceA", "model2"));
+    }
+
+    #[test]
+    fn text_sha8_is_eight_hex_chars() {
+        let h = text_sha8("Greetings, traveler.");
+        assert_eq!(h.len(), 8);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn text_sha8_matches_known_vector() {
+        // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb924...
+        assert_eq!(text_sha8(""), "e3b0c442");
+    }
+
+    #[test]
+    fn text_sha8_is_sensitive_to_whitespace() {
+        // The engine hashes raw node text — leading/trailing whitespace counts.
+        assert_ne!(text_sha8("hello"), text_sha8(" hello "));
+    }
+}

--- a/creator/src-tauri/src/elevenlabs.rs
+++ b/creator/src-tauri/src/elevenlabs.rs
@@ -19,6 +19,7 @@ use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager};
 
 use crate::settings;
+use crate::voices::VoiceSettings;
 
 const API_BASE: &str = "https://api.elevenlabs.io/v1";
 
@@ -63,14 +64,54 @@ pub struct VoiceClip {
 
 // ─── Hashing ─────────────────────────────────────────────────────
 
-fn cache_hash(text: &str, voice_id: &str, model_id: &str) -> String {
+fn cache_hash(text: &str, voice_id: &str, model_id: &str, settings: &VoiceSettings) -> String {
     let mut hasher = Sha256::new();
     hasher.update(text.as_bytes());
     hasher.update(b"|");
     hasher.update(voice_id.as_bytes());
     hasher.update(b"|");
     hasher.update(model_id.as_bytes());
+    hasher.update(b"|");
+    // Delivery settings change the audio, so they must change the cache key.
+    hasher.update(settings_fingerprint(settings).as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+/// Deterministic string form of the (clamped) settings for cache keying.
+fn settings_fingerprint(s: &VoiceSettings) -> String {
+    fn f(o: Option<f32>) -> String {
+        o.map(|x| format!("{x:.3}")).unwrap_or_else(|| "_".to_string())
+    }
+    format!(
+        "st{}|si{}|sy{}|sp{}|b{}",
+        f(s.stability),
+        f(s.similarity_boost),
+        f(s.style),
+        f(s.speed),
+        s.use_speaker_boost
+            .map(|b| if b { "1" } else { "0" })
+            .unwrap_or("_"),
+    )
+}
+
+/// Clamp settings to ElevenLabs' accepted ranges. None stays None (omitted from
+/// the request → the voice's own default applies).
+fn normalize_settings(s: VoiceSettings) -> VoiceSettings {
+    VoiceSettings {
+        stability: s.stability.map(|v| v.clamp(0.0, 1.0)),
+        similarity_boost: s.similarity_boost.map(|v| v.clamp(0.0, 1.0)),
+        style: s.style.map(|v| v.clamp(0.0, 1.0)),
+        use_speaker_boost: s.use_speaker_boost,
+        speed: s.speed.map(|v| v.clamp(0.7, 1.2)),
+    }
+}
+
+fn settings_is_empty(s: &VoiceSettings) -> bool {
+    s.stability.is_none()
+        && s.similarity_boost.is_none()
+        && s.style.is_none()
+        && s.use_speaker_boost.is_none()
+        && s.speed.is_none()
 }
 
 /// First 8 hex chars of SHA-256 over the exact raw node text. This is the
@@ -131,6 +172,36 @@ pub async fn elevenlabs_list_voices(app: AppHandle) -> Result<Vec<ElevenLabsVoic
 struct TtsRequest {
     text: String,
     model_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    voice_settings: Option<ApiVoiceSettings>,
+}
+
+/// ElevenLabs request-body shape for voice settings (snake_case, as the API
+/// expects). Built from the camelCase `VoiceSettings` storage type.
+#[derive(Debug, Serialize)]
+struct ApiVoiceSettings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stability: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    similarity_boost: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    style: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    use_speaker_boost: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    speed: Option<f32>,
+}
+
+impl From<&VoiceSettings> for ApiVoiceSettings {
+    fn from(s: &VoiceSettings) -> Self {
+        Self {
+            stability: s.stability,
+            similarity_boost: s.similarity_boost,
+            style: s.style,
+            use_speaker_boost: s.use_speaker_boost,
+            speed: s.speed,
+        }
+    }
 }
 
 /// Synthesize a dialogue line into an MP3 clip via ElevenLabs.
@@ -144,6 +215,7 @@ pub async fn elevenlabs_synthesize(
     text: String,
     voice_id: String,
     model_id: Option<String>,
+    voice_settings: Option<VoiceSettings>,
 ) -> Result<VoiceClip, String> {
     if text.trim().is_empty() {
         return Err("Voice-over text is empty.".to_string());
@@ -157,7 +229,9 @@ pub async fn elevenlabs_synthesize(
         .filter(|m| !m.is_empty())
         .unwrap_or_else(|| DEFAULT_MODEL.to_string());
 
-    let cache_hash = cache_hash(&text, &voice_id, &model_id);
+    let settings = normalize_settings(voice_settings.unwrap_or_default());
+
+    let cache_hash = cache_hash(&text, &voice_id, &model_id, &settings);
     let text_sha8 = text_sha8(&text);
     let dir = voices_cache_dir(&app).await?;
     let file_path = dir.join(format!("{cache_hash}.mp3"));
@@ -180,14 +254,19 @@ pub async fn elevenlabs_synthesize(
     }
 
     // ─── Request ─────────────────────────────────────────────
-    let settings = settings::get_settings(app.clone()).await?;
-    if settings.elevenlabs_api_key.is_empty() {
+    let app_settings = settings::get_settings(app.clone()).await?;
+    if app_settings.elevenlabs_api_key.is_empty() {
         return Err("ElevenLabs API key not configured. Set it in Settings.".to_string());
     }
 
     let body = TtsRequest {
         text: text.clone(),
         model_id: model_id.clone(),
+        voice_settings: if settings_is_empty(&settings) {
+            None
+        } else {
+            Some(ApiVoiceSettings::from(&settings))
+        },
     };
 
     let client = crate::http::shared_client();
@@ -195,7 +274,7 @@ pub async fn elevenlabs_synthesize(
         .post(format!(
             "{API_BASE}/text-to-speech/{voice_id}?output_format={OUTPUT_FORMAT}"
         ))
-        .header("xi-api-key", &settings.elevenlabs_api_key)
+        .header("xi-api-key", &app_settings.elevenlabs_api_key)
         .header("Accept", "audio/mpeg")
         .json(&body)
         .send()
@@ -237,19 +316,54 @@ fn to_data_url(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    fn no_settings() -> VoiceSettings {
+        VoiceSettings::default()
+    }
+
     #[test]
     fn cache_hash_is_deterministic() {
-        let a = cache_hash("Greetings, traveler.", "voiceA", "eleven_multilingual_v2");
-        let b = cache_hash("Greetings, traveler.", "voiceA", "eleven_multilingual_v2");
+        let a = cache_hash("Greetings, traveler.", "voiceA", "eleven_multilingual_v2", &no_settings());
+        let b = cache_hash("Greetings, traveler.", "voiceA", "eleven_multilingual_v2", &no_settings());
         assert_eq!(a, b);
     }
 
     #[test]
     fn cache_hash_varies_with_text_voice_and_model() {
-        let base = cache_hash("hello", "voiceA", "model1");
-        assert_ne!(base, cache_hash("world", "voiceA", "model1"));
-        assert_ne!(base, cache_hash("hello", "voiceB", "model1"));
-        assert_ne!(base, cache_hash("hello", "voiceA", "model2"));
+        let base = cache_hash("hello", "voiceA", "model1", &no_settings());
+        assert_ne!(base, cache_hash("world", "voiceA", "model1", &no_settings()));
+        assert_ne!(base, cache_hash("hello", "voiceB", "model1", &no_settings()));
+        assert_ne!(base, cache_hash("hello", "voiceA", "model2", &no_settings()));
+    }
+
+    #[test]
+    fn cache_hash_varies_with_voice_settings() {
+        let base = cache_hash("hello", "voiceA", "model1", &no_settings());
+        let tweaked = VoiceSettings {
+            stability: Some(0.2),
+            ..VoiceSettings::default()
+        };
+        assert_ne!(base, cache_hash("hello", "voiceA", "model1", &tweaked));
+        // Same settings → same hash.
+        assert_eq!(
+            cache_hash("hello", "voiceA", "model1", &tweaked),
+            cache_hash("hello", "voiceA", "model1", &tweaked),
+        );
+    }
+
+    #[test]
+    fn normalize_settings_clamps_to_ranges() {
+        let n = normalize_settings(VoiceSettings {
+            stability: Some(1.5),
+            similarity_boost: Some(-0.2),
+            style: Some(2.0),
+            use_speaker_boost: Some(false),
+            speed: Some(3.0),
+        });
+        assert_eq!(n.stability, Some(1.0));
+        assert_eq!(n.similarity_boost, Some(0.0));
+        assert_eq!(n.style, Some(1.0));
+        assert_eq!(n.speed, Some(1.2));
+        assert_eq!(n.use_speaker_boost, Some(false));
     }
 
     #[test]

--- a/creator/src-tauri/src/elevenlabs.rs
+++ b/creator/src-tauri/src/elevenlabs.rs
@@ -194,6 +194,63 @@ pub async fn elevenlabs_list_voices(app: AppHandle) -> Result<Vec<ElevenLabsVoic
     Ok(parsed.voices.into_iter().map(ElevenLabsVoice::from).collect())
 }
 
+/// `/v1/voices/{id}/settings` response (snake_case). Mapped to the camelCase
+/// `VoiceSettings` the frontend stores.
+#[derive(Debug, Default, Deserialize)]
+struct ApiVoiceSettingsResponse {
+    #[serde(default)]
+    stability: Option<f32>,
+    #[serde(default)]
+    similarity_boost: Option<f32>,
+    #[serde(default)]
+    style: Option<f32>,
+    #[serde(default)]
+    use_speaker_boost: Option<bool>,
+    #[serde(default)]
+    speed: Option<f32>,
+}
+
+impl From<ApiVoiceSettingsResponse> for VoiceSettings {
+    fn from(r: ApiVoiceSettingsResponse) -> Self {
+        Self {
+            stability: r.stability,
+            similarity_boost: r.similarity_boost,
+            style: r.style,
+            use_speaker_boost: r.use_speaker_boost,
+            speed: r.speed,
+        }
+    }
+}
+
+/// Fetch a voice's own saved settings, used to seed the editor sliders so they
+/// start at the voice's defaults rather than a generic baseline.
+#[tauri::command]
+pub async fn elevenlabs_voice_settings(
+    app: AppHandle,
+    voice_id: String,
+) -> Result<VoiceSettings, String> {
+    if voice_id.trim().is_empty() {
+        return Err("No voice id.".to_string());
+    }
+    let settings = settings::get_settings(app).await?;
+    if settings.elevenlabs_api_key.is_empty() {
+        return Err("ElevenLabs API key not configured. Set it in Settings.".to_string());
+    }
+    let client = crate::http::shared_client();
+    let response = client
+        .get(format!("{API_BASE}/voices/{voice_id}/settings"))
+        .header("xi-api-key", &settings.elevenlabs_api_key)
+        .send()
+        .await
+        .map_err(|e| format!("ElevenLabs voice settings request failed: {e}"))?;
+    let response = crate::http::check_response(response).await?;
+    let parsed: ApiVoiceSettingsResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse voice settings response: {e}"))?;
+    Ok(VoiceSettings::from(parsed))
+}
+
 #[derive(Debug, Serialize)]
 struct TtsRequest {
     text: String,

--- a/creator/src-tauri/src/elevenlabs.rs
+++ b/creator/src-tauri/src/elevenlabs.rs
@@ -266,6 +266,14 @@ mod tests {
     }
 
     #[test]
+    fn text_sha8_matches_contract_reference_vectors() {
+        // Cross-repo reference vectors shared with AmbonMUD's GmcpEmitter.sha8.
+        // `printf 'Hello!' | sha256sum` → 334d016f…
+        assert_eq!(text_sha8("Hello!"), "334d016f");
+        assert_eq!(text_sha8("Hello there!"), "89b8b8e4");
+    }
+
+    #[test]
     fn text_sha8_is_sensitive_to_whitespace() {
         // The engine hashes raw node text — leading/trailing whitespace counts.
         assert_ne!(text_sha8("hello"), text_sha8(" hello "));

--- a/creator/src-tauri/src/elevenlabs.rs
+++ b/creator/src-tauri/src/elevenlabs.rs
@@ -367,6 +367,85 @@ fn to_data_url(bytes: &[u8]) -> String {
     format!("data:audio/mpeg;base64,{b64}")
 }
 
+// ─── Cache status + readback (panel rehydration) ─────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceStatusQuery {
+    /// Opaque key echoed back so the frontend can map results to lines.
+    pub key: String,
+    pub text: String,
+    pub voice_id: String,
+    #[serde(default)]
+    pub model_id: Option<String>,
+    #[serde(default)]
+    pub voice_settings: Option<VoiceSettings>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceStatusResult {
+    pub key: String,
+    pub cache_hash: String,
+    pub text_sha8: String,
+    pub present: bool,
+}
+
+/// For each line, compute its clip cache key and report whether the MP3 is
+/// already cached on disk. Lets the panel restore "already generated" status
+/// after a reopen or app restart without re-calling ElevenLabs.
+#[tauri::command]
+pub async fn voice_clip_status(
+    app: AppHandle,
+    queries: Vec<VoiceStatusQuery>,
+) -> Result<Vec<VoiceStatusResult>, String> {
+    let dir = voices_cache_dir(&app).await?;
+    let mut out = Vec::with_capacity(queries.len());
+    for q in queries {
+        let text_sha8 = text_sha8(&q.text);
+        if q.text.trim().is_empty() || q.voice_id.trim().is_empty() {
+            out.push(VoiceStatusResult {
+                key: q.key,
+                cache_hash: String::new(),
+                text_sha8,
+                present: false,
+            });
+            continue;
+        }
+        let model_id = q
+            .model_id
+            .map(|m| m.trim().to_string())
+            .filter(|m| !m.is_empty())
+            .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+        let settings = normalize_settings(q.voice_settings.unwrap_or_default());
+        let cache_hash = cache_hash(&q.text, &q.voice_id, &model_id, &settings);
+        let path = dir.join(format!("{cache_hash}.mp3"));
+        let present = matches!(tokio::fs::metadata(&path).await, Ok(m) if m.is_file() && m.len() > 0);
+        out.push(VoiceStatusResult {
+            key: q.key,
+            cache_hash,
+            text_sha8,
+            present,
+        });
+    }
+    Ok(out)
+}
+
+/// Read a cached clip back as a data URL for preview playback. Used when a
+/// line's status was rehydrated from disk (no in-memory data URL yet).
+#[tauri::command]
+pub async fn read_voice_clip(app: AppHandle, cache_hash: String) -> Result<String, String> {
+    if cache_hash.is_empty() || !cache_hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("Invalid clip id.".to_string());
+    }
+    let dir = voices_cache_dir(&app).await?;
+    let path = dir.join(format!("{cache_hash}.mp3"));
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|e| format!("Cached clip not found: {e}"))?;
+    Ok(to_data_url(&bytes))
+}
+
 // ─── Tests ───────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/creator/src-tauri/src/elevenlabs.rs
+++ b/creator/src-tauri/src/elevenlabs.rs
@@ -139,9 +139,35 @@ async fn voices_cache_dir(app: &AppHandle) -> Result<std::path::PathBuf, String>
 
 // ─── Commands ────────────────────────────────────────────────────
 
+/// ElevenLabs `/v1/voices` response shape. The API returns snake_case keys
+/// (`voice_id`, `preview_url`), so this parse type uses plain field names —
+/// distinct from the camelCase IPC `ElevenLabsVoice` we hand the frontend.
+/// Unknown fields are ignored.
+#[derive(Debug, Deserialize)]
+struct ApiVoice {
+    voice_id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    category: String,
+    #[serde(default)]
+    preview_url: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct ListVoicesResponse {
-    voices: Vec<ElevenLabsVoice>,
+    voices: Vec<ApiVoice>,
+}
+
+impl From<ApiVoice> for ElevenLabsVoice {
+    fn from(v: ApiVoice) -> Self {
+        Self {
+            voice_id: v.voice_id,
+            name: v.name,
+            category: v.category,
+            preview_url: v.preview_url,
+        }
+    }
 }
 
 /// List the voices available on the configured ElevenLabs account.
@@ -165,7 +191,7 @@ pub async fn elevenlabs_list_voices(app: AppHandle) -> Result<Vec<ElevenLabsVoic
         .json()
         .await
         .map_err(|e| format!("Failed to parse ElevenLabs voices response: {e}"))?;
-    Ok(parsed.voices)
+    Ok(parsed.voices.into_iter().map(ElevenLabsVoice::from).collect())
 }
 
 #[derive(Debug, Serialize)]
@@ -364,6 +390,35 @@ mod tests {
         assert_eq!(n.style, Some(1.0));
         assert_eq!(n.speed, Some(1.2));
         assert_eq!(n.use_speaker_boost, Some(false));
+    }
+
+    #[test]
+    fn parses_snake_case_voices_response() {
+        // ElevenLabs returns snake_case keys + many extra fields we ignore.
+        let body = r#"{
+            "voices": [
+                {
+                    "voice_id": "21m00Tcm4TlvDq8ikWAM",
+                    "name": "Rachel",
+                    "category": "premade",
+                    "preview_url": "https://example.com/rachel.mp3",
+                    "labels": {"accent": "american"},
+                    "settings": null
+                },
+                { "voice_id": "abc123", "name": "Goblin" }
+            ]
+        }"#;
+        let parsed: ListVoicesResponse = serde_json::from_str(body).unwrap();
+        let voices: Vec<ElevenLabsVoice> =
+            parsed.voices.into_iter().map(ElevenLabsVoice::from).collect();
+        assert_eq!(voices.len(), 2);
+        assert_eq!(voices[0].voice_id, "21m00Tcm4TlvDq8ikWAM");
+        assert_eq!(voices[0].name, "Rachel");
+        assert_eq!(voices[0].preview_url, "https://example.com/rachel.mp3");
+        // Missing category/preview_url default to empty, don't fail the parse.
+        assert_eq!(voices[1].voice_id, "abc123");
+        assert_eq!(voices[1].category, "");
+        assert_eq!(voices[1].preview_url, "");
     }
 
     #[test]

--- a/creator/src-tauri/src/elevenlabs.rs
+++ b/creator/src-tauri/src/elevenlabs.rs
@@ -83,7 +83,7 @@ fn settings_fingerprint(s: &VoiceSettings) -> String {
         o.map(|x| format!("{x:.3}")).unwrap_or_else(|| "_".to_string())
     }
     format!(
-        "st{}|si{}|sy{}|sp{}|b{}",
+        "st{}|si{}|sy{}|sp{}|b{}|p{}",
         f(s.stability),
         f(s.similarity_boost),
         f(s.style),
@@ -91,7 +91,66 @@ fn settings_fingerprint(s: &VoiceSettings) -> String {
         s.use_speaker_boost
             .map(|b| if b { "1" } else { "0" })
             .unwrap_or("_"),
+        f(s.sentence_pause),
     )
+}
+
+/// Insert `<break time="Xs" />` after sentence-ending punctuation so spoken
+/// dialogue gets a beat between sentences. Applied only to the synthesis input
+/// — the stored/displayed/hashed node text is untouched. Skips text that
+/// already contains break tags, and caps inserted breaks to avoid the
+/// instability ElevenLabs warns about with many tags.
+fn insert_sentence_breaks(text: &str, pause_secs: f32) -> String {
+    if pause_secs <= 0.0 || text.contains("<break") {
+        return text.to_string();
+    }
+    const MAX_BREAKS: usize = 8;
+    let tag = format!("<break time=\"{pause_secs:.2}s\" />");
+    let s: Vec<char> = text.chars().collect();
+    let n = s.len();
+    let mut out = String::with_capacity(text.len() + tag.len() * 4);
+    let mut inserted = 0;
+    let mut i = 0;
+    while i < n {
+        out.push(s[i]);
+        if inserted < MAX_BREAKS && matches!(s[i], '.' | '!' | '?') {
+            // Swallow a run of consecutive enders / closing quotes (e.g. "?!",
+            // "...", a period before a closing quote) so we break after the
+            // whole cluster, not inside it.
+            let mut j = i + 1;
+            while j < n
+                && matches!(
+                    s[j],
+                    '.' | '!' | '?' | '"' | '\'' | ')' | ']' | '\u{201D}' | '\u{2019}'
+                )
+            {
+                out.push(s[j]);
+                j += 1;
+            }
+            let ws_start = j;
+            while j < n && s[j].is_whitespace() {
+                j += 1;
+            }
+            let had_ws = j > ws_start;
+            let more_text = j < n;
+            if had_ws && more_text {
+                out.push(' ');
+                out.push_str(&tag);
+                out.push(' ');
+                inserted += 1;
+            } else {
+                // No whitespace boundary (e.g. "3.14") or end of line — keep
+                // whatever we consumed verbatim, no break.
+                for ch in &s[ws_start..j] {
+                    out.push(*ch);
+                }
+            }
+            i = j;
+            continue;
+        }
+        i += 1;
+    }
+    out
 }
 
 /// Clamp settings to ElevenLabs' accepted ranges. None stays None (omitted from
@@ -103,6 +162,7 @@ fn normalize_settings(s: VoiceSettings) -> VoiceSettings {
         style: s.style.map(|v| v.clamp(0.0, 1.0)),
         use_speaker_boost: s.use_speaker_boost,
         speed: s.speed.map(|v| v.clamp(0.7, 1.2)),
+        sentence_pause: s.sentence_pause.map(|v| v.clamp(0.0, 2.0)),
     }
 }
 
@@ -218,6 +278,8 @@ impl From<ApiVoiceSettingsResponse> for VoiceSettings {
             style: r.style,
             use_speaker_boost: r.use_speaker_boost,
             speed: r.speed,
+            // Not an ElevenLabs voice setting — always defaults to no pause.
+            sentence_pause: None,
         }
     }
 }
@@ -342,8 +404,12 @@ pub async fn elevenlabs_synthesize(
         return Err("ElevenLabs API key not configured. Set it in Settings.".to_string());
     }
 
+    // Sentence pauses are an Arcanum-side text transform, not a voice setting:
+    // they only affect what we send to ElevenLabs, never `text_sha8`/the path.
+    let synth_text = insert_sentence_breaks(&text, settings.sentence_pause.unwrap_or(0.0));
+
     let body = TtsRequest {
-        text: text.clone(),
+        text: synth_text,
         model_id: model_id.clone(),
         voice_settings: if settings_is_empty(&settings) {
             None
@@ -551,12 +617,46 @@ mod tests {
             style: Some(2.0),
             use_speaker_boost: Some(false),
             speed: Some(3.0),
+            sentence_pause: Some(5.0),
         });
         assert_eq!(n.stability, Some(1.0));
         assert_eq!(n.similarity_boost, Some(0.0));
         assert_eq!(n.style, Some(1.0));
         assert_eq!(n.speed, Some(1.2));
         assert_eq!(n.use_speaker_boost, Some(false));
+        assert_eq!(n.sentence_pause, Some(2.0));
+    }
+
+    #[test]
+    fn cache_hash_varies_with_sentence_pause() {
+        let base = cache_hash("hello", "voiceA", "model1", &no_settings());
+        let paused = VoiceSettings {
+            sentence_pause: Some(0.8),
+            ..VoiceSettings::default()
+        };
+        assert_ne!(base, cache_hash("hello", "voiceA", "model1", &paused));
+    }
+
+    #[test]
+    fn insert_sentence_breaks_adds_tags_between_sentences() {
+        let out = insert_sentence_breaks("Hello there. Stay a while.", 1.0);
+        assert_eq!(out, "Hello there. <break time=\"1.00s\" /> Stay a while.");
+    }
+
+    #[test]
+    fn insert_sentence_breaks_groups_clusters_and_skips_trailing() {
+        // "?!" cluster gets one break; the final sentence gets no trailing tag.
+        let out = insert_sentence_breaks("Really?! Yes.", 0.5);
+        assert_eq!(out, "Really?! <break time=\"0.50s\" /> Yes.");
+    }
+
+    #[test]
+    fn insert_sentence_breaks_noop_cases() {
+        // Zero pause, decimals, and pre-existing break tags are left alone.
+        assert_eq!(insert_sentence_breaks("One. Two.", 0.0), "One. Two.");
+        assert_eq!(insert_sentence_breaks("Pi is 3.14 exactly.", 1.0), "Pi is 3.14 exactly.");
+        let existing = "A. <break time=\"2.00s\" /> B.";
+        assert_eq!(insert_sentence_breaks(existing, 1.0), existing);
     }
 
     #[test]

--- a/creator/src-tauri/src/elevenlabs.rs
+++ b/creator/src-tauri/src/elevenlabs.rs
@@ -271,6 +271,9 @@ mod tests {
         // `printf 'Hello!' | sha256sum` → 334d016f…
         assert_eq!(text_sha8("Hello!"), "334d016f");
         assert_eq!(text_sha8("Hello there!"), "89b8b8e4");
+        // YAML `|` literal block (clip chomping) → exactly one trailing newline.
+        // The terminal '\n' is hash-significant; `|-` (strip) would differ.
+        assert_eq!(text_sha8("Hello there!\nStay a while.\n"), "df658e4d");
     }
 
     #[test]

--- a/creator/src-tauri/src/elevenlabs.rs
+++ b/creator/src-tauri/src/elevenlabs.rs
@@ -295,24 +295,55 @@ pub async fn elevenlabs_synthesize(
         },
     };
 
+    // Retry transient failures with backoff. ElevenLabs returns 429
+    // `too_many_concurrent_requests` when parallel calls exceed the plan's
+    // concurrency cap, and occasional 5xx under load — both clear on retry,
+    // so a bulk "Generate all" doesn't lose most of its lines to the cap.
     let client = crate::http::shared_client();
-    let response = client
-        .post(format!(
-            "{API_BASE}/text-to-speech/{voice_id}?output_format={OUTPUT_FORMAT}"
-        ))
-        .header("xi-api-key", &app_settings.elevenlabs_api_key)
-        .header("Accept", "audio/mpeg")
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| format!("ElevenLabs TTS request failed: {e}"))?;
+    let url = format!("{API_BASE}/text-to-speech/{voice_id}?output_format={OUTPUT_FORMAT}");
+    const MAX_ATTEMPTS: u32 = 5;
+    let mut last_err = String::new();
+    let mut bytes = None;
 
-    let response = crate::http::check_response(response).await?;
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| format!("Failed to read TTS response bytes: {e}"))?;
+    for attempt in 1..=MAX_ATTEMPTS {
+        match client
+            .post(&url)
+            .header("xi-api-key", &app_settings.elevenlabs_api_key)
+            .header("Accept", "audio/mpeg")
+            .json(&body)
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                let b = resp
+                    .bytes()
+                    .await
+                    .map_err(|e| format!("Failed to read TTS response bytes: {e}"))?;
+                bytes = Some(b);
+                break;
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let text = resp.text().await.unwrap_or_default();
+                let retryable = status.is_server_error() || status.as_u16() == 429;
+                last_err = format!("ElevenLabs TTS failed ({status}): {text}");
+                if !retryable || attempt == MAX_ATTEMPTS {
+                    return Err(last_err);
+                }
+            }
+            Err(e) => {
+                last_err = format!("ElevenLabs TTS request failed: {e}");
+                if attempt == MAX_ATTEMPTS {
+                    return Err(last_err);
+                }
+            }
+        }
+        // Backoff: 600ms, 1.2s, 2.4s, 4.8s — long enough for in-flight
+        // concurrent requests to clear the cap.
+        tokio::time::sleep(std::time::Duration::from_millis(600u64 << (attempt - 1))).await;
+    }
 
+    let bytes = bytes.ok_or(last_err)?;
     if bytes.is_empty() {
         return Err("ElevenLabs returned an empty audio body.".to_string());
     }

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -188,6 +188,8 @@ pub fn run() {
                     openai_tts::openai_tts_generate,
                     elevenlabs::elevenlabs_list_voices,
                     elevenlabs::elevenlabs_synthesize,
+                    elevenlabs::voice_clip_status,
+                    elevenlabs::read_voice_clip,
                     sketch::analyze_sketch,
                     rag::rag_upsert_chunks,
                     rag::rag_retrieve,

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -187,6 +187,7 @@ pub fn run() {
                     openai_images::openai_generate_image,
                     openai_tts::openai_tts_generate,
                     elevenlabs::elevenlabs_list_voices,
+                    elevenlabs::elevenlabs_voice_settings,
                     elevenlabs::elevenlabs_synthesize,
                     elevenlabs::voice_clip_status,
                     elevenlabs::read_voice_clip,

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -9,6 +9,8 @@ mod captions;
 #[cfg(feature = "ai")]
 mod deepinfra;
 #[cfg(feature = "ai")]
+mod elevenlabs;
+#[cfg(feature = "ai")]
 mod embeddings;
 #[cfg(feature = "ai")]
 mod rag;
@@ -42,6 +44,7 @@ mod sketch;
 mod video_encode;
 mod video_export;
 mod vibes;
+mod voices;
 
 macro_rules! base_handler {
     ($($extra:path),* $(,)?) => {
@@ -106,9 +109,12 @@ macro_rules! base_handler {
             r2::deploy_zones_to_r2,
             r2::deploy_showcase_to_r2,
             r2::deploy_story_video_to_r2,
+            r2::deploy_voices_to_r2,
             hub::publish_to_hub,
             vibes::save_zone_vibe,
             vibes::load_zone_vibe,
+            voices::load_voice_map,
+            voices::save_voice_map,
             arcanum_meta::load_arcanum_meta,
             arcanum_meta::save_arcanum_meta,
             admin::load_admin_config,
@@ -180,6 +186,8 @@ pub fn run() {
                     runware::runware_generate_video,
                     openai_images::openai_generate_image,
                     openai_tts::openai_tts_generate,
+                    elevenlabs::elevenlabs_list_voices,
+                    elevenlabs::elevenlabs_synthesize,
                     sketch::analyze_sketch,
                     rag::rag_upsert_chunks,
                     rag::rag_retrieve,

--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -1126,28 +1126,19 @@ pub async fn deploy_zones_to_r2(
     Ok(progress)
 }
 
-/// Structural R2 object key for a dialogue clip:
-/// `voices/<zone>/<templateKey>/<nodeId>.mp3`. This is the path the AmbonMUD
-/// engine currently resolves `voiceUrl` to.
-fn voice_object_key_plain(zone: &str, template_key: &str, node_id: &str) -> String {
-    format!("voices/{zone}/{template_key}/{node_id}.mp3")
-}
-
-/// Edit-safe R2 object key embedding the agreed text hash:
-/// `voices/<zone>/<templateKey>/<nodeId>.<sha8>.mp3`. The engine resolves to
-/// this once it adopts the `.<sha8>` variant; an edited line publishes to a
-/// fresh path so stale audio is never served.
+/// R2 object key for a dialogue clip, embedding the agreed text hash:
+/// `voices/<zone>/<templateKey>/<nodeId>.<sha8>.mp3`. The AmbonMUD engine
+/// resolves `voiceUrl` to the identical key (it recomputes `<sha8>` from the
+/// same raw `node.text`), so both repos derive byte-identical paths. An edited
+/// line publishes to a fresh key, so stale audio is never served.
 fn voice_object_key(zone: &str, template_key: &str, node_id: &str, text_sha8: &str) -> String {
     format!("voices/{zone}/{template_key}/{node_id}.{text_sha8}.mp3")
 }
 
-/// Upload synthesized dialogue clips to R2. Each clip is published to BOTH the
-/// structural path (`…/<nodeId>.mp3`) and the edit-safe hashed path
-/// (`…/<nodeId>.<sha8>.mp3`) so it resolves whether the AmbonMUD engine emits
-/// the structural URL (current behavior) or the hashed variant (future flip).
-/// Re-uploads are skipped when the source bytes match the last publish (via the
-/// runtime sync-state cache, keyed per object). The structural path is
-/// overwritten in place on edit; the hashed path lands at a fresh key.
+/// Upload synthesized dialogue clips to R2 at the voice-over contract path.
+/// Skips re-uploading clips whose source bytes match the last publish (via the
+/// runtime sync-state cache). Because the object key embeds the text hash, an
+/// edited line publishes to a fresh path and never serves stale audio.
 #[tauri::command]
 pub async fn deploy_voices_to_r2(
     app: AppHandle,
@@ -1166,9 +1157,8 @@ pub async fn deploy_voices_to_r2(
     let client = crate::http::shared_client();
     let mut sync_state = load_runtime_sync_state(&app).await;
 
-    // Each job publishes to two object keys (structural + hashed).
     let mut progress = SyncProgress {
-        total: jobs.len() * 2,
+        total: jobs.len(),
         uploaded: 0,
         skipped: 0,
         failed: 0,
@@ -1177,59 +1167,54 @@ pub async fn deploy_voices_to_r2(
 
     for job in &jobs {
         if job.zone.is_empty() || job.template_key.is_empty() || job.node_id.is_empty() {
-            progress.failed += 2;
+            progress.failed += 1;
             progress
                 .errors
                 .push(format!("{}: missing zone/template/node", job.cache_hash));
             continue;
         }
 
+        let object_key =
+            voice_object_key(&job.zone, &job.template_key, &job.node_id, &job.text_sha8);
+
         let file_path = voices_dir.join(format!("{}.mp3", job.cache_hash));
         let body = match tokio::fs::read(&file_path).await {
             Ok(b) => b,
             Err(e) => {
-                progress.failed += 2;
-                progress.errors.push(format!(
-                    "{}/{}/{}: clip not generated yet ({e})",
-                    job.zone, job.template_key, job.node_id
-                ));
+                progress.failed += 1;
+                progress
+                    .errors
+                    .push(format!("{object_key}: clip not generated yet ({e})"));
                 continue;
             }
         };
+
+        // Skip re-upload when the source bytes match the last publish.
         let src_hash = sha256_hex(&body);
+        if sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
+            progress.skipped += 1;
+            continue;
+        }
 
-        let object_keys = [
-            voice_object_key_plain(&job.zone, &job.template_key, &job.node_id),
-            voice_object_key(&job.zone, &job.template_key, &job.node_id, &job.text_sha8),
-        ];
-
-        for object_key in object_keys {
-            // Skip re-upload when the source bytes match the last publish.
-            if sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
-                progress.skipped += 1;
-                continue;
+        match upload_object(
+            &client,
+            &s.r2_account_id,
+            &s.r2_bucket,
+            &s.r2_access_key_id,
+            &s.r2_secret_access_key,
+            &object_key,
+            body,
+            "audio/mpeg",
+        )
+        .await
+        {
+            Ok(()) => {
+                progress.uploaded += 1;
+                sync_state.insert(object_key.clone(), src_hash);
             }
-
-            match upload_object(
-                &client,
-                &s.r2_account_id,
-                &s.r2_bucket,
-                &s.r2_access_key_id,
-                &s.r2_secret_access_key,
-                &object_key,
-                body.clone(),
-                "audio/mpeg",
-            )
-            .await
-            {
-                Ok(()) => {
-                    progress.uploaded += 1;
-                    sync_state.insert(object_key.clone(), src_hash.clone());
-                }
-                Err(e) => {
-                    progress.failed += 1;
-                    progress.errors.push(format!("{object_key}: {e}"));
-                }
+            Err(e) => {
+                progress.failed += 1;
+                progress.errors.push(format!("{object_key}: {e}"));
             }
         }
     }
@@ -1462,10 +1447,12 @@ mod tests {
     }
 
     #[test]
-    fn voice_object_key_plain_matches_structural_template() {
+    fn voice_object_key_uses_reference_hash_vector() {
+        // sha8("Hello!") == 334d016f — the contract reference vector. The path
+        // must land exactly where the AmbonMUD engine resolves voiceUrl.
         assert_eq!(
-            voice_object_key_plain("tutorial_glade", "headmaster_aldric", "root"),
-            "voices/tutorial_glade/headmaster_aldric/root.mp3"
+            voice_object_key("tutorial_glade", "headmaster_aldric", "root", "334d016f"),
+            "voices/tutorial_glade/headmaster_aldric/root.334d016f.mp3"
         );
     }
 

--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -24,6 +24,21 @@ pub struct SyncProgress {
     pub errors: Vec<String>,
 }
 
+/// One dialogue clip to publish. The cached MP3 lives at
+/// `assets/voices/<cache_hash>.mp3` (written by `elevenlabs::synthesize`);
+/// it's uploaded to the contract path built from the other three fields.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceUploadJob {
+    pub zone: String,
+    pub template_key: String,
+    pub node_id: String,
+    /// First 8 hex of SHA-256(raw node text). Both repos agree on this.
+    pub text_sha8: String,
+    /// Cache filename stem of the local clip to upload.
+    pub cache_hash: String,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct RuntimeImageProfile {
     max_width: u32,
@@ -1111,6 +1126,102 @@ pub async fn deploy_zones_to_r2(
     Ok(progress)
 }
 
+/// Build the contract R2 object key for a dialogue clip:
+/// `voices/<zone>/<templateKey>/<nodeId>.<sha8>.mp3`. The AmbonMUD engine
+/// constructs the identical string from the same three values plus the
+/// agreed text hash, so both repos resolve to the same object.
+fn voice_object_key(zone: &str, template_key: &str, node_id: &str, text_sha8: &str) -> String {
+    format!("voices/{zone}/{template_key}/{node_id}.{text_sha8}.mp3")
+}
+
+/// Upload synthesized dialogue clips to R2 at the voice-over contract path.
+/// Skips re-uploading clips whose source bytes match the last publish (via the
+/// runtime sync-state cache). Because the object key embeds the text hash, an
+/// edited line publishes to a fresh path and never serves stale audio.
+#[tauri::command]
+pub async fn deploy_voices_to_r2(
+    app: AppHandle,
+    jobs: Vec<VoiceUploadJob>,
+) -> Result<SyncProgress, String> {
+    let s = settings::get_settings(app.clone()).await?;
+    if s.r2_account_id.is_empty()
+        || s.r2_access_key_id.is_empty()
+        || s.r2_secret_access_key.is_empty()
+        || s.r2_bucket.is_empty()
+    {
+        return Err("R2 credentials not configured. Set them in Settings.".to_string());
+    }
+
+    let voices_dir = assets_base_dir(&app)?.join("voices");
+    let client = crate::http::shared_client();
+    let mut sync_state = load_runtime_sync_state(&app).await;
+
+    let mut progress = SyncProgress {
+        total: jobs.len(),
+        uploaded: 0,
+        skipped: 0,
+        failed: 0,
+        errors: Vec::new(),
+    };
+
+    for job in &jobs {
+        if job.zone.is_empty() || job.template_key.is_empty() || job.node_id.is_empty() {
+            progress.failed += 1;
+            progress
+                .errors
+                .push(format!("{}: missing zone/template/node", job.cache_hash));
+            continue;
+        }
+
+        let object_key =
+            voice_object_key(&job.zone, &job.template_key, &job.node_id, &job.text_sha8);
+
+        let file_path = voices_dir.join(format!("{}.mp3", job.cache_hash));
+        let body = match tokio::fs::read(&file_path).await {
+            Ok(b) => b,
+            Err(e) => {
+                progress.failed += 1;
+                progress
+                    .errors
+                    .push(format!("{object_key}: clip not generated yet ({e})"));
+                continue;
+            }
+        };
+
+        // Skip re-upload when the source bytes match the last publish.
+        let src_hash = sha256_hex(&body);
+        if sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
+            progress.skipped += 1;
+            continue;
+        }
+
+        match upload_object(
+            &client,
+            &s.r2_account_id,
+            &s.r2_bucket,
+            &s.r2_access_key_id,
+            &s.r2_secret_access_key,
+            &object_key,
+            body,
+            "audio/mpeg",
+        )
+        .await
+        {
+            Ok(()) => {
+                progress.uploaded += 1;
+                sync_state.insert(object_key.clone(), src_hash);
+            }
+            Err(e) => {
+                progress.failed += 1;
+                progress.errors.push(format!("{object_key}: {e}"));
+            }
+        }
+    }
+
+    save_runtime_sync_state(&app, &sync_state).await;
+    Ok(progress)
+}
+
 // ─── Import from R2 ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1320,4 +1431,26 @@ pub async fn deploy_showcase_to_r2(
 
     let domain = s.r2_custom_domain.trim_end_matches('/');
     Ok(format!("{domain}/{object_key}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn voice_object_key_matches_contract_template() {
+        assert_eq!(
+            voice_object_key("tutorial_glade", "headmaster_aldric", "root", "1a2b3c4d"),
+            "voices/tutorial_glade/headmaster_aldric/root.1a2b3c4d.mp3"
+        );
+    }
+
+    #[test]
+    fn voice_object_key_distinguishes_nodes_and_hashes() {
+        let a = voice_object_key("z", "m", "root", "aaaaaaaa");
+        let b = voice_object_key("z", "m", "farewell", "aaaaaaaa");
+        let c = voice_object_key("z", "m", "root", "bbbbbbbb");
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+    }
 }

--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -1126,18 +1126,28 @@ pub async fn deploy_zones_to_r2(
     Ok(progress)
 }
 
-/// Build the contract R2 object key for a dialogue clip:
-/// `voices/<zone>/<templateKey>/<nodeId>.<sha8>.mp3`. The AmbonMUD engine
-/// constructs the identical string from the same three values plus the
-/// agreed text hash, so both repos resolve to the same object.
+/// Structural R2 object key for a dialogue clip:
+/// `voices/<zone>/<templateKey>/<nodeId>.mp3`. This is the path the AmbonMUD
+/// engine currently resolves `voiceUrl` to.
+fn voice_object_key_plain(zone: &str, template_key: &str, node_id: &str) -> String {
+    format!("voices/{zone}/{template_key}/{node_id}.mp3")
+}
+
+/// Edit-safe R2 object key embedding the agreed text hash:
+/// `voices/<zone>/<templateKey>/<nodeId>.<sha8>.mp3`. The engine resolves to
+/// this once it adopts the `.<sha8>` variant; an edited line publishes to a
+/// fresh path so stale audio is never served.
 fn voice_object_key(zone: &str, template_key: &str, node_id: &str, text_sha8: &str) -> String {
     format!("voices/{zone}/{template_key}/{node_id}.{text_sha8}.mp3")
 }
 
-/// Upload synthesized dialogue clips to R2 at the voice-over contract path.
-/// Skips re-uploading clips whose source bytes match the last publish (via the
-/// runtime sync-state cache). Because the object key embeds the text hash, an
-/// edited line publishes to a fresh path and never serves stale audio.
+/// Upload synthesized dialogue clips to R2. Each clip is published to BOTH the
+/// structural path (`…/<nodeId>.mp3`) and the edit-safe hashed path
+/// (`…/<nodeId>.<sha8>.mp3`) so it resolves whether the AmbonMUD engine emits
+/// the structural URL (current behavior) or the hashed variant (future flip).
+/// Re-uploads are skipped when the source bytes match the last publish (via the
+/// runtime sync-state cache, keyed per object). The structural path is
+/// overwritten in place on edit; the hashed path lands at a fresh key.
 #[tauri::command]
 pub async fn deploy_voices_to_r2(
     app: AppHandle,
@@ -1156,8 +1166,9 @@ pub async fn deploy_voices_to_r2(
     let client = crate::http::shared_client();
     let mut sync_state = load_runtime_sync_state(&app).await;
 
+    // Each job publishes to two object keys (structural + hashed).
     let mut progress = SyncProgress {
-        total: jobs.len(),
+        total: jobs.len() * 2,
         uploaded: 0,
         skipped: 0,
         failed: 0,
@@ -1166,54 +1177,59 @@ pub async fn deploy_voices_to_r2(
 
     for job in &jobs {
         if job.zone.is_empty() || job.template_key.is_empty() || job.node_id.is_empty() {
-            progress.failed += 1;
+            progress.failed += 2;
             progress
                 .errors
                 .push(format!("{}: missing zone/template/node", job.cache_hash));
             continue;
         }
 
-        let object_key =
-            voice_object_key(&job.zone, &job.template_key, &job.node_id, &job.text_sha8);
-
         let file_path = voices_dir.join(format!("{}.mp3", job.cache_hash));
         let body = match tokio::fs::read(&file_path).await {
             Ok(b) => b,
             Err(e) => {
-                progress.failed += 1;
-                progress
-                    .errors
-                    .push(format!("{object_key}: clip not generated yet ({e})"));
+                progress.failed += 2;
+                progress.errors.push(format!(
+                    "{}/{}/{}: clip not generated yet ({e})",
+                    job.zone, job.template_key, job.node_id
+                ));
                 continue;
             }
         };
-
-        // Skip re-upload when the source bytes match the last publish.
         let src_hash = sha256_hex(&body);
-        if sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
-            progress.skipped += 1;
-            continue;
-        }
 
-        match upload_object(
-            &client,
-            &s.r2_account_id,
-            &s.r2_bucket,
-            &s.r2_access_key_id,
-            &s.r2_secret_access_key,
-            &object_key,
-            body,
-            "audio/mpeg",
-        )
-        .await
-        {
-            Ok(()) => {
-                progress.uploaded += 1;
-                sync_state.insert(object_key.clone(), src_hash);
+        let object_keys = [
+            voice_object_key_plain(&job.zone, &job.template_key, &job.node_id),
+            voice_object_key(&job.zone, &job.template_key, &job.node_id, &job.text_sha8),
+        ];
+
+        for object_key in object_keys {
+            // Skip re-upload when the source bytes match the last publish.
+            if sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
+                progress.skipped += 1;
+                continue;
             }
-            Err(e) => {
-                progress.failed += 1;
-                progress.errors.push(format!("{object_key}: {e}"));
+
+            match upload_object(
+                &client,
+                &s.r2_account_id,
+                &s.r2_bucket,
+                &s.r2_access_key_id,
+                &s.r2_secret_access_key,
+                &object_key,
+                body.clone(),
+                "audio/mpeg",
+            )
+            .await
+            {
+                Ok(()) => {
+                    progress.uploaded += 1;
+                    sync_state.insert(object_key.clone(), src_hash.clone());
+                }
+                Err(e) => {
+                    progress.failed += 1;
+                    progress.errors.push(format!("{object_key}: {e}"));
+                }
             }
         }
     }
@@ -1442,6 +1458,14 @@ mod tests {
         assert_eq!(
             voice_object_key("tutorial_glade", "headmaster_aldric", "root", "1a2b3c4d"),
             "voices/tutorial_glade/headmaster_aldric/root.1a2b3c4d.mp3"
+        );
+    }
+
+    #[test]
+    fn voice_object_key_plain_matches_structural_template() {
+        assert_eq!(
+            voice_object_key_plain("tutorial_glade", "headmaster_aldric", "root"),
+            "voices/tutorial_glade/headmaster_aldric/root.mp3"
         );
     }
 

--- a/creator/src-tauri/src/settings.rs
+++ b/creator/src-tauri/src/settings.rs
@@ -40,6 +40,8 @@ pub struct Settings {
     #[serde(default)]
     pub openai_api_key: String,
     #[serde(default)]
+    pub elevenlabs_api_key: String,
+    #[serde(default)]
     pub voyage_api_key: String,
     #[serde(default = "default_image_model")]
     pub image_model: String,
@@ -136,6 +138,7 @@ impl Default for Settings {
             anthropic_api_key: String::new(),
             openrouter_api_key: String::new(),
             openai_api_key: String::new(),
+            elevenlabs_api_key: String::new(),
             voyage_api_key: String::new(),
             image_model: default_image_model(),
             enhance_model: default_enhance_model(),
@@ -219,6 +222,7 @@ pub async fn get_settings(app: AppHandle) -> Result<Settings, String> {
                 anthropic_api_key: user.anthropic_api_key,
                 openrouter_api_key: user.openrouter_api_key,
                 openai_api_key: user.openai_api_key,
+                elevenlabs_api_key: user.elevenlabs_api_key,
                 voyage_api_key: user.voyage_api_key,
                 github_pat: user.github_pat,
                 hub_api_url: user.hub_api_url,
@@ -288,6 +292,7 @@ pub async fn get_merged_settings(
             anthropic_api_key: user.anthropic_api_key,
             openrouter_api_key: user.openrouter_api_key,
             openai_api_key: user.openai_api_key,
+            elevenlabs_api_key: user.elevenlabs_api_key,
             voyage_api_key: user.voyage_api_key,
             github_pat: user.github_pat,
             hub_api_url: user.hub_api_url,

--- a/creator/src-tauri/src/voices.rs
+++ b/creator/src-tauri/src/voices.rs
@@ -1,0 +1,58 @@
+// ─── Dialogue voice map ──────────────────────────────────────────
+// Per-project mapping of mob templateKey → ElevenLabs voiceId, plus a
+// project-wide default voice and synthesis model. This map is Arcanum-only:
+// it never leaves the creator. The AmbonMUD engine never sees voiceIds — it
+// only resolves the published clip URL (see docs/VOICE_OVER_CONTRACT.md in
+// the AmbonMUD repo).
+//
+// Stored as `<project_dir>/.arcanum/voices.json`, kept out of the
+// server-read zone YAML so synthesis config never reaches the MUD.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+const VOICE_MAP_FILE: &str = ".arcanum/voices.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceMap {
+    /// Voice used for any mob without an explicit assignment.
+    #[serde(default)]
+    pub default_voice_id: String,
+    /// ElevenLabs model id used for all synthesis (e.g. `eleven_multilingual_v2`).
+    #[serde(default)]
+    pub model_id: String,
+    /// templateKey → ElevenLabs voiceId.
+    #[serde(default)]
+    pub assignments: HashMap<String, String>,
+}
+
+fn voice_map_path(project_dir: &str) -> PathBuf {
+    Path::new(project_dir).join(VOICE_MAP_FILE)
+}
+
+/// Load the project's voice map. Returns an empty map when none has been
+/// saved yet (rather than erroring) so the panel can start from blank.
+#[tauri::command]
+pub async fn load_voice_map(project_dir: String) -> Result<VoiceMap, String> {
+    let path = voice_map_path(&project_dir);
+    if !path.exists() {
+        return Ok(VoiceMap::default());
+    }
+    let data = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| format!("Failed to read voice map: {e}"))?;
+    serde_json::from_str(&data).map_err(|e| format!("Failed to parse voice map: {e}"))
+}
+
+#[tauri::command]
+pub async fn save_voice_map(project_dir: String, map: VoiceMap) -> Result<(), String> {
+    let path = voice_map_path(&project_dir);
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("Failed to create .arcanum dir: {e}"))?;
+    }
+    crate::fs_utils::write_json_file(&path, &map, "voice map").await
+}

--- a/creator/src-tauri/src/voices.rs
+++ b/creator/src-tauri/src/voices.rs
@@ -32,6 +32,11 @@ pub struct VoiceSettings {
     pub use_speaker_boost: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub speed: Option<f32>,
+    /// Extra pause (seconds) inserted after each sentence. Not an ElevenLabs
+    /// voice setting — Arcanum injects `<break>` tags into the synthesis input
+    /// only; the stored/displayed/hashed node text is unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sentence_pause: Option<f32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/creator/src-tauri/src/voices.rs
+++ b/creator/src-tauri/src/voices.rs
@@ -14,6 +14,26 @@ use std::path::{Path, PathBuf};
 
 const VOICE_MAP_FILE: &str = ".arcanum/voices.json";
 
+/// Per-request ElevenLabs delivery controls. Every field is optional — an
+/// unset field falls back to the project default, then to ElevenLabs' own
+/// voice default. Stored in the voice map (per-mob + a project default) and
+/// passed through to `elevenlabs_synthesize`. camelCase on the wire for the
+/// frontend; the ElevenLabs request body uses its own snake_case shape.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct VoiceSettings {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stability: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub similarity_boost: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_speaker_boost: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speed: Option<f32>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct VoiceMap {
@@ -26,6 +46,13 @@ pub struct VoiceMap {
     /// templateKey → ElevenLabs voiceId.
     #[serde(default)]
     pub assignments: HashMap<String, String>,
+    /// Project-wide delivery defaults, applied to mobs without an override.
+    #[serde(default)]
+    pub default_settings: VoiceSettings,
+    /// templateKey → per-mob delivery overrides (each field falls back to
+    /// `default_settings` when unset).
+    #[serde(default)]
+    pub settings: HashMap<String, VoiceSettings>,
 }
 
 fn voice_map_path(project_dir: &str) -> PathBuf {

--- a/creator/src/components/MainArea.tsx
+++ b/creator/src/components/MainArea.tsx
@@ -39,6 +39,7 @@ const AdminDashboard = lazy(() => import("./admin/AdminDashboard").then(m => ({ 
 const TuningWizard = lazy(() => import("./tuning/TuningWizard").then(m => ({ default: m.TuningWizard })));
 const AppearancePanel = lazy(() => import("./AppearancePanel").then(m => ({ default: m.AppearancePanel })));
 const PlaytestPanel = lazy(() => import("./playtest/PlaytestPanel").then(m => ({ default: m.PlaytestPanel })));
+const VoiceOverPanel = lazy(() => import("./VoiceOverPanel"));
 const BackupPanel = lazy(() => import("./BackupPanel").then(m => ({ default: m.BackupPanel })));
 
 function IslandBackPill({ island }: { island: Island }) {
@@ -120,6 +121,7 @@ export function MainArea() {
           case "tuningWizard": content = <TuningWizard />; break;
           case "appearance": content = <AppearancePanel />; break;
           case "playtest": content = <PlaytestPanel />; break;
+          case "voices": content = <VoiceOverPanel />; break;
           case "backup": content = <BackupPanel />; break;
           default: content = null;
         }

--- a/creator/src/components/VoiceOverPanel.tsx
+++ b/creator/src/components/VoiceOverPanel.tsx
@@ -378,7 +378,16 @@ export default function VoiceOverPanel() {
         </details>
 
         {voicesError && (
-          <p className="mt-2 text-2xs text-status-error">Couldn't load voices: {voicesError}</p>
+          <div className="mt-2 flex items-start gap-2 text-2xs text-status-error">
+            <span className="min-w-0 flex-1 break-words">Couldn't load voices: {voicesError}</span>
+            <button
+              onClick={() => fetchVoices()}
+              disabled={loadingVoices}
+              className="focus-ring shrink-0 rounded border border-status-error/40 px-2 py-0.5 text-3xs text-status-error transition hover:bg-status-error/10 disabled:opacity-40"
+            >
+              {loadingVoices ? "Retrying…" : "Retry"}
+            </button>
+          </div>
         )}
 
         {/* Per-mob assignment */}

--- a/creator/src/components/VoiceOverPanel.tsx
+++ b/creator/src/components/VoiceOverPanel.tsx
@@ -1,0 +1,429 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useZoneStore } from "@/stores/zoneStore";
+import { useProjectStore } from "@/stores/projectStore";
+import { useAssetStore } from "@/stores/assetStore";
+import { useVoiceStore } from "@/stores/voiceStore";
+import { panelTab } from "@/lib/panelRegistry";
+import {
+  ELEVENLABS_MODELS,
+  lineKey,
+  sha8,
+  type DialogueLine,
+} from "@/types/voiceover";
+
+interface MobGroup {
+  zone: string;
+  templateKey: string;
+  mobName: string;
+  lineCount: number;
+}
+
+/** Flatten every voiceable NPC dialogue line across all loaded zones. */
+function collectLines(zones: Map<string, { data: import("@/types/world").WorldFile }>): DialogueLine[] {
+  const lines: DialogueLine[] = [];
+  for (const { data } of zones.values()) {
+    const zone = data.zone;
+    const mobs = data.mobs ?? {};
+    for (const [templateKey, mob] of Object.entries(mobs)) {
+      const dialogue = mob.dialogue;
+      if (!dialogue) continue;
+      for (const [nodeId, node] of Object.entries(dialogue)) {
+        if (!node.text || !node.text.trim()) continue;
+        lines.push({ zone, templateKey, mobName: mob.name ?? templateKey, nodeId, text: node.text });
+      }
+    }
+  }
+  lines.sort((a, b) => {
+    if (a.zone !== b.zone) return a.zone.localeCompare(b.zone);
+    if (a.templateKey !== b.templateKey) return a.templateKey.localeCompare(b.templateKey);
+    if (a.nodeId === "root") return -1;
+    if (b.nodeId === "root") return 1;
+    return a.nodeId.localeCompare(b.nodeId);
+  });
+  return lines;
+}
+
+export default function VoiceOverPanel() {
+  const zones = useZoneStore((s) => s.zones);
+  const projectDir = useProjectStore((s) => s.project?.mudDir);
+
+  const openTab = useProjectStore((s) => s.openTab);
+
+  const settings = useAssetStore((s) => s.settings);
+  const loadSettings = useAssetStore((s) => s.loadSettings);
+
+  const voiceMap = useVoiceStore((s) => s.voiceMap);
+  const voices = useVoiceStore((s) => s.voices);
+  const loadingVoices = useVoiceStore((s) => s.loadingVoices);
+  const voicesError = useVoiceStore((s) => s.voicesError);
+  const results = useVoiceStore((s) => s.results);
+  const generating = useVoiceStore((s) => s.generating);
+  const publishing = useVoiceStore((s) => s.publishing);
+  const lastPublish = useVoiceStore((s) => s.lastPublish);
+
+  const loadVoiceMap = useVoiceStore((s) => s.loadVoiceMap);
+  const saveVoiceMap = useVoiceStore((s) => s.saveVoiceMap);
+  const setDefaultVoice = useVoiceStore((s) => s.setDefaultVoice);
+  const setModel = useVoiceStore((s) => s.setModel);
+  const setAssignment = useVoiceStore((s) => s.setAssignment);
+  const resolveVoiceId = useVoiceStore((s) => s.resolveVoiceId);
+  const fetchVoices = useVoiceStore((s) => s.fetchVoices);
+  const synthesizeLine = useVoiceStore((s) => s.synthesizeLine);
+  const generateAll = useVoiceStore((s) => s.generateAll);
+  const publishToR2 = useVoiceStore((s) => s.publishToR2);
+
+  const [savingMap, setSavingMap] = useState(false);
+  const [savedMap, setSavedMap] = useState(false);
+  const [sha8Map, setSha8Map] = useState<Record<string, string>>({});
+
+  const hasKey = !!settings?.elevenlabs_api_key;
+  const r2Configured = !!(
+    settings?.r2_account_id &&
+    settings?.r2_access_key_id &&
+    settings?.r2_secret_access_key &&
+    settings?.r2_bucket
+  );
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  useEffect(() => {
+    if (projectDir) loadVoiceMap();
+  }, [projectDir, loadVoiceMap]);
+
+  useEffect(() => {
+    if (hasKey && voices.length === 0 && !loadingVoices && !voicesError) {
+      fetchVoices();
+    }
+  }, [hasKey, voices.length, loadingVoices, voicesError, fetchVoices]);
+
+  const lines = useMemo(() => collectLines(zones), [zones]);
+
+  const mobGroups = useMemo<MobGroup[]>(() => {
+    const map = new Map<string, MobGroup>();
+    for (const line of lines) {
+      const key = `${line.zone} ${line.templateKey}`;
+      const existing = map.get(key);
+      if (existing) {
+        existing.lineCount += 1;
+      } else {
+        map.set(key, { zone: line.zone, templateKey: line.templateKey, mobName: line.mobName, lineCount: 1 });
+      }
+    }
+    return [...map.values()];
+  }, [lines]);
+
+  // Compute the contract hash of each line's current text so we can flag
+  // clips that were generated against an older version of the line.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const next: Record<string, string> = {};
+      for (const line of lines) {
+        next[lineKey(line.zone, line.templateKey, line.nodeId)] = await sha8(line.text);
+      }
+      if (!cancelled) setSha8Map(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [lines]);
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const playClip = (dataUrl: string) => {
+    audioRef.current?.pause();
+    const audio = new Audio(dataUrl);
+    audioRef.current = audio;
+    audio.play().catch(() => {});
+  };
+
+  const voiceName = (voiceId: string) => voices.find((v) => v.voiceId === voiceId)?.name ?? voiceId;
+
+  const doneCount = useMemo(() => {
+    let n = 0;
+    for (const line of lines) {
+      const st = results.get(lineKey(line.zone, line.templateKey, line.nodeId));
+      if (st?.status === "done") n += 1;
+    }
+    return n;
+  }, [lines, results]);
+
+  const handleSaveMap = async () => {
+    setSavingMap(true);
+    try {
+      await saveVoiceMap();
+      setSavedMap(true);
+      setTimeout(() => setSavedMap(false), 2000);
+    } finally {
+      setSavingMap(false);
+    }
+  };
+
+  // ─── Guards ──────────────────────────────────────────────────────
+  if (!projectDir) {
+    return (
+      <div className="mx-auto flex w-full max-w-2xl flex-col gap-3 px-6 py-10 text-sm text-text-muted">
+        Open a world project to generate dialogue voice-overs.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 overflow-y-auto px-6 py-6">
+      {/* Header */}
+      <header>
+        <h2 className="font-display text-lg uppercase tracking-widest text-text-primary">
+          Dialogue Voice-Over
+        </h2>
+        <p className="mt-1 max-w-3xl text-2xs leading-5 text-text-muted">
+          Synthesize spoken audio for every NPC dialogue line with ElevenLabs and publish the clips
+          to your CDN. The web client plays them as players talk to NPCs; telnet is unaffected.
+          Choices stay text-only.
+        </p>
+      </header>
+
+      {/* API key warning */}
+      {!hasKey && (
+        <div className="rounded-xl border border-status-warning/30 bg-status-warning/5 px-4 py-3 text-2xs leading-5 text-status-warning">
+          No ElevenLabs API key configured. Add one in{" "}
+          <button
+            className="underline underline-offset-2 hover:text-text-primary"
+            onClick={() => openTab(panelTab("services"))}
+          >
+            Settings → Services
+          </button>{" "}
+          to fetch voices and synthesize audio.
+        </div>
+      )}
+
+      {/* ─── Voice assignment ─────────────────────────────────────── */}
+      <section className="rounded-xl border border-border-default bg-bg-secondary/40 p-4">
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <h3 className="font-display text-sm uppercase tracking-widest text-text-primary">
+            Voices
+          </h3>
+          <div className="flex items-center gap-2">
+            {savedMap && <span className="text-2xs text-status-success">Saved</span>}
+            <button
+              onClick={handleSaveMap}
+              disabled={savingMap}
+              className="action-button action-button-secondary action-button-sm focus-ring"
+            >
+              {savingMap ? "Saving…" : "Save voices"}
+            </button>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-2xs uppercase tracking-wider text-text-muted">Default voice</span>
+            <select
+              value={voiceMap.defaultVoiceId}
+              onChange={(e) => setDefaultVoice(e.target.value)}
+              disabled={!voices.length}
+              className="rounded border border-border-default bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+            >
+              <option value="">{loadingVoices ? "Loading voices…" : "— select —"}</option>
+              {voices.map((v) => (
+                <option key={v.voiceId} value={v.voiceId}>
+                  {v.name}
+                  {v.category ? ` (${v.category})` : ""}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-2xs uppercase tracking-wider text-text-muted">Model</span>
+            <select
+              value={voiceMap.modelId}
+              onChange={(e) => setModel(e.target.value)}
+              className="rounded border border-border-default bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+            >
+              {ELEVENLABS_MODELS.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {voicesError && (
+          <p className="mt-2 text-2xs text-status-error">Couldn't load voices: {voicesError}</p>
+        )}
+
+        {/* Per-mob assignment */}
+        {mobGroups.length > 0 && (
+          <div className="mt-4">
+            <p className="mb-2 text-2xs uppercase tracking-wider text-text-muted">
+              Per-NPC voices ({mobGroups.length} speaking{" "}
+              {mobGroups.length === 1 ? "NPC" : "NPCs"})
+            </p>
+            <ul className="flex flex-col gap-1.5">
+              {mobGroups.map((g) => {
+                const key = `${g.zone} ${g.templateKey}`;
+                const assigned = voiceMap.assignments[g.templateKey] ?? "";
+                return (
+                  <li
+                    key={key}
+                    className="flex items-center gap-3 rounded border border-border-muted bg-bg-primary px-2.5 py-1.5"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <span className="text-xs text-text-primary">{g.mobName}</span>
+                      <span className="ml-2 font-mono text-3xs text-text-muted/70">
+                        {g.zone}:{g.templateKey} · {g.lineCount} line{g.lineCount !== 1 ? "s" : ""}
+                      </span>
+                    </div>
+                    <select
+                      value={assigned}
+                      onChange={(e) => setAssignment(g.templateKey, e.target.value)}
+                      disabled={!voices.length}
+                      className="w-48 rounded border border-border-default bg-bg-secondary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+                    >
+                      <option value="">
+                        Default
+                        {voiceMap.defaultVoiceId ? ` (${voiceName(voiceMap.defaultVoiceId)})` : ""}
+                      </option>
+                      {voices.map((v) => (
+                        <option key={v.voiceId} value={v.voiceId}>
+                          {v.name}
+                        </option>
+                      ))}
+                    </select>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      {/* ─── Generation ───────────────────────────────────────────── */}
+      <section className="rounded-xl border border-border-default bg-bg-secondary/40 p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <h3 className="font-display text-sm uppercase tracking-widest text-text-primary">
+            Lines{" "}
+            <span className="ml-1 text-2xs font-normal normal-case tracking-normal text-text-muted">
+              {doneCount}/{lines.length} generated
+            </span>
+          </h3>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => generateAll(lines)}
+              disabled={!hasKey || generating || lines.length === 0}
+              className="action-button action-button-primary action-button-sm focus-ring"
+            >
+              {generating ? "Generating…" : "Generate all"}
+            </button>
+            <button
+              onClick={() => publishToR2(lines)}
+              disabled={!r2Configured || publishing || doneCount === 0}
+              title={r2Configured ? undefined : "Configure Cloudflare R2 in Settings to publish."}
+              className="action-button action-button-secondary action-button-sm focus-ring"
+            >
+              {publishing ? "Publishing…" : "Publish to R2"}
+            </button>
+          </div>
+        </div>
+
+        {lastPublish && (
+          <div className="mb-3 rounded border border-border-muted bg-bg-primary px-3 py-2 text-2xs text-text-muted">
+            Published: {lastPublish.uploaded} uploaded, {lastPublish.skipped} unchanged,{" "}
+            {lastPublish.failed} failed.
+            {lastPublish.errors.length > 0 && (
+              <ul className="mt-1 list-disc pl-4 text-status-error">
+                {lastPublish.errors.slice(0, 5).map((err, i) => (
+                  <li key={i}>{err}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        {lines.length === 0 ? (
+          <p className="rounded border border-dashed border-border-muted bg-bg-primary px-3 py-6 text-center text-2xs italic text-text-muted/70">
+            No NPC dialogue found in the loaded zones. Add dialogue to a mob, then return here.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {lines.map((line) => {
+              const key = lineKey(line.zone, line.templateKey, line.nodeId);
+              const st = results.get(key);
+              const clip = st?.clip;
+              const stale = clip ? sha8Map[key] !== undefined && sha8Map[key] !== clip.textSha8 : false;
+              const effectiveVoice = resolveVoiceId(line.templateKey);
+              return (
+                <li
+                  key={key}
+                  className="flex items-center gap-2 rounded border border-border-muted bg-bg-primary px-2.5 py-1.5"
+                >
+                  <div className="w-44 shrink-0">
+                    <div className="truncate text-xs text-text-primary">{line.mobName}</div>
+                    <div className="truncate font-mono text-3xs text-text-muted/70">
+                      {line.zone} · {line.nodeId}
+                    </div>
+                  </div>
+                  <div className="min-w-0 flex-1 truncate text-2xs text-text-secondary" title={line.text}>
+                    {line.text}
+                  </div>
+                  <StatusBadge status={st?.status ?? "idle"} stale={stale} error={st?.error} />
+                  {clip && (
+                    <button
+                      onClick={() => playClip(clip.dataUrl)}
+                      className="focus-ring inline-flex h-6 w-6 items-center justify-center rounded border border-border-default text-xs text-text-muted transition hover:bg-bg-tertiary hover:text-text-primary"
+                      title="Play preview"
+                      aria-label={`Play ${line.mobName} ${line.nodeId}`}
+                    >
+                      ▶
+                    </button>
+                  )}
+                  <button
+                    onClick={() => synthesizeLine(line)}
+                    disabled={!hasKey || !effectiveVoice || st?.status === "generating"}
+                    className="focus-ring shrink-0 rounded border border-border-default px-2 py-0.5 text-3xs text-text-muted transition hover:bg-bg-tertiary hover:text-text-primary disabled:opacity-40"
+                    title={effectiveVoice ? "Generate this line" : "Assign a voice first"}
+                  >
+                    {clip ? "Regenerate" : "Generate"}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function StatusBadge({
+  status,
+  stale,
+  error,
+}: {
+  status: "idle" | "generating" | "done" | "error";
+  stale: boolean;
+  error?: string;
+}) {
+  if (status === "generating") {
+    return <span className="shrink-0 text-3xs uppercase tracking-ui text-accent">working…</span>;
+  }
+  if (status === "error") {
+    return (
+      <span className="shrink-0 text-3xs uppercase tracking-ui text-status-error" title={error}>
+        error
+      </span>
+    );
+  }
+  if (status === "done") {
+    return stale ? (
+      <span className="shrink-0 text-3xs uppercase tracking-ui text-status-warning" title="Line edited since this clip was generated — regenerate.">
+        edited
+      </span>
+    ) : (
+      <span className="shrink-0 text-3xs uppercase tracking-ui text-status-success">ready</span>
+    );
+  }
+  return <span className="shrink-0 text-3xs uppercase tracking-ui text-text-muted/50">—</span>;
+}

--- a/creator/src/components/VoiceOverPanel.tsx
+++ b/creator/src/components/VoiceOverPanel.tsx
@@ -87,7 +87,7 @@ export default function VoiceOverPanel() {
   const publishing = useVoiceStore((s) => s.publishing);
   const lastPublish = useVoiceStore((s) => s.lastPublish);
 
-  const mapLoaded = useVoiceStore((s) => s.mapLoaded);
+  const loadedDir = useVoiceStore((s) => s.loadedDir);
   const loadVoiceMap = useVoiceStore((s) => s.loadVoiceMap);
   const saveVoiceMap = useVoiceStore((s) => s.saveVoiceMap);
   const rehydrate = useVoiceStore((s) => s.rehydrate);
@@ -164,23 +164,23 @@ export default function VoiceOverPanel() {
   }, [lines]);
 
   // Auto-save the voice map shortly after any change so assignments and
-  // settings survive closing the panel or restarting the app. Gated on
-  // mapLoaded so we never persist the empty default over a real saved file
-  // before the on-disk map has loaded.
+  // settings survive closing the panel or restarting the app. Gated on the map
+  // having loaded for *this* project so we never persist the empty default (or
+  // a previous project's map) over a real saved file.
   useEffect(() => {
-    if (!projectDir || !mapLoaded) return;
+    if (!projectDir || loadedDir !== projectDir) return;
     const t = setTimeout(() => {
       saveVoiceMap().catch(() => {});
     }, 600);
     return () => clearTimeout(t);
-  }, [voiceMap, projectDir, mapLoaded, saveVoiceMap]);
+  }, [voiceMap, projectDir, loadedDir, saveVoiceMap]);
 
   // Final flush on unmount, so an edit made within the debounce window is still
-  // persisted if the panel closes immediately after.
+  // persisted if the panel closes immediately after. saveVoiceMap self-guards
+  // on the loaded dir, so it's a no-op if the project already switched.
   useEffect(() => {
     return () => {
-      const s = useVoiceStore.getState();
-      if (s.mapLoaded) s.saveVoiceMap().catch(() => {});
+      useVoiceStore.getState().saveVoiceMap().catch(() => {});
     };
   }, []);
 

--- a/creator/src/components/VoiceOverPanel.tsx
+++ b/creator/src/components/VoiceOverPanel.tsx
@@ -5,10 +5,17 @@ import { useAssetStore } from "@/stores/assetStore";
 import { useVoiceStore } from "@/stores/voiceStore";
 import { panelTab } from "@/lib/panelRegistry";
 import {
+  ELEVENLABS_DEFAULT_SETTINGS,
   ELEVENLABS_MODELS,
   lineKey,
+  resolveVoiceSettings,
+  settingsAreEmpty,
   sha8,
+  VOICE_SETTING_FIELDS,
   type DialogueLine,
+  type ElevenLabsVoice,
+  type VoiceMap,
+  type VoiceSettings,
 } from "@/types/voiceover";
 
 interface MobGroup {
@@ -16,6 +23,18 @@ interface MobGroup {
   templateKey: string;
   mobName: string;
   lineCount: number;
+}
+
+/** Fill any unset setting with the ElevenLabs default so sliders always have a
+ *  concrete value to display. */
+function effectiveSettings(s: VoiceSettings): Required<VoiceSettings> {
+  return {
+    stability: s.stability ?? ELEVENLABS_DEFAULT_SETTINGS.stability,
+    similarityBoost: s.similarityBoost ?? ELEVENLABS_DEFAULT_SETTINGS.similarityBoost,
+    style: s.style ?? ELEVENLABS_DEFAULT_SETTINGS.style,
+    useSpeakerBoost: s.useSpeakerBoost ?? ELEVENLABS_DEFAULT_SETTINGS.useSpeakerBoost,
+    speed: s.speed ?? ELEVENLABS_DEFAULT_SETTINGS.speed,
+  };
 }
 
 /** Flatten every voiceable NPC dialogue line across all loaded zones. */
@@ -66,6 +85,10 @@ export default function VoiceOverPanel() {
   const setDefaultVoice = useVoiceStore((s) => s.setDefaultVoice);
   const setModel = useVoiceStore((s) => s.setModel);
   const setAssignment = useVoiceStore((s) => s.setAssignment);
+  const setDefaultSettings = useVoiceStore((s) => s.setDefaultSettings);
+  const clearDefaultSettings = useVoiceStore((s) => s.clearDefaultSettings);
+  const setMobSettings = useVoiceStore((s) => s.setMobSettings);
+  const clearMobSettings = useVoiceStore((s) => s.clearMobSettings);
   const resolveVoiceId = useVoiceStore((s) => s.resolveVoiceId);
   const fetchVoices = useVoiceStore((s) => s.fetchVoices);
   const synthesizeLine = useVoiceStore((s) => s.synthesizeLine);
@@ -250,6 +273,28 @@ export default function VoiceOverPanel() {
           </label>
         </div>
 
+        {/* Project-wide delivery defaults */}
+        <details className="mt-3 rounded border border-border-muted bg-bg-primary px-3 py-2">
+          <summary className="cursor-pointer select-none text-2xs uppercase tracking-wider text-text-muted">
+            Default delivery
+            {!settingsAreEmpty(voiceMap.defaultSettings) && (
+              <span className="ml-2 rounded-full bg-accent/15 px-1.5 py-0.5 text-3xs normal-case tracking-normal text-accent">
+                customized
+              </span>
+            )}
+          </summary>
+          <div className="mt-2">
+            <VoiceSettingsEditor
+              effective={effectiveSettings(voiceMap.defaultSettings)}
+              onSet={(field, value) =>
+                setDefaultSettings({ [field]: value } as Partial<VoiceSettings>)
+              }
+              onReset={clearDefaultSettings}
+              canReset={!settingsAreEmpty(voiceMap.defaultSettings)}
+            />
+          </div>
+        </details>
+
         {voicesError && (
           <p className="mt-2 text-2xs text-status-error">Couldn't load voices: {voicesError}</p>
         )}
@@ -262,39 +307,20 @@ export default function VoiceOverPanel() {
               {mobGroups.length === 1 ? "NPC" : "NPCs"})
             </p>
             <ul className="flex flex-col gap-1.5">
-              {mobGroups.map((g) => {
-                const key = `${g.zone} ${g.templateKey}`;
-                const assigned = voiceMap.assignments[g.templateKey] ?? "";
-                return (
-                  <li
-                    key={key}
-                    className="flex items-center gap-3 rounded border border-border-muted bg-bg-primary px-2.5 py-1.5"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <span className="text-xs text-text-primary">{g.mobName}</span>
-                      <span className="ml-2 font-mono text-3xs text-text-muted/70">
-                        {g.zone}:{g.templateKey} · {g.lineCount} line{g.lineCount !== 1 ? "s" : ""}
-                      </span>
-                    </div>
-                    <select
-                      value={assigned}
-                      onChange={(e) => setAssignment(g.templateKey, e.target.value)}
-                      disabled={!voices.length}
-                      className="w-48 rounded border border-border-default bg-bg-secondary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
-                    >
-                      <option value="">
-                        Default
-                        {voiceMap.defaultVoiceId ? ` (${voiceName(voiceMap.defaultVoiceId)})` : ""}
-                      </option>
-                      {voices.map((v) => (
-                        <option key={v.voiceId} value={v.voiceId}>
-                          {v.name}
-                        </option>
-                      ))}
-                    </select>
-                  </li>
-                );
-              })}
+              {mobGroups.map((g) => (
+                <MobAssignmentRow
+                  key={`${g.zone} ${g.templateKey}`}
+                  group={g}
+                  voices={voices}
+                  voiceMap={voiceMap}
+                  defaultVoiceLabel={voiceMap.defaultVoiceId ? voiceName(voiceMap.defaultVoiceId) : ""}
+                  onAssign={(voiceId) => setAssignment(g.templateKey, voiceId)}
+                  onSet={(field, value) =>
+                    setMobSettings(g.templateKey, { [field]: value } as Partial<VoiceSettings>)
+                  }
+                  onReset={() => clearMobSettings(g.templateKey)}
+                />
+              ))}
             </ul>
           </div>
         )}
@@ -393,6 +419,134 @@ export default function VoiceOverPanel() {
           </ul>
         )}
       </section>
+    </div>
+  );
+}
+
+interface MobAssignmentRowProps {
+  group: MobGroup;
+  voices: ElevenLabsVoice[];
+  voiceMap: VoiceMap;
+  defaultVoiceLabel: string;
+  onAssign: (voiceId: string) => void;
+  onSet: (field: keyof VoiceSettings, value: number | boolean) => void;
+  onReset: () => void;
+}
+
+function MobAssignmentRow({
+  group,
+  voices,
+  voiceMap,
+  defaultVoiceLabel,
+  onAssign,
+  onSet,
+  onReset,
+}: MobAssignmentRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const assigned = voiceMap.assignments[group.templateKey] ?? "";
+  const customized = !settingsAreEmpty(voiceMap.settings[group.templateKey]);
+  const effective = effectiveSettings(resolveVoiceSettings(voiceMap, group.templateKey));
+
+  return (
+    <li className="rounded border border-border-muted bg-bg-primary">
+      <div className="flex items-center gap-3 px-2.5 py-1.5">
+        <div className="min-w-0 flex-1">
+          <span className="text-xs text-text-primary">{group.mobName}</span>
+          <span className="ml-2 font-mono text-3xs text-text-muted/70">
+            {group.zone}:{group.templateKey} · {group.lineCount} line
+            {group.lineCount !== 1 ? "s" : ""}
+          </span>
+        </div>
+        <select
+          value={assigned}
+          onChange={(e) => onAssign(e.target.value)}
+          disabled={!voices.length}
+          className="w-48 rounded border border-border-default bg-bg-secondary px-2 py-1 text-xs text-text-primary outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+        >
+          <option value="">Default{defaultVoiceLabel ? ` (${defaultVoiceLabel})` : ""}</option>
+          {voices.map((v) => (
+            <option key={v.voiceId} value={v.voiceId}>
+              {v.name}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={() => setExpanded((x) => !x)}
+          aria-expanded={expanded}
+          title="Delivery settings"
+          className={`focus-ring inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border text-xs transition ${
+            customized
+              ? "border-accent/40 text-accent hover:bg-accent/10"
+              : "border-border-default text-text-muted hover:bg-bg-tertiary hover:text-text-primary"
+          }`}
+        >
+          &#x2699;
+        </button>
+      </div>
+      {expanded && (
+        <div className="border-t border-border-muted px-2.5 py-2">
+          <VoiceSettingsEditor
+            effective={effective}
+            onSet={onSet}
+            onReset={onReset}
+            canReset={customized}
+          />
+        </div>
+      )}
+    </li>
+  );
+}
+
+interface VoiceSettingsEditorProps {
+  effective: Required<VoiceSettings>;
+  onSet: (field: keyof VoiceSettings, value: number | boolean) => void;
+  onReset: () => void;
+  canReset: boolean;
+}
+
+function VoiceSettingsEditor({ effective, onSet, onReset, canReset }: VoiceSettingsEditorProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      {VOICE_SETTING_FIELDS.map((f) => (
+        <div key={f.key} className="flex items-center gap-2">
+          <label className="w-20 shrink-0 text-2xs text-text-muted" title={f.hint}>
+            {f.label}
+          </label>
+          <input
+            type="range"
+            min={f.min}
+            max={f.max}
+            step={f.step}
+            value={effective[f.key] as number}
+            onChange={(e) => onSet(f.key, parseFloat(e.target.value))}
+            className="h-1.5 flex-1 accent-accent"
+            aria-label={f.label}
+          />
+          <span className="w-9 shrink-0 text-right font-mono text-3xs text-text-secondary">
+            {(effective[f.key] as number).toFixed(2)}
+          </span>
+        </div>
+      ))}
+      <div className="flex items-center justify-between gap-2 pt-0.5">
+        <label className="flex cursor-pointer items-center gap-1.5 text-2xs text-text-muted">
+          <input
+            type="checkbox"
+            checked={effective.useSpeakerBoost}
+            onChange={(e) => onSet("useSpeakerBoost", e.target.checked)}
+            className="accent-accent"
+          />
+          Speaker boost
+        </label>
+        <button
+          onClick={onReset}
+          disabled={!canReset}
+          className="focus-ring rounded border border-border-default px-2 py-0.5 text-3xs text-text-muted transition hover:bg-bg-tertiary hover:text-text-primary disabled:opacity-40"
+          title="Clear overrides for this scope"
+        >
+          Reset
+        </button>
+      </div>
+      <p className="text-3xs text-text-muted/60">Unset values fall back to ElevenLabs defaults.</p>
     </div>
   );
 }

--- a/creator/src/components/VoiceOverPanel.tsx
+++ b/creator/src/components/VoiceOverPanel.tsx
@@ -80,8 +80,11 @@ export default function VoiceOverPanel() {
   const publishing = useVoiceStore((s) => s.publishing);
   const lastPublish = useVoiceStore((s) => s.lastPublish);
 
+  const mapLoaded = useVoiceStore((s) => s.mapLoaded);
   const loadVoiceMap = useVoiceStore((s) => s.loadVoiceMap);
   const saveVoiceMap = useVoiceStore((s) => s.saveVoiceMap);
+  const rehydrate = useVoiceStore((s) => s.rehydrate);
+  const ensureClipDataUrl = useVoiceStore((s) => s.ensureClipDataUrl);
   const setDefaultVoice = useVoiceStore((s) => s.setDefaultVoice);
   const setModel = useVoiceStore((s) => s.setModel);
   const setAssignment = useVoiceStore((s) => s.setAssignment);
@@ -153,12 +156,47 @@ export default function VoiceOverPanel() {
     };
   }, [lines]);
 
+  // Auto-save the voice map shortly after any change so assignments and
+  // settings survive closing the panel or restarting the app. Gated on
+  // mapLoaded so we never persist the empty default over a real saved file
+  // before the on-disk map has loaded.
+  useEffect(() => {
+    if (!projectDir || !mapLoaded) return;
+    const t = setTimeout(() => {
+      saveVoiceMap().catch(() => {});
+    }, 600);
+    return () => clearTimeout(t);
+  }, [voiceMap, projectDir, mapLoaded, saveVoiceMap]);
+
+  // Final flush on unmount, so an edit made within the debounce window is still
+  // persisted if the panel closes immediately after.
+  useEffect(() => {
+    return () => {
+      const s = useVoiceStore.getState();
+      if (s.mapLoaded) s.saveVoiceMap().catch(() => {});
+    };
+  }, []);
+
+  // Restore "already generated" status from the on-disk clip cache whenever the
+  // lines or voice config change. Debounced so slider drags don't spam queries.
+  useEffect(() => {
+    if (!lines.length) return;
+    const t = setTimeout(() => {
+      rehydrate(lines).catch(() => {});
+    }, 300);
+    return () => clearTimeout(t);
+  }, [lines, voiceMap, rehydrate]);
+
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const playClip = (dataUrl: string) => {
     audioRef.current?.pause();
     const audio = new Audio(dataUrl);
     audioRef.current = audio;
     audio.play().catch(() => {});
+  };
+  const handlePlay = async (key: string) => {
+    const url = await ensureClipDataUrl(key);
+    if (url) playClip(url);
   };
 
   const voiceName = (voiceId: string) => voices.find((v) => v.voiceId === voiceId)?.name ?? voiceId;
@@ -428,7 +466,7 @@ export default function VoiceOverPanel() {
                   <StatusBadge status={st?.status ?? "idle"} stale={stale} error={st?.error} />
                   {clip && (
                     <button
-                      onClick={() => playClip(clip.dataUrl)}
+                      onClick={() => handlePlay(key)}
                       className="focus-ring inline-flex h-6 w-6 items-center justify-center rounded border border-border-default text-xs text-text-muted transition hover:bg-bg-tertiary hover:text-text-primary"
                       title="Play preview"
                       aria-label={`Play ${line.mobName} ${line.nodeId}`}

--- a/creator/src/components/VoiceOverPanel.tsx
+++ b/creator/src/components/VoiceOverPanel.tsx
@@ -172,6 +172,19 @@ export default function VoiceOverPanel() {
     return n;
   }, [lines, results]);
 
+  const errorSummary = useMemo(() => {
+    let count = 0;
+    let firstMessage = "";
+    for (const line of lines) {
+      const st = results.get(lineKey(line.zone, line.templateKey, line.nodeId));
+      if (st?.status === "error") {
+        count += 1;
+        if (!firstMessage && st.error) firstMessage = st.error;
+      }
+    }
+    return { count, firstMessage };
+  }, [lines, results]);
+
   const handleSaveMap = async () => {
     setSavingMap(true);
     try {
@@ -368,6 +381,17 @@ export default function VoiceOverPanel() {
           </div>
         )}
 
+        {errorSummary.count > 0 && (
+          <div className="mb-3 rounded border border-status-error/30 bg-status-error/5 px-3 py-2 text-2xs text-status-error">
+            {errorSummary.count} line{errorSummary.count !== 1 ? "s" : ""} failed to generate.
+            {errorSummary.firstMessage && (
+              <span className="mt-1 block break-words font-mono text-3xs opacity-90">
+                {errorSummary.firstMessage}
+              </span>
+            )}
+          </div>
+        )}
+
         {lines.length === 0 ? (
           <p className="rounded border border-dashed border-border-muted bg-bg-primary px-3 py-6 text-center text-2xs italic text-text-muted/70">
             No NPC dialogue found in the loaded zones. Add dialogue to a mob, then return here.
@@ -391,8 +415,15 @@ export default function VoiceOverPanel() {
                       {line.zone} · {line.nodeId}
                     </div>
                   </div>
-                  <div className="min-w-0 flex-1 truncate text-2xs text-text-secondary" title={line.text}>
-                    {line.text}
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-2xs text-text-secondary" title={line.text}>
+                      {line.text}
+                    </div>
+                    {st?.status === "error" && st.error && (
+                      <div className="truncate text-3xs text-status-error" title={st.error}>
+                        {st.error}
+                      </div>
+                    )}
                   </div>
                   <StatusBadge status={st?.status ?? "idle"} stale={stale} error={st?.error} />
                   {clip && (

--- a/creator/src/components/VoiceOverPanel.tsx
+++ b/creator/src/components/VoiceOverPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { useAssetStore } from "@/stores/assetStore";
@@ -25,15 +25,19 @@ interface MobGroup {
   lineCount: number;
 }
 
-/** Fill any unset setting with the ElevenLabs default so sliders always have a
- *  concrete value to display. */
-function effectiveSettings(s: VoiceSettings): Required<VoiceSettings> {
+/** Fill any unset field from a baseline so sliders always have a concrete value.
+ *  The baseline is the assigned voice's own defaults (which themselves fall back
+ *  to the generic ElevenLabs defaults). */
+function fillRequired(
+  s: VoiceSettings,
+  base: Required<VoiceSettings>,
+): Required<VoiceSettings> {
   return {
-    stability: s.stability ?? ELEVENLABS_DEFAULT_SETTINGS.stability,
-    similarityBoost: s.similarityBoost ?? ELEVENLABS_DEFAULT_SETTINGS.similarityBoost,
-    style: s.style ?? ELEVENLABS_DEFAULT_SETTINGS.style,
-    useSpeakerBoost: s.useSpeakerBoost ?? ELEVENLABS_DEFAULT_SETTINGS.useSpeakerBoost,
-    speed: s.speed ?? ELEVENLABS_DEFAULT_SETTINGS.speed,
+    stability: s.stability ?? base.stability,
+    similarityBoost: s.similarityBoost ?? base.similarityBoost,
+    style: s.style ?? base.style,
+    useSpeakerBoost: s.useSpeakerBoost ?? base.useSpeakerBoost,
+    speed: s.speed ?? base.speed,
   };
 }
 
@@ -73,6 +77,8 @@ export default function VoiceOverPanel() {
 
   const voiceMap = useVoiceStore((s) => s.voiceMap);
   const voices = useVoiceStore((s) => s.voices);
+  const voiceDefaults = useVoiceStore((s) => s.voiceDefaults);
+  const fetchVoiceDefaults = useVoiceStore((s) => s.fetchVoiceDefaults);
   const loadingVoices = useVoiceStore((s) => s.loadingVoices);
   const voicesError = useVoiceStore((s) => s.voicesError);
   const results = useVoiceStore((s) => s.results);
@@ -187,6 +193,18 @@ export default function VoiceOverPanel() {
     return () => clearTimeout(t);
   }, [lines, voiceMap, rehydrate]);
 
+  // Fetch each in-use voice's own default settings so the sliders seed from them.
+  useEffect(() => {
+    if (!voices.length) return;
+    const ids = new Set<string>();
+    if (voiceMap.defaultVoiceId) ids.add(voiceMap.defaultVoiceId);
+    for (const g of mobGroups) {
+      const vid = voiceMap.assignments[g.templateKey] || voiceMap.defaultVoiceId;
+      if (vid) ids.add(vid);
+    }
+    ids.forEach((id) => fetchVoiceDefaults(id));
+  }, [voices.length, voiceMap, mobGroups, fetchVoiceDefaults]);
+
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const playClip = (dataUrl: string) => {
     audioRef.current?.pause();
@@ -200,6 +218,14 @@ export default function VoiceOverPanel() {
   };
 
   const voiceName = (voiceId: string) => voices.find((v) => v.voiceId === voiceId)?.name ?? voiceId;
+
+  // Slider baseline for a voice: its own ElevenLabs defaults, falling back to
+  // the generic defaults until they've been fetched.
+  const baselineFor = useCallback(
+    (voiceId: string): Required<VoiceSettings> =>
+      fillRequired(voiceDefaults[voiceId] ?? {}, ELEVENLABS_DEFAULT_SETTINGS),
+    [voiceDefaults],
+  );
 
   const doneCount = useMemo(() => {
     let n = 0;
@@ -336,9 +362,13 @@ export default function VoiceOverPanel() {
           </summary>
           <div className="mt-2">
             <VoiceSettingsEditor
-              effective={effectiveSettings(voiceMap.defaultSettings)}
+              effective={fillRequired(voiceMap.defaultSettings, baselineFor(voiceMap.defaultVoiceId))}
+              overrides={voiceMap.defaultSettings}
               onSet={(field, value) =>
                 setDefaultSettings({ [field]: value } as Partial<VoiceSettings>)
+              }
+              onResetField={(field) =>
+                setDefaultSettings({ [field]: undefined } as Partial<VoiceSettings>)
               }
               onReset={clearDefaultSettings}
               canReset={!settingsAreEmpty(voiceMap.defaultSettings)}
@@ -364,10 +394,14 @@ export default function VoiceOverPanel() {
                   group={g}
                   voices={voices}
                   voiceMap={voiceMap}
+                  baseline={baselineFor(voiceMap.assignments[g.templateKey] || voiceMap.defaultVoiceId)}
                   defaultVoiceLabel={voiceMap.defaultVoiceId ? voiceName(voiceMap.defaultVoiceId) : ""}
                   onAssign={(voiceId) => setAssignment(g.templateKey, voiceId)}
                   onSet={(field, value) =>
                     setMobSettings(g.templateKey, { [field]: value } as Partial<VoiceSettings>)
+                  }
+                  onResetField={(field) =>
+                    setMobSettings(g.templateKey, { [field]: undefined } as Partial<VoiceSettings>)
                   }
                   onReset={() => clearMobSettings(g.templateKey)}
                 />
@@ -496,9 +530,11 @@ interface MobAssignmentRowProps {
   group: MobGroup;
   voices: ElevenLabsVoice[];
   voiceMap: VoiceMap;
+  baseline: Required<VoiceSettings>;
   defaultVoiceLabel: string;
   onAssign: (voiceId: string) => void;
   onSet: (field: keyof VoiceSettings, value: number | boolean) => void;
+  onResetField: (field: keyof VoiceSettings) => void;
   onReset: () => void;
 }
 
@@ -506,15 +542,18 @@ function MobAssignmentRow({
   group,
   voices,
   voiceMap,
+  baseline,
   defaultVoiceLabel,
   onAssign,
   onSet,
+  onResetField,
   onReset,
 }: MobAssignmentRowProps) {
   const [expanded, setExpanded] = useState(false);
   const assigned = voiceMap.assignments[group.templateKey] ?? "";
-  const customized = !settingsAreEmpty(voiceMap.settings[group.templateKey]);
-  const effective = effectiveSettings(resolveVoiceSettings(voiceMap, group.templateKey));
+  const overrides = voiceMap.settings[group.templateKey] ?? {};
+  const customized = !settingsAreEmpty(overrides);
+  const effective = fillRequired(resolveVoiceSettings(voiceMap, group.templateKey), baseline);
 
   return (
     <li className="rounded border border-border-muted bg-bg-primary">
@@ -556,7 +595,9 @@ function MobAssignmentRow({
         <div className="border-t border-border-muted px-2.5 py-2">
           <VoiceSettingsEditor
             effective={effective}
+            overrides={overrides}
             onSet={onSet}
+            onResetField={onResetField}
             onReset={onReset}
             canReset={customized}
           />
@@ -568,36 +609,66 @@ function MobAssignmentRow({
 
 interface VoiceSettingsEditorProps {
   effective: Required<VoiceSettings>;
+  /** The stored partial for this scope — which fields are explicit overrides. */
+  overrides: VoiceSettings;
   onSet: (field: keyof VoiceSettings, value: number | boolean) => void;
+  onResetField: (field: keyof VoiceSettings) => void;
   onReset: () => void;
   canReset: boolean;
 }
 
-function VoiceSettingsEditor({ effective, onSet, onReset, canReset }: VoiceSettingsEditorProps) {
+function VoiceSettingsEditor({
+  effective,
+  overrides,
+  onSet,
+  onResetField,
+  onReset,
+  canReset,
+}: VoiceSettingsEditorProps) {
+  const boostOverridden = overrides.useSpeakerBoost !== undefined;
   return (
     <div className="flex flex-col gap-2">
-      {VOICE_SETTING_FIELDS.map((f) => (
-        <div key={f.key} className="flex items-center gap-2">
-          <label className="w-20 shrink-0 text-2xs text-text-muted" title={f.hint}>
-            {f.label}
-          </label>
-          <input
-            type="range"
-            min={f.min}
-            max={f.max}
-            step={f.step}
-            value={effective[f.key] as number}
-            onChange={(e) => onSet(f.key, parseFloat(e.target.value))}
-            className="h-1.5 flex-1 accent-accent"
-            aria-label={f.label}
-          />
-          <span className="w-9 shrink-0 text-right font-mono text-3xs text-text-secondary">
-            {(effective[f.key] as number).toFixed(2)}
-          </span>
-        </div>
-      ))}
+      {VOICE_SETTING_FIELDS.map((f) => {
+        const overridden = overrides[f.key] !== undefined;
+        return (
+          <div key={f.key} className="flex items-center gap-2">
+            <label
+              className={`w-20 shrink-0 text-2xs ${overridden ? "text-accent" : "text-text-muted"}`}
+              title={f.hint}
+            >
+              {f.label}
+            </label>
+            <input
+              type="range"
+              min={f.min}
+              max={f.max}
+              step={f.step}
+              value={effective[f.key] as number}
+              onChange={(e) => onSet(f.key, parseFloat(e.target.value))}
+              className="h-1.5 flex-1 accent-accent"
+              aria-label={f.label}
+            />
+            <span className="w-9 shrink-0 text-right font-mono text-3xs text-text-secondary">
+              {(effective[f.key] as number).toFixed(2)}
+            </span>
+            <button
+              onClick={() => onResetField(f.key)}
+              disabled={!overridden}
+              title={overridden ? "Reset to voice default" : "At voice default"}
+              aria-label={`Reset ${f.label} to voice default`}
+              className="focus-ring h-4 w-4 shrink-0 rounded text-3xs text-text-muted transition hover:text-text-primary disabled:opacity-20"
+            >
+              &times;
+            </button>
+          </div>
+        );
+      })}
       <div className="flex items-center justify-between gap-2 pt-0.5">
-        <label className="flex cursor-pointer items-center gap-1.5 text-2xs text-text-muted">
+        <label
+          className={`flex cursor-pointer items-center gap-1.5 text-2xs ${
+            boostOverridden ? "text-accent" : "text-text-muted"
+          }`}
+        >
           <input
             type="checkbox"
             checked={effective.useSpeakerBoost}
@@ -605,17 +676,31 @@ function VoiceSettingsEditor({ effective, onSet, onReset, canReset }: VoiceSetti
             className="accent-accent"
           />
           Speaker boost
+          {boostOverridden && (
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                onResetField("useSpeakerBoost");
+              }}
+              title="Reset to voice default"
+              className="focus-ring ml-0.5 text-3xs hover:text-text-primary"
+            >
+              &times;
+            </button>
+          )}
         </label>
         <button
           onClick={onReset}
           disabled={!canReset}
           className="focus-ring rounded border border-border-default px-2 py-0.5 text-3xs text-text-muted transition hover:bg-bg-tertiary hover:text-text-primary disabled:opacity-40"
-          title="Clear overrides for this scope"
+          title="Reset all fields to the voice default"
         >
-          Reset
+          Reset all
         </button>
       </div>
-      <p className="text-3xs text-text-muted/60">Unset values fall back to ElevenLabs defaults.</p>
+      <p className="text-3xs text-text-muted/60">
+        Sliders start at the voice's own defaults; accent labels are your overrides. × resets a field.
+      </p>
     </div>
   );
 }

--- a/creator/src/components/VoiceOverPanel.tsx
+++ b/creator/src/components/VoiceOverPanel.tsx
@@ -38,6 +38,7 @@ function fillRequired(
     style: s.style ?? base.style,
     useSpeakerBoost: s.useSpeakerBoost ?? base.useSpeakerBoost,
     speed: s.speed ?? base.speed,
+    sentencePause: s.sentencePause ?? base.sentencePause,
   };
 }
 
@@ -648,8 +649,9 @@ function VoiceSettingsEditor({
               className="h-1.5 flex-1 accent-accent"
               aria-label={f.label}
             />
-            <span className="w-9 shrink-0 text-right font-mono text-3xs text-text-secondary">
+            <span className="w-12 shrink-0 text-right font-mono text-3xs text-text-secondary">
               {(effective[f.key] as number).toFixed(2)}
+              {(f as { suffix?: string }).suffix ?? ""}
             </span>
             <button
               onClick={() => onResetField(f.key)}

--- a/creator/src/components/config/panels/ApiSettingsPanel.tsx
+++ b/creator/src/components/config/panels/ApiSettingsPanel.tsx
@@ -10,7 +10,7 @@ import type { ProjectSettings, Settings } from "@/types/assets";
 // here is the only touch point when a new provider key is added.
 
 interface ProviderCard {
-  id: "deepinfra" | "anthropic" | "openrouter" | "runware" | "openai";
+  id: "deepinfra" | "anthropic" | "openrouter" | "runware" | "openai" | "elevenlabs";
   label: string;
   keyField: keyof Settings & (
     | "deepinfra_api_key"
@@ -18,6 +18,7 @@ interface ProviderCard {
     | "openrouter_api_key"
     | "runware_api_key"
     | "openai_api_key"
+    | "elevenlabs_api_key"
   );
   helpUrl: string;
   /** Which pipelines this provider feeds. Displayed under the key
@@ -60,6 +61,13 @@ const PROVIDER_CARDS: ProviderCard[] = [
     keyField: "openai_api_key",
     helpUrl: "platform.openai.com/api-keys",
     uses: "Image generation (GPT Image 2) and text-to-speech.",
+  },
+  {
+    id: "elevenlabs",
+    label: "ElevenLabs",
+    keyField: "elevenlabs_api_key",
+    helpUrl: "elevenlabs.io/app/settings/api-keys",
+    uses: "Dialogue voice-over synthesis.",
   },
 ];
 

--- a/creator/src/lib/panelRegistry.ts
+++ b/creator/src/lib/panelRegistry.ts
@@ -61,6 +61,7 @@ const STUDIO_PANELS: PanelDef[] = [
   { id: "studioAbilities", label: "Icons", host: "studio", kicker: "Studio", title: "Icons", description: "Ability and status-effect icon generation.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F532}", aiOnly: true },
   { id: "sprites", label: "Player Sprites", host: "command", kicker: "Studio", title: "Player sprites", description: "Visible identity, unlockable variants, and portrait logic.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F9CD}" },
   { id: "playtest", label: "Playtest", host: "command", kicker: "Studio", title: "Playtest", description: "Walk through your world room-by-room. Read descriptions, meet mobs, try dialogue, inspect items and gathering nodes.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F6B6}" },
+  { id: "voices", label: "Voice-Over", host: "command", kicker: "Studio", title: "Dialogue voice-over", description: "Synthesize spoken audio for NPC dialogue with ElevenLabs and publish the clips to your CDN.", maxWidth: "max-w-7xl", island: "forge", glyph: "\u{1F3A4}", aiOnly: true },
   ART_STYLE_PANEL,
 ];
 

--- a/creator/src/stores/voiceStore.ts
+++ b/creator/src/stores/voiceStore.ts
@@ -14,8 +14,10 @@ import {
   type VoiceUploadJob,
 } from "@/types/voiceover";
 
-/** Max parallel ElevenLabs calls — kept low to respect provider concurrency limits. */
-const SYNTH_CONCURRENCY = 3;
+/** Max parallel ElevenLabs calls. Kept at 2 because free/starter plans cap
+ *  concurrent requests low (2–3) and over-cap calls 429; the backend also
+ *  retries transient 429/5xx with backoff. */
+const SYNTH_CONCURRENCY = 2;
 
 const EMPTY_MAP: VoiceMap = {
   defaultVoiceId: "",

--- a/creator/src/stores/voiceStore.ts
+++ b/creator/src/stores/voiceStore.ts
@@ -43,6 +43,16 @@ function pruneResultsForMob(
   return next;
 }
 
+/** Merge a settings patch, dropping any field set back to undefined so a
+ *  per-field reset truly clears the override (rather than storing undefined). */
+function mergeSettings(base: VoiceSettings, patch: Partial<VoiceSettings>): VoiceSettings {
+  const next: VoiceSettings = { ...base, ...patch };
+  for (const k of Object.keys(next) as (keyof VoiceSettings)[]) {
+    if (next[k] === undefined) delete next[k];
+  }
+  return next;
+}
+
 export type LineStatus = "idle" | "generating" | "done" | "error";
 
 export interface LineState {
@@ -59,6 +69,8 @@ interface VoiceStore {
   voices: ElevenLabsVoice[];
   loadingVoices: boolean;
   voicesError: string | null;
+  /** voiceId → that voice's own ElevenLabs default settings (slider baseline). */
+  voiceDefaults: Record<string, VoiceSettings>;
   /** lineKey → generation state. */
   results: Map<string, LineState>;
   generating: boolean;
@@ -79,6 +91,7 @@ interface VoiceStore {
   clearDefaultSettings: () => void;
 
   fetchVoices: () => Promise<void>;
+  fetchVoiceDefaults: (voiceId: string) => Promise<void>;
 
   synthesizeLine: (line: DialogueLine) => Promise<void>;
   generateAll: (lines: DialogueLine[]) => Promise<void>;
@@ -96,6 +109,7 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
   voices: [],
   loadingVoices: false,
   voicesError: null,
+  voiceDefaults: {},
   results: new Map(),
   generating: false,
   publishing: false,
@@ -212,7 +226,7 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
     set((s) => ({
       voiceMap: {
         ...s.voiceMap,
-        defaultSettings: { ...s.voiceMap.defaultSettings, ...patch },
+        defaultSettings: mergeSettings(s.voiceMap.defaultSettings, patch),
       },
     })),
 
@@ -222,7 +236,12 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
   setMobSettings: (templateKey, patch) =>
     set((s) => {
       const settings = { ...s.voiceMap.settings };
-      settings[templateKey] = { ...settings[templateKey], ...patch };
+      const merged = mergeSettings(settings[templateKey] ?? {}, patch);
+      if (Object.keys(merged).length === 0) {
+        delete settings[templateKey];
+      } else {
+        settings[templateKey] = merged;
+      }
       return {
         voiceMap: { ...s.voiceMap, settings },
         results: pruneResultsForMob(s.results, templateKey),
@@ -246,6 +265,18 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
       set({ voices, loadingVoices: false });
     } catch (e) {
       set({ loadingVoices: false, voicesError: String(e) });
+    }
+  },
+
+  fetchVoiceDefaults: async (voiceId) => {
+    if (!voiceId || get().voiceDefaults[voiceId] !== undefined) return;
+    // Reserve the slot up front so concurrent callers don't double-fetch.
+    set((s) => ({ voiceDefaults: { ...s.voiceDefaults, [voiceId]: {} } }));
+    try {
+      const settings = await invoke<VoiceSettings>("elevenlabs_voice_settings", { voiceId });
+      set((s) => ({ voiceDefaults: { ...s.voiceDefaults, [voiceId]: settings } }));
+    } catch {
+      // Leave the empty placeholder so sliders fall back to the generic baseline.
     }
   },
 

--- a/creator/src/stores/voiceStore.ts
+++ b/creator/src/stores/voiceStore.ts
@@ -1,0 +1,223 @@
+import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
+import { useProjectStore } from "@/stores/projectStore";
+import type { SyncProgress } from "@/types/assets";
+import {
+  DEFAULT_ELEVENLABS_MODEL,
+  lineKey,
+  type DialogueLine,
+  type ElevenLabsVoice,
+  type VoiceClip,
+  type VoiceMap,
+  type VoiceUploadJob,
+} from "@/types/voiceover";
+
+/** Max parallel ElevenLabs calls — kept low to respect provider concurrency limits. */
+const SYNTH_CONCURRENCY = 3;
+
+const EMPTY_MAP: VoiceMap = {
+  defaultVoiceId: "",
+  modelId: DEFAULT_ELEVENLABS_MODEL,
+  assignments: {},
+};
+
+export type LineStatus = "idle" | "generating" | "done" | "error";
+
+export interface LineState {
+  status: LineStatus;
+  clip?: VoiceClip;
+  error?: string;
+}
+
+interface VoiceStore {
+  voiceMap: VoiceMap;
+  voices: ElevenLabsVoice[];
+  loadingVoices: boolean;
+  voicesError: string | null;
+  /** lineKey → generation state. */
+  results: Map<string, LineState>;
+  generating: boolean;
+  publishing: boolean;
+  lastPublish: SyncProgress | null;
+
+  loadVoiceMap: () => Promise<void>;
+  saveVoiceMap: () => Promise<void>;
+  setDefaultVoice: (voiceId: string) => void;
+  setModel: (modelId: string) => void;
+  setAssignment: (templateKey: string, voiceId: string) => void;
+  resolveVoiceId: (templateKey: string) => string;
+
+  fetchVoices: () => Promise<void>;
+
+  synthesizeLine: (line: DialogueLine) => Promise<void>;
+  generateAll: (lines: DialogueLine[]) => Promise<void>;
+  publishToR2: (lines: DialogueLine[]) => Promise<SyncProgress | null>;
+  reset: () => void;
+}
+
+function projectDir(): string | undefined {
+  return useProjectStore.getState().project?.mudDir;
+}
+
+export const useVoiceStore = create<VoiceStore>((set, get) => ({
+  voiceMap: EMPTY_MAP,
+  voices: [],
+  loadingVoices: false,
+  voicesError: null,
+  results: new Map(),
+  generating: false,
+  publishing: false,
+  lastPublish: null,
+
+  loadVoiceMap: async () => {
+    const dir = projectDir();
+    if (!dir) return;
+    try {
+      const map = await invoke<VoiceMap>("load_voice_map", { projectDir: dir });
+      set({
+        voiceMap: {
+          defaultVoiceId: map.defaultVoiceId ?? "",
+          modelId: map.modelId || DEFAULT_ELEVENLABS_MODEL,
+          assignments: map.assignments ?? {},
+        },
+      });
+    } catch (e) {
+      console.error("Failed to load voice map", e);
+    }
+  },
+
+  saveVoiceMap: async () => {
+    const dir = projectDir();
+    if (!dir) return;
+    await invoke("save_voice_map", { projectDir: dir, map: get().voiceMap });
+  },
+
+  setDefaultVoice: (voiceId) =>
+    set((s) => ({ voiceMap: { ...s.voiceMap, defaultVoiceId: voiceId } })),
+
+  setModel: (modelId) =>
+    set((s) => ({ voiceMap: { ...s.voiceMap, modelId } })),
+
+  setAssignment: (templateKey, voiceId) =>
+    set((s) => {
+      const assignments = { ...s.voiceMap.assignments };
+      if (voiceId) {
+        assignments[templateKey] = voiceId;
+      } else {
+        delete assignments[templateKey];
+      }
+      return { voiceMap: { ...s.voiceMap, assignments } };
+    }),
+
+  resolveVoiceId: (templateKey) => {
+    const { voiceMap } = get();
+    return voiceMap.assignments[templateKey] || voiceMap.defaultVoiceId;
+  },
+
+  fetchVoices: async () => {
+    set({ loadingVoices: true, voicesError: null });
+    try {
+      const voices = await invoke<ElevenLabsVoice[]>("elevenlabs_list_voices");
+      set({ voices, loadingVoices: false });
+    } catch (e) {
+      set({ loadingVoices: false, voicesError: String(e) });
+    }
+  },
+
+  synthesizeLine: async (line) => {
+    const key = lineKey(line.zone, line.templateKey, line.nodeId);
+    const voiceId = get().resolveVoiceId(line.templateKey);
+    if (!voiceId) {
+      set((s) => {
+        const results = new Map(s.results);
+        results.set(key, { status: "error", error: "No voice assigned (set a default or per-mob voice)." });
+        return { results };
+      });
+      return;
+    }
+
+    set((s) => {
+      const results = new Map(s.results);
+      results.set(key, { ...results.get(key), status: "generating" });
+      return { results };
+    });
+
+    try {
+      const clip = await invoke<VoiceClip>("elevenlabs_synthesize", {
+        text: line.text,
+        voiceId,
+        modelId: get().voiceMap.modelId || DEFAULT_ELEVENLABS_MODEL,
+      });
+      set((s) => {
+        const results = new Map(s.results);
+        results.set(key, { status: "done", clip });
+        return { results };
+      });
+    } catch (e) {
+      set((s) => {
+        const results = new Map(s.results);
+        results.set(key, { status: "error", error: String(e) });
+        return { results };
+      });
+    }
+  },
+
+  generateAll: async (lines) => {
+    if (get().generating) return;
+    set({ generating: true });
+    try {
+      const queue = [...lines];
+      const worker = async () => {
+        for (;;) {
+          const line = queue.shift();
+          if (!line) return;
+          await get().synthesizeLine(line);
+        }
+      };
+      const pool = Array.from(
+        { length: Math.min(SYNTH_CONCURRENCY, queue.length) },
+        () => worker(),
+      );
+      await Promise.all(pool);
+    } finally {
+      set({ generating: false });
+    }
+  },
+
+  publishToR2: async (lines) => {
+    if (get().publishing) return null;
+    set({ publishing: true, lastPublish: null });
+    try {
+      const { results } = get();
+      const jobs: VoiceUploadJob[] = [];
+      for (const line of lines) {
+        const state = results.get(lineKey(line.zone, line.templateKey, line.nodeId));
+        if (state?.status === "done" && state.clip) {
+          jobs.push({
+            zone: line.zone,
+            templateKey: line.templateKey,
+            nodeId: line.nodeId,
+            textSha8: state.clip.textSha8,
+            cacheHash: state.clip.cacheHash,
+          });
+        }
+      }
+      const progress = await invoke<SyncProgress>("deploy_voices_to_r2", { jobs });
+      set({ lastPublish: progress, publishing: false });
+      return progress;
+    } catch (e) {
+      const progress: SyncProgress = {
+        total: 0,
+        uploaded: 0,
+        skipped: 0,
+        failed: 0,
+        errors: [String(e)],
+      };
+      set({ lastPublish: progress, publishing: false });
+      return progress;
+    }
+  },
+
+  reset: () =>
+    set({ results: new Map(), lastPublish: null }),
+}));

--- a/creator/src/stores/voiceStore.ts
+++ b/creator/src/stores/voiceStore.ts
@@ -8,9 +8,12 @@ import {
   resolveVoiceSettings,
   type DialogueLine,
   type ElevenLabsVoice,
+  type LineClip,
   type VoiceClip,
   type VoiceMap,
   type VoiceSettings,
+  type VoiceStatusQuery,
+  type VoiceStatusResult,
   type VoiceUploadJob,
 } from "@/types/voiceover";
 
@@ -44,12 +47,15 @@ export type LineStatus = "idle" | "generating" | "done" | "error";
 
 export interface LineState {
   status: LineStatus;
-  clip?: VoiceClip;
+  clip?: LineClip;
   error?: string;
 }
 
 interface VoiceStore {
   voiceMap: VoiceMap;
+  /** True once the voice map has been read from disk, so remounts don't
+   *  reload and clobber unsaved in-memory edits. */
+  mapLoaded: boolean;
   voices: ElevenLabsVoice[];
   loadingVoices: boolean;
   voicesError: string | null;
@@ -61,6 +67,8 @@ interface VoiceStore {
 
   loadVoiceMap: () => Promise<void>;
   saveVoiceMap: () => Promise<void>;
+  rehydrate: (lines: DialogueLine[]) => Promise<void>;
+  ensureClipDataUrl: (key: string) => Promise<string | undefined>;
   setDefaultVoice: (voiceId: string) => void;
   setModel: (modelId: string) => void;
   setAssignment: (templateKey: string, voiceId: string) => void;
@@ -84,6 +92,7 @@ function projectDir(): string | undefined {
 
 export const useVoiceStore = create<VoiceStore>((set, get) => ({
   voiceMap: EMPTY_MAP,
+  mapLoaded: false,
   voices: [],
   loadingVoices: false,
   voicesError: null,
@@ -93,6 +102,9 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
   lastPublish: null,
 
   loadVoiceMap: async () => {
+    // Only read from disk once per session — remounting the panel must not
+    // overwrite in-memory edits with the (older) saved file.
+    if (get().mapLoaded) return;
     const dir = projectDir();
     if (!dir) return;
     try {
@@ -105,6 +117,7 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
           defaultSettings: map.defaultSettings ?? {},
           settings: map.settings ?? {},
         },
+        mapLoaded: true,
       });
     } catch (e) {
       console.error("Failed to load voice map", e);
@@ -115,6 +128,59 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
     const dir = projectDir();
     if (!dir) return;
     await invoke("save_voice_map", { projectDir: dir, map: get().voiceMap });
+  },
+
+  rehydrate: async (lines) => {
+    const { voiceMap } = get();
+    const queries: VoiceStatusQuery[] = lines.map((line) => ({
+      key: lineKey(line.zone, line.templateKey, line.nodeId),
+      text: line.text,
+      voiceId: voiceMap.assignments[line.templateKey] || voiceMap.defaultVoiceId,
+      modelId: voiceMap.modelId || DEFAULT_ELEVENLABS_MODEL,
+      voiceSettings: resolveVoiceSettings(voiceMap, line.templateKey),
+    }));
+    if (!queries.length) return;
+    let statuses: VoiceStatusResult[];
+    try {
+      statuses = await invoke<VoiceStatusResult[]>("voice_clip_status", { queries });
+    } catch {
+      return;
+    }
+    set((s) => {
+      const results = new Map(s.results);
+      for (const st of statuses) {
+        const cur = results.get(st.key);
+        // Only fill lines we don't already have richer state for, so we never
+        // clobber an in-progress, freshly-generated, or errored entry.
+        if (st.present && (!cur || cur.status === "idle")) {
+          results.set(st.key, {
+            status: "done",
+            clip: { cacheHash: st.cacheHash, textSha8: st.textSha8 },
+          });
+        }
+      }
+      return { results };
+    });
+  },
+
+  ensureClipDataUrl: async (key) => {
+    const cur = get().results.get(key);
+    if (!cur?.clip) return undefined;
+    if (cur.clip.dataUrl) return cur.clip.dataUrl;
+    try {
+      const dataUrl = await invoke<string>("read_voice_clip", {
+        cacheHash: cur.clip.cacheHash,
+      });
+      set((s) => {
+        const results = new Map(s.results);
+        const c = results.get(key);
+        if (c?.clip) results.set(key, { ...c, clip: { ...c.clip, dataUrl } });
+        return { results };
+      });
+      return dataUrl;
+    } catch {
+      return undefined;
+    }
   },
 
   setDefaultVoice: (voiceId) =>
@@ -202,7 +268,7 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
     });
 
     try {
-      const clip = await invoke<VoiceClip>("elevenlabs_synthesize", {
+      const vc = await invoke<VoiceClip>("elevenlabs_synthesize", {
         text: line.text,
         voiceId,
         modelId: get().voiceMap.modelId || DEFAULT_ELEVENLABS_MODEL,
@@ -210,7 +276,10 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
       });
       set((s) => {
         const results = new Map(s.results);
-        results.set(key, { status: "done", clip });
+        results.set(key, {
+          status: "done",
+          clip: { cacheHash: vc.cacheHash, textSha8: vc.textSha8, dataUrl: vc.dataUrl },
+        });
         return { results };
       });
     } catch (e) {

--- a/creator/src/stores/voiceStore.ts
+++ b/creator/src/stores/voiceStore.ts
@@ -5,10 +5,12 @@ import type { SyncProgress } from "@/types/assets";
 import {
   DEFAULT_ELEVENLABS_MODEL,
   lineKey,
+  resolveVoiceSettings,
   type DialogueLine,
   type ElevenLabsVoice,
   type VoiceClip,
   type VoiceMap,
+  type VoiceSettings,
   type VoiceUploadJob,
 } from "@/types/voiceover";
 
@@ -19,7 +21,22 @@ const EMPTY_MAP: VoiceMap = {
   defaultVoiceId: "",
   modelId: DEFAULT_ELEVENLABS_MODEL,
   assignments: {},
+  defaultSettings: {},
+  settings: {},
 };
+
+/** Drop generated results for a mob's lines so changed voice/settings show as
+ *  needing regeneration. lineKey is `${zone} ${templateKey} ${nodeId}`. */
+function pruneResultsForMob(
+  results: Map<string, LineState>,
+  templateKey: string,
+): Map<string, LineState> {
+  const next = new Map(results);
+  for (const key of results.keys()) {
+    if (key.split(" ")[1] === templateKey) next.delete(key);
+  }
+  return next;
+}
 
 export type LineStatus = "idle" | "generating" | "done" | "error";
 
@@ -46,6 +63,10 @@ interface VoiceStore {
   setModel: (modelId: string) => void;
   setAssignment: (templateKey: string, voiceId: string) => void;
   resolveVoiceId: (templateKey: string) => string;
+  setDefaultSettings: (patch: Partial<VoiceSettings>) => void;
+  setMobSettings: (templateKey: string, patch: Partial<VoiceSettings>) => void;
+  clearMobSettings: (templateKey: string) => void;
+  clearDefaultSettings: () => void;
 
   fetchVoices: () => Promise<void>;
 
@@ -79,6 +100,8 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
           defaultVoiceId: map.defaultVoiceId ?? "",
           modelId: map.modelId || DEFAULT_ELEVENLABS_MODEL,
           assignments: map.assignments ?? {},
+          defaultSettings: map.defaultSettings ?? {},
+          settings: map.settings ?? {},
         },
       });
     } catch (e) {
@@ -106,13 +129,47 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
       } else {
         delete assignments[templateKey];
       }
-      return { voiceMap: { ...s.voiceMap, assignments } };
+      return {
+        voiceMap: { ...s.voiceMap, assignments },
+        results: pruneResultsForMob(s.results, templateKey),
+      };
     }),
 
   resolveVoiceId: (templateKey) => {
     const { voiceMap } = get();
     return voiceMap.assignments[templateKey] || voiceMap.defaultVoiceId;
   },
+
+  setDefaultSettings: (patch) =>
+    set((s) => ({
+      voiceMap: {
+        ...s.voiceMap,
+        defaultSettings: { ...s.voiceMap.defaultSettings, ...patch },
+      },
+    })),
+
+  clearDefaultSettings: () =>
+    set((s) => ({ voiceMap: { ...s.voiceMap, defaultSettings: {} } })),
+
+  setMobSettings: (templateKey, patch) =>
+    set((s) => {
+      const settings = { ...s.voiceMap.settings };
+      settings[templateKey] = { ...settings[templateKey], ...patch };
+      return {
+        voiceMap: { ...s.voiceMap, settings },
+        results: pruneResultsForMob(s.results, templateKey),
+      };
+    }),
+
+  clearMobSettings: (templateKey) =>
+    set((s) => {
+      const settings = { ...s.voiceMap.settings };
+      delete settings[templateKey];
+      return {
+        voiceMap: { ...s.voiceMap, settings },
+        results: pruneResultsForMob(s.results, templateKey),
+      };
+    }),
 
   fetchVoices: async () => {
     set({ loadingVoices: true, voicesError: null });
@@ -147,6 +204,7 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
         text: line.text,
         voiceId,
         modelId: get().voiceMap.modelId || DEFAULT_ELEVENLABS_MODEL,
+        voiceSettings: resolveVoiceSettings(get().voiceMap, line.templateKey),
       });
       set((s) => {
         const results = new Map(s.results);

--- a/creator/src/stores/voiceStore.ts
+++ b/creator/src/stores/voiceStore.ts
@@ -63,9 +63,10 @@ export interface LineState {
 
 interface VoiceStore {
   voiceMap: VoiceMap;
-  /** True once the voice map has been read from disk, so remounts don't
-   *  reload and clobber unsaved in-memory edits. */
-  mapLoaded: boolean;
+  /** Project dir the in-memory voice map was loaded for. Remounting the panel
+   *  for the same project must not reload (and clobber unsaved edits), but
+   *  switching projects must — so we key on the dir, not a one-shot boolean. */
+  loadedDir: string | null;
   voices: ElevenLabsVoice[];
   loadingVoices: boolean;
   voicesError: string | null;
@@ -105,7 +106,7 @@ function projectDir(): string | undefined {
 
 export const useVoiceStore = create<VoiceStore>((set, get) => ({
   voiceMap: EMPTY_MAP,
-  mapLoaded: false,
+  loadedDir: null,
   voices: [],
   loadingVoices: false,
   voicesError: null,
@@ -116,11 +117,12 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
   lastPublish: null,
 
   loadVoiceMap: async () => {
-    // Only read from disk once per session — remounting the panel must not
-    // overwrite in-memory edits with the (older) saved file.
-    if (get().mapLoaded) return;
     const dir = projectDir();
     if (!dir) return;
+    // Already loaded for this project — remounting must not clobber in-memory
+    // edits with the (older) saved file. A different dir means the project was
+    // switched, so fall through and reload (and drop the old project's clips).
+    if (get().loadedDir === dir) return;
     try {
       const map = await invoke<VoiceMap>("load_voice_map", { projectDir: dir });
       set({
@@ -131,7 +133,9 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
           defaultSettings: map.defaultSettings ?? {},
           settings: map.settings ?? {},
         },
-        mapLoaded: true,
+        loadedDir: dir,
+        results: new Map(),
+        lastPublish: null,
       });
     } catch (e) {
       console.error("Failed to load voice map", e);
@@ -140,7 +144,10 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
 
   saveVoiceMap: async () => {
     const dir = projectDir();
-    if (!dir) return;
+    // Only persist a map we actually loaded for this same project. Guards the
+    // autosave/unmount-flush from writing a stale (previous-project) map to a
+    // newly-opened project's path before its own map has loaded.
+    if (!dir || get().loadedDir !== dir) return;
     await invoke("save_voice_map", { projectDir: dir, map: get().voiceMap });
   },
 
@@ -160,17 +167,31 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
     } catch {
       return;
     }
+    // `voice_clip_status` reports the cache key for each line's *current* voice/
+    // model/settings/text and whether that clip is on disk. Treating it as the
+    // source of truth lets a global change (default voice, model, delivery
+    // settings) — none of which prune per-mob — invalidate now-stale clips, not
+    // just text edits. Without this, changing the default voice and publishing
+    // would ship audio synthesized with the old voice while the row says "ready".
     set((s) => {
       const results = new Map(s.results);
       for (const st of statuses) {
         const cur = results.get(st.key);
-        // Only fill lines we don't already have richer state for, so we never
-        // clobber an in-progress, freshly-generated, or errored entry.
-        if (st.present && (!cur || cur.status === "idle")) {
-          results.set(st.key, {
-            status: "done",
-            clip: { cacheHash: st.cacheHash, textSha8: st.textSha8 },
-          });
+        if (st.present) {
+          // A clip for the current config exists. Mark done unless we hold a
+          // richer transient state (generating/error) or the identical done.
+          const matchesCurrent = cur?.status === "done" && cur.clip?.cacheHash === st.cacheHash;
+          if (!cur || cur.status === "idle" || (cur.status === "done" && !matchesCurrent)) {
+            results.set(st.key, {
+              status: "done",
+              clip: { cacheHash: st.cacheHash, textSha8: st.textSha8 },
+            });
+          }
+        } else if (cur?.status === "done" && cur.clip && cur.clip.cacheHash !== st.cacheHash) {
+          // The stored clip was generated for a different voice/model/settings/
+          // text and no clip exists for the current config — drop it so it
+          // neither shows "ready" nor publishes stale audio.
+          results.delete(st.key);
         }
       }
       return { results };

--- a/creator/src/types/__tests__/voiceover.test.ts
+++ b/creator/src/types/__tests__/voiceover.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
 import { lineKey, sha8 } from "@/types/voiceover";
 
 describe("sha8 (voice-over contract hash)", () => {
@@ -24,6 +25,35 @@ describe("sha8 (voice-over contract hash)", () => {
 
   it("is deterministic", async () => {
     expect(await sha8("root line")).toBe(await sha8("root line"));
+  });
+});
+
+// Parser-parity boundary with AmbonMUD (PR #1203 @ bd7f56d5). The engine
+// hashes the dialogue text its WorldLoader (Jackson + SnakeYAML) produces; we
+// hash what our `yaml` package produces. Block scalars are the only place the
+// two could diverge (trailing-newline chomping), so we pin the exact bytes a
+// real `|` / `|-` block parses to — through the same parseDocument().toJS()
+// path the dialogue loader uses — and the resulting hash.
+describe("block-scalar parity (cross-repo)", () => {
+  function nodeText(blockYaml: string): string {
+    const doc = `mobs:\n  sage:\n    name: Sage\n    dialogue:\n      n:\n        text: ${blockYaml}`;
+    return parseDocument(doc).toJS().mobs.sage.dialogue.n.text as string;
+  }
+
+  it("`|` literal block clips to exactly one trailing newline", () => {
+    const text = nodeText("|\n          Hello there!\n          Stay a while.\n");
+    expect(text).toBe("Hello there!\nStay a while.\n");
+  });
+
+  it("`|` literal block hashes to the engine's reference vector", async () => {
+    const text = nodeText("|\n          Hello there!\n          Stay a while.\n");
+    expect(await sha8(text)).toBe("df658e4d");
+  });
+
+  it("`|-` strip block drops the trailing newline and hashes differently", async () => {
+    const strip = nodeText("|-\n          Hello there!\n          Stay a while.\n");
+    expect(strip).toBe("Hello there!\nStay a while.");
+    expect(await sha8(strip)).not.toBe("df658e4d");
   });
 });
 

--- a/creator/src/types/__tests__/voiceover.test.ts
+++ b/creator/src/types/__tests__/voiceover.test.ts
@@ -7,6 +7,12 @@ describe("sha8 (voice-over contract hash)", () => {
     expect(await sha8("")).toBe("e3b0c442");
   });
 
+  // Cross-repo reference vectors shared with AmbonMUD's GmcpEmitter.sha8.
+  it("matches the contract reference vectors", async () => {
+    expect(await sha8("Hello!")).toBe("334d016f");
+    expect(await sha8("Hello there!")).toBe("89b8b8e4");
+  });
+
   it("returns 8 hex chars", async () => {
     const h = await sha8("Greetings, traveler.");
     expect(h).toMatch(/^[0-9a-f]{8}$/);

--- a/creator/src/types/__tests__/voiceover.test.ts
+++ b/creator/src/types/__tests__/voiceover.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { lineKey, sha8 } from "@/types/voiceover";
+
+describe("sha8 (voice-over contract hash)", () => {
+  // Must match Rust `elevenlabs::text_sha8` and the AmbonMUD engine.
+  it("matches the SHA-256 empty-string vector", async () => {
+    expect(await sha8("")).toBe("e3b0c442");
+  });
+
+  it("returns 8 hex chars", async () => {
+    const h = await sha8("Greetings, traveler.");
+    expect(h).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it("is sensitive to surrounding whitespace (raw text, no trim)", async () => {
+    expect(await sha8("hello")).not.toBe(await sha8(" hello "));
+  });
+
+  it("is deterministic", async () => {
+    expect(await sha8("root line")).toBe(await sha8("root line"));
+  });
+});
+
+describe("lineKey", () => {
+  it("composes a stable identity from zone/template/node", () => {
+    expect(lineKey("tutorial_glade", "headmaster_aldric", "root")).toBe(
+      "tutorial_glade headmaster_aldric root",
+    );
+  });
+});

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -83,6 +83,7 @@ export interface Settings {
   anthropic_api_key: string;
   openrouter_api_key: string;
   openai_api_key: string;
+  elevenlabs_api_key: string;
   image_model: string;
   enhance_model: string;
   prompt_llm_provider: string;

--- a/creator/src/types/voiceover.ts
+++ b/creator/src/types/voiceover.ts
@@ -1,0 +1,89 @@
+// Dialogue voice-over types. Arcanum synthesizes NPC dialogue lines via
+// ElevenLabs and publishes the clips to R2 at the path the AmbonMUD engine
+// resolves. See docs/VOICE_OVER_CONTRACT.md in the AmbonMUD repo.
+
+/** Mirrors the Rust ElevenLabsVoice struct. */
+export interface ElevenLabsVoice {
+  voiceId: string;
+  name: string;
+  category: string;
+  previewUrl: string;
+}
+
+/** Mirrors the Rust VoiceClip struct returned by elevenlabs_synthesize. */
+export interface VoiceClip {
+  filePath: string;
+  cacheHash: string;
+  /** First 8 hex chars of SHA-256(raw node text) — the contract hash. */
+  textSha8: string;
+  /** data:audio/mpeg;base64,... for in-app preview playback. */
+  dataUrl: string;
+  sizeBytes: number;
+  cached: boolean;
+}
+
+/** Mirrors the Rust VoiceMap struct (.arcanum/voices.json). */
+export interface VoiceMap {
+  defaultVoiceId: string;
+  modelId: string;
+  /** templateKey → ElevenLabs voiceId. */
+  assignments: Record<string, string>;
+}
+
+/** Mirrors the Rust VoiceUploadJob struct passed to deploy_voices_to_r2. */
+export interface VoiceUploadJob {
+  zone: string;
+  templateKey: string;
+  nodeId: string;
+  textSha8: string;
+  cacheHash: string;
+}
+
+/** A single voiceable NPC dialogue line, flattened across all loaded zones. */
+export interface DialogueLine {
+  zone: string;
+  templateKey: string;
+  mobName: string;
+  nodeId: string;
+  text: string;
+}
+
+/** ElevenLabs synthesis models offered in the picker. */
+export const ELEVENLABS_MODELS = [
+  {
+    id: "eleven_multilingual_v2",
+    label: "Multilingual v2",
+    description: "Highest quality, most expressive. Default.",
+  },
+  {
+    id: "eleven_turbo_v2_5",
+    label: "Turbo v2.5",
+    description: "Faster and cheaper, slightly lower fidelity.",
+  },
+  {
+    id: "eleven_flash_v2_5",
+    label: "Flash v2.5",
+    description: "Lowest latency, lowest cost.",
+  },
+] as const;
+
+export const DEFAULT_ELEVENLABS_MODEL = "eleven_multilingual_v2";
+
+/** Stable identity for a dialogue line across the panel + result maps. */
+export function lineKey(zone: string, templateKey: string, nodeId: string): string {
+  return `${zone} ${templateKey} ${nodeId}`;
+}
+
+/**
+ * First 8 hex chars of SHA-256 over the exact raw text. Must match the Rust
+ * `elevenlabs::text_sha8` and the AmbonMUD engine byte-for-byte — hashes the
+ * UTF-8 bytes of `text` verbatim with no trimming or normalization.
+ */
+export async function sha8(text: string): Promise<string> {
+  const bytes = new TextEncoder().encode(text);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  const hex = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return hex.slice(0, 8);
+}

--- a/creator/src/types/voiceover.ts
+++ b/creator/src/types/voiceover.ts
@@ -31,6 +31,9 @@ export interface VoiceSettings {
   style?: number;
   useSpeakerBoost?: boolean;
   speed?: number;
+  /** Extra pause (seconds) inserted after each sentence. Not an ElevenLabs
+   *  voice setting — Arcanum injects `<break>` tags into the synthesis input. */
+  sentencePause?: number;
 }
 
 /** Lightweight generated-clip handle held in the panel's per-line state.
@@ -77,6 +80,7 @@ export const ELEVENLABS_DEFAULT_SETTINGS: Required<VoiceSettings> = {
   style: 0,
   useSpeakerBoost: true,
   speed: 1.0,
+  sentencePause: 0,
 };
 
 /** Numeric delivery controls surfaced as sliders. `useSpeakerBoost` is a
@@ -86,12 +90,14 @@ export const VOICE_SETTING_FIELDS = [
   { key: "similarityBoost", label: "Similarity", min: 0, max: 1, step: 0.05, hint: "How closely to match the source voice." },
   { key: "style", label: "Style", min: 0, max: 1, step: 0.05, hint: "Amplify the voice's character (slower to render)." },
   { key: "speed", label: "Speed", min: 0.7, max: 1.2, step: 0.05, hint: "Delivery pacing." },
+  { key: "sentencePause", label: "Sentence pause", min: 0, max: 2, step: 0.1, suffix: "s", hint: "Extra pause inserted after each sentence (added to the audio only, not the displayed text)." },
 ] as const satisfies readonly {
   key: keyof VoiceSettings;
   label: string;
   min: number;
   max: number;
   step: number;
+  suffix?: string;
   hint: string;
 }[];
 
@@ -105,6 +111,7 @@ export function resolveVoiceSettings(map: VoiceMap, templateKey: string): VoiceS
     style: over.style ?? base.style,
     useSpeakerBoost: over.useSpeakerBoost ?? base.useSpeakerBoost,
     speed: over.speed ?? base.speed,
+    sentencePause: over.sentencePause ?? base.sentencePause,
   };
 }
 
@@ -116,7 +123,8 @@ export function settingsAreEmpty(s: VoiceSettings | undefined): boolean {
     s.similarityBoost === undefined &&
     s.style === undefined &&
     s.useSpeakerBoost === undefined &&
-    s.speed === undefined
+    s.speed === undefined &&
+    s.sentencePause === undefined
   );
 }
 

--- a/creator/src/types/voiceover.ts
+++ b/creator/src/types/voiceover.ts
@@ -22,12 +22,77 @@ export interface VoiceClip {
   cached: boolean;
 }
 
+/** Per-request ElevenLabs delivery controls (mirrors Rust VoiceSettings).
+ *  Every field optional — unset falls back to the project default, then to
+ *  ElevenLabs' own voice default. */
+export interface VoiceSettings {
+  stability?: number;
+  similarityBoost?: number;
+  style?: number;
+  useSpeakerBoost?: boolean;
+  speed?: number;
+}
+
 /** Mirrors the Rust VoiceMap struct (.arcanum/voices.json). */
 export interface VoiceMap {
   defaultVoiceId: string;
   modelId: string;
   /** templateKey → ElevenLabs voiceId. */
   assignments: Record<string, string>;
+  /** Project-wide delivery defaults. */
+  defaultSettings: VoiceSettings;
+  /** templateKey → per-mob delivery overrides. */
+  settings: Record<string, VoiceSettings>;
+}
+
+/** ElevenLabs' own defaults, shown in sliders when nothing is set. */
+export const ELEVENLABS_DEFAULT_SETTINGS: Required<VoiceSettings> = {
+  stability: 0.5,
+  similarityBoost: 0.75,
+  style: 0,
+  useSpeakerBoost: true,
+  speed: 1.0,
+};
+
+/** Numeric delivery controls surfaced as sliders. `useSpeakerBoost` is a
+ *  separate checkbox. */
+export const VOICE_SETTING_FIELDS = [
+  { key: "stability", label: "Stability", min: 0, max: 1, step: 0.05, hint: "Low = more emotional & variable; high = flat & consistent." },
+  { key: "similarityBoost", label: "Similarity", min: 0, max: 1, step: 0.05, hint: "How closely to match the source voice." },
+  { key: "style", label: "Style", min: 0, max: 1, step: 0.05, hint: "Amplify the voice's character (slower to render)." },
+  { key: "speed", label: "Speed", min: 0.7, max: 1.2, step: 0.05, hint: "Delivery pacing." },
+] as const satisfies readonly {
+  key: keyof VoiceSettings;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  hint: string;
+}[];
+
+/** Merge a mob's per-NPC overrides over the project defaults, field by field. */
+export function resolveVoiceSettings(map: VoiceMap, templateKey: string): VoiceSettings {
+  const base = map.defaultSettings ?? {};
+  const over = map.settings?.[templateKey] ?? {};
+  return {
+    stability: over.stability ?? base.stability,
+    similarityBoost: over.similarityBoost ?? base.similarityBoost,
+    style: over.style ?? base.style,
+    useSpeakerBoost: over.useSpeakerBoost ?? base.useSpeakerBoost,
+    speed: over.speed ?? base.speed,
+  };
+}
+
+/** True when no field is set (so the backend omits voice_settings entirely). */
+export function settingsAreEmpty(s: VoiceSettings | undefined): boolean {
+  if (!s) return true;
+  return (
+    s.stability === undefined &&
+    s.similarityBoost === undefined &&
+    s.style === undefined &&
+    s.useSpeakerBoost === undefined &&
+    s.speed === undefined
+  );
 }
 
 /** Mirrors the Rust VoiceUploadJob struct passed to deploy_voices_to_r2. */

--- a/creator/src/types/voiceover.ts
+++ b/creator/src/types/voiceover.ts
@@ -33,6 +33,31 @@ export interface VoiceSettings {
   speed?: number;
 }
 
+/** Lightweight generated-clip handle held in the panel's per-line state.
+ *  `dataUrl` is loaded lazily (absent for clips rehydrated from disk). */
+export interface LineClip {
+  cacheHash: string;
+  textSha8: string;
+  dataUrl?: string;
+}
+
+/** Mirrors the Rust VoiceStatusQuery — one per line, for cache rehydration. */
+export interface VoiceStatusQuery {
+  key: string;
+  text: string;
+  voiceId: string;
+  modelId?: string;
+  voiceSettings?: VoiceSettings;
+}
+
+/** Mirrors the Rust VoiceStatusResult. */
+export interface VoiceStatusResult {
+  key: string;
+  cacheHash: string;
+  textSha8: string;
+  present: boolean;
+}
+
 /** Mirrors the Rust VoiceMap struct (.arcanum/voices.json). */
 export interface VoiceMap {
   defaultVoiceId: string;


### PR DESCRIPTION
## Summary

Implements the **Arcanum half** of the mob dialogue voice-over contract defined in [AmbonMUD PR #1203](https://github.com/jnoecker/AmbonMUD/pull/1203): walk dialogue YAML → synthesize each NPC line via **ElevenLabs** → upload the MP3 to **R2** at the agreed path. The AmbonMUD engine/web-client half (GMCP `voiceUrl`, `ambonmud.voices.enabled`/`baseUrl`, playback) lives in that repo.

Per the contract's decisions, this PR uses:
- **Direct ElevenLabs API** (new user-level `elevenlabs_api_key`) — Arcanum owns the key, voice mapping, cost, and licensing.
- **Per-project voice map** (`.arcanum/voices.json`, `templateKey → voiceId`) kept out of the server-read zone YAML, assigned in a dedicated panel.
- **Hashed R2 path** — `voices/<zone>/<templateKey>/<nodeId>.<sha8>.mp3`, where `<sha8>` is the first 8 lowercase-hex chars of `SHA-256(raw UTF-8 node text)`. The AmbonMUD engine resolves `voiceUrl` to the identical key, recomputing `<sha8>` from the same raw `node.text` — so both repos derive byte-identical paths and an edited line lands at a fresh key (no stale audio).

## Changes

**Backend (Rust)**
- `settings.rs` — user-level `elevenlabs_api_key` (struct + `Default` + both merge paths).
- `elevenlabs.rs` *(new)* — `elevenlabs_list_voices` (`GET /v1/voices`) and `elevenlabs_synthesize` (`POST /v1/text-to-speech/{id}`). Content-addressed MP3 cache under `assets/voices/<hash>.mp3`; returns `text_sha8` + a base64 data URL for in-app preview.
- `voices.rs` *(new)* — `load_voice_map` / `save_voice_map`.
- `r2.rs` — `deploy_voices_to_r2` uploads each clip to the hashed key (`audio/mpeg`), reusing the SigV4 signer + runtime sync-state skip.
- `lib.rs` — modules + commands registered.

**Frontend**
- `types/voiceover.ts` + `voiceStore.ts` — walks every loaded zone's `mob.dialogue`, synthesizes with a 3-wide concurrency pool, publishes.
- `VoiceOverPanel.tsx` *(new)* — Voice-Over panel (Forge island, AI-only): default + per-NPC voice/model assignment, per-line table with preview playback and an **"edited → regenerate"** staleness flag, Generate-all / Publish-to-R2.
- `ApiSettingsPanel.tsx` — ElevenLabs key card in **Settings → Services**.

## Contract fidelity (verified against AmbonMUD#1203)

- `<zone>`/`<templateKey>`/`<nodeId>` derived from the YAML zone field + mob/dialogue map keys.
- MP3 / `audio/mpeg`; choices never voiced; voiceId/templateKey never leave Arcanum.
- Upload guarded to skip blank zone/template/node — mirrors the engine's "emit only on complete identity" rule.
- **Hash spec agreement** — SHA-256 over **raw** UTF-8 node text (no trimming/normalization), first 8 lowercase-hex chars. Shared reference vectors asserted in both the Rust (`elevenlabs::text_sha8`, `r2` path) and TS (`sha8`) suites:

  | text | sha8 |
  |---|---|
  | `Hello!` | `334d016f` |
  | `Hello there!` | `89b8b8e4` |
  | `Hello there!\nStay a while.\n` (a `\|` literal block) | `df658e4d` |

- **Block-scalar parser parity** — confirmed Arcanum's `yaml` package and the engine's WorldLoader (Jackson + SnakeYAML) produce the *identical* byte sequence for YAML block scalars: `\|` clips to exactly one trailing newline, `\|-` strips it. New Vitest cases parse real `\|` / `\|-` blocks through the same `parseDocument().toJS()` path the dialogue loader uses and assert the exact bytes + hash, so a chomping divergence would surface as a failing test rather than a prod 404.

## Testing

- `bunx tsc --noEmit` — clean
- `cargo check` — clean
- Rust unit tests: cache-hash determinism, `text_sha8` shape + known/reference/block-scalar vectors, hashed R2 path building
- Vitest: client `sha8` empty + reference vectors, block-scalar parity (`\|` / `\|-`), `lineKey`
- Full suites green (Rust + Vitest)

## Note

The panel voices lines from zones currently **loaded** in the editor (same `zoneStore` the rest of the app uses). Voicing every zone on disk regardless of what's open would be a small follow-up.