### PR TITLE
Add group_bg and group_widget global assets

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -953,6 +953,30 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     optional: true,
   },
   {
+    key: "group_bg",
+    defaultFilename: "group_bg.png",
+    label: "Group Panel Background",
+    description:
+      "Fully painted backdrop for the group/party panel. A carved-wood frame around an aged-parchment center where the party roster overlays. Falls back to the procedural panel when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "An ornate carved-wood frame backdrop filling the frame edge to edge — dark timber wrapped in moonlit vines and night-blooming wildflowers, brass fittings and corner studs, a soft hanging lantern glow, an aged-parchment central area where a party roster overlays, cool night-fae tones with warm lantern accents, wide landscape composition, no figures, no readable text.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
+    key: "group_widget",
+    defaultFilename: "group_widget.png",
+    label: "Group Panel",
+    description: "Services-menu nav button that opens the group/party panel. Optional; falls back to a CSS button.",
+    assetType: "ability_icon",
+    defaultPrompt:
+      "A single small party of three adventurer silhouettes grouped together, bold silhouette that reads at small size, centered, soft outline, transparent background.",
+    transparent: true,
+    optional: true,
+  },
+  {
     key: "trainer_bg",
     defaultFilename: "trainer_bg.png",
     label: "Trainer Board Texture",


### PR DESCRIPTION
@
## Summary

Group/party panel reskin assets. Both optional, CSS fallback.

| Key | Depicts | Type / aspect |
|---|---|---|
| `group_bg` | Night-fae parchment backdrop for the group/party panel (carved-wood frame, aged-parchment center; party roster overlays) | `background`, landscape |
| `group_widget` | Services-menu nav button (small party-of-three icon) | `ability_icon` |

`group_bg` matches the night-fae backdrop family (`bank_bg`/`chat_bg`/`who_bg`/`guild_bg`/`friends_bg`). `group_widget` joins the `*_widget` services-menu family; uses a three-figure party glyph to distinguish it from `friends_widget` (pair) and `social_widget` (speech bubbles).

## Changes
- **`requiredGlobalAssets.ts`** — add both keys (co-located after the guild group).

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — validation/global-asset tests pass

## Out of scope (separate repo)
Group panel layout/compositing lives in the AmbonMUD web client. Resolution per piece: authored key → CSS fallback.
@