### PR TITLE
Add Woodland Fae Cabinet character-panel assets

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -983,6 +983,19 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     aspect: "landscape",
     optional: true,
   },
+  {
+    key: "character_scribe_bg",
+    defaultFilename: "character_scribe_bg.png",
+    label: "Character Scribe Page",
+    description:
+      "Parchment/tome page the describe editor opens onto, where the player writes their character's roleplay tale. The text area renders over the writable page. Falls back to a procedural parchment when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "An open aged-parchment tome page filling the frame edge to edge — warm paper with soft fibers, faint stains and gentle wear, a clean blank writable area in the center, a delicate carved-wood and leaf border with faint gilt flourishes at the margins, soft ambient light, wide landscape composition, no writing, no ruled lines, no figures, no readable text, suitable as a backdrop behind a character description editor.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
   // Inn (recall) modal: a card backdrop plus the hangable key.
   {
     key: "inn_bg",

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -888,6 +888,101 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     transparent: false,
     aspect: "landscape",
   },
+  // Character panel — the "Woodland Fae Cabinet". A layered set: the cabinet
+  // backdrop is the hero cover; the niche is the sprite alcove; frame/plaque/
+  // charm are carved chrome the readouts sit in; the two gem buttons open the
+  // achievements and prestige panels. Each resolves authored key → carved-CSS
+  // fallback, so they can ship incrementally. The world's visual style is
+  // applied on top, so non-fae worlds get a themed variant.
+  {
+    key: "character_bg",
+    defaultFilename: "character_bg.png",
+    label: "Character Cabinet Backdrop",
+    description:
+      "The hero backdrop for the character panel — the full carved-wood cabinet (outer frame, vines, crystals, brass corners, ambient forest). Fills the sheet as a cover and bakes in the non-interactive chrome; the cards overlay it. Falls back to a carved CSS panel.",
+    assetType: "background",
+    defaultPrompt:
+      "An ornate carved-wood cabinet backdrop filling the frame edge to edge — a grand frame of dark polished wood wrapped in living vines and tiny mushrooms, glowing crystals and brass corner fittings, a soft enchanted forest in the depths, warm magical light, an open uncluttered center where character cards overlay, wide landscape composition, no figures, no readable text.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
+    key: "character_niche",
+    defaultFilename: "character_niche.png",
+    label: "Character Sprite Niche",
+    description:
+      "The arched forest-diorama alcove the player sprite stands in (left showcase). The live sprite renders centered in front; author transparency outside the arch (or let the cabinet frame mask it). Falls back to a carved CSS alcove.",
+    assetType: "background",
+    defaultPrompt:
+      "An arched forest-diorama alcove viewed head-on — a tall rounded archway opening onto a misty enchanted woodland glade with dappled light, soft glowing motes, ferns and luminous flowers receding into the trees, portrait composition, an empty center where a character figure will stand in front, no figures, no readable text.",
+    transparent: false,
+    aspect: "portrait",
+    optional: true,
+  },
+  {
+    key: "character_frame",
+    defaultFilename: "character_frame.png",
+    label: "Character Panel Frame",
+    description:
+      "Reusable carved panel frame bounding the identity + vitals cards. Used as a 9-slice (~48px corner insets) with a transparent center. Falls back to a carved CSS border.",
+    assetType: "ornament",
+    defaultPrompt:
+      "A single ornate carved-wood panel frame filling the canvas edge to edge, the border carved with vines and leaves with small brass corner fittings, an open empty center, isolated decorative frame element, transparent background, no scene, no readable text.",
+    transparent: true,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
+    key: "character_plaque",
+    defaultFilename: "character_plaque.png",
+    label: "Character Readout Plaque",
+    description:
+      "Darker carved recess behind grouped readouts (the STATS column and the damage/armor/dodge strip). Used as a 9-slice (~24px insets) with a semi-opaque dark-wood center so light text reads. Falls back to a carved CSS recess.",
+    assetType: "ornament",
+    defaultPrompt:
+      "A single dark carved-wood plaque, a sunken recessed panel with a semi-opaque dark-wood center for light text to read against, a carved leafy border with small brass studs, isolated decorative element, transparent outside the plaque, no scene, no readable text.",
+    transparent: true,
+    optional: true,
+  },
+  {
+    key: "character_charm",
+    defaultFilename: "character_charm.png",
+    label: "Active-Effect Charm",
+    description:
+      "Carved charm/locket holder behind each active-effect icon (~96px square, transparent socket center). CSS tints the glow per effect color. Falls back to a carved CSS socket.",
+    assetType: "ornament",
+    defaultPrompt:
+      "A single small carved-wood charm or locket holder, a round socket frame of dark wood and brass with a leaf motif and an empty transparent center where an effect icon sits, isolated decorative element, transparent background, no scene, no readable text.",
+    transparent: true,
+    optional: true,
+  },
+  {
+    key: "char_btn_achievements",
+    defaultFilename: "char_btn_achievements.png",
+    label: "Achievements Button",
+    description:
+      "Ornate emerald/green gem button that opens the achievements browser. Wide button (usable as 9-slice); the label is rendered in CSS over it for i18n. Falls back to a carved CSS gem button.",
+    assetType: "ornament",
+    defaultPrompt:
+      "A single ornate horizontal UI button set with a large faceted emerald-green gem, a dark carved-wood and brass frame with leaf flourishes and a soft green inner glow, isolated decorative button element, transparent background, blank face, no readable text.",
+    transparent: true,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
+    key: "char_btn_prestige",
+    defaultFilename: "char_btn_prestige.png",
+    label: "Prestige Button",
+    description:
+      "Ornate amethyst/purple gem button that opens the prestige panel. Wide button (usable as 9-slice); the label is rendered in CSS over it for i18n. Falls back to a carved CSS gem button.",
+    assetType: "ornament",
+    defaultPrompt:
+      "A single ornate horizontal UI button set with a large faceted amethyst-purple gem, a dark carved-wood and brass frame with leaf flourishes and a soft violet inner glow, isolated decorative button element, transparent background, blank face, no readable text.",
+    transparent: true,
+    aspect: "landscape",
+    optional: true,
+  },
   // Inn (recall) modal: a card backdrop plus the hangable key.
   {
     key: "inn_bg",


### PR DESCRIPTION
@
## Summary

Registers the global assets for the MUD-side character-panel reskin ("Woodland Fae Cabinet"). The character panel is **per-player UI with no world entity**, so this is purely new `globalAssets` keys (like the HUD chrome / `bank_bg`) — no type, sanitize, editor, or `AssetType` changes. Authors can generate, import, and assign each in the Global Assets panel; every key resolves **authored → carved-CSS fallback**, so art can ship incrementally.

## New keys (all optional)

| Key | Depicts | Type / aspect |
|---|---|---|
| `character_bg` | Full carved-wood cabinet backdrop (frame, vines, crystals, brass, forest) — the hero cover; bakes in non-interactive chrome | `background`, landscape |
| `character_niche` | Arched forest-diorama alcove the sprite stands in (sprite renders in front) | `background`, portrait |
| `character_frame` | Reusable carved panel frame around identity + vitals cards (9-slice, ~48px insets, transparent center) | `ornament`, landscape |
| `character_plaque` | Darker carved recess behind grouped readouts (STATS column, dmg/armor/dodge strip) (9-slice, ~24px insets, semi-opaque center) | `ornament` |
| `character_charm` | Carved charm/locket holder behind each active-effect icon (~96px, transparent socket; CSS tints glow) | `ornament` |
| `char_btn_achievements` | Ornate emerald gem button (label in CSS over it) | `ornament`, landscape |
| `char_btn_prestige` | Ornate amethyst gem button (label in CSS over it) | `ornament`, landscape |

Backdrops use the `background` type (full scene generation); the carved chrome + gem buttons use the transparent `ornament` type (isolated decorative element, no scene). The worlds visual style is applied on top, so non-fae worlds get a themed variant. All marked `optional` so existing worlds arent flagged as missing them.

## Done in CSS/SVG on the MUD side (no asset needed)
HP/Mana/XP bars, Auto Loot/Peek toggles, title dropdown, gender segmented control, wimpy slider/stepper, sprite-carousel arrows, and the small glyphs (heart, droplet, xp-rune, sword, shield, leaf, stat letters).

## Changes
- **`requiredGlobalAssets.ts`** — add the seven keys (grouped after `equipment_bg`). They auto-appear in the Global Assets panel + generator.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — 2119 passed

## Out of scope (separate repo)
The character-panel layout, 9-slice usage, sprite-in-niche compositing, gem-button label overlays, and all the CSS/SVG chrome live in the AmbonMUD web client. Resolution per piece is authored key → carved-CSS fallback.
@