### PR TITLE
Add door_portal global asset

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -227,6 +227,19 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     optional: true,
   },
   {
+    key: "door_portal",
+    defaultFilename: "door_portal.png",
+    label: "Door Portal",
+    description:
+      "Swirling portal shown in the doorway behind the leaf, revealed as the door opens. Fills the doorway opening (the frame and leaf composite on top). Global only; falls back to a CSS vortex.",
+    assetType: "background",
+    defaultPrompt:
+      "A swirling arcane portal vortex filling the frame — concentric rings of glowing energy spiraling into a luminous depth, soft magical bloom and drifting motes, cool blue-violet and warm aurum-gold tones, portrait composition sized to fill a doorway opening, no door, no frame, no figures, no readable text.",
+    transparent: false,
+    aspect: "portrait",
+    optional: true,
+  },
+  {
     key: "dialog_indicator",
     defaultFilename: "dialog_indicator.png",
     label: "Dialog Indicator",


### PR DESCRIPTION
@
## Summary

Adds the `door_portal` global asset — a swirling portal shown in the doorway **behind the leaf**, revealed as the door opens (the destination-reveal beat for the Warded Threshold door reskin). Extends the door art group from #260.

## New key (optional)

| Key | Depicts | Type / aspect |
|---|---|---|
| `door_portal` | Swirling portal vortex filling the doorway opening; frame + leaf composite on top | `background`, portrait |

**Global only** (no per-door override), `optional` — falls back to a CSS vortex. Sized portrait to fill the doorway opening, like `door_frame`/`door_leaf`.

## Changes
- **`requiredGlobalAssets.ts`** — add `door_portal` next to the rest of the door group (`door_frame`/`door_leaf`/`door_lock`/`door_bg`). Auto-appears in the Global Assets panel + generator.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — validation/global-asset tests pass

## Out of scope (separate repo)
The web client composites it behind the leaf and reveals it as the door swings open; resolution is authored `door_portal` → CSS vortex fallback.
@