### PR TITLE
Add guild_bg global asset

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -855,6 +855,17 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     optional: true,
   },
   {
+    key: "guild_widget",
+    defaultFilename: "guild_widget.png",
+    label: "Guild Panel",
+    description: "Services-menu nav button that opens the guild panel. Optional; falls back to a CSS button.",
+    assetType: "ability_icon",
+    defaultPrompt:
+      "A single heraldic guild crest — a banner or shield emblem with a simple charge, centered, soft outline, transparent background.",
+    transparent: true,
+    optional: true,
+  },
+  {
     key: "trainer_bg",
     defaultFilename: "trainer_bg.png",
     label: "Trainer Board Texture",

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -842,6 +842,19 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     optional: true,
   },
   {
+    key: "guild_bg",
+    defaultFilename: "guild_bg.png",
+    label: "Guild Panel Background",
+    description:
+      "Fully painted frame/backdrop for the guild panel. A carved-wood frame around an aged-parchment center where the guild roster and info overlay. Falls back to the procedural panel when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "An ornate carved-wood frame backdrop filling the frame edge to edge — dark timber wrapped in moonlit vines and night-blooming wildflowers, brass fittings and corner studs, a soft hanging lantern glow, an aged-parchment central area where a guild roster overlays, cool night-fae tones with warm lantern accents, wide landscape composition, no figures, no readable text.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
     key: "trainer_bg",
     defaultFilename: "trainer_bg.png",
     label: "Trainer Board Texture",


### PR DESCRIPTION
@
## Summary

Adds `guild_bg` — a painted carved-wood frame backdrop for the guild panel, in the **night-fae parchment** theme consistent with the other panel backgrounds (`bank_bg`, `chat_bg`, `who_bg`, `character_bg`). The guild roster + info overlay the parchment center.

## New key (optional)

| Key | Depicts | Type / aspect |
|---|---|---|
| `guild_bg` | Carved-wood frame around an aged-parchment center; moonlit vines, night-blooming wildflowers, lantern glow | `background`, landscape |

Optional — falls back to the procedural panel. Auto-appears in the Global Assets panel + generator. World visual style applies on top.

## Changes
- **`requiredGlobalAssets.ts`** — add `guild_bg` with the backdrop group (after `chat_bg`).

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — validation/global-asset tests pass

## Out of scope (separate repo)
The guild panel layout/compositing lives in the AmbonMUD web client. Resolution: authored `guild_bg` → CSS fallback.
@