### PR TITLE
Customizable lever artwork + sign/lever global assets

### DIFF
--- a/creator/src/components/AssetGenerator.tsx
+++ b/creator/src/components/AssetGenerator.tsx
@@ -30,7 +30,7 @@ interface AssetCategory {
 }
 
 const ASSET_CATEGORIES: AssetCategory[] = [
-  { label: "World",      types: ["room", "zone_map", "gathering_node", "background"] },
+  { label: "World",      types: ["room", "zone_map", "gathering_node", "lever_handle", "lever_plate", "background"] },
   { label: "Characters",  types: ["mob", "pet", "player_sprite", "entity_portrait", "class_portrait", "race_portrait"] },
   { label: "Items",       types: ["item", "ability_icon", "ability_sprite", "status_effect_icon"] },
   { label: "Lore",        types: ["lore_character", "lore_location", "lore_organization", "lore_species", "lore_item", "lore_event", "lore_map"] },

--- a/creator/src/components/config/panels/SharedAssetsPanel.tsx
+++ b/creator/src/components/config/panels/SharedAssetsPanel.tsx
@@ -368,6 +368,7 @@ export function SharedAssetsPanel({ config, onChange }: ConfigPanelProps) {
         filename: globalAssets[spec.key] ?? "",
         fallback: BUNDLED_GLOBAL_ASSETS[spec.key],
         generateSpec: spec,
+        optional: spec.optional,
         scope: "global" as const,
       })),
     [globalAssets],

--- a/creator/src/components/ui/CommandPalette.tsx
+++ b/creator/src/components/ui/CommandPalette.tsx
@@ -124,6 +124,7 @@ export function CommandPalette({ onClose }: { onClose: () => void }) {
         type: "panel",
         title: panel.label,
         subtitle: panel.description,
+        searchText: panel.searchText,
         action: () => openTab(panelTab(panel.id)),
       });
     }

--- a/creator/src/components/zone/LeverArtEditor.tsx
+++ b/creator/src/components/zone/LeverArtEditor.tsx
@@ -1,0 +1,231 @@
+import { useState } from "react";
+import type { FeatureFile, WorldFile } from "@/types/world";
+import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import { useImageSrc } from "@/lib/useImageSrc";
+import { composePrompt, getFormatForAssetType, type ArtStyle } from "@/lib/arcanumPrompts";
+import { useConfigStore } from "@/stores/configStore";
+
+/** Layered-lever defaults — the renderer (and the MUD web client) fall back to
+ *  these when a feature omits the field. The handle sprite rotates around
+ *  `pivot` between `upAngle` (ready) and `downAngle` (pulled). */
+export const LEVER_ART_DEFAULTS = {
+  pivot: { x: 0.5, y: 0.85 },
+  upAngle: -28,
+  downAngle: 28,
+} as const;
+
+interface LeverArtEditorProps {
+  world: WorldFile;
+  roomId: string;
+  featureId: string;
+  feature: FeatureFile;
+  onPatch: (p: Partial<FeatureFile>) => void;
+}
+
+type EditTarget = "handle" | "plate";
+
+/**
+ * Appearance editor for LEVER features. A lever is rendered as a static base
+ * plate with a handle sprite rotated around a pivot — the same two-layer model
+ * the MUD web client consumes. This panel generates each sprite, lets the
+ * author tune the pivot + swing angles, and previews the motion live.
+ */
+export function LeverArtEditor({ world, roomId, featureId, feature, onPatch }: LeverArtEditorProps) {
+  const [target, setTarget] = useState<EditTarget>("handle");
+  const [previewDown, setPreviewDown] = useState(false);
+
+  const pivot = feature.leverPivot ?? LEVER_ART_DEFAULTS.pivot;
+  const upAngle = feature.upAngle ?? LEVER_ART_DEFAULTS.upAngle;
+  const downAngle = feature.downAngle ?? LEVER_ART_DEFAULTS.downAngle;
+
+  // Fall back to the world-default lever sprites (Global Assets) when this
+  // lever doesn't define its own — matches how the MUD renders it.
+  const globalAssets = useConfigStore((s) => s.config?.globalAssets);
+  const resolvedPlate = feature.plateImage || globalAssets?.lever_plate || undefined;
+  const resolvedHandle = feature.handleImage || globalAssets?.lever_handle || undefined;
+  const usingDefault = !feature.handleImage && !!resolvedHandle;
+
+  const plateSrc = useImageSrc(resolvedPlate);
+  const handleSrc = useImageSrc(resolvedHandle);
+  const angle = previewDown ? downAngle : upAngle;
+
+  const setPivot = (axis: "x" | "y", value: number) =>
+    onPatch({ leverPivot: { ...pivot, [axis]: value } });
+
+  const assetType = target === "handle" ? "lever_handle" : "lever_plate";
+  const field = target === "handle" ? "handleImage" : "plateImage";
+  const label = feature.displayName || "lever";
+
+  return (
+    <details className="mt-1 rounded border border-border-muted bg-bg-secondary/40">
+      <summary className="cursor-pointer select-none px-2 py-1.5 font-display text-2xs uppercase tracking-widest text-accent">
+        Lever appearance
+      </summary>
+      <div className="flex flex-col gap-3 p-2">
+        <div className="flex gap-3">
+          {/* Live preview */}
+          <div className="flex flex-col items-center gap-1.5">
+            <div
+              className="relative h-44 w-36 overflow-hidden rounded-lg border border-border-muted bg-bg-tertiary/50"
+              aria-label="Lever preview"
+            >
+              {plateSrc && (
+                <img
+                  src={plateSrc}
+                  alt=""
+                  className="pointer-events-none absolute inset-0 h-full w-full object-contain"
+                />
+              )}
+              {handleSrc ? (
+                <img
+                  src={handleSrc}
+                  alt=""
+                  className="pointer-events-none absolute inset-0 h-full w-full object-contain"
+                  style={{
+                    transformOrigin: `${pivot.x * 100}% ${pivot.y * 100}%`,
+                    transform: `translate(${(0.5 - pivot.x) * 100}%, ${(0.5 - pivot.y) * 100}%) rotate(${angle}deg)`,
+                    transition: "transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1)",
+                  }}
+                />
+              ) : (
+                <div className="absolute inset-0 flex items-center justify-center px-2 text-center text-2xs italic text-text-muted">
+                  No handle art yet — generate below or set a world default in Global Assets
+                </div>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => setPreviewDown((d) => !d)}
+              className="focus-ring rounded bg-bg-elevated px-2 py-1 text-2xs text-text-secondary hover:text-text-primary"
+            >
+              {previewDown ? "Showing: Pulled ▾" : "Showing: Ready ▴"}
+            </button>
+            {usingDefault && (
+              <span className="text-center text-2xs italic text-text-muted">
+                Using world default
+              </span>
+            )}
+          </div>
+
+          {/* Tuning */}
+          <div className="flex flex-1 flex-col gap-2">
+            <AngleSlider
+              label="Up angle (ready)"
+              value={upAngle}
+              min={-90}
+              max={20}
+              onChange={(v) => onPatch({ upAngle: v })}
+            />
+            <AngleSlider
+              label="Down angle (pulled)"
+              value={downAngle}
+              min={-20}
+              max={90}
+              onChange={(v) => onPatch({ downAngle: v })}
+            />
+            <AngleSlider
+              label="Pivot X"
+              value={pivot.x}
+              min={0}
+              max={1}
+              step={0.01}
+              format={(v) => v.toFixed(2)}
+              onChange={(v) => setPivot("x", v)}
+            />
+            <AngleSlider
+              label="Pivot Y"
+              value={pivot.y}
+              min={0}
+              max={1}
+              step={0.01}
+              format={(v) => v.toFixed(2)}
+              onChange={(v) => setPivot("y", v)}
+            />
+            <button
+              type="button"
+              onClick={() =>
+                onPatch({
+                  leverPivot: { ...LEVER_ART_DEFAULTS.pivot },
+                  upAngle: LEVER_ART_DEFAULTS.upAngle,
+                  downAngle: LEVER_ART_DEFAULTS.downAngle,
+                })
+              }
+              className="focus-ring self-start rounded px-1 text-2xs text-text-muted hover:text-text-primary"
+            >
+              ↺ Reset pivot &amp; angles
+            </button>
+          </div>
+        </div>
+
+        {/* Sprite generators */}
+        <div className="flex gap-1">
+          {(["handle", "plate"] as EditTarget[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTarget(t)}
+              className={[
+                "focus-ring rounded px-2 py-1 text-2xs font-display uppercase tracking-wider transition",
+                target === t
+                  ? "bg-accent/20 text-accent"
+                  : "text-text-muted hover:text-text-primary",
+              ].join(" ")}
+            >
+              {t === "handle" ? "Handle sprite" : "Plate sprite"}
+            </button>
+          ))}
+        </div>
+
+        <EntityArtGenerator
+          key={target}
+          assetType={assetType}
+          surface="worldbuilding"
+          currentImage={feature[field]}
+          onAccept={(fileName) => onPatch({ [field]: fileName })}
+          getPrompt={(style: ArtStyle) => composePrompt(assetType, style, label)}
+          entityContext={`A ${label} — the ${target} sprite for a layered pull-lever puzzle device. ${
+            target === "handle"
+              ? "Just the handle arm in a neutral upright pose, no mounting plate."
+              : "Just the mounting plate with a central pivot socket, no handle arm."
+          }`}
+          framingHint={getFormatForAssetType(assetType)}
+          context={{
+            zone: world.zone,
+            entity_type: assetType,
+            entity_id: `${roomId}:${featureId}`,
+          }}
+        />
+      </div>
+    </details>
+  );
+}
+
+interface AngleSliderProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  format?: (v: number) => string;
+  onChange: (v: number) => void;
+}
+
+function AngleSlider({ label, value, min, max, step = 1, format, onChange }: AngleSliderProps) {
+  return (
+    <label className="flex flex-col gap-0.5">
+      <span className="flex items-center justify-between text-2xs text-text-muted">
+        <span>{label}</span>
+        <span className="font-mono text-text-secondary">{format ? format(value) : `${value}°`}</span>
+      </span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="accent-accent"
+      />
+    </label>
+  );
+}

--- a/creator/src/components/zone/RoomFeaturesEditor.tsx
+++ b/creator/src/components/zone/RoomFeaturesEditor.tsx
@@ -23,6 +23,7 @@ import {
   TextInput,
 } from "@/components/ui/FormWidgets";
 import { FEATURE_ICONS } from "@/assets/ui";
+import { LeverArtEditor } from "./LeverArtEditor";
 
 interface RoomFeaturesEditorProps {
   world: WorldFile;
@@ -235,7 +236,15 @@ const FeatureRow = memo(function FeatureRow({
         {type === "CONTAINER" && (
           <ContainerFields world={world} feature={feature} onPatch={patch} />
         )}
-        {type === "LEVER" && <LeverFields feature={feature} onPatch={patch} />}
+        {type === "LEVER" && (
+          <LeverFields
+            world={world}
+            roomId={roomId}
+            featureId={featureId}
+            feature={feature}
+            onPatch={patch}
+          />
+        )}
         {type === "SIGN" && <SignFields feature={feature} onPatch={patch} />}
       </div>
     </div>
@@ -380,9 +389,15 @@ function ContainerFields({ world, feature, onPatch }: ContainerFieldsProps) {
 }
 
 function LeverFields({
+  world,
+  roomId,
+  featureId,
   feature,
   onPatch,
 }: {
+  world: WorldFile;
+  roomId: string;
+  featureId: string;
   feature: FeatureFile;
   onPatch: (p: Partial<FeatureFile>) => void;
 }) {
@@ -413,6 +428,13 @@ function LeverFields({
           dense
         />
       </FieldRow>
+      <LeverArtEditor
+        world={world}
+        roomId={roomId}
+        featureId={featureId}
+        feature={feature}
+        onPatch={onPatch}
+      />
     </>
   );
 }

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -537,6 +537,39 @@ describe("sanitizeZone — output cleanup", () => {
     expect(result.items!.coin!.respawnSeconds).toBe(30);
   });
 
+  it("round-trips layered lever art fields", () => {
+    const world: WorldFile = {
+      zone: "test",
+      startRoom: "room_a",
+      rooms: {
+        room_a: {
+          title: "A",
+          description: "A",
+          features: {
+            lever: {
+              type: "LEVER",
+              displayName: "an ostentatious brass lever",
+              keyword: "lever",
+              initialState: "up",
+              plateImage: "plate.png",
+              handleImage: "handle.png",
+              leverPivot: { x: 0.5, y: 0.85 },
+              upAngle: -28,
+              downAngle: 32,
+            },
+          },
+        },
+      },
+    };
+
+    const lever = sanitizeZone(world).rooms.room_a.features!.lever!;
+    expect(lever.plateImage).toBe("plate.png");
+    expect(lever.handleImage).toBe("handle.png");
+    expect(lever.leverPivot).toEqual({ x: 0.5, y: 0.85 });
+    expect(lever.upAngle).toBe(-28);
+    expect(lever.downAngle).toBe(32);
+  });
+
   it("strips legacy room audio field on output", () => {
     const result = sanitizeZone(makeWorld({
       rooms: {

--- a/creator/src/lib/__tests__/validateConfig.test.ts
+++ b/creator/src/lib/__tests__/validateConfig.test.ts
@@ -150,6 +150,7 @@ const BASE_CONFIG: AppConfig = {
     feature_door: "feature_door.png",
     feature_container: "feature_container.png",
     feature_lever: "feature_lever.png",
+    feature_sign: "feature_sign.png",
     dialog_indicator: "dialog_indicator.png",
     aggro_indicator: "aggro_indicator.png",
     quest_available_indicator: "quest_available_indicator.png",

--- a/creator/src/lib/arcanumPrompts.ts
+++ b/creator/src/lib/arcanumPrompts.ts
@@ -153,6 +153,8 @@ export const FORMAT_BY_ASSET_TYPE: Partial<Record<AssetType, string>> = {
   pet: FORMAT_BY_TYPE.mob,
   item: FORMAT_BY_TYPE.item,
   gathering_node: FORMAT_BY_TYPE.gathering_node,
+  lever_plate: "1:1 square sprite of a single lever mounting plate viewed straight head-on, centered, the whole plate in frame with padding, no handle arm, no wall, no characters, clean flat background",
+  lever_handle: "1:1 square sprite of a single lever handle/arm oriented vertically pointing straight up, centered, the pivot end at the bottom and the grip at the top, the whole handle in frame with padding, no mounting plate, no wall, no characters, clean flat background",
   player_sprite: FORMAT_BY_TYPE.mob,
   race_portrait: FORMAT_BY_TYPE.race_portrait,
   class_portrait: FORMAT_BY_TYPE.class_portrait,
@@ -196,6 +198,8 @@ export const BG_REMOVAL_ASSET_TYPES: ReadonlySet<string> = new Set([
   "pet",
   "entity_portrait",
   "gathering_node",
+  "lever_plate",
+  "lever_handle",
   "ability_sprite",
   "player_sprite",
 ]);
@@ -439,6 +443,20 @@ export const ASSET_TEMPLATES: Record<AssetType, { label: string; templates: Reco
     templates: {
       arcanum: `A solitary interactable resource node grounded on a dark cosmic-stone floor — perhaps an aurum-veined ore outcrop, a cluster of luminous crystalline herbs, a glowing tide-pool, or a hollow at the base of an ancient tree — rendered with faithful material detail in the Arcanum palette, warm aurum-gold light pooling on the harvestable surfaces with soft bloom, baroque energy filaments curling from the node like delicate scrollwork tendrils, deep cosmic indigo and abyssal navy void surrounding it, blue-violet atmospheric mist drifting around the base, the silhouette is clearly readable as something a player would walk up to and gather from, centered square composition with the node grounded at the lower third of the frame, painterly oil technique, extremely detailed, no characters, no hands, no UI`,
       gentle_magic: `A solitary interactable resource node resting on a soft mossy patch of ground — perhaps a pale silver ore vein in a weathered stone, a cluster of luminous lavender mushrooms, a small herb patch with dusty rose blossoms, or a calm reflective pool flecked with soft gold — rendered with warm gentle detail in the Gentle Magic palette, source-ambiguous diffused light with no harsh shadows, faint floating motes of warm gold drifting upward from the harvestable surfaces, pale blue and lavender atmospheric haze fading to deep mist behind, tiny moss-green tufts and dusty rose buds at the base, the silhouette is clearly readable as something a player would walk up to and gather from, centered square composition with the node grounded at the lower third of the frame, painterly, luminous, dreamlike, no characters, no hands, no UI`,
+    },
+  },
+  lever_handle: {
+    label: "Lever Handle",
+    templates: {
+      arcanum: `A single ornate lever handle rendered as an isolated game sprite, oriented vertically and pointing straight up in a neutral upright pose — a slender polished shaft of dark metal chased with aurum-gold filigree rising from a rounded pivot knuckle at its base, crowned by a gripable orb finial at the top, warm aurum-gold light pooling along the shaft with soft bloom, cool blue-violet accents in the shadows, NO mounting plate, NO wall, NO floor, NO other hardware — only the handle arm itself, centered upright with the pivot end at the bottom, painterly, luminous, extremely detailed`,
+      gentle_magic: `A single charming lever handle rendered as an isolated game sprite, oriented vertically and pointing straight up in a neutral upright pose — a gently curved shaft of weathered brass or carved wood rising from a smooth rounded pivot knuckle at its base, topped by a rounded gripable knob, soft source-ambiguous light with a faint warm glow, lavender and pale-gold undertones, NO mounting plate, NO wall, NO floor, NO other hardware — only the handle arm itself, centered upright with the pivot end at the bottom, painterly, luminous, dreamlike`,
+    },
+  },
+  lever_plate: {
+    label: "Lever Plate",
+    templates: {
+      arcanum: `A single lever mounting plate rendered as an isolated game sprite, viewed straight head-on — an ornate circular or shield-shaped backing plate of dark metal with aurum-gold baroque scrollwork around its rim and a central pivot socket at its middle where a handle would attach, warm golden bloom around the socket, cool blue-violet ambient fill in the recesses, NO handle, NO arm, NO lever shaft present, NO wall, NO floor, only the plate, centered with padding on all sides, painterly, luminous, extremely detailed`,
+      gentle_magic: `A single lever mounting plate rendered as an isolated game sprite, viewed straight head-on — a gently rounded backing plate of weathered brass or carved wood with soft decorative trim and a central pivot socket at its middle where a handle would attach, faint warm inner glow, lavender and pale-gold undertones, NO handle, NO arm, NO lever shaft present, NO wall, NO floor, only the plate, centered with padding on all sides, painterly, luminous, dreamlike`,
     },
   },
   faction_emblem: {

--- a/creator/src/lib/assetRefs.ts
+++ b/creator/src/lib/assetRefs.ts
@@ -97,6 +97,16 @@ export function normalizeWorldAssetRefs(world: WorldFile): WorldFile {
         music: normalizeAssetRef(room.music),
         ambient: normalizeAssetRef(room.ambient),
         audio: normalizeAssetRef(room.audio),
+        features: room.features
+          ? mapEntries(room.features, (feature) =>
+              feature.plateImage || feature.handleImage
+                ? compactObject({
+                    ...feature,
+                    plateImage: normalizeAssetRef(feature.plateImage),
+                    handleImage: normalizeAssetRef(feature.handleImage),
+                  })
+                : feature)
+          : undefined,
       })),
     mobs: mapOptionalEntries(world.mobs, (mob) =>
       compactObject({

--- a/creator/src/lib/panelRegistry.ts
+++ b/creator/src/lib/panelRegistry.ts
@@ -36,6 +36,9 @@ export interface PanelDef {
   glyph?: string;
   /** Panel requires AI features and is hidden in the community build. */
   aiOnly?: boolean;
+  /** Extra terms matched by the command palette but not displayed — aliases,
+   *  former names, common synonyms. */
+  searchText?: string;
 }
 
 // ─── Studio panels ──────────────────────────────────────────────────
@@ -130,7 +133,7 @@ const OPERATIONS_PANELS: PanelDef[] = [
   { id: "services", label: "Services", host: "config", kicker: "Operations", title: "Services", description: "Provider API keys and per-project AI pipeline.", maxWidth: "max-w-5xl", island: "settings", glyph: "\u{1F511}" },
   { id: "r2Settings", label: "Cloudflare R2", host: "config", kicker: "Operations", title: "Cloudflare R2", description: "Asset CDN credentials for self-hosted deployments.", maxWidth: "max-w-5xl", island: "settings", glyph: "\u2601\uFE0F" },
   { id: "deployment", label: "Deployment", host: "config", kicker: "Operations", title: "Deployment", description: "Export, sync, and deploy your MUD.", maxWidth: "max-w-5xl", island: "spire", glyph: "\u{1F680}" },
-  { id: "sharedAssets", label: "Shared Assets", host: "config", kicker: "Operations", title: "Shared assets", description: "Global asset keys and image configuration.", maxWidth: "max-w-5xl", island: "livingWorld", glyph: "\u{1F4E6}" },
+  { id: "sharedAssets", label: "Global Assets", host: "config", kicker: "Operations", title: "Global assets", description: "Global asset keys and image configuration.", maxWidth: "max-w-5xl", island: "livingWorld", glyph: "\u{1F4E6}", searchText: "shared assets" },
   { id: "rawYaml", label: "Raw YAML", host: "config", kicker: "Advanced", title: "Raw configuration", description: "Inspect or edit the exact serialized YAML when the structured editors are not enough.", maxWidth: "max-w-6xl", island: "settings", glyph: "\u{1F4DD}" },
   { id: "versionControl", label: "Version Control", host: "config", kicker: "Operations", title: "Version control", description: "Git status, commits, push/pull, and conflict resolution for standalone projects.", maxWidth: "max-w-5xl", island: "settings", glyph: "\u{1F33F}" },
   { id: "backup", label: "Backups", host: "command", kicker: "Operations", title: "Backups & Snapshots", description: "Autosave, periodic snapshots, and zip archives. A safety net beyond git.", maxWidth: "max-w-5xl", island: "settings", glyph: "\u{1F5C4}\uFE0F" },

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -29,6 +29,12 @@ export interface RequiredGlobalAsset {
   transparent: boolean;
   /** Generation aspect ratio. Defaults to "square" (1024×1024) when omitted. */
   aspect?: "square" | "landscape" | "portrait";
+  /**
+   * Optional assets have a sensible built-in/derived fallback, so leaving them
+   * unassigned is not flagged as a validation warning. They still appear in the
+   * Global Assets panel so authors can override the default look.
+   */
+  optional?: boolean;
 }
 
 export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
@@ -85,6 +91,39 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     assetType: "ability_icon",
     defaultPrompt: "A single iron lever on a mounting plate, centered, soft outline.",
     transparent: true,
+  },
+  {
+    key: "feature_sign",
+    defaultFilename: "feature_sign.png",
+    label: "Sign Badge",
+    description: "Overlay placed on rooms that have a sign players can read.",
+    assetType: "ability_icon",
+    defaultPrompt: "A single hand-carved wooden signpost with a blank face, centered, soft outline, no text.",
+    transparent: true,
+  },
+  {
+    key: "lever_handle",
+    defaultFilename: "lever_handle.png",
+    label: "Default Lever Handle",
+    description:
+      "World-default handle sprite for any lever that doesn't define its own. Rotates around the pivot between the up (ready) and down (pulled) angles.",
+    assetType: "lever_handle",
+    defaultPrompt:
+      "A single ornate lever handle in a neutral upright pose, the grip at the top and the pivot/mount end at the bottom, isolated as a sprite, no mounting plate, transparent background.",
+    transparent: true,
+    optional: true,
+  },
+  {
+    key: "lever_plate",
+    defaultFilename: "lever_plate.png",
+    label: "Default Lever Plate",
+    description:
+      "World-default mounting plate drawn behind any lever that doesn't define its own. Optional — the handle alone is enough.",
+    assetType: "lever_plate",
+    defaultPrompt:
+      "A single lever mounting plate viewed head-on with a central pivot socket where a handle would attach, isolated as a sprite, no handle arm, transparent background.",
+    transparent: true,
+    optional: true,
   },
   {
     key: "dialog_indicator",
@@ -939,9 +978,10 @@ export const REQUIRED_GLOBAL_ASSET_KEYS: ReadonlySet<string> = new Set(
   REQUIRED_GLOBAL_ASSETS.map((a) => a.key),
 );
 
-/** Returns the keys missing or unassigned (empty value) in the given map. */
+/** Returns the keys missing or unassigned (empty value) in the given map.
+ *  Optional assets (which have a built-in/derived fallback) are never reported. */
 export function missingRequiredGlobalAssets(
   assets: Record<string, string>,
 ): RequiredGlobalAsset[] {
-  return REQUIRED_GLOBAL_ASSETS.filter((a) => !assets[a.key]?.trim());
+  return REQUIRED_GLOBAL_ASSETS.filter((a) => !a.optional && !assets[a.key]?.trim());
 }

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -132,6 +132,11 @@ function normalizeFeatureFile(feature: FeatureFile): FeatureFile {
     if (feature.initialState) out.initialState = feature.initialState;
     if (feature.resetWithZone != null) out.resetWithZone = feature.resetWithZone;
     if (feature.respawnSeconds != null) out.respawnSeconds = feature.respawnSeconds;
+    if (feature.plateImage) out.plateImage = feature.plateImage;
+    if (feature.handleImage) out.handleImage = feature.handleImage;
+    if (feature.leverPivot) out.leverPivot = { x: feature.leverPivot.x, y: feature.leverPivot.y };
+    if (feature.upAngle != null) out.upAngle = feature.upAngle;
+    if (feature.downAngle != null) out.downAngle = feature.downAngle;
   } else if (type === "SIGN") {
     if (feature.text != null) out.text = feature.text;
   }

--- a/creator/src/lib/zoneEdits.ts
+++ b/creator/src/lib/zoneEdits.ts
@@ -730,6 +730,11 @@ function cleanFeature(feature: FeatureFile): FeatureFile {
     if (feature.initialState) out.initialState = feature.initialState;
     if (feature.resetWithZone != null) out.resetWithZone = feature.resetWithZone;
     if (feature.respawnSeconds != null) out.respawnSeconds = feature.respawnSeconds;
+    if (feature.plateImage) out.plateImage = feature.plateImage;
+    if (feature.handleImage) out.handleImage = feature.handleImage;
+    if (feature.leverPivot) out.leverPivot = { x: feature.leverPivot.x, y: feature.leverPivot.y };
+    if (feature.upAngle != null) out.upAngle = feature.upAngle;
+    if (feature.downAngle != null) out.downAngle = feature.downAngle;
   } else if (type === "SIGN") {
     if (feature.text != null) out.text = feature.text;
   }

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -52,6 +52,8 @@ export type AssetType =
   | "pet"
   | "item"
   | "gathering_node"
+  | "lever_plate"
+  | "lever_handle"
   | "player_sprite"
   | "race_portrait"
   | "class_portrait"
@@ -290,6 +292,8 @@ export const ENTITY_DIMENSIONS: Record<string, { width: number; height: number; 
   pet: { width: 1024, height: 1024, label: "1024×1024 (Portrait)" },
   item: { width: 1024, height: 1024, label: "1024×1024 (Icon)" },
   gathering_node: { width: 1024, height: 1024, label: "1024×1024 (Sprite)" },
+  lever_plate: { width: 1024, height: 1024, label: "1024×1024 (Sprite)" },
+  lever_handle: { width: 1024, height: 1024, label: "1024×1024 (Sprite)" },
   ability: { width: 1024, height: 1024, label: "1024×1024 (Icon)" },
   shop: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },
   dungeon: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -172,6 +172,22 @@ export interface FeatureFile {
   items?: string[];
   /** Text content for SIGN type. */
   text?: string;
+  /**
+   * LEVER art (layered, procedurally animated). The handle sprite rotates
+   * around `leverPivot` between `upAngle` and `downAngle`; the optional plate
+   * sprite is drawn behind it and never moves. All LEVER-only; renderers fall
+   * back to a built-in vector lever when `handleImage` is unset.
+   */
+  /** Static base/housing sprite filename, drawn behind the handle (optional). */
+  plateImage?: string;
+  /** Rotating handle sprite filename, drawn in a neutral upright pose (optional). */
+  handleImage?: string;
+  /** Pivot on the handle sprite as fractions [0..1] of its width/height. Default { x: 0.5, y: 0.94 }. */
+  leverPivot?: { x: number; y: number };
+  /** Handle rotation in degrees when the lever is "up" (ready). Default -28. */
+  upAngle?: number;
+  /** Handle rotation in degrees when the lever is "down" (pulled). Default 28. */
+  downAngle?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Levers can now carry **their own two-layer artwork** — a static mounting **plate** plus a **handle** sprite that rotates around a pivot between an up (ready) and down (pulled) angle. The engine's lever state model is unchanged (`up`/`down`); "neutral" is just the pivot sweeping through center, so there's no third state.

Also bundles two small related items requested alongside it:
- **`feature_sign`** room badge added as a global asset (the kiosk badge for rooms with a readable sign).
- **"Shared Assets" → "Global Assets"** rename, with a `"shared assets"` search alias so Ctrl+K still finds it by the old name.

## What's included

**Data model** (`FeatureFile`, LEVER-only, all optional): `plateImage`, `handleImage`, `leverPivot {x,y}`, `upAngle`, `downAngle`. Round-trips through `sanitizeZone`/`zoneEdits`; image refs normalized on save in `assetRefs.ts`.

**Art generation:** new `lever_handle` / `lever_plate` asset types (style templates, formats, 1024² dims, bg-removal). New `LeverArtEditor` under the lever feature — live layered preview with a Ready/Pulled toggle that animates the swing, plus pivot + angle sliders and two reused `EntityArtGenerator` panels.

**World default:** optional `lever_handle` / `lever_plate` keys in Global Assets. Optional ⇒ no perpetual "Missing" warning; shown as "Using built-in default". The lever editor preview falls back to these when a lever defines no art of its own.

**Tests:** lever-art round-trip in `sanitizeZone.test.ts`; `feature_sign` added to the `validateConfig` fixture. Typecheck clean, 2114 tests pass.

## MUD-side contract (handoff)

Levers render as a two-layer sprite; levers without art fall back to the existing built-in vector lever. New fields on each LEVER `RoomFeature` in zone YAML (`rooms.<room>.features.<key>`):

```yaml
features:
  vault_lever:
    type: LEVER
    displayName: an ostentatious brass lever
    keyword: lever
    initialState: up
    # --- new, all optional ---
    plateImage: "<sha256>.webp"     # static base, drawn behind the handle
    handleImage: "<sha256>.webp"    # rotating handle, neutral upright pose
    leverPivot: { x: 0.5, y: 0.85 } # pivot as fraction of the handle sprite
    upAngle: -28                    # handle rotation (deg) when state = up
    downAngle: 28                   # handle rotation (deg) when state = down
```

Image refs are content-addressed filenames (same scheme as room/mob/item `image`), resolved against the world's image base URL (R2); they're transparent cutouts.

**Defaults when a field is absent:** `leverPivot {x:0.5, y:0.85}`, `upAngle -28`, `downAngle 28`.

**Resolution / fallback chain** (per lever):
`feature.handleImage` → `globalAssets.lever_handle` → built-in vector lever
`feature.plateImage` → `globalAssets.lever_plate` → none (plate is fully optional)

### Three changes needed server-side
1. **`WorldLoader.kt`** — parse the five new fields into the lever feature DTO (`leverPivot` is nested `{x,y}`; angles are numbers, allow negatives).
2. **GMCP** (`GmcpEmitter.kt` + `web-v3/.../applyGmcpPackage.ts` + `types.ts RoomFeature`) — carry `plateImage`, `handleImage`, `leverPivot`, `upAngle`, `downAngle` to the client (static per-lever; can ride the room/feature payload). The two global-asset keys ride along in the already-plumbed `globalAssets`.
3. **`WorldFeaturesPopout.tsx` `LeverWidget`** — when a handle resolves, replace the hand-drawn `<svg>` with the layered render below; otherwise keep the current SVG. The "Ready"/"Pulled" label logic stays.

### Rendering math (matches Arcanum's preview exactly)
Both sprites overlay a square box, `object-contain`:

```tsx
const { x: px, y: py } = feature.leverPivot ?? { x: 0.5, y: 0.85 };
const angle = feature.state === "down" ? (feature.downAngle ?? 28) : (feature.upAngle ?? -28);

// plate: <img> filling the box, object-contain, no transform
// handle: <img> filling the box, object-contain, plus:
style={{
  transformOrigin: `${px * 100}% ${py * 100}%`,
  transform: `translate(${(0.5 - px) * 100}%, ${(0.5 - py) * 100}%) rotate(${angle}deg)`,
  transition: "transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1)",
}}
```

The `translate` lands the handle's pivot at the box center (where the plate's socket sits); `rotate` spins around it. Changing `feature.state` re-renders with the other angle and the CSS transition produces the swing.

**Why two angles, not a 3-frame flipbook:** independent AI generations drift frame-to-frame; rotating one consistent sprite gives smooth motion at any framerate with no drift, and the pivot/angles are data the author tunes in Arcanum.
