### PR TITLE
Add admin_bg global asset

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -1164,6 +1164,19 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     optional: true,
   },
   {
+    key: "admin_bg",
+    defaultFilename: "admin_bg.png",
+    label: "Staff Admin Background",
+    description:
+      "Fully painted backdrop for the staff admin / control panel — a regal celestial cathedral. The admin controls and readouts overlay it. Falls back to the procedural panel when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "A regal celestial-cathedral backdrop filling the frame edge to edge — deep midnight-blue with ornate gold filigree framing, tall blue-and-violet stained-glass arched windows, winged sigil emblems, glowing crescent moons and a golden star compass, a faint starfield and soft gilt sparkles, an open uncluttered dark center where admin controls overlay, authoritative cool blue-and-gold glow, no figures, no readable text, suitable as a backdrop behind a staff control panel.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
     key: "dice_bg",
     defaultFilename: "dice_bg.png",
     label: "Dice Table Background",


### PR DESCRIPTION
@
## Summary

Adds `admin_bg` — the backdrop for the staff admin / control panel ("Staff Control"), a **regal celestial cathedral** matching the concept (midnight blue, ornate gold filigree, blue/violet stained-glass arches, winged sigils, crescent moons, star compass). The admin controls overlay it.

| Key | Depicts | Type / aspect |
|---|---|---|
| `admin_bg` | Regal celestial cathedral — gold filigree, stained glass, winged sigils, crescent moons | `background`, landscape |

Optional — falls back to the procedural panel.

## Changes
- **`requiredGlobalAssets.ts`** — add `admin_bg` next to its celestial sibling `auction_bg`.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — validation/global-asset tests pass

## Out of scope (separate repo)
Staff control panel layout lives in the AmbonMUD web client. Resolution: authored `admin_bg` → CSS fallback.
@