### PR TITLE
Add housing_bg global asset

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -1085,6 +1085,19 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     transparent: false,
     aspect: "landscape",
   },
+  {
+    key: "housing_bg",
+    defaultFilename: "housing_bg.png",
+    label: "Housing Broker Background",
+    description:
+      "Fully painted backdrop for the housing broker / estates panel. A sunlit estate-garden scene; the estate list and room-template panels overlay it. Falls back to the procedural panel when absent. (The housing_broker room icon doubles as the panel emblem.)",
+    assetType: "background",
+    defaultPrompt:
+      "A grand sunlit estate-garden courtyard backdrop filling the frame edge to edge — a wisteria-draped wrought-iron arbor with hanging lanterns, blooming rose beds and cobblestone paths, a stately castle estate rising in the distance under a warm bright sky, lush greenery, an open uncluttered center where estate panels overlay, warm golden daylight, no figures, no readable text, suitable as a backdrop behind a housing broker panel.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
   // Character panel — the "Woodland Fae Cabinet". A layered set: the cabinet
   // backdrop is the hero cover; the niche is the sprite alcove; frame/plaque/
   // charm are carved chrome the readouts sit in; the two gem buttons open the


### PR DESCRIPTION
@
## Summary

Adds `housing_bg` — the backdrop for the housing broker / estates panel. Unlike the night-fae and velvet panels, this is a **bright sunlit estate-garden** scene (wisteria arbor, hanging lanterns, rose beds, a distant castle estate), matching the concept art. The estate list + room-template panels overlay it. Pairs with the existing `housing_broker` room icon.

| Key | Depicts | Type / aspect |
|---|---|---|
| `housing_bg` | Sunlit estate-garden courtyard — wisteria arbor, lanterns, roses, distant castle | `background`, landscape |

Optional — falls back to the procedural panel.

## Changes
- **`requiredGlobalAssets.ts`** — add `housing_bg` (after `equipment_bg`, away from the open stylist PRs edit zone to keep merges clean).

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — validation/global-asset tests pass

## Out of scope (separate repo)
Housing broker panel layout lives in the AmbonMUD web client. Resolution: authored `housing_bg` → CSS fallback.
@