### PR TITLE
Add staff_action_btn / staff_action_btn_active global assets

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -1177,6 +1177,32 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     optional: true,
   },
   {
+    key: "staff_action_btn",
+    defaultFilename: "staff_action_btn.png",
+    label: "Staff Action Button",
+    description:
+      "Stained-glass button background for staff action rows in the admin / control panel (idle state). Sits behind the action label + description. Pairs with staff_action_btn_active for the hover/pressed state. Falls back to the procedural button styling when absent.",
+    assetType: "ornament",
+    defaultPrompt:
+      "A wide horizontal button panel rendered as deep blue-and-violet stained glass set in an ornate gold filigree frame, edge to edge, matching a celestial-cathedral admin theme — midnight-blue glass with faint star motifs, slender gold border with small corner flourishes, a dark uncluttered interior where a button label overlays, subtle gilt sparkle, soft cool glow, no figures, no readable text, transparent background outside the frame.",
+    transparent: true,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
+    key: "staff_action_btn_active",
+    defaultFilename: "staff_action_btn_active.png",
+    label: "Staff Action Button (Active)",
+    description:
+      "Stained-glass button background for staff action rows in the admin / control panel — the lit hover/pressed/selected state. Brighter, more saturated version of staff_action_btn. Falls back to the procedural button styling when absent.",
+    assetType: "ornament",
+    defaultPrompt:
+      "A wide horizontal button panel rendered as glowing blue-and-violet stained glass set in a bright gold filigree frame, edge to edge, matching a celestial-cathedral admin theme — luminous backlit midnight-blue glass with faint star motifs, radiant gold border with corner flourishes, a dark interior where a button label overlays, warm gilt sparkle and a soft ember-gold inner glow signaling the active state, no figures, no readable text, transparent background outside the frame.",
+    transparent: true,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
     key: "dice_bg",
     defaultFilename: "dice_bg.png",
     label: "Dice Table Background",


### PR DESCRIPTION
Adds a pair of optional global asset keys for stained-glass admin action button backgrounds, matching the celestial-cathedral `admin_bg` theme.

- **staff_action_btn** — idle state (deep blue/violet stained glass in a gold filigree frame, edge-to-edge)
- **staff_action_btn_active** — lit hover/pressed/selected state (brighter, backlit, ember-gold inner glow)

Both use `assetType: "ornament"` (edge-to-edge framing, transparent outside the frame), landscape aspect for the wide button rows, and are `optional` → procedural button styling fallback when absent. Placed right after `admin_bg` in `requiredGlobalAssets.ts`.