### PR TITLE
Add customizable puzzle backgrounds (Conundrum Codex)

### DIFF
--- a/creator/src/components/editors/PuzzleBackgroundEditor.tsx
+++ b/creator/src/components/editors/PuzzleBackgroundEditor.tsx
@@ -1,0 +1,76 @@
+import type { PuzzleFile, WorldFile } from "@/types/world";
+import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import { useImageSrc } from "@/lib/useImageSrc";
+import type { ArtStyle } from "@/lib/arcanumPrompts";
+import { useConfigStore } from "@/stores/configStore";
+
+interface PuzzleBackgroundEditorProps {
+  world: WorldFile;
+  puzzleId: string;
+  puzzle: PuzzleFile;
+  onPatch: (p: Partial<PuzzleFile>) => void;
+}
+
+const FRAMING =
+  "Wide landscape backdrop, an open grimoire/codex page with a clean flat blank center where the riddle and answer overlay on top, decorative gilt margins, no writing, no readable text, no figures.";
+
+/**
+ * Appearance editor for a puzzle's optional backdrop — the "Conundrum Codex"
+ * tome the web client renders behind the riddle. The question text and answer
+ * input sit on top. Falls back to the world-default `puzzle_bg` global asset,
+ * then a procedural tome page, when unset.
+ */
+export function PuzzleBackgroundEditor({
+  world,
+  puzzleId,
+  puzzle,
+  onPatch,
+}: PuzzleBackgroundEditorProps) {
+  const globalAssets = useConfigStore((s) => s.config?.globalAssets);
+  const resolved = puzzle.backgroundImage || globalAssets?.puzzle_bg || undefined;
+  const usingDefault = !puzzle.backgroundImage && !!resolved;
+  const previewSrc = useImageSrc(resolved);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col items-center gap-1.5">
+        <div
+          className="relative aspect-[3/2] w-full overflow-hidden rounded-lg border border-border-muted bg-bg-tertiary/50"
+          aria-label="Puzzle background preview"
+        >
+          {previewSrc ? (
+            <img
+              src={previewSrc}
+              alt=""
+              className="pointer-events-none absolute inset-0 h-full w-full object-cover"
+            />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center px-2 text-center text-2xs italic text-text-muted">
+              No background art — generate below, set a world default in Global Assets (puzzle_bg), or leave blank for the CSS tome fallback
+            </div>
+          )}
+        </div>
+        {usingDefault && (
+          <span className="text-center text-2xs italic text-text-muted">
+            Using world default (puzzle_bg)
+          </span>
+        )}
+      </div>
+
+      <EntityArtGenerator
+        assetType="background"
+        surface="worldbuilding"
+        currentImage={puzzle.backgroundImage}
+        onAccept={(fileName) => onPatch({ backgroundImage: fileName })}
+        getPrompt={(_style: ArtStyle) => FRAMING}
+        entityContext={`A backdrop for a riddle puzzle — an open grimoire or codex page with a clear central area where the riddle text and the player's answer overlay. Scholarly, painterly, on-brand.`}
+        framingHint={FRAMING}
+        context={{
+          zone: world.zone,
+          entity_type: "puzzle_bg",
+          entity_id: puzzleId,
+        }}
+      />
+    </div>
+  );
+}

--- a/creator/src/components/editors/PuzzleEditor.tsx
+++ b/creator/src/components/editors/PuzzleEditor.tsx
@@ -22,6 +22,7 @@ import {
   CompactField,
 } from "@/components/ui/FormWidgets";
 import { DeleteEntityButton } from "./EditorShared";
+import { PuzzleBackgroundEditor } from "./PuzzleBackgroundEditor";
 
 interface PuzzleEditorProps {
   puzzleId: string;
@@ -361,6 +362,15 @@ export function PuzzleEditor({
             </FieldRow>
           )}
         </div>
+      </Section>
+
+      <Section title="Appearance" defaultExpanded={false}>
+        <PuzzleBackgroundEditor
+          world={world}
+          puzzleId={puzzleId}
+          puzzle={puzzle}
+          onPatch={patch}
+        />
       </Section>
 
       <Section title="Settings" defaultExpanded={false}>

--- a/creator/src/lib/__tests__/assetRefs.test.ts
+++ b/creator/src/lib/__tests__/assetRefs.test.ts
@@ -65,4 +65,28 @@ describe("normalizeWorldAssetRefs", () => {
     expect(world.rooms.entrance?.music).toBe("theme.mp3");
     expect(world.mobs?.guide?.image).toBe("/images/mobs/guide.png");
   });
+
+  it("normalizes a puzzle's backgroundImage ref", () => {
+    const world = normalizeWorldAssetRefs({
+      zone: "tutorial_glade",
+      startRoom: "entrance",
+      rooms: {
+        entrance: { title: "Entrance", description: "" },
+      },
+      puzzles: {
+        sphinx: {
+          type: "riddle",
+          roomId: "entrance",
+          answer: "footsteps",
+          reward: { type: "give_gold", amount: 10 },
+          backgroundImage: "C:\\assets\\images\\codex.png",
+        },
+      },
+    });
+
+    expect(world.puzzles?.sphinx?.backgroundImage).toBe("codex.png");
+    // Untouched fields survive the pass-through.
+    expect(world.puzzles?.sphinx?.answer).toBe("footsteps");
+    expect(world.puzzles?.sphinx?.reward.type).toBe("give_gold");
+  });
 });

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -610,6 +610,28 @@ describe("sanitizeZone — output cleanup", () => {
     expect(features.sign!.backgroundImage).toBe("sign_bg.webp");
   });
 
+  it("preserves a puzzle's backgroundImage on output", () => {
+    const world: WorldFile = {
+      zone: "test",
+      startRoom: "room_a",
+      rooms: {
+        room_a: { title: "A", description: "A" },
+      },
+      puzzles: {
+        sphinx: {
+          type: "riddle",
+          roomId: "room_a",
+          answer: "footsteps",
+          reward: { type: "give_gold", gold: 10 },
+          backgroundImage: "codex.webp",
+        },
+      },
+    };
+
+    const result = sanitizeZone(world) as WorldFile;
+    expect(result.puzzles!.sphinx!.backgroundImage).toBe("codex.webp");
+  });
+
   it("strips legacy room audio field on output", () => {
     const result = sanitizeZone(makeWorld({
       rooms: {

--- a/creator/src/lib/assetRefs.ts
+++ b/creator/src/lib/assetRefs.ts
@@ -136,6 +136,13 @@ export function normalizeWorldAssetRefs(world: WorldFile): WorldFile {
         ...recipe,
         image: normalizeAssetRef(recipe.image),
       })),
+    puzzles: mapOptionalEntries(world.puzzles, (puzzle) =>
+      puzzle.backgroundImage
+        ? compactObject({
+            ...puzzle,
+            backgroundImage: normalizeAssetRef(puzzle.backgroundImage),
+          })
+        : puzzle),
   };
 }
 

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -777,6 +777,19 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     transparent: false,
     aspect: "landscape",
   },
+  {
+    key: "puzzle_bg",
+    defaultFilename: "puzzle_bg.png",
+    label: "Puzzle Codex Page",
+    description:
+      "Backdrop behind the puzzle card — the \"Conundrum Codex\". An open grimoire/parchment spread with a clear blank writable page; the riddle text and the answer input render on top. Falls back to a procedural tome page when absent. A puzzle may override its own via the per-puzzle background field.",
+    assetType: "background",
+    defaultPrompt:
+      "An open leather-bound grimoire viewed from above, two facing aged-parchment pages with a soft shadowed center gutter, a clean flat blank writable area in the center for a riddle and answer to overlay, warm paper with subtle fibers and gentle wear, faint arcane illumination and gilt flourishes in the margins, leather binding edges, no writing, no ruled lines, no figures, no readable text, suitable as a backdrop behind a riddle page.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
   // Terminal writing-desk: a desk-surface texture plus the resting quill.
   {
     key: "terminal_bg",

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -297,6 +297,7 @@ export const ENTITY_DIMENSIONS: Record<string, { width: number; height: number; 
   container_bg: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },
   sign_bg: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },
   lever_bg: { width: 1024, height: 1536, label: "1024×1536 (Portrait)" },
+  puzzle_bg: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },
   ability: { width: 1024, height: 1024, label: "1024×1024 (Icon)" },
   shop: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },
   dungeon: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -639,4 +639,12 @@ export interface PuzzleFile {
   successMessage?: string;
   cooldownMs?: number;
   resetOnFail?: boolean;
+  /**
+   * Optional backdrop for the puzzle card (the "Conundrum Codex" tome). The
+   * web client renders it behind the riddle page; the question text and the
+   * answer input sit on top. Content-addressed filename, resolved against the
+   * world image base. Resolution order: `backgroundImage` → `puzzle_bg` global
+   * asset → polished CSS fallback.
+   */
+  backgroundImage?: string;
 }


### PR DESCRIPTION
@
## Summary

Extends the per-feature background contract (#258) to **puzzles**. Adds an optional `backgroundImage` field on `PuzzleFile` plus a `puzzle_bg` global default. The web client renders this behind the riddle card — the "Conundrum Codex" tome theme — with the question text and answer input on top.

Resolution order: `backgroundImage` (per-puzzle) → `puzzle_bg` (global) → CSS tome fallback. Everything optional, degrades gracefully.

## Theme

The puzzle panel reskins to an open grimoire/codex page: the riddle is inked on the page, and (web-client work, separate repo) submitting "inscribes" the answer, which **vanishes in a puff of flame** — gold flare on success, ash-scatter on fail. The flame is driven entirely by the existing success/fail answer-check result, so it needs nothing from the Arcanum side; this PR is the authoring + asset half.

## Changes

- **`types/world.ts`** — add `PuzzleFile.backgroundImage`
- **`requiredGlobalAssets.ts`** — new `puzzle_bg` world default (optional `background`, grimoire-spread prompt, sibling of `spellbook_bg`). Auto-appears in the Global Assets panel + generator.
- **`types/assets.ts`** — generation dimensions for `puzzle_bg` (1536×1024 landscape)
- **`assetRefs.ts`** — normalize the puzzle ref on serialization (puzzles were previously passed through untouched by the world ref normalizer; the field otherwise survives via spread)
- **`PuzzleBackgroundEditor.tsx`** (new) — in-editor generator with fallback-aware preview (shows the world default when not overridden), wired into `PuzzleEditor` as a collapsible **Appearance** section
- **tests** — assetRefs normalization + sanitizeZone round-trip

## Verification

- `bunx tsc --noEmit` — clean
- `bun run test` — 2117 passed (added assetRefs + sanitizeZone cases)

## Out of scope (separate repo — server/web work in progress in parallel)

The `PuzzlePopout` reskin (tome styling, `desk_quill` accent, "inscribe your answer…" / **Inscribe** microcopy, and the flame-burn submit animation) lives in the AmbonMUD web client. Key/field names here match what that side consumes.
@