### PR TITLE
Add regen.innMultiplier config field

### DIFF
--- a/creator/src/components/config/panels/RegenPanel.tsx
+++ b/creator/src/components/config/panels/RegenPanel.tsx
@@ -52,6 +52,14 @@ export function RegenPanel({ config, onChange }: ConfigPanelProps) {
               step={0.05}
             />
           </FieldRow>
+          <FieldRow label="Inn Multiplier" hint="Multiplier applied to HP/MP regen in rooms flagged as inns. 2.0 doubles regen so resting at an inn is meaningfully faster. Must be >= 1.0.">
+            <NumberInput
+              value={r.innMultiplier}
+              onCommit={(v) => patch({ innMultiplier: v ?? 2.0 })}
+              min={1}
+              step={0.5}
+            />
+          </FieldRow>
         </div>
       </Section>
 

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -616,6 +616,7 @@ function parseRegenConfig(raw: unknown): AppConfig["regen"] {
     minIntervalMillis: asNumber(s.minIntervalMillis, 1000),
     regenPercent: asNumber(s.regenPercent, 0.05),
     inCombatMultiplier: asNumber(s.inCombatMultiplier, 0.5),
+    innMultiplier: asNumber(s.innMultiplier, 2.0),
     mana: {
       baseIntervalMillis: asNumber(mana.baseIntervalMillis, 3000),
       minIntervalMillis: asNumber(mana.minIntervalMillis, 1000),

--- a/creator/src/lib/tuning/__tests__/presets.test.ts
+++ b/creator/src/lib/tuning/__tests__/presets.test.ts
@@ -255,8 +255,8 @@ describe("validation", () => {
 describe("field coverage", () => {
   const allPaths = Object.keys(FIELD_METADATA);
 
-  it("FIELD_METADATA has 157 entries (sanity check)", () => {
-    expect(allPaths).toHaveLength(157);
+  it("FIELD_METADATA has 158 entries (sanity check)", () => {
+    expect(allPaths).toHaveLength(158);
   });
 
   for (const preset of TUNING_PRESETS) {

--- a/creator/src/lib/tuning/fieldMetadata.ts
+++ b/creator/src/lib/tuning/fieldMetadata.ts
@@ -1056,6 +1056,14 @@ export const FIELD_METADATA: Record<string, FieldMeta> = {
     max: 1,
     impact: "high",
   },
+  "regen.innMultiplier": {
+    label: "Inn Regen Multiplier",
+    description:
+      "Multiplier applied to HP/MP regen in rooms flagged as inns. 2.0 doubles regen so resting at an inn is meaningfully faster than the field. Must be >= 1.0.",
+    section: TuningSection.WorldSocial,
+    min: 1,
+    impact: "medium",
+  },
   "regen.mana.baseIntervalMillis": {
     label: "Mana Regen Base Interval",
     description: "Base milliseconds between mana regen ticks before stat reduction",

--- a/creator/src/lib/tuning/presets.ts
+++ b/creator/src/lib/tuning/presets.ts
@@ -281,6 +281,7 @@ export const CASUAL_PRESET: TuningPreset = {
       minIntervalMillis: 800,
       regenPercent: 0.25,
       inCombatMultiplier: 0.6,
+      innMultiplier: 2.0,
       mana: {
         baseIntervalMillis: 3000,
         minIntervalMillis: 800,
@@ -625,6 +626,7 @@ export const BALANCED_PRESET: TuningPreset = {
       minIntervalMillis: 1000,
       regenPercent: 0.15,
       inCombatMultiplier: 0.33,
+      innMultiplier: 2.0,
       mana: {
         baseIntervalMillis: 4000,
         minIntervalMillis: 1000,
@@ -968,6 +970,7 @@ export const HARDCORE_PRESET: TuningPreset = {
       minIntervalMillis: 2800,
       regenPercent: 0.08,
       inCombatMultiplier: 0,
+      innMultiplier: 2.0,
       mana: {
         baseIntervalMillis: 5500,
         minIntervalMillis: 2800,
@@ -1115,7 +1118,7 @@ export const SOLO_STORY_PRESET: TuningPreset = {
     globalQuests: { enabled: true, intervalMs: 3600000, durationMs: 1800000 },
     // 7.5%/2000ms = 6 HP/s on a 160-HP starter — sandbox forgiveness.
     // In-combat multiplier 0.5 keeps boss fights from feeling trivial.
-    regen: { maxPlayersPerTick: 20, baseIntervalMillis: 2000, minIntervalMillis: 500, regenPercent: 0.075, inCombatMultiplier: 0.5, mana: { baseIntervalMillis: 2000, minIntervalMillis: 500, regenPercent: 0.067 } },
+    regen: { maxPlayersPerTick: 20, baseIntervalMillis: 2000, minIntervalMillis: 500, regenPercent: 0.075, inCombatMultiplier: 0.5, innMultiplier: 2.0, mana: { baseIntervalMillis: 2000, minIntervalMillis: 500, regenPercent: 0.067 } },
     worldTime: { cycleLengthMs: 1200000, dawnHour: 5, dayHour: 7, duskHour: 18, nightHour: 20 },
     weather: { minTransitionMs: 120000, maxTransitionMs: 300000 },
     group: { maxSize: 6, inviteTimeoutMs: 60000, xpBonusPerMember: 0.20 },
@@ -1198,7 +1201,7 @@ export const PVP_ARENA_PRESET: TuningPreset = {
     // 3.7%/4800ms ≈ 1.0 HP/s on a 135-HP starter — PvE recovery is light;
     // in-combat regen is disabled so PvP duels are decided by burst, not
     // by waiting out a regen war.
-    regen: { maxPlayersPerTick: 10, baseIntervalMillis: 4800, minIntervalMillis: 1300, regenPercent: 0.037, inCombatMultiplier: 0, mana: { baseIntervalMillis: 4800, minIntervalMillis: 1300, regenPercent: 0.032 } },
+    regen: { maxPlayersPerTick: 10, baseIntervalMillis: 4800, minIntervalMillis: 1300, regenPercent: 0.037, inCombatMultiplier: 0, innMultiplier: 2.0, mana: { baseIntervalMillis: 4800, minIntervalMillis: 1300, regenPercent: 0.032 } },
     worldTime: { cycleLengthMs: 1800000, dawnHour: 5, dayHour: 7, duskHour: 18, nightHour: 20 },
     weather: { minTransitionMs: 180000, maxTransitionMs: 600000 },
     group: { maxSize: 4, inviteTimeoutMs: 30000, xpBonusPerMember: 0.15 },
@@ -1280,7 +1283,7 @@ export const LORE_EXPLORER_PRESET: TuningPreset = {
     // 15%/1200ms = 25 HP/s on a 200-HP starter — explorer-grade self-healing.
     // In-combat multiplier 1.0 means combat is pure flavor; nothing short of
     // a boss can drop you.
-    regen: { maxPlayersPerTick: 25, baseIntervalMillis: 1200, minIntervalMillis: 280, regenPercent: 0.15, inCombatMultiplier: 1, mana: { baseIntervalMillis: 1200, minIntervalMillis: 280, regenPercent: 0.125 } },
+    regen: { maxPlayersPerTick: 25, baseIntervalMillis: 1200, minIntervalMillis: 280, regenPercent: 0.15, inCombatMultiplier: 1, innMultiplier: 2.0, mana: { baseIntervalMillis: 1200, minIntervalMillis: 280, regenPercent: 0.125 } },
     worldTime: { cycleLengthMs: 900000, dawnHour: 5, dayHour: 7, duskHour: 18, nightHour: 20 },
     weather: { minTransitionMs: 60000, maxTransitionMs: 180000 },
     group: { maxSize: 8, inviteTimeoutMs: 120000, xpBonusPerMember: 0.25 },

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -468,6 +468,8 @@ export interface RegenConfig {
   minIntervalMillis: number;
   regenPercent: number;
   inCombatMultiplier: number;
+  /** Regen multiplier applied in inn rooms (hp5/mp5 boost). Must be >= 1.0. Default 2.0. */
+  innMultiplier: number;
   mana: {
     baseIntervalMillis: number;
     minIntervalMillis: number;


### PR DESCRIPTION
@
## Summary

Adds `regen.innMultiplier` to match the new server-side `ambonMUD.engine.regen.innMultiplier`. It multiplies HP/MP regen (hp5/mp5) in rooms flagged as inns. **Default 2.0** (doubled regen), **must be >= 1.0** — mirrors the existing `inCombatMultiplier` knob.

## Changes
- **`types/config.ts`** — `RegenConfig.innMultiplier: number` (required, like the rest of RegenConfig)
- **`loader.ts`** — `parseRegenConfig` defaults it to `2.0`; round-trips via the existing whole-`regen` writer in `saveConfig`/`exportMud` (no serializer change needed)
- **`RegenPanel.tsx`** — "Inn Multiplier" field, `min={1}`, default 2.0, with a hint
- **`tuning/fieldMetadata.ts`** — `regen.innMultiplier` wizard entry (`min: 1`)
- **`tuning/presets.ts`** — `innMultiplier: 2.0` on all six presets (the preset-coverage invariant requires every metadata field be set per preset)
- **`tuning/__tests__/presets.test.ts`** — bump metadata sanity count 157 → 158

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — 2125 passed (the preset-coverage + metadata-count invariants now include the new field)

## Cross-repo
Matches server `ambonMUD.engine.regen.innMultiplier` (>= 1.0, default 2.0). The inn regen boost (hp5/mp5 doubled), recall-point, and death-respawn behavior are documented for context.
@