### PR TITLE
Add customizable bank background (The Vault)

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -793,6 +793,18 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     transparent: false,
   },
   {
+    key: "bank_bg",
+    defaultFilename: "bank_bg.png",
+    label: "Bank Vault Background",
+    description: "Backdrop behind the bank card — the \"Vault\". A marble-and-brass treasury interior; the gold balance and item-vault drawers render on top. Falls back to the procedural panel when absent. (The bank_vault door icon doubles as the panel emblem.)",
+    assetType: "background",
+    defaultPrompt:
+      "A dim treasury vault interior filling the frame edge to edge — polished marble walls and floor, gleaming brass fittings and a great round vault door suggested in the background, rows of safety-deposit drawers along one side, warm aurum-gold light pooling softly, deep secure atmosphere, no coins in focus, no figures, no readable text, suitable as a backdrop behind a bank panel.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
     key: "trainer_bg",
     defaultFilename: "trainer_bg.png",
     label: "Trainer Board Texture",


### PR DESCRIPTION
@
## Summary

Reskins the bank to **The Vault** — a marble-and-brass treasury. Unlike containers/levers/doors, the bank is a `bank: true` **room flag** with no per-instance entity (the web `BankPanel` is fully procedural), so this is a **world-global** asset only, exactly like `shop_bg`/`trainer_bg`.

The Arcanum-side change is a single new global asset key. The existing `bank_vault` door icon doubles as the panel emblem, so no new emblem asset is needed.

## Contract (for the parallel server/web work)

**New global asset key (optional):**

| Key | Depicts |
|---|---|
| `bank_bg` | Marble + brass vault interior; the gold balance and item-vault drawers render on top |

Plus the **existing** `bank_vault` icon as the panel header emblem.

**Resolution:** `bank_bg` global → procedural CSS panel (current look). Optional, so existing worlds arent flagged as missing it.

## Delight (web-client, off existing state)
- Gold deposit/withdraw → coins glint / the balance rolls; item **Store** → a safety-deposit drawer slides shut (reverse on Withdraw).
- The `Item Vault` capacity bar can read as filling vault drawers.
- `bank_vault` door icon as the header emblem.

## Changes
- **`requiredGlobalAssets.ts`** — add the optional `bank_bg` background (landscape, vault-interior prompt). Auto-appears in the Global Assets panel + generator.

No type/sanitize/editor changes — `bank_bg` is a plain `globalAssets` string handled by the existing map plumbing.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — 2119 passed

## Out of scope (separate repo)
The `BankPanel` reskin (vault backdrop, drawer/coin treatment, animations) lives in the AmbonMUD web client and keys off existing bank state. The only new asset it needs is `bank_bg`; everything else reuses `bank_vault` + existing bank GMCP state.
@