### PR TITLE
Add who panel assets (who_bg + examine/tell buttons)

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -862,10 +862,10 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     defaultFilename: "who_examine_btn.png",
     label: "Who — Examine Button",
     description:
-      "Small square per-row button on the who panel that examines the selected player. Falls back to a carved CSS button.",
-    assetType: "ornament",
+      "Small square per-row icon on the who panel that examines the selected player. Bold silhouette that reads at small size; CSS provides the button chrome. Falls back to a CSS button.",
+    assetType: "ability_icon",
     defaultPrompt:
-      "A single small square carved-wood and brass UI button with a centered magnifying-glass / eye motif and a cool blue gem accent, soft inner glow, isolated decorative button element, transparent background, no readable text.",
+      "A single magnifying glass, bold silhouette that reads at small size, centered, soft outline, transparent background.",
     transparent: true,
     optional: true,
   },
@@ -874,10 +874,10 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     defaultFilename: "who_tell_btn.png",
     label: "Who — Send Tell Button",
     description:
-      "Small square per-row button on the who panel that opens a private tell to the selected player. Falls back to a carved CSS button.",
-    assetType: "ornament",
+      "Small square per-row icon on the who panel that opens a private tell to the selected player. Bold silhouette that reads at small size; CSS provides the button chrome. Falls back to a CSS button.",
+    assetType: "ability_icon",
     defaultPrompt:
-      "A single small square carved-wood and brass UI button with a centered sealed-letter / speech-bubble motif and a warm violet gem accent, soft inner glow, isolated decorative button element, transparent background, no readable text.",
+      "A single speech-bubble icon, bold silhouette that reads at small size, centered, soft outline, transparent background.",
     transparent: true,
     optional: true,
   },

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -862,12 +862,11 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     defaultFilename: "who_examine_btn.png",
     label: "Who — Examine Button",
     description:
-      "Per-row button on the who panel that examines the selected player. The label/icon is rendered in CSS over it. Falls back to a carved CSS button.",
+      "Small square per-row button on the who panel that examines the selected player. Falls back to a carved CSS button.",
     assetType: "ornament",
     defaultPrompt:
-      "A single ornate carved-wood and brass UI button with a faceted blue gem and a faint magnifying-glass / eye motif, soft cool inner glow, isolated decorative button element, transparent background, blank face, no readable text.",
+      "A single small square carved-wood and brass UI button with a centered magnifying-glass / eye motif and a cool blue gem accent, soft inner glow, isolated decorative button element, transparent background, no readable text.",
     transparent: true,
-    aspect: "landscape",
     optional: true,
   },
   {
@@ -875,12 +874,22 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     defaultFilename: "who_tell_btn.png",
     label: "Who — Send Tell Button",
     description:
-      "Per-row button on the who panel that opens a private tell to the selected player. The label/icon is rendered in CSS over it. Falls back to a carved CSS button.",
+      "Small square per-row button on the who panel that opens a private tell to the selected player. Falls back to a carved CSS button.",
     assetType: "ornament",
     defaultPrompt:
-      "A single ornate carved-wood and brass UI button with a faceted violet gem and a faint sealed-letter / speech-bubble motif, soft warm inner glow, isolated decorative button element, transparent background, blank face, no readable text.",
+      "A single small square carved-wood and brass UI button with a centered sealed-letter / speech-bubble motif and a warm violet gem accent, soft inner glow, isolated decorative button element, transparent background, no readable text.",
     transparent: true,
-    aspect: "landscape",
+    optional: true,
+  },
+  {
+    key: "who_widget",
+    defaultFilename: "who_widget.png",
+    label: "Who Panel",
+    description: "Services-menu nav button that opens the who panel (online-player roster). Optional; falls back to a CSS button.",
+    assetType: "ability_icon",
+    defaultPrompt:
+      "A single roster / list-of-people icon — a small parchment scroll with a row of tiny figures or names, centered, soft outline, transparent background.",
+    transparent: true,
     optional: true,
   },
   {

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -841,6 +841,48 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     aspect: "landscape",
     optional: true,
   },
+  // Who panel (online-player roster): a painted backdrop plus the two per-row
+  // action buttons (examine, send tell). All optional; each resolves authored
+  // key → CSS fallback.
+  {
+    key: "who_bg",
+    defaultFilename: "who_bg.png",
+    label: "Who Panel Background",
+    description:
+      "Fully painted backdrop for the who panel — the roster of online players. The name list and per-row action buttons overlay it. Falls back to the procedural panel when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "An ornate carved-wood roster board backdrop filling the frame edge to edge — a grand timber frame wrapped in vines and wildflowers, brass fittings and corner studs, a soft hanging lantern glow, an open uncluttered central area where a list of player names overlays, warm magical light, wide landscape composition, no figures, no readable text.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
+    key: "who_examine_btn",
+    defaultFilename: "who_examine_btn.png",
+    label: "Who — Examine Button",
+    description:
+      "Per-row button on the who panel that examines the selected player. The label/icon is rendered in CSS over it. Falls back to a carved CSS button.",
+    assetType: "ornament",
+    defaultPrompt:
+      "A single ornate carved-wood and brass UI button with a faceted blue gem and a faint magnifying-glass / eye motif, soft cool inner glow, isolated decorative button element, transparent background, blank face, no readable text.",
+    transparent: true,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
+    key: "who_tell_btn",
+    defaultFilename: "who_tell_btn.png",
+    label: "Who — Send Tell Button",
+    description:
+      "Per-row button on the who panel that opens a private tell to the selected player. The label/icon is rendered in CSS over it. Falls back to a carved CSS button.",
+    assetType: "ornament",
+    defaultPrompt:
+      "A single ornate carved-wood and brass UI button with a faceted violet gem and a faint sealed-letter / speech-bubble motif, soft warm inner glow, isolated decorative button element, transparent background, blank face, no readable text.",
+    transparent: true,
+    aspect: "landscape",
+    optional: true,
+  },
   {
     key: "trainer_bg",
     defaultFilename: "trainer_bg.png",


### PR DESCRIPTION
@
## Summary

Registers the global assets for the who-panel (online-player roster) redesign. Per-player UI, so plain `globalAssets` keys — no type/sanitize/editor changes.

## New keys (all optional, CSS fallback)

| Key | Depicts | Type / aspect |
|---|---|---|
| `who_bg` | Painted carved-wood roster backdrop; the name list + per-row buttons overlay it | `background`, landscape |
| `who_examine_btn` | Per-row button to examine the selected player | `ornament`, landscape |
| `who_tell_btn` | Per-row button to open a private tell to the selected player | `ornament`, landscape |

`who_bg` is a sibling of `bank_bg`/`chat_bg` (painted hero backdrop). The two buttons follow the `char_btn_*` pattern (`ornament` + transparent; label/icon rendered in CSS over them). Co-located as a "Who panel" group in the file.

## Changes
- **`requiredGlobalAssets.ts`** — add `who_bg`, `who_examine_btn`, `who_tell_btn`. Auto-appear in the Global Assets panel + generator.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — 2125 passed

## Out of scope (separate repo)
The who-panel layout and button wiring live in the AmbonMUD web client. Resolution per piece: authored key → CSS fallback.
@