### PR TITLE
Add customizable door art (Warded Threshold)

### DIFF
--- a/creator/src/components/zone/DoorArtEditor.tsx
+++ b/creator/src/components/zone/DoorArtEditor.tsx
@@ -1,0 +1,221 @@
+import { useState } from "react";
+import type { DoorFile, WorldFile } from "@/types/world";
+import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import { useImageSrc } from "@/lib/useImageSrc";
+import { composePrompt, getFormatForAssetType, type ArtStyle } from "@/lib/arcanumPrompts";
+import { useConfigStore } from "@/stores/configStore";
+
+/** Layered-door defaults — the renderer (and the MUD web client) fall back to
+ *  these when a door omits the field. The leaf sprite swings on its `hinge`
+ *  edge between closed (0°) and `openAngle`. */
+export const DOOR_ART_DEFAULTS = {
+  hinge: "left" as const,
+  openAngle: 100,
+};
+
+interface DoorArtEditorProps {
+  world: WorldFile;
+  roomId: string;
+  direction: string;
+  door: DoorFile;
+  onPatch: (p: Partial<DoorFile>) => void;
+}
+
+type EditTarget = "leaf" | "frame";
+
+/**
+ * Appearance editor for an exit's door. A door is rendered as a static frame
+ * with a leaf sprite that swings around its hinge edge — the same two-layer
+ * model the MUD web client consumes (the "Warded Threshold"). This panel
+ * generates each sprite, lets the author pick the hinge side + open angle, and
+ * previews the swing live. The locked-state ward seal is a world-wide global
+ * asset (`door_lock`), not per-door.
+ */
+export function DoorArtEditor({ world, roomId, direction, door, onPatch }: DoorArtEditorProps) {
+  const [target, setTarget] = useState<EditTarget>("leaf");
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const hinge = door.hinge ?? DOOR_ART_DEFAULTS.hinge;
+  const openAngle = door.openAngle ?? DOOR_ART_DEFAULTS.openAngle;
+
+  // Fall back to the world-default door sprites (Global Assets) when this door
+  // doesn't define its own — matches how the MUD renders it.
+  const globalAssets = useConfigStore((s) => s.config?.globalAssets);
+  const resolvedFrame = door.frameImage || globalAssets?.door_frame || undefined;
+  const resolvedLeaf = door.leafImage || globalAssets?.door_leaf || undefined;
+  const usingDefault = !door.leafImage && !!resolvedLeaf;
+
+  const frameSrc = useImageSrc(resolvedFrame);
+  const leafSrc = useImageSrc(resolvedLeaf);
+
+  const angle = previewOpen ? (hinge === "left" ? -openAngle : openAngle) : 0;
+
+  const assetType = target === "leaf" ? "door_leaf" : "door_frame";
+  const field = target === "leaf" ? "leafImage" : "frameImage";
+  const label = `${direction} door`;
+
+  return (
+    <details className="mt-1 rounded border border-border-muted bg-bg-secondary/40">
+      <summary className="cursor-pointer select-none px-2 py-1.5 font-display text-2xs uppercase tracking-widest text-accent">
+        Door appearance
+      </summary>
+      <div className="flex flex-col gap-3 p-2">
+        <div className="flex gap-3">
+          {/* Live preview */}
+          <div className="flex flex-col items-center gap-1.5">
+            <div
+              className="relative h-44 w-32 overflow-hidden rounded-lg border border-border-muted bg-bg-tertiary/50"
+              style={{ perspective: "600px" }}
+              aria-label="Door preview"
+            >
+              {leafSrc ? (
+                <img
+                  src={leafSrc}
+                  alt=""
+                  className="pointer-events-none absolute inset-0 h-full w-full object-contain"
+                  style={{
+                    transformOrigin: hinge === "left" ? "left center" : "right center",
+                    transform: `rotateY(${angle}deg)`,
+                    transition: "transform 0.5s cubic-bezier(0.34, 1.2, 0.64, 1)",
+                  }}
+                />
+              ) : (
+                <div className="absolute inset-0 flex items-center justify-center px-2 text-center text-2xs italic text-text-muted">
+                  No leaf art yet — generate below or set a world default in Global Assets
+                </div>
+              )}
+              {/* Frame drawn on top so the leaf reads as swinging within it. */}
+              {frameSrc && (
+                <img
+                  src={frameSrc}
+                  alt=""
+                  className="pointer-events-none absolute inset-0 h-full w-full object-contain"
+                />
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => setPreviewOpen((o) => !o)}
+              className="focus-ring rounded bg-bg-elevated px-2 py-1 text-2xs text-text-secondary hover:text-text-primary"
+            >
+              {previewOpen ? "Showing: Open ▸" : "Showing: Closed ▪"}
+            </button>
+            {usingDefault && (
+              <span className="text-center text-2xs italic text-text-muted">
+                Using world default
+              </span>
+            )}
+          </div>
+
+          {/* Tuning */}
+          <div className="flex flex-1 flex-col gap-2">
+            <label className="flex flex-col gap-0.5">
+              <span className="text-2xs text-text-muted">Hinge side</span>
+              <div className="flex gap-1">
+                {(["left", "right"] as const).map((h) => (
+                  <button
+                    key={h}
+                    type="button"
+                    onClick={() => onPatch({ hinge: h === DOOR_ART_DEFAULTS.hinge ? undefined : h })}
+                    className={[
+                      "focus-ring flex-1 rounded px-2 py-1 text-2xs font-display uppercase tracking-wider transition",
+                      hinge === h
+                        ? "bg-accent/20 text-accent"
+                        : "text-text-muted hover:text-text-primary",
+                    ].join(" ")}
+                  >
+                    {h}
+                  </button>
+                ))}
+              </div>
+            </label>
+            <AngleSlider
+              label="Open angle"
+              value={openAngle}
+              min={30}
+              max={160}
+              onChange={(v) => onPatch({ openAngle: v })}
+            />
+            <button
+              type="button"
+              onClick={() => onPatch({ hinge: undefined, openAngle: undefined })}
+              className="focus-ring self-start rounded px-1 text-2xs text-text-muted hover:text-text-primary"
+            >
+              ↺ Reset hinge &amp; angle
+            </button>
+            <p className="text-2xs leading-snug text-text-muted">
+              The locked-state ward seal is a world asset — set{" "}
+              <span className="font-mono">door_lock</span> in Global Assets.
+            </p>
+          </div>
+        </div>
+
+        {/* Sprite generators */}
+        <div className="flex gap-1">
+          {(["leaf", "frame"] as EditTarget[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTarget(t)}
+              className={[
+                "focus-ring rounded px-2 py-1 text-2xs font-display uppercase tracking-wider transition",
+                target === t
+                  ? "bg-accent/20 text-accent"
+                  : "text-text-muted hover:text-text-primary",
+              ].join(" ")}
+            >
+              {t === "leaf" ? "Leaf sprite" : "Frame sprite"}
+            </button>
+          ))}
+        </div>
+
+        <EntityArtGenerator
+          key={target}
+          assetType={assetType}
+          surface="worldbuilding"
+          currentImage={door[field]}
+          onAccept={(fileName) => onPatch({ [field]: fileName })}
+          getPrompt={(style: ArtStyle) => composePrompt(assetType, style, label)}
+          entityContext={`A ${label} — the ${target} sprite for a layered swinging door. ${
+            target === "leaf"
+              ? "Just the closed door panel, no surrounding frame."
+              : "Just the empty doorway frame, the opening hollow, no door panel inside."
+          }`}
+          framingHint={getFormatForAssetType(assetType)}
+          context={{
+            zone: world.zone,
+            entity_type: assetType,
+            entity_id: `${roomId}:${direction}`,
+          }}
+        />
+      </div>
+    </details>
+  );
+}
+
+interface AngleSliderProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+}
+
+function AngleSlider({ label, value, min, max, onChange }: AngleSliderProps) {
+  return (
+    <label className="flex flex-col gap-0.5">
+      <span className="flex items-center justify-between text-2xs text-text-muted">
+        <span>{label}</span>
+        <span className="font-mono text-text-secondary">{value}°</span>
+      </span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="accent-accent"
+      />
+    </label>
+  );
+}

--- a/creator/src/components/zone/DoorArtEditor.tsx
+++ b/creator/src/components/zone/DoorArtEditor.tsx
@@ -8,11 +8,13 @@ import { useConfigStore } from "@/stores/configStore";
 /** Layered-door defaults — the renderer (and the MUD web client) fall back to
  *  these when a door omits the field. The leaf sprite swings on its `hinge`
  *  edge between closed (0°) and `openAngle`. */
+// Match the door art distributed with the MUD so the editor preview reflects
+// the real fit whenever an author hasn't overridden these per-door.
 export const DOOR_ART_DEFAULTS = {
-  hinge: "left" as const,
-  openAngle: 100,
-  leafScale: 0.72,
-  leafOffsetY: 0.04,
+  hinge: "right" as const,
+  openAngle: 60,
+  leafScale: 0.76,
+  leafOffsetY: 0.09,
 };
 
 interface DoorArtEditorProps {

--- a/creator/src/components/zone/DoorArtEditor.tsx
+++ b/creator/src/components/zone/DoorArtEditor.tsx
@@ -11,6 +11,8 @@ import { useConfigStore } from "@/stores/configStore";
 export const DOOR_ART_DEFAULTS = {
   hinge: "left" as const,
   openAngle: 100,
+  leafScale: 0.72,
+  leafOffsetY: 0.04,
 };
 
 interface DoorArtEditorProps {
@@ -37,6 +39,8 @@ export function DoorArtEditor({ world, roomId, direction, door, onPatch }: DoorA
 
   const hinge = door.hinge ?? DOOR_ART_DEFAULTS.hinge;
   const openAngle = door.openAngle ?? DOOR_ART_DEFAULTS.openAngle;
+  const leafScale = door.leafScale ?? DOOR_ART_DEFAULTS.leafScale;
+  const leafOffsetY = door.leafOffsetY ?? DOOR_ART_DEFAULTS.leafOffsetY;
 
   // Fall back to the world-default door sprites (Global Assets) when this door
   // doesn't define its own — matches how the MUD renders it.
@@ -68,29 +72,41 @@ export function DoorArtEditor({ world, roomId, direction, door, onPatch }: DoorA
               style={{ perspective: "600px" }}
               aria-label="Door preview"
             >
-              {leafSrc ? (
-                <img
-                  src={leafSrc}
-                  alt=""
-                  className="pointer-events-none absolute inset-0 h-full w-full object-contain"
-                  style={{
-                    transformOrigin: hinge === "left" ? "left center" : "right center",
-                    transform: `rotateY(${angle}deg)`,
-                    transition: "transform 0.5s cubic-bezier(0.34, 1.2, 0.64, 1)",
-                  }}
-                />
-              ) : (
-                <div className="absolute inset-0 flex items-center justify-center px-2 text-center text-2xs italic text-text-muted">
-                  No leaf art yet — generate below or set a world default in Global Assets
-                </div>
-              )}
-              {/* Frame drawn on top so the leaf reads as swinging within it. */}
+              {/* Frame drawn first so it sits behind the leaf — the door opens
+                  toward the viewer, so the swinging leaf passes in front. */}
               {frameSrc && (
                 <img
                   src={frameSrc}
                   alt=""
                   className="pointer-events-none absolute inset-0 h-full w-full object-contain"
                 />
+              )}
+              {leafSrc ? (
+                <div
+                  className="pointer-events-none absolute"
+                  style={{
+                    left: "50%",
+                    top: "50%",
+                    width: `${leafScale * 100}%`,
+                    height: `${leafScale * 100}%`,
+                    transform: `translate(-50%, calc(-50% + ${leafOffsetY * 100}%))`,
+                  }}
+                >
+                  <img
+                    src={leafSrc}
+                    alt=""
+                    className="h-full w-full object-contain"
+                    style={{
+                      transformOrigin: hinge === "left" ? "left center" : "right center",
+                      transform: `rotateY(${angle}deg)`,
+                      transition: "transform 0.5s cubic-bezier(0.34, 1.2, 0.64, 1)",
+                    }}
+                  />
+                </div>
+              ) : (
+                <div className="absolute inset-0 flex items-center justify-center px-2 text-center text-2xs italic text-text-muted">
+                  No leaf art yet — generate below or set a world default in Global Assets
+                </div>
               )}
             </div>
             <button
@@ -136,12 +152,37 @@ export function DoorArtEditor({ world, roomId, direction, door, onPatch }: DoorA
               max={160}
               onChange={(v) => onPatch({ openAngle: v })}
             />
+            <AngleSlider
+              label="Leaf size"
+              value={leafScale}
+              min={0.4}
+              max={1}
+              step={0.02}
+              format={(v) => `${Math.round(v * 100)}%`}
+              onChange={(v) => onPatch({ leafScale: v })}
+            />
+            <AngleSlider
+              label="Leaf offset Y"
+              value={leafOffsetY}
+              min={-0.2}
+              max={0.2}
+              step={0.01}
+              format={(v) => v.toFixed(2)}
+              onChange={(v) => onPatch({ leafOffsetY: v })}
+            />
             <button
               type="button"
-              onClick={() => onPatch({ hinge: undefined, openAngle: undefined })}
+              onClick={() =>
+                onPatch({
+                  hinge: undefined,
+                  openAngle: undefined,
+                  leafScale: undefined,
+                  leafOffsetY: undefined,
+                })
+              }
               className="focus-ring self-start rounded px-1 text-2xs text-text-muted hover:text-text-primary"
             >
-              ↺ Reset hinge &amp; angle
+              ↺ Reset hinge, angle &amp; fit
             </button>
             <p className="text-2xs leading-snug text-text-muted">
               The locked-state ward seal is a world asset — set{" "}
@@ -198,20 +239,23 @@ interface AngleSliderProps {
   value: number;
   min: number;
   max: number;
+  step?: number;
+  format?: (v: number) => string;
   onChange: (v: number) => void;
 }
 
-function AngleSlider({ label, value, min, max, onChange }: AngleSliderProps) {
+function AngleSlider({ label, value, min, max, step = 1, format, onChange }: AngleSliderProps) {
   return (
     <label className="flex flex-col gap-0.5">
       <span className="flex items-center justify-between text-2xs text-text-muted">
         <span>{label}</span>
-        <span className="font-mono text-text-secondary">{value}°</span>
+        <span className="font-mono text-text-secondary">{format ? format(value) : `${value}°`}</span>
       </span>
       <input
         type="range"
         min={min}
         max={max}
+        step={step}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
         className="accent-accent"

--- a/creator/src/components/zone/ExitDoorEditor.tsx
+++ b/creator/src/components/zone/ExitDoorEditor.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/zoneEdits";
 import { CheckboxInput, NumberInput, SelectInput, TextInput } from "@/components/ui/FormWidgets";
 import { useConfigStore } from "@/stores/configStore";
+import { DoorArtEditor } from "./DoorArtEditor";
 
 interface ExitDoorEditorProps {
   world: WorldFile;
@@ -163,6 +164,13 @@ export function ExitDoorEditor({
                 dense
               />
             </div>
+            <DoorArtEditor
+              world={world}
+              roomId={roomId}
+              direction={direction}
+              door={door!}
+              onPatch={patchDoor}
+            />
           </div>
         )}
       </div>

--- a/creator/src/lib/__tests__/assetRefs.test.ts
+++ b/creator/src/lib/__tests__/assetRefs.test.ts
@@ -89,4 +89,38 @@ describe("normalizeWorldAssetRefs", () => {
     expect(world.puzzles?.sphinx?.answer).toBe("footsteps");
     expect(world.puzzles?.sphinx?.reward.type).toBe("give_gold");
   });
+
+  it("normalizes an exit door's frame/leaf refs", () => {
+    const world = normalizeWorldAssetRefs({
+      zone: "tutorial_glade",
+      startRoom: "entrance",
+      rooms: {
+        entrance: {
+          title: "Entrance",
+          description: "",
+          exits: {
+            east: {
+              to: "hall",
+              door: {
+                initialState: "closed",
+                hinge: "right",
+                frameImage: "C:\\assets\\images\\frame.png",
+                leafImage: "/images/doors/leaf.png",
+              },
+            },
+            west: "outside",
+          },
+        },
+        hall: { title: "Hall", description: "" },
+      },
+    });
+
+    const east = world.rooms.entrance?.exits?.east;
+    const door = typeof east === "string" ? undefined : east?.door;
+    expect(door?.frameImage).toBe("frame.png");
+    expect(door?.leafImage).toBe("/images/doors/leaf.png");
+    // Non-image door fields and string exits survive untouched.
+    expect(door?.hinge).toBe("right");
+    expect(world.rooms.entrance?.exits?.west).toBe("outside");
+  });
 });

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -649,6 +649,8 @@ describe("sanitizeZone — output cleanup", () => {
                 leafImage: "leaf.webp",
                 hinge: "right",
                 openAngle: 120,
+                leafScale: 0.66,
+                leafOffsetY: 0.05,
               },
             },
           },
@@ -662,6 +664,8 @@ describe("sanitizeZone — output cleanup", () => {
     expect(door.leafImage).toBe("leaf.webp");
     expect(door.hinge).toBe("right");
     expect(door.openAngle).toBe(120);
+    expect(door.leafScale).toBe(0.66);
+    expect(door.leafOffsetY).toBe(0.05);
   });
 
   it("strips legacy room audio field on output", () => {

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { sanitizeZone, sanitizeId, buildIdRemap } from "../sanitizeZone";
-import type { WorldFile } from "@/types/world";
+import type { ExitValue, WorldFile } from "@/types/world";
 
 // ─── sanitizeId ───────────────────────────────────────────────────
 
@@ -630,6 +630,38 @@ describe("sanitizeZone — output cleanup", () => {
 
     const result = sanitizeZone(world) as WorldFile;
     expect(result.puzzles!.sphinx!.backgroundImage).toBe("codex.webp");
+  });
+
+  it("preserves per-door layered art fields on output", () => {
+    const world: WorldFile = {
+      zone: "test",
+      startRoom: "room_a",
+      rooms: {
+        room_a: {
+          title: "A",
+          description: "A",
+          exits: {
+            east: {
+              to: "room_b",
+              door: {
+                initialState: "closed",
+                frameImage: "frame.webp",
+                leafImage: "leaf.webp",
+                hinge: "right",
+                openAngle: 120,
+              },
+            },
+          },
+        },
+        room_b: { title: "B", description: "B" },
+      },
+    };
+
+    const door = (sanitizeZone(world).rooms.room_a.exits!.east as ExitValue).door!;
+    expect(door.frameImage).toBe("frame.webp");
+    expect(door.leafImage).toBe("leaf.webp");
+    expect(door.hinge).toBe("right");
+    expect(door.openAngle).toBe(120);
   });
 
   it("strips legacy room audio field on output", () => {

--- a/creator/src/lib/arcanumPrompts.ts
+++ b/creator/src/lib/arcanumPrompts.ts
@@ -155,6 +155,8 @@ export const FORMAT_BY_ASSET_TYPE: Partial<Record<AssetType, string>> = {
   gathering_node: FORMAT_BY_TYPE.gathering_node,
   lever_plate: "1:1 square sprite of a single lever mounting plate viewed straight head-on, centered, the whole plate in frame with padding, no handle arm, no wall, no characters, clean flat background",
   lever_handle: "1:1 square sprite of a single lever handle/arm oriented vertically pointing straight up, centered, the pivot end at the bottom and the grip at the top, the whole handle in frame with padding, no mounting plate, no wall, no characters, clean flat background",
+  door_frame: "2:3 portrait sprite of a single empty doorway frame viewed straight head-on, the opening hollow and empty (no door panel inside), centered with padding, no door leaf, no wall around it, no characters, clean flat background",
+  door_leaf: "2:3 portrait sprite of a single closed door panel/leaf viewed straight head-on, the whole leaf in frame with padding, no surrounding frame, no wall, no characters, clean flat background",
   player_sprite: FORMAT_BY_TYPE.mob,
   race_portrait: FORMAT_BY_TYPE.race_portrait,
   class_portrait: FORMAT_BY_TYPE.class_portrait,
@@ -200,6 +202,8 @@ export const BG_REMOVAL_ASSET_TYPES: ReadonlySet<string> = new Set([
   "gathering_node",
   "lever_plate",
   "lever_handle",
+  "door_frame",
+  "door_leaf",
   "ability_sprite",
   "player_sprite",
 ]);
@@ -457,6 +461,20 @@ export const ASSET_TEMPLATES: Record<AssetType, { label: string; templates: Reco
     templates: {
       arcanum: `A single lever mounting plate rendered as an isolated game sprite, viewed straight head-on — an ornate circular or shield-shaped backing plate of dark metal with aurum-gold baroque scrollwork around its rim and a central pivot socket at its middle where a handle would attach, warm golden bloom around the socket, cool blue-violet ambient fill in the recesses, NO handle, NO arm, NO lever shaft present, NO wall, NO floor, only the plate, centered with padding on all sides, painterly, luminous, extremely detailed`,
       gentle_magic: `A single lever mounting plate rendered as an isolated game sprite, viewed straight head-on — a gently rounded backing plate of weathered brass or carved wood with soft decorative trim and a central pivot socket at its middle where a handle would attach, faint warm inner glow, lavender and pale-gold undertones, NO handle, NO arm, NO lever shaft present, NO wall, NO floor, only the plate, centered with padding on all sides, painterly, luminous, dreamlike`,
+    },
+  },
+  door_leaf: {
+    label: "Door Leaf",
+    templates: {
+      arcanum: `A single closed door panel rendered as an isolated game sprite, viewed straight head-on — a tall slab of dark timber bound with aurum-gold iron banding and studs, a chased filigree handle and a faint warded keyhole, warm aurum-gold light pooling along the metalwork with soft bloom, cool blue-violet accents in the grain, NO surrounding frame, NO doorway arch, NO wall, NO floor, only the door leaf itself, centered upright with padding on all sides, painterly, luminous, extremely detailed`,
+      gentle_magic: `A single closed door panel rendered as an isolated game sprite, viewed straight head-on — a tall plank of weathered wood with gentle grain, soft rounded iron bands, a simple rounded handle and a small keyhole, faint source-ambiguous warm glow, lavender and pale-gold undertones, NO surrounding frame, NO doorway arch, NO wall, NO floor, only the door leaf itself, centered upright with padding on all sides, painterly, luminous, dreamlike`,
+    },
+  },
+  door_frame: {
+    label: "Door Frame",
+    templates: {
+      arcanum: `A single empty doorway frame rendered as an isolated game sprite, viewed straight head-on — an ornate arched portal of dark cosmic stone edged with aurum-gold baroque scrollwork, the opening hollow and empty with nothing inside it, warm golden bloom tracing the inner edge, cool blue-violet ambient fill in the recesses, NO door panel, NO leaf, NO wall around it, NO floor, only the frame, centered with even padding, painterly, luminous, extremely detailed`,
+      gentle_magic: `A single empty doorway frame rendered as an isolated game sprite, viewed straight head-on — a gently arched portal of weathered stone or carved wood with soft decorative trim, the opening hollow and empty with nothing inside it, faint warm inner glow tracing the edge, lavender and pale-gold undertones, NO door panel, NO leaf, NO wall around it, NO floor, only the frame, centered with even padding, painterly, luminous, dreamlike`,
     },
   },
   faction_emblem: {

--- a/creator/src/lib/assetRefs.ts
+++ b/creator/src/lib/assetRefs.ts
@@ -108,6 +108,19 @@ export function normalizeWorldAssetRefs(world: WorldFile): WorldFile {
                   })
                 : feature)
           : undefined,
+        exits: room.exits
+          ? mapEntries(room.exits, (exit) =>
+              typeof exit !== "string" && exit.door && (exit.door.frameImage || exit.door.leafImage)
+                ? {
+                    ...exit,
+                    door: compactObject({
+                      ...exit.door,
+                      frameImage: normalizeAssetRef(exit.door.frameImage),
+                      leafImage: normalizeAssetRef(exit.door.leafImage),
+                    }),
+                  }
+                : exit)
+          : undefined,
       })),
     mobs: mapOptionalEntries(world.mobs, (mob) =>
       compactObject({

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -170,6 +170,62 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     aspect: "portrait",
     optional: true,
   },
+  // World-default door art (layered, procedurally animated — the "Warded
+  // Threshold"). The leaf swings on its hinge over the static frame; the seal
+  // overlay glows while locked and shatters on unlock. A door may override the
+  // frame/leaf per-exit; the seal + backdrop are world-wide. All optional —
+  // each falls back to the polished CSS card when absent.
+  {
+    key: "door_frame",
+    defaultFilename: "door_frame.png",
+    label: "Default Door Frame",
+    description:
+      "World-default doorway frame drawn behind any door that doesn't define its own. The leaf swings within it. Optional.",
+    assetType: "door_frame",
+    defaultPrompt:
+      "A single empty doorway frame viewed straight head-on, an ornate arched portal with the opening hollow and empty, isolated as a sprite, no door panel, no wall, transparent background.",
+    transparent: true,
+    aspect: "portrait",
+    optional: true,
+  },
+  {
+    key: "door_leaf",
+    defaultFilename: "door_leaf.png",
+    label: "Default Door Leaf",
+    description:
+      "World-default swinging door panel for any door that doesn't define its own. Rotates on its hinge between closed and open. Optional.",
+    assetType: "door_leaf",
+    defaultPrompt:
+      "A single closed door panel viewed straight head-on, a tall slab of timber with iron banding and a handle, isolated as a sprite, no surrounding frame, no wall, transparent background.",
+    transparent: true,
+    aspect: "portrait",
+    optional: true,
+  },
+  {
+    key: "door_lock",
+    defaultFilename: "door_lock.png",
+    label: "Door Ward Seal",
+    description:
+      "Warded-seal overlay drawn over a locked door — a glowing rune-sigil that shatters into motes when the door is unlocked. Centered overlay. Optional; falls back to a CSS lock glyph.",
+    assetType: "ability_icon",
+    defaultPrompt:
+      "A single circular arcane ward-seal sigil, glowing concentric runic rings around a central locked glyph, centered, soft magical bloom, no door, no readable text, transparent background.",
+    transparent: true,
+    optional: true,
+  },
+  {
+    key: "door_bg",
+    defaultFilename: "door_bg.png",
+    label: "Door Card Background",
+    description:
+      "Backdrop behind the door card — a threshold wall or passage. The framed door renders on top. Optional; falls back to a CSS panel.",
+    assetType: "background",
+    defaultPrompt:
+      "A dimly lit threshold wall of weathered stone or timber with a recessed alcove where a doorway sits, soft ambient torch glow, deep atmospheric depth, wide landscape backdrop, no door panel, no figures, no readable text.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
   {
     key: "dialog_indicator",
     defaultFilename: "dialog_indicator.png",

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -110,6 +110,10 @@ function normalizeDoorFile(door?: DoorFile): DoorFile | undefined {
   if (door.keyConsumed != null) normalized.keyConsumed = door.keyConsumed;
   if (door.resetWithZone != null) normalized.resetWithZone = door.resetWithZone;
   if (door.respawnSeconds != null) normalized.respawnSeconds = door.respawnSeconds;
+  if (door.frameImage) normalized.frameImage = door.frameImage;
+  if (door.leafImage) normalized.leafImage = door.leafImage;
+  if (door.hinge) normalized.hinge = door.hinge;
+  if (door.openAngle != null) normalized.openAngle = door.openAngle;
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -114,6 +114,8 @@ function normalizeDoorFile(door?: DoorFile): DoorFile | undefined {
   if (door.leafImage) normalized.leafImage = door.leafImage;
   if (door.hinge) normalized.hinge = door.hinge;
   if (door.openAngle != null) normalized.openAngle = door.openAngle;
+  if (door.leafScale != null) normalized.leafScale = door.leafScale;
+  if (door.leafOffsetY != null) normalized.leafOffsetY = door.leafOffsetY;
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 }

--- a/creator/src/lib/zoneEdits.ts
+++ b/creator/src/lib/zoneEdits.ts
@@ -556,6 +556,10 @@ function cleanDoor(door: DoorFile): DoorFile | undefined {
   if (door.keyConsumed != null) out.keyConsumed = door.keyConsumed;
   if (door.resetWithZone != null) out.resetWithZone = door.resetWithZone;
   if (door.respawnSeconds != null) out.respawnSeconds = door.respawnSeconds;
+  if (door.frameImage) out.frameImage = door.frameImage;
+  if (door.leafImage) out.leafImage = door.leafImage;
+  if (door.hinge) out.hinge = door.hinge;
+  if (door.openAngle != null) out.openAngle = door.openAngle;
   return Object.keys(out).length > 0 ? out : undefined;
 }
 

--- a/creator/src/lib/zoneEdits.ts
+++ b/creator/src/lib/zoneEdits.ts
@@ -560,6 +560,8 @@ function cleanDoor(door: DoorFile): DoorFile | undefined {
   if (door.leafImage) out.leafImage = door.leafImage;
   if (door.hinge) out.hinge = door.hinge;
   if (door.openAngle != null) out.openAngle = door.openAngle;
+  if (door.leafScale != null) out.leafScale = door.leafScale;
+  if (door.leafOffsetY != null) out.leafOffsetY = door.leafOffsetY;
   return Object.keys(out).length > 0 ? out : undefined;
 }
 

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -54,6 +54,8 @@ export type AssetType =
   | "gathering_node"
   | "lever_plate"
   | "lever_handle"
+  | "door_frame"
+  | "door_leaf"
   | "player_sprite"
   | "race_portrait"
   | "class_portrait"
@@ -294,6 +296,8 @@ export const ENTITY_DIMENSIONS: Record<string, { width: number; height: number; 
   gathering_node: { width: 1024, height: 1024, label: "1024×1024 (Sprite)" },
   lever_plate: { width: 1024, height: 1024, label: "1024×1024 (Sprite)" },
   lever_handle: { width: 1024, height: 1024, label: "1024×1024 (Sprite)" },
+  door_frame: { width: 1024, height: 1536, label: "1024×1536 (Portrait)" },
+  door_leaf: { width: 1024, height: 1536, label: "1024×1536 (Portrait)" },
   container_bg: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },
   sign_bg: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },
   lever_bg: { width: 1024, height: 1536, label: "1024×1536 (Portrait)" },

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -158,6 +158,17 @@ export interface DoorFile {
   hinge?: "left" | "right";
   /** Leaf rotation in degrees when the door is open. Closed is always 0. Default 100. */
   openAngle?: number;
+  /**
+   * Leaf size as a fraction (0..1) of the frame box, so the leaf sits inside
+   * the frame's opening rather than overflowing it. Ornate frames have a small
+   * central opening, so this is usually < 1. Default 0.72.
+   */
+  leafScale?: number;
+  /**
+   * Vertical placement of the leaf within the frame as a fraction (-1..1) of
+   * the box; positive nudges down so the leaf rests on the threshold. Default 0.04.
+   */
+  leafOffsetY?: number;
   /** Legacy alias; normalized to `initialState` on output. */
   closed?: boolean;
   /** Legacy alias; normalized to `initialState` on output. */

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -143,6 +143,21 @@ export interface DoorFile {
    * = only resets with the zone.
    */
   respawnSeconds?: number;
+  /**
+   * Door art (layered, procedurally animated — the "Warded Threshold"). The
+   * leaf sprite swings on its hinge between closed (0°) and `openAngle`; the
+   * static frame sprite is drawn behind it and never moves. The world-default
+   * `door_lock` seal overlay renders on top while locked. All optional;
+   * renderers fall back to `door_frame`/`door_leaf` globals, then a CSS card.
+   */
+  /** Static frame/portal sprite, drawn behind the leaf (optional). */
+  frameImage?: string;
+  /** Swinging leaf sprite, drawn closed in a neutral upright pose (optional). */
+  leafImage?: string;
+  /** Which edge the leaf is hinged on. Default "left". */
+  hinge?: "left" | "right";
+  /** Leaf rotation in degrees when the door is open. Closed is always 0. Default 100. */
+  openAngle?: number;
   /** Legacy alias; normalized to `initialState` on output. */
   closed?: boolean;
   /** Legacy alias; normalized to `initialState` on output. */

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -154,19 +154,19 @@ export interface DoorFile {
   frameImage?: string;
   /** Swinging leaf sprite, drawn closed in a neutral upright pose (optional). */
   leafImage?: string;
-  /** Which edge the leaf is hinged on. Default "left". */
+  /** Which edge the leaf is hinged on. Default "right". */
   hinge?: "left" | "right";
-  /** Leaf rotation in degrees when the door is open. Closed is always 0. Default 100. */
+  /** Leaf rotation in degrees when the door is open. Closed is always 0. Default 60. */
   openAngle?: number;
   /**
    * Leaf size as a fraction (0..1) of the frame box, so the leaf sits inside
    * the frame's opening rather than overflowing it. Ornate frames have a small
-   * central opening, so this is usually < 1. Default 0.72.
+   * central opening, so this is usually < 1. Default 0.76.
    */
   leafScale?: number;
   /**
    * Vertical placement of the leaf within the frame as a fraction (-1..1) of
-   * the box; positive nudges down so the leaf rests on the threshold. Default 0.04.
+   * the box; positive nudges down so the leaf rests on the threshold. Default 0.09.
    */
   leafOffsetY?: number;
   /** Legacy alias; normalized to `initialState` on output. */


### PR DESCRIPTION
@
## Summary

Gives doors the **levers layered, animated art model** — the natural fit since a door is a state machine (open / closed / locked), not just a backdrop. A door becomes a static **frame** sprite + a **leaf** sprite that swings on its hinge between closed (0°) and `openAngle`, with the world-default `door_lock` **ward seal** overlaying a locked door. Theme: the **Warded Threshold** — a glowing rune-seal that shatters into motes on unlock, then the leaf swings open.

Doors are `ExitValue.door` sub-objects (not feature entities), so the art fields live on `DoorFile` and the editor slots into the existing inline `ExitDoorEditor`.

## Contract (for the parallel server work)

**`DoorFile` — new per-door fields (all optional):**

| Field | Type | Purpose |
|---|---|---|
| `frameImage` | string | Static frame/portal sprite (= lever `plateImage`) |
| `leafImage` | string | Swinging leaf (= lever `handleImage`) |
| `hinge` | `"left" \| "right"` | Hinge edge (default `left`) |
| `openAngle` | number | Open swing angle; closed is always 0° (default 100) |

**New global asset keys (world defaults, all optional):**

| Key | Depicts |
|---|---|
| `door_frame` | Default frame sprite |
| `door_leaf` | Default leaf sprite |
| `door_lock` | Ward-seal overlay (glows locked, shatters on unlock) — **global only** |
| `door_bg` | Backdrop behind the card |

**Resolution per door:** `frameImage` → `door_frame` → CSS; `leafImage` → `door_leaf` → CSS; `door_lock` / `door_bg` are global.

## Changes

- **`types/world.ts`** — 4 new `DoorFile` fields
- **`sanitizeZone.normalizeDoorFile` + `zoneEdits.cleanDoor`** — whitelist the new fields (both, or theyd drop on save/edit)
- **`assetRefs.ts`** — normalize frame/leaf refs on the room→exits→door path (doors were previously untouched by the world normalizer)
- **`requiredGlobalAssets.ts`** — `door_frame`, `door_leaf`, `door_lock`, `door_bg`
- **`types/assets.ts` + `arcanumPrompts.ts`** — new `door_frame` / `door_leaf` AssetTypes with dims, templates, format hints, bg-removal (mirrors `lever_plate`/`lever_handle`)
- **`DoorArtEditor.tsx`** (new) — live swing preview (hinge + open-angle tuning) + frame/leaf sprite generators, wired into `ExitDoorEditor`
- **tests** — sanitizeZone round-trip + assetRefs door normalization

## Verification

- `bunx tsc --noEmit` — clean
- `bun run test` — 2119 passed (added sanitizeZone + assetRefs cases)

## Out of scope (separate repo — server/web in parallel)

The web-client door reskin — the warded-seal glow/shatter, the leaf swing + destination peek-through, and the unlock/open microcopy — lives in the AmbonMUD web client and keys off the existing door state. Field/asset names here match what that side consumes. Per the design call, the lock is a **global `door_lock`** (no per-door override); we can add a per-door `lockImage` later if individually-warded doors are wanted.
@
