### PR TITLE
Add stylist_bg global asset

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -979,6 +979,19 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     optional: true,
   },
   {
+    key: "stylist_bg",
+    defaultFilename: "stylist_bg.png",
+    label: "Stylist Panel Background",
+    description:
+      "Fully painted backdrop for the stylist panel (appearance / race change) — the velvet purple dressing room. An ornate standing mirror amid draped fabric; the style options overlay the center. Falls back to the procedural panel when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "A plush velvet dressing-room backdrop filling the frame edge to edge — deep amethyst and violet tones, richly draped curtains and fabric, a tall ornate gilt-framed standing mirror, soft ambient glow with faint starlight sparkles on the glass, gentle atmospheric depth, an open uncluttered center where style options overlay, no figures, no reflection of a person, no readable text, suitable as a backdrop behind a stylist panel.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
     key: "group_widget",
     defaultFilename: "group_widget.png",
     label: "Group Panel",


### PR DESCRIPTION
@
## Summary

Adds `stylist_bg` — the backdrop for the stylist panel (appearance / race change), in the **velvet purple dressing room** theme (matching the `equipment_bg` dressing-room family rather than the night-fae carved-wood panels). Pairs with the existing `stylist_mirror` room icon.

| Key | Depicts | Type / aspect |
|---|---|---|
| `stylist_bg` | Plush velvet dressing room — deep amethyst tones, draped fabric, ornate standing mirror; style options overlay the center | `background`, landscape |

Optional — falls back to the procedural panel.

## Changes
- **`requiredGlobalAssets.ts`** — add `stylist_bg` with the backdrop group.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — validation/global-asset tests pass

## Out of scope (separate repo)
Stylist panel layout lives in the AmbonMUD web client. Resolution: authored `stylist_bg` → CSS fallback.
@