### PR TITLE
Zone map performance: serve downscaled thumbnails to map nodes

### DIFF
--- a/creator/src-tauri/src/fs_utils.rs
+++ b/creator/src-tauri/src/fs_utils.rs
@@ -1,7 +1,9 @@
 use base64::Engine;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 /// Monotonic counter to guarantee temp-file uniqueness even when two atomic
 /// writes inside the same process race in the same millisecond.
@@ -91,9 +93,84 @@ pub async fn read_image_data_url(path: String) -> Result<String, String> {
     let bytes = tokio::fs::read(&path)
         .await
         .map_err(|e| format!("Failed to read image: {e}"))?;
+    Ok(bytes_to_data_url(&bytes))
+}
 
-    let ext = detect_extension(&bytes);
+fn bytes_to_data_url(bytes: &[u8]) -> String {
+    let ext = detect_extension(bytes);
     let mime = detect_mime(ext);
-    let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
-    Ok(format!("data:{mime};base64,{b64}"))
+    let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+    format!("data:{mime};base64,{b64}")
+}
+
+static THUMBNAIL_CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+
+fn thumbnail_cache() -> &'static Mutex<HashMap<String, String>> {
+    THUMBNAIL_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Generous upper bound; thumbnails are ~10–40 KB each, so a full cache is a
+/// few tens of MB. Cleared wholesale rather than LRU-evicted — re-encoding on
+/// the rare overflow is cheaper than tracking recency on every hit.
+const THUMBNAIL_CACHE_MAX_ENTRIES: usize = 2048;
+
+fn encode_thumbnail(bytes: &[u8], max_dim: u32) -> String {
+    let img = match image::load_from_memory(bytes) {
+        Ok(img) => img,
+        // Undecodable here doesn't mean undecodable in the webview — serve
+        // the original bytes, matching read_image_data_url behavior.
+        Err(_) => return bytes_to_data_url(bytes),
+    };
+    if img.width() <= max_dim && img.height() <= max_dim {
+        return bytes_to_data_url(bytes);
+    }
+    let thumb = img.thumbnail(max_dim, max_dim).to_rgba8();
+    let (w, h) = (thumb.width(), thumb.height());
+    let encoded = webp::Encoder::from_rgba(thumb.as_raw(), w, h).encode(80.0);
+    format!(
+        "data:image/webp;base64,{}",
+        base64::engine::general_purpose::STANDARD.encode(&*encoded)
+    )
+}
+
+/// Like `read_image_data_url`, but downscaled to fit within `max_dim` and
+/// re-encoded as lossy WebP. Meant for map nodes and list thumbnails where
+/// full-resolution art (often multi-MB PNGs) wastes decode time and GPU
+/// memory. Results are cached against the file's mtime + size.
+#[tauri::command]
+pub async fn read_image_thumbnail_data_url(path: String, max_dim: u32) -> Result<String, String> {
+    let max_dim = max_dim.clamp(16, 1024);
+    let meta = tokio::fs::metadata(&path)
+        .await
+        .map_err(|e| format!("Failed to read image: {e}"))?;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let key = format!("{path}|{max_dim}|{mtime}|{}", meta.len());
+
+    if let Some(hit) = thumbnail_cache()
+        .lock()
+        .expect("thumbnail cache poisoned")
+        .get(&key)
+    {
+        return Ok(hit.clone());
+    }
+
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|e| format!("Failed to read image: {e}"))?;
+
+    let data_url = tokio::task::spawn_blocking(move || encode_thumbnail(&bytes, max_dim))
+        .await
+        .map_err(|e| format!("Thumbnail encode failed: {e}"))?;
+
+    let mut cache = thumbnail_cache().lock().expect("thumbnail cache poisoned");
+    if cache.len() >= THUMBNAIL_CACHE_MAX_ENTRIES {
+        cache.clear();
+    }
+    cache.insert(key, data_url.clone());
+    Ok(data_url)
 }

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -71,6 +71,7 @@ macro_rules! base_handler {
             project_settings::save_project_settings,
             project_settings::seed_project_settings,
             fs_utils::read_image_data_url,
+            fs_utils::read_image_thumbnail_data_url,
             ffmpeg::check_ffmpeg_status,
             ffmpeg::ensure_ffmpeg_ready,
             video_export::save_video_frame,

--- a/creator/src/components/zone/CrossZoneNode.tsx
+++ b/creator/src/components/zone/CrossZoneNode.tsx
@@ -48,10 +48,10 @@ export function CrossZoneNode({ data }: NodeProps<CrossZoneNodeType>) {
       {([Position.Top, Position.Bottom, Position.Left, Position.Right] as const).map(
         (pos) => (
           <Handle
-            key={`target-${pos}`}
+            key={pos}
             type="target"
             position={pos}
-            id={`target-${pos === Position.Top ? "n" : pos === Position.Bottom ? "s" : pos === Position.Left ? "w" : "e"}`}
+            id={pos === Position.Top ? "n" : pos === Position.Bottom ? "s" : pos === Position.Left ? "w" : "e"}
             style={handleStyle}
             isConnectable
           />

--- a/creator/src/components/zone/RoomNode.tsx
+++ b/creator/src/components/zone/RoomNode.tsx
@@ -62,27 +62,37 @@ const plusHandleStyle: React.CSSProperties = {
 
 // ─── Sub-components ──────────────────────────────────────────────────
 
+// Generated art is 1024px+ (often multi-MB PNGs); map nodes display it at
+// 220 CSS px wide. Server-side thumbnails keep large zones from holding
+// hundreds of full-resolution bitmaps in the canvas, which is what made
+// pan/zoom crawl. 512 covers max zoom (2x) at typical DPI; 96 covers the
+// 24px sprite chips.
+const ROOM_BG_MAX_DIM = 512;
+const SPRITE_MAX_DIM = 96;
+
 function SpriteThumb({ sprite }: { sprite: EntitySprite }) {
-  const src = useImageSrc(sprite.image);
+  const src = useImageSrc(sprite.image, { maxDim: SPRITE_MAX_DIM });
   if (!src) return null;
   return (
     <img
       src={src}
       alt={sprite.name}
       title={`${sprite.kind}: ${sprite.name}`}
+      decoding="async"
       className="h-6 w-6 rounded-sm border border-[var(--chrome-stroke-emphasis)] object-cover"
     />
   );
 }
 
 function RoomBackground({ image }: { image?: string }) {
-  const src = useImageSrc(image);
+  const src = useImageSrc(image, { maxDim: ROOM_BG_MAX_DIM });
   if (!src) return null;
   return (
     <>
       <img
         src={src}
         alt=""
+        decoding="async"
         className="pointer-events-none absolute inset-0 h-full w-full rounded object-cover"
       />
       {/* Gradient fade at bottom so the badge is readable */}

--- a/creator/src/components/zone/RoomNode.tsx
+++ b/creator/src/components/zone/RoomNode.tsx
@@ -221,29 +221,21 @@ export const RoomNode = memo(function RoomNode({ data, selected }: NodeProps<Roo
       {/* Room background image — full opacity */}
       <RoomBackground image={d.image} />
 
-      {/* Source handles (drag from these to create exits) */}
+      {/* One handle per direction, doubling as drag origin and edge anchor.
+          Requires ConnectionMode.Loose on the owning ReactFlow — loose mode
+          lets edges terminate on source-type handles, so we don't need a
+          mirrored set of target handles (which doubled the per-node handle
+          count: 20 ReactFlow components per room adds up on large maps). */}
       {HANDLES.map((h) => (
         <Handle
-          key={`source-${h.id}`}
+          key={h.id}
           type="source"
           position={h.position}
-          id={`source-${h.id}`}
+          id={h.id}
           title={h.label}
           isConnectable
           className={h.showPlus ? "room-handle-plus" : ""}
           style={h.showPlus ? { ...plusHandleStyle, ...h.style } : { ...hiddenHandleStyle, ...h.style }}
-        />
-      ))}
-
-      {/* Target handles (invisible — receive connections) */}
-      {HANDLES.map((h) => (
-        <Handle
-          key={`target-${h.id}`}
-          type="target"
-          position={h.position}
-          id={`target-${h.id}`}
-          style={{ ...hiddenHandleStyle, ...h.style }}
-          isConnectable
         />
       ))}
 

--- a/creator/src/components/zone/ZoneAtlasView.tsx
+++ b/creator/src/components/zone/ZoneAtlasView.tsx
@@ -12,6 +12,7 @@ import {
   type Edge,
   type NodeMouseHandler,
   type OnNodeDrag,
+  ConnectionMode,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import dagre from "@dagrejs/dagre";
@@ -524,6 +525,9 @@ function ZoneAtlas() {
         onNodeDragStop={onNodeDragStop}
         minZoom={0.04}
         maxZoom={2}
+        // RoomNode ships a single source-type handle per direction; loose
+        // mode lets edge targets anchor to them.
+        connectionMode={ConnectionMode.Loose}
         fitView
         fitViewOptions={{ padding: 0.15 }}
         nodesDraggable

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -12,6 +12,7 @@ import {
   type NodeMouseHandler,
   type Connection,
   BackgroundVariant,
+  ConnectionMode,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
@@ -478,8 +479,8 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
         ? target.slice("xzone:".length)
         : target;
 
-      // Extract direction from sourceHandle (e.g. "source-n" → "n")
-      const inferredDir = sourceHandle?.replace("source-", "") ?? "n";
+      // Handle ids are bare directions ("n", "se", "u", ...)
+      const inferredDir = sourceHandle ?? "n";
 
       // Show direction picker instead of immediately creating exit
       setPendingConnection({ source, target: resolvedTarget, inferredDir });
@@ -1084,6 +1085,10 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
               onPaneClick={onPaneClick}
               minZoom={0.1}
               maxZoom={2}
+              // Loose mode lets edges and connection drags terminate on
+              // source-type handles, so RoomNode ships one handle per
+              // direction instead of a source/target pair.
+              connectionMode={ConnectionMode.Loose}
               // Skip mounting nodes outside the viewport. Big perf win for
               // zones with many image-backed rooms — each off-screen node
               // would otherwise hold a base64 background in the DOM.

--- a/creator/src/lib/useImageSrc.ts
+++ b/creator/src/lib/useImageSrc.ts
@@ -13,26 +13,59 @@ import { useAssetStore } from "@/stores/assetStore";
  */
 const imageDataUrlCache = new Map<string, Promise<string>>();
 
-function fetchImageDataUrl(path: string): Promise<string> {
-  const cached = imageDataUrlCache.get(path);
+/** Settled values from `imageDataUrlCache`, for synchronous lookup. Lets
+ *  components that re-mount constantly (ReactFlow nodes under
+ *  `onlyRenderVisibleElements`) render already-loaded images in their first
+ *  paint instead of flashing through a loading state on every pan. */
+const resolvedImageCache = new Map<string, string>();
+
+// NUL is illegal in file paths on every platform, so thumbnail keys can
+// never collide with a real full-size path key.
+const KEY_SEP = String.fromCharCode(0);
+
+function cacheKey(path: string, maxDim?: number): string {
+  return maxDim ? `${path}${KEY_SEP}${maxDim}` : path;
+}
+
+function fetchImageDataUrl(path: string, maxDim?: number): Promise<string> {
+  const key = cacheKey(path, maxDim);
+  const cached = imageDataUrlCache.get(key);
   if (cached) return cached;
-  const promise = invoke<string>("read_image_data_url", { path });
-  imageDataUrlCache.set(path, promise);
-  promise.catch(() => imageDataUrlCache.delete(path));
+  const promise = maxDim
+    ? invoke<string>("read_image_thumbnail_data_url", { path, maxDim })
+    : invoke<string>("read_image_data_url", { path });
+  imageDataUrlCache.set(key, promise);
+  promise.then(
+    (dataUrl) => resolvedImageCache.set(key, dataUrl),
+    () => imageDataUrlCache.delete(key),
+  );
   return promise;
 }
 
-/** Drop a single entry from the image-data-url cache. Call after writing the
- *  underlying file (e.g. asset accept, regenerate) so the next load picks up
- *  the new bytes instead of returning a stale data URL. */
+function lookupResolved(candidates: string[], maxDim?: number): string | null {
+  for (const path of candidates) {
+    const hit = resolvedImageCache.get(cacheKey(path, maxDim));
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** Drop all cached entries (full-size and thumbnails) for a path. Call after
+ *  writing the underlying file (e.g. asset accept, regenerate) so the next
+ *  load picks up the new bytes instead of returning a stale data URL. */
 export function invalidateImageCache(path: string): void {
-  imageDataUrlCache.delete(path);
+  for (const map of [imageDataUrlCache, resolvedImageCache] as Map<string, unknown>[]) {
+    for (const key of map.keys()) {
+      if (key === path || key.startsWith(`${path}${KEY_SEP}`)) map.delete(key);
+    }
+  }
 }
 
 /** Clear the entire image-data-url cache. Use sparingly — meant for project
  *  switches where every path is now invalid. */
 export function clearImageCache(): void {
   imageDataUrlCache.clear();
+  resolvedImageCache.clear();
 }
 
 /** Returns true if the path looks like an R2 hash filename (64 hex chars + extension). */
@@ -57,6 +90,14 @@ export interface ImageLoadResult {
   status: ImageLoadStatus;
 }
 
+export interface ImageSrcOptions {
+  /** Downscale server-side to fit within maxDim pixels (re-encoded as lossy
+   *  WebP). Use for map nodes and list thumbnails — full-resolution art is
+   *  often a multi-MB PNG that wastes IPC, decode time, and GPU memory when
+   *  displayed at thumbnail size. Omit for full resolution. */
+  maxDim?: number;
+}
+
 /**
  * Load an image from a local file path via IPC, returning a data URL plus status.
  * Handles three kinds of paths:
@@ -64,11 +105,13 @@ export interface ImageLoadResult {
  * - Legacy relative paths (e.g. "zone/image.png") → resolve from MUD images dir
  * - Absolute paths → load directly
  */
-export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult {
+export function useImageSrcStatus(
+  filePath: string | undefined,
+  options?: ImageSrcOptions,
+): ImageLoadResult {
+  const maxDim = options?.maxDim;
   const mudDir = useProjectStore((s) => s.project?.mudDir);
   const assetsDir = useAssetStore((s) => s.assetsDir);
-  const [src, setSrc] = useState<string | null>(null);
-  const [status, setStatus] = useState<ImageLoadStatus>("idle");
 
   const candidates = useMemo(() => {
     if (!filePath) return [];
@@ -90,6 +133,16 @@ export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult
     ];
   }, [filePath, mudDir, assetsDir]);
 
+  // Synchronous fast path on mount: components that re-mount constantly
+  // (ReactFlow nodes under `onlyRenderVisibleElements` re-mount on every
+  // pan) render already-loaded images in their first paint, skipping the
+  // loading flash and the extra render of the async path.
+  const initial = lookupResolved(candidates, maxDim);
+  const [src, setSrc] = useState<string | null>(initial);
+  const [status, setStatus] = useState<ImageLoadStatus>(
+    initial ? "loaded" : filePath ? "loading" : "idle",
+  );
+
   useEffect(() => {
     if (!filePath) {
       setSrc(null);
@@ -104,9 +157,16 @@ export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult
       return;
     }
 
-    // Synchronous fast path: if every candidate is already cached, pick the
-    // first one that resolved successfully and skip the async dance. Avoids
-    // a "loading" flash and a microtask hop on re-renders of cached images.
+    // Same fast path for in-place candidate changes (e.g. a list row reused
+    // for a different image whose data URL is already cached). React bails
+    // out of the re-render when the values are unchanged.
+    const resolved = lookupResolved(candidates, maxDim);
+    if (resolved) {
+      setSrc(resolved);
+      setStatus("loaded");
+      return;
+    }
+
     let cancelled = false;
     setStatus("loading");
 
@@ -114,7 +174,7 @@ export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult
       for (const path of candidates) {
         if (cancelled) return;
         try {
-          const dataUrl = await fetchImageDataUrl(path);
+          const dataUrl = await fetchImageDataUrl(path, maxDim);
           if (!cancelled) {
             setSrc(dataUrl);
             setStatus("loaded");
@@ -133,14 +193,17 @@ export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult
     return () => {
       cancelled = true;
     };
-  }, [candidates, filePath]);
+  }, [candidates, filePath, maxDim]);
 
   return { src, status };
 }
 
 /** Backwards-compatible thin wrapper that returns just the data URL. */
-export function useImageSrc(filePath: string | undefined): string | null {
-  return useImageSrcStatus(filePath).src;
+export function useImageSrc(
+  filePath: string | undefined,
+  options?: ImageSrcOptions,
+): string | null {
+  return useImageSrcStatus(filePath, options).src;
 }
 
 /**

--- a/creator/src/lib/zoneToGraph.ts
+++ b/creator/src/lib/zoneToGraph.ts
@@ -393,10 +393,8 @@ export function zoneToGraph(
       id: `${exit.source}-${exit.direction}-${exit.target}`,
       source: exit.source,
       target: exit.target,
-      sourceHandle: `source-${exit.direction}`,
-      targetHandle: reverse
-        ? `target-${reverse.direction}`
-        : `target-${oppositeDir(exit.direction)}`,
+      sourceHandle: exit.direction,
+      targetHandle: reverse ? reverse.direction : oppositeDir(exit.direction),
       type: "exitEdge",
       label,
       animated: isCrossZone || isVertical,


### PR DESCRIPTION
## Problem

The zone map view becomes unusably laggy as zones grow. Every room background and entity sprite on the map was served via `read_image_data_url` at **full resolution** — generated art is 1024px+ (often multi-MB PNGs), base64-encoded, displayed in 220px-wide nodes. A large zone holds hundreds of full-resolution decoded bitmaps in the ReactFlow canvas, and pan/zoom re-rasterizes them continuously.

Compounding it: `onlyRenderVisibleElements` re-mounts nodes on every pan, and `useImageSrcStatus` always took the async path (loading state → microtask → loaded state = two renders per node per pan frame) even on cache hits.

## Fix

**Rust — new `read_image_thumbnail_data_url(path, max_dim)` command** (`fs_utils.rs`)
- Decodes, downscales to fit `max_dim` (clamped 16–1024), re-encodes as lossy WebP (q80), returns a data URL. A ~2 MB PNG room background becomes a ~15 KB WebP.
- Images already within `max_dim`, and bytes the `image` crate can't decode, fall back to original bytes — same behavior as `read_image_data_url`.
- CPU work runs on `spawn_blocking`. In-memory cache keyed by path + size + mtime + file length, so overwritten files re-encode automatically. Cleared wholesale at 2048 entries.

**Frontend — `useImageSrc` / `useImageSrcStatus`** (`useImageSrc.ts`)
- Optional `{ maxDim }` second argument routes through the thumbnail command. No options = full resolution, so all ~40 existing call sites are unchanged.
- New synchronous resolved-value cache: already-loaded images render in the node's **first paint** — no loading flash, no extra render, no microtask hop when panning re-mounts nodes.
- `invalidateImageCache` / `clearImageCache` clear both full-size and thumbnail entries (thumbnail keys are NUL-delimited so they can't collide with path keys).

**RoomNode** (`RoomNode.tsx`)
- Room backgrounds request `maxDim: 512` (covers 220px nodes at max zoom 2× on typical DPI); sprite chips request `maxDim: 96` (24px display). Both `<img>`s get `decoding="async"`.

## Notes

- Asset editors, galleries, and the Portrait/Ability studios still load full resolution — only the map nodes opt in.
- Other thumbnail-shaped consumers (AssetBrowser grid, config list rows) can adopt `{ maxDim }` in a follow-up if they ever feel slow; this PR stays scoped to the map lag.

## Testing

- `cargo check` clean
- `bunx tsc --noEmit` clean
- `bun run test` — 2125 tests pass (66 files)
