### PR TITLE
Route player sprite generation through the standard art pipeline

### DIFF
--- a/creator/src/components/PlayerSpriteHelpers.tsx
+++ b/creator/src/components/PlayerSpriteHelpers.tsx
@@ -308,7 +308,7 @@ export function PromptPreviewModal({
               Preview & Generate
             </h2>
             <p className="mt-0.5 text-2xs text-text-muted">
-              Review and tweak the prompt before generating &mdash; {imageId}
+              Review and tweak the AI-enhanced prompt before generating &mdash; {imageId}
             </p>
           </div>
           <ActionButton onClick={onClose} variant="ghost" size="icon">x</ActionButton>

--- a/creator/src/components/PlayerSpriteManager.tsx
+++ b/creator/src/components/PlayerSpriteManager.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { memo, useState, useMemo, useCallback, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useSpriteDefinitionStore } from "@/stores/spriteDefinitionStore";
 import { useConfigStore } from "@/stores/configStore";
@@ -10,13 +10,12 @@ import { save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { writeFile } from "@tauri-apps/plugin-fs";
 import { BulkBgRemoval } from "@/components/ui/BulkBgRemoval";
 import { AI_ENABLED } from "@/lib/featureFlags";
-import { ENTITY_DIMENSIONS, resolveImageModel } from "@/types/assets";
+import { ENTITY_DIMENSIONS, modelNativelyTransparent, resolveImageModel } from "@/types/assets";
 import { generateAssetImage } from "@/lib/imageGen";
+import { getNegativePrompt } from "@/lib/arcanumPrompts";
 import {
-  buildSpritePrompt,
-  generateSpriteTemplate,
+  buildEnhancedSpritePrompt,
   type SpriteDimensions,
-  type SpritePromptTemplate,
 } from "@/lib/spritePromptGen";
 import type {
   SpriteDefinition,
@@ -49,9 +48,6 @@ function primaryImageId(id: string, def: SpriteDefinition): string {
 function primaryAssetKey(id: string, def: SpriteDefinition): string {
   return primaryImageId(id, def);
 }
-
-const SPRITE_TEMPLATE_VIBE =
-  "Character creation sprites for a fantasy world — each one should be a compelling standalone portrait.";
 
 function findRequirement<T extends RequirementType>(
   requirements: SpriteRequirement[],
@@ -193,6 +189,7 @@ export function PlayerSpriteManager() {
   const assets = useAssetStore((s) => s.assets);
   const assetsDir = useAssetStore((s) => s.assetsDir);
   const settings = useAssetStore((s) => s.settings);
+  const artStyle = useAssetStore((s) => s.artStyle);
   const loadAssets = useAssetStore((s) => s.loadAssets);
   const acceptAsset = useAssetStore((s) => s.acceptAsset);
   const deleteAsset = useAssetStore((s) => s.deleteAsset);
@@ -219,8 +216,6 @@ export function PlayerSpriteManager() {
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
   const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
   const [promptPreview, setPromptPreview] = useState<{ imageId: string; prompt: string } | null>(null);
-  const spriteTemplateRef = useRef<SpritePromptTemplate | null>(null);
-  const spriteTemplatePromiseRef = useRef<Promise<SpritePromptTemplate | null> | null>(null);
 
   const races = useMemo(() => config ? Object.keys(config.races) : [], [config]);
   const classes = useMemo(() => config ? Object.keys(config.classes).filter((c) => c !== "base") : [], [config]);
@@ -236,11 +231,6 @@ export function PlayerSpriteManager() {
     settings?.anthropic_api_key ||
     settings?.openrouter_api_key
   );
-
-  useEffect(() => {
-    spriteTemplateRef.current = null;
-    spriteTemplatePromiseRef.current = null;
-  }, [config]);
 
   // Map imageId → asset file name + asset id for thumbnails & lightbox
   const spriteAssetMap = useMemo(() => {
@@ -335,32 +325,6 @@ export function PlayerSpriteManager() {
 
   const selectedDef = selectedId ? definitions[selectedId] : null;
 
-  const ensureSpriteTemplate = useCallback(async (): Promise<SpritePromptTemplate | null> => {
-    if (spriteTemplateRef.current) return spriteTemplateRef.current;
-    if (spriteTemplatePromiseRef.current) return spriteTemplatePromiseRef.current;
-    if (!config || !hasLlmKey) return null;
-
-    const promise = generateSpriteTemplate(
-      Object.keys(config.races),
-      Object.keys(config.classes),
-      SPRITE_TEMPLATE_VIBE,
-    )
-      .then((template) => {
-        spriteTemplateRef.current = template;
-        return template;
-      })
-      .catch((error) => {
-        console.warn("Failed to generate sprite prompt template, using fallback prompt composition.", error);
-        return null;
-      })
-      .finally(() => {
-        spriteTemplatePromiseRef.current = null;
-      });
-
-    spriteTemplatePromiseRef.current = promise;
-    return promise;
-  }, [config, hasLlmKey]);
-
   const handleAdd = useCallback(() => {
     const id = newId.trim().toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_]/g, "");
     if (!id || definitions[id]) return;
@@ -413,16 +377,18 @@ export function PlayerSpriteManager() {
         const resolved = findSpriteEntry(definitions, imageId);
         if (!resolved) throw new Error(`Unable to resolve sprite definition for "${imageId}".`);
 
-        const template = await ensureSpriteTemplate();
-        const dimensions = resolveSpriteDimensions(resolved.definition, resolved.variant);
-        const rawPrompt = buildSpritePrompt(
-          dimensions,
-          template,
-          spritePromptNotes(resolved.definition, resolved.variant),
-        );
-        const finalPrompt = rawPrompt;
         const model = resolveImageModel(imageProvider, settings?.image_model);
         if (!model) throw new Error("No image model available");
+
+        const dimensions = resolveSpriteDimensions(resolved.definition, resolved.variant);
+        const finalPrompt = await buildEnhancedSpritePrompt({
+          displayName: resolved.variant?.displayName || resolved.definition.displayName,
+          dimensions,
+          notes: spritePromptNotes(resolved.definition, resolved.variant),
+          style: artStyle,
+          nativeTransparency: modelNativelyTransparent(imageProvider, model.id),
+          enhance: hasLlmKey,
+        });
 
         const dims = ENTITY_DIMENSIONS.player_sprite ?? { width: 512, height: 512 };
 
@@ -433,6 +399,7 @@ export function PlayerSpriteManager() {
           width: dims.width,
           height: dims.height,
           assetType: "player_sprite",
+          negativePrompt: getNegativePrompt("player_sprite"),
         });
 
         const assetContext: AssetContext = { zone: "sprites", entity_type: "player_sprite", entity_id: imageId };
@@ -453,7 +420,7 @@ export function PlayerSpriteManager() {
         setGenerating(null);
       }
     },
-    [acceptAsset, config, definitions, ensureSpriteTemplate, hasApiKey, imageProvider, loadAssets, settings],
+    [acceptAsset, artStyle, definitions, hasApiKey, hasLlmKey, imageProvider, loadAssets, settings],
   );
 
   const handleExportSheet = useCallback(async () => {
@@ -642,16 +609,25 @@ export function PlayerSpriteManager() {
       const resolved = findSpriteEntry(definitions, imageId);
       if (!resolved) return;
 
-      const template = await ensureSpriteTemplate();
+      const model = resolveImageModel(imageProvider, settings?.image_model);
       const dimensions = resolveSpriteDimensions(resolved.definition, resolved.variant);
-      const rawPrompt = buildSpritePrompt(
-        dimensions,
-        template,
-        spritePromptNotes(resolved.definition, resolved.variant),
-      );
-      setPromptPreview({ imageId, prompt: rawPrompt });
+
+      setGenerating(imageId);
+      try {
+        const prompt = await buildEnhancedSpritePrompt({
+          displayName: resolved.variant?.displayName || resolved.definition.displayName,
+          dimensions,
+          notes: spritePromptNotes(resolved.definition, resolved.variant),
+          style: artStyle,
+          nativeTransparency: model ? modelNativelyTransparent(imageProvider, model.id) : false,
+          enhance: hasLlmKey,
+        });
+        setPromptPreview({ imageId, prompt });
+      } finally {
+        setGenerating(null);
+      }
     },
-    [config, definitions, ensureSpriteTemplate],
+    [artStyle, definitions, hasLlmKey, imageProvider, settings],
   );
 
   const handleGenerateWithPrompt = useCallback(
@@ -676,6 +652,7 @@ export function PlayerSpriteManager() {
           width: dims.width,
           height: dims.height,
           assetType: "player_sprite",
+          negativePrompt: getNegativePrompt("player_sprite"),
         });
 
         const assetContext: AssetContext = { zone: "sprites", entity_type: "player_sprite", entity_id: imageId };
@@ -696,7 +673,7 @@ export function PlayerSpriteManager() {
         setGenerating(null);
       }
     },
-    [promptPreview, acceptAsset, hasApiKey, hasLlmKey, imageProvider, loadAssets, settings],
+    [promptPreview, acceptAsset, hasApiKey, imageProvider, loadAssets, settings],
   );
 
   return (

--- a/creator/src/components/SpriteScaffold.tsx
+++ b/creator/src/components/SpriteScaffold.tsx
@@ -8,11 +8,10 @@ import { useFocusTrap } from "@/lib/useFocusTrap";
 import { removeBgAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
 import { ENTITY_DIMENSIONS, resolveImageModel, requestsTransparentBackground, modelNativelyTransparent } from "@/types/assets";
 import { generateAssetImage } from "@/lib/imageGen";
+import { getNegativePrompt } from "@/lib/arcanumPrompts";
 import {
-  buildSpritePrompt,
+  buildEnhancedSpritePrompt,
   generateArtDirection,
-  generateSpriteTemplate,
-  type SpritePromptTemplate,
 } from "@/lib/spritePromptGen";
 import {
   computeGaps,
@@ -22,9 +21,6 @@ import {
 } from "@/lib/spriteScaffold";
 import type { AssetContext } from "@/types/assets";
 import { ActionButton } from "./ui/FormWidgets";
-
-const SPRITE_TEMPLATE_VIBE =
-  "Character creation sprites for a fantasy world — each one should be a compelling standalone portrait.";
 
 const GENDER_OPTIONS = [
   { value: "male", label: "Male" },
@@ -52,6 +48,7 @@ export function SpriteScaffold({ onClose, onComplete }: SpriteScaffoldProps) {
   const saveDefinitions = useSpriteDefinitionStore((s) => s.saveDefinitions);
   const project = useProjectStore((s) => s.project);
   const settings = useAssetStore((s) => s.settings);
+  const artStyle = useAssetStore((s) => s.artStyle);
   const acceptAsset = useAssetStore((s) => s.acceptAsset);
   const loadAssets = useAssetStore((s) => s.loadAssets);
 
@@ -143,19 +140,6 @@ export function SpriteScaffold({ onClose, onComplete }: SpriteScaffoldProps) {
     }
     await saveDefinitions(project);
 
-    let template: SpritePromptTemplate | null = null;
-    if (hasLlmKey) {
-      try {
-        template = await generateSpriteTemplate(
-          Object.keys(config.races),
-          Object.keys(config.classes),
-          SPRITE_TEMPLATE_VIBE,
-        );
-      } catch {
-        // Fall back to default template composition
-      }
-    }
-
     const concurrency = settings.batch_concurrency ?? 3;
     const queue = [...slots.keys()];
     let done = 0;
@@ -173,29 +157,37 @@ export function SpriteScaffold({ onClose, onComplete }: SpriteScaffoldProps) {
 
         try {
           const dimensions = { race: slot.race, playerClass: slot.playerClass, gender: slot.gender };
+          const defForSlot = pairs.find(([id]) => id === slot.id)?.[1];
+          const displayName = defForSlot?.displayName ?? slot.id;
 
           let artDirection: string | undefined;
           if (hasLlmKey) {
             try {
-              const defForSlot = pairs.find(([id]) => id === slot.id)?.[1];
               artDirection = await generateArtDirection(
-                defForSlot?.displayName ?? slot.id,
+                displayName,
                 slot.race,
                 slot.playerClass,
                 slot.gender,
               );
-              if (artDirection) {
-                setDefinition(slot.id, { ...defForSlot!, artDirection });
+              if (artDirection && defForSlot) {
+                setDefinition(slot.id, { ...defForSlot, artDirection });
               }
             } catch {
               // Art direction is best-effort; proceed without it
             }
           }
 
-          const prompt = buildSpritePrompt(dimensions, template, artDirection);
-
           const model = resolveImageModel(imageProvider, settings?.image_model);
           if (!model) throw new Error("No image model available");
+
+          const prompt = await buildEnhancedSpritePrompt({
+            displayName,
+            dimensions,
+            notes: artDirection,
+            style: artStyle,
+            nativeTransparency: modelNativelyTransparent(imageProvider, model.id),
+            enhance: hasLlmKey,
+          });
 
           const dims = ENTITY_DIMENSIONS.player_sprite ?? { width: 512, height: 512 };
 
@@ -206,6 +198,7 @@ export function SpriteScaffold({ onClose, onComplete }: SpriteScaffoldProps) {
             width: dims.width,
             height: dims.height,
             assetType: "player_sprite",
+            negativePrompt: getNegativePrompt("player_sprite"),
           });
 
           const imageId = slot.id;
@@ -248,7 +241,7 @@ export function SpriteScaffold({ onClose, onComplete }: SpriteScaffoldProps) {
     setPhase("done");
   }, [
     config, project, settings, filteredMissing, definitions, hasLlmKey,
-    imageProvider, setDefinition, saveDefinitions,
+    artStyle, imageProvider, setDefinition, saveDefinitions,
     acceptAsset, loadAssets,
   ]);
 

--- a/creator/src/lib/__tests__/spritePromptGen.test.ts
+++ b/creator/src/lib/__tests__/spritePromptGen.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildEnhancedSpritePrompt,
+  spriteBasePrompt,
+  spriteContext,
+} from "../spritePromptGen";
+import {
+  SPRITE_FRAMING_DIRECTIVE,
+  SPRITE_SAFETY_DIRECTIVE,
+} from "../arcanumPrompts";
+import { useConfigStore } from "@/stores/configStore";
+import type { ApplicationConfig } from "@/types/config";
+
+const TEST_CONFIG = {
+  races: {
+    emberkin: {
+      bodyDescription: "small flame-wreathed humanoid with obsidian skin",
+      imagePromptDirective: "NO HUMAN FACE",
+    },
+  },
+  classes: {
+    warden: { outfitDescription: "rust-red leather armor with a curved hunting bow" },
+  },
+} as unknown as ApplicationConfig;
+
+afterEach(() => {
+  useConfigStore.setState({ config: null });
+});
+
+describe("spriteContext", () => {
+  it("describes the sprite's purpose and dimensions", () => {
+    const context = spriteContext("Emberkin Warden", {
+      race: "emberkin",
+      playerClass: "warden",
+      gender: "female",
+    });
+    expect(context).toContain('"Emberkin Warden"');
+    expect(context).toMatch(/standing/i);
+    expect(context).toContain("Gender: female");
+    expect(context).toContain("Race: emberkin");
+    expect(context).toContain("Class: warden");
+  });
+
+  it("includes config descriptions and the race hard constraint", () => {
+    useConfigStore.setState({ config: TEST_CONFIG });
+    const context = spriteContext("Emberkin Warden", {
+      race: "emberkin",
+      playerClass: "warden",
+    });
+    expect(context).toContain("flame-wreathed humanoid");
+    expect(context).toContain("rust-red leather armor");
+    expect(context).toContain("NO HUMAN FACE");
+  });
+
+  it("falls back to traveler's clothing when no class is set", () => {
+    const context = spriteContext("Wanderer", { race: "emberkin" });
+    expect(context).toMatch(/traveler's clothing/);
+  });
+
+  it("appends free-form notes as art direction", () => {
+    const context = spriteContext("Hero", {}, "wields a flaming greatsword");
+    expect(context).toContain("Art direction: wields a flaming greatsword");
+  });
+});
+
+describe("spriteBasePrompt", () => {
+  it("uses the standing full-body sprite format with bg-removal safety", () => {
+    const prompt = spriteBasePrompt({ race: "emberkin", gender: "male" }, "gentle_magic");
+    expect(prompt).toMatch(/full-body character sprite/i);
+    expect(prompt).toMatch(/standing pose/i);
+    expect(prompt).toContain(SPRITE_SAFETY_DIRECTIVE);
+  });
+
+  it("uses light framing rules for native-transparency models", () => {
+    const prompt = spriteBasePrompt({ race: "emberkin" }, "gentle_magic", undefined, true);
+    expect(prompt).toContain(SPRITE_FRAMING_DIRECTIVE);
+    expect(prompt).not.toContain(SPRITE_SAFETY_DIRECTIVE);
+  });
+
+  it("carries the race image-prompt directive verbatim", () => {
+    useConfigStore.setState({ config: TEST_CONFIG });
+    const prompt = spriteBasePrompt({ race: "emberkin" }, "arcanum");
+    expect(prompt).toContain("NO HUMAN FACE");
+  });
+});
+
+describe("buildEnhancedSpritePrompt", () => {
+  it("returns the composed base prompt without an LLM when enhancement is off", async () => {
+    const prompt = await buildEnhancedSpritePrompt({
+      displayName: "Emberkin Warden",
+      dimensions: { race: "emberkin", playerClass: "warden" },
+      style: "gentle_magic",
+      enhance: false,
+    });
+    expect(prompt).toBe(spriteBasePrompt({ race: "emberkin", playerClass: "warden" }, "gentle_magic"));
+  });
+});

--- a/creator/src/lib/arcanumPrompts.ts
+++ b/creator/src/lib/arcanumPrompts.ts
@@ -128,6 +128,7 @@ export const FORMAT_BY_TYPE: Record<string, string> = {
   gathering_node: "1:1 square interactable resource node sprite, 3/4 isometric perspective view of an in-world harvest point grounded on the floor, full silhouette visible, clean simple background, no hands, no characters, no UI",
   ability_icon: "1:1 square ability icon centered in frame, symbolic/iconic representation",
   status_effect_icon: "1:1 square status effect icon centered in frame, symbolic/iconic representation",
+  player_sprite: "1:1 square full-body character sprite, the entire figure visible head to toe in a relaxed confident standing pose, facing the viewer, centered with padding on all sides, clean simple background, clear readable silhouette at small sizes",
   race_portrait: "3:2 landscape orientation character portrait, close-up to mid-shot framing, richly detailed painterly environment background",
   class_portrait: "3:2 landscape orientation action portrait, mid-shot framing, dynamic or atmospheric pose, richly detailed painterly environment background",
   faction_emblem: "1:1 square heraldic sigil centered in frame, single iconic emblem fills most of the canvas, dark uniform background suitable for a circular badge, no text, no scenery, no characters",
@@ -157,7 +158,7 @@ export const FORMAT_BY_ASSET_TYPE: Partial<Record<AssetType, string>> = {
   lever_handle: "1:1 square sprite of a single lever handle/arm oriented vertically pointing straight up, centered, the pivot end at the bottom and the grip at the top, the whole handle in frame with padding, no mounting plate, no wall, no characters, clean flat background",
   door_frame: "2:3 portrait sprite of a single empty doorway frame viewed straight head-on, the opening hollow and empty (no door panel inside), centered with padding, no door leaf, no wall around it, no characters, clean flat background",
   door_leaf: "2:3 portrait sprite of a single closed door panel/leaf viewed straight head-on, the whole leaf in frame with padding, no surrounding frame, no wall, no characters, clean flat background",
-  player_sprite: FORMAT_BY_TYPE.mob,
+  player_sprite: FORMAT_BY_TYPE.player_sprite,
   race_portrait: FORMAT_BY_TYPE.race_portrait,
   class_portrait: FORMAT_BY_TYPE.class_portrait,
   faction_emblem: FORMAT_BY_TYPE.faction_emblem,
@@ -417,8 +418,8 @@ export const ASSET_TEMPLATES: Record<AssetType, { label: string; templates: Reco
   player_sprite: {
     label: "Player Sprite",
     templates: {
-      arcanum: `A heroic fantasy character portrait against deep cosmic indigo void — the character stands in a confident adventuring pose, rendered with faithful anatomy and detailed equipment appropriate to their class and level, baroque aurum-gold energy scrollwork frames the figure as an ornate portrait border, warm golden light illuminates the character from a central point creating soft bloom, cool blue-violet atmospheric fill provides depth, the character's race is clearly depicted with distinct physical features, equipment quality and ornamentation reflects their power tier, centered square portrait composition, painterly, luminous, extremely detailed, heroic`,
-      gentle_magic: `A fantasy character portrait in a gentle enchanted setting — the character stands in a natural adventuring pose, rendered with faithful anatomy and detailed equipment appropriate to their class and level, soft ambient light in lavender and pale blue creates a dreamlike atmosphere, the character's race is clearly depicted with warm approachable features, equipment has a handcrafted quality with subtle magical glow, floating motes of light and gentle atmospheric haze surround the figure, small organic details like moss or tiny flowers at their feet, centered square portrait composition, painterly, luminous, dreamlike, characterful`,
+      arcanum: `A full-body fantasy adventurer rendered as an isolated game sprite — the entire figure visible from head to toe in a relaxed confident standing pose, weight settled naturally, facing the viewer, rendered with faithful anatomy and detailed class-defining equipment depicted realistically with Arcanum palette lighting, warm aurum-gold light catching armor edges and fabric folds with soft bloom, cool blue-violet tones in the shadows, the character's race clearly depicted with distinct physical features, a clear strong silhouette that reads instantly even at small sizes, centered square composition with padding on all sides, painterly, luminous, extremely detailed`,
+      gentle_magic: `A full-body fantasy adventurer rendered as an isolated game sprite — the entire figure visible from head to toe in a relaxed natural standing pose, facing the viewer, rendered with faithful anatomy and handcrafted class-defining equipment with a subtle magical glow, soft ambient lighting in the Gentle Magic palette with lavender and pale blue undertones and soft gold highlights, no harsh shadows, the character's race clearly depicted with warm approachable features, a clear gentle silhouette that reads instantly even at small sizes, centered square composition with padding on all sides, painterly, luminous, dreamlike, characterful`,
     },
   },
   class_portrait: {

--- a/creator/src/lib/spritePromptGen.ts
+++ b/creator/src/lib/spritePromptGen.ts
@@ -1,19 +1,19 @@
 import { invoke } from "@tauri-apps/api/core";
-import { getStyleSuffix, parseLlmJson } from "./arcanumPrompts";
+import {
+  getEnhanceSystemPrompt,
+  getFormatForAssetType,
+  getPreamble,
+  getStyleSuffix,
+  withSpriteSafety,
+  type ArtStyle,
+} from "./arcanumPrompts";
 import { useConfigStore } from "@/stores/configStore";
-import { buildToneDirective, buildVisualStyleDirective } from "./loreGeneration";
+import { buildToneDirective } from "./loreGeneration";
 import {
   DEFAULT_RACE_BODY_DESCRIPTIONS,
   DEFAULT_CLASS_OUTFIT_DESCRIPTIONS,
 } from "./defaultSpriteData";
 import { AI_ENABLED } from "@/lib/featureFlags";
-
-// Fallback art-direction when the world has no visualStyle defined.
-// Kept lean — we never want project-specific aesthetic baked into code —
-// but dense enough to stop FLUX drifting into its default painterly
-// ranger-in-a-forest look on a minimal prompt.
-const GENERIC_SPRITE_STYLE_FALLBACK =
-  "Digital fantasy character illustration, painterly with clear readable silhouette, consistent world aesthetic. NOT a photograph, NOT a 3D render, NOT concept art.";
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -23,10 +23,16 @@ export interface SpriteDimensions {
   gender?: string;
 }
 
-export interface SpritePromptTemplate {
-  raceDescriptions: Record<string, string>;
-  classOutfits: Record<string, string>;
-  generatedAt: string;
+export interface SpritePromptArgs {
+  displayName: string;
+  dimensions: SpriteDimensions;
+  /** Free-form steering text: artDirection, description, variant label. */
+  notes?: string;
+  style: ArtStyle;
+  /** Model produces native transparency — use light framing rules instead of the lavender chroma-key. */
+  nativeTransparency?: boolean;
+  /** Run the LLM enhancement pass. When false, returns the composed base prompt. */
+  enhance?: boolean;
 }
 
 // ─── Data resolution ─────────────────────────────────────────────────
@@ -60,130 +66,115 @@ export function getClassOutfitDescription(cls: string): string {
 
 // ─── Prompt assembly ─────────────────────────────────────────────────
 
-function resolveRaceFragment(
-  race: string,
-  template: SpritePromptTemplate | null,
-): string {
-  if (template?.raceDescriptions[race]) return `${race}, ${template.raceDescriptions[race]}`;
-  return race;
-}
-
-function resolveClassFragment(
-  cls: string,
-  template: SpritePromptTemplate | null,
-): string {
-  if (template?.classOutfits[cls]) return template.classOutfits[cls];
-  return cls;
-}
-
-export function buildSpritePrompt(
-  dimensions: SpriteDimensions,
-  template?: SpritePromptTemplate | null,
-  extraContext?: string,
-): string {
-  const subject: string[] = [];
-
-  if (dimensions.gender) subject.push(dimensions.gender);
-
+function spriteSubject(dimensions: SpriteDimensions): string {
+  const parts: string[] = [];
+  if (dimensions.gender) parts.push(dimensions.gender);
   if (dimensions.race) {
-    subject.push(extraContext?.trim()
-      ? `${extraContext.trim()} (${dimensions.race})`
-      : resolveRaceFragment(dimensions.race, template ?? null));
-  } else if (extraContext?.trim()) {
-    subject.push(extraContext.trim());
-  }
-
-  if (dimensions.playerClass) {
-    subject.push(resolveClassFragment(dimensions.playerClass, template ?? null));
+    const desc = getRaceBodyDescription(dimensions.race);
+    parts.push(desc !== dimensions.race ? `${dimensions.race} (${desc})` : dimensions.race);
   } else {
-    subject.push("wearing simple traveler's clothing");
+    parts.push("adventurer");
   }
+  if (dimensions.playerClass) {
+    parts.push(getClassOutfitDescription(dimensions.playerClass));
+  } else {
+    parts.push("wearing simple traveler's clothing");
+  }
+  return parts.join(", ");
+}
 
-  // Wire world-defined visualStyle and tone into the prompt so sprites
-  // respect the same aesthetic as portraits and world art. Without this,
-  // FLUX ignores the world and falls back to its generic painterly
-  // fantasy default.
-  const visualStyle = buildVisualStyleDirective("worldbuilding");
-  const toneDirective = buildToneDirective({ imageContext: true });
-  const prefix = visualStyle
-    ? `${visualStyle}. NOT a photograph, NOT a 3D render, NOT concept art.`
-    : GENERIC_SPRITE_STYLE_FALLBACK;
-  const toneLine = toneDirective ? `\n${toneDirective}\n` : "";
+/**
+ * Entity-context block fed to the prompt enhancer — same role as
+ * `mobContext` in the zone batch pipeline.
+ */
+export function spriteContext(
+  displayName: string,
+  dimensions: SpriteDimensions,
+  notes?: string,
+): string {
+  const parts = [
+    `Player character sprite "${displayName}" — a full-body standing figure used as a "player is standing here" marker composited into room scenes at small sizes.`,
+  ];
+  if (dimensions.gender) parts.push(`Gender: ${dimensions.gender}`);
+  if (dimensions.race) {
+    const desc = getRaceBodyDescription(dimensions.race);
+    parts.push(desc !== dimensions.race ? `Race: ${dimensions.race} — ${desc}` : `Race: ${dimensions.race}`);
+  }
+  if (dimensions.playerClass) {
+    const desc = getClassOutfitDescription(dimensions.playerClass);
+    parts.push(
+      desc !== dimensions.playerClass
+        ? `Class: ${dimensions.playerClass} — outfit: ${desc}`
+        : `Class: ${dimensions.playerClass}`,
+    );
+  } else {
+    parts.push("No class — wearing simple traveler's clothing");
+  }
+  const directive = getRaceImagePromptDirective(dimensions.race);
+  if (directive) {
+    parts.push(`Hard constraint for this race (must never be contradicted): ${directive}`);
+  }
+  if (notes?.trim()) parts.push(`Art direction: ${notes.trim()}`);
+  return parts.join("\n");
+}
 
-  const body = `1:1 square full-body character illustration, centered, clean neutral background. ${subject.join(", ")}`;
-
-  // Race-level verbatim directive (e.g. "NO FACE NO HUMAN FACE") — placed
-  // adjacent to the subject so FLUX gives it real weight, not after the
-  // style suffix where late tokens get downweighted.
+/**
+ * Composed base prompt — used directly when LLM enhancement is unavailable,
+ * and handed to the enhancer as the reference style template. Mirrors the
+ * `mobPrompt` shape from the zone batch pipeline.
+ */
+export function spriteBasePrompt(
+  dimensions: SpriteDimensions,
+  style: ArtStyle,
+  notes?: string,
+  nativeTransparency?: boolean,
+): string {
+  const preamble = getPreamble(style, "worldbuilding");
+  const tone = buildToneDirective({ imageContext: true });
+  const toneLine = tone ? `\n${tone}\n` : "";
+  const notesLine = notes?.trim() ? ` ${notes.trim()}.` : "";
   const directive = getRaceImagePromptDirective(dimensions.race);
   const directiveBlock = directive ? `\n\n${directive}` : "";
 
-  return `${prefix}${toneLine}\n\n${body}${directiveBlock}\n\n${getStyleSuffix("worldbuilding")}`;
+  const inner = `${getFormatForAssetType("player_sprite")}. ${preamble}${toneLine}
+
+A full-body standing figure of a ${spriteSubject(dimensions)}.${notesLine} Relaxed confident standing pose, entire figure visible head to toe, clear readable silhouette, painterly, luminous, extremely detailed${directiveBlock}
+
+${getStyleSuffix("worldbuilding")}`;
+
+  return withSpriteSafety(inner, "player_sprite", nativeTransparency);
 }
 
-export function fillSpriteTemplate(
-  template: SpritePromptTemplate,
-  dimensions: SpriteDimensions,
-): string {
-  return buildSpritePrompt(dimensions, template);
-}
+/**
+ * The single sprite prompt path — every generation surface (single
+ * generate, prompt preview, Fill Gaps bulk) goes through here. Runs the
+ * same per-entity LLM enhancement as the zone batch art pipeline; falls
+ * back to the composed base prompt if the LLM is unavailable or errors.
+ */
+export async function buildEnhancedSpritePrompt(args: SpritePromptArgs): Promise<string> {
+  const base = spriteBasePrompt(args.dimensions, args.style, args.notes, args.nativeTransparency);
+  if (!args.enhance || !AI_ENABLED) return base;
 
-// ─── Template generation ─────────────────────────────────────────────
+  try {
+    const systemPrompt = getEnhanceSystemPrompt(
+      args.style,
+      "player_sprite",
+      "worldbuilding",
+      args.nativeTransparency,
+    );
+    const context = spriteContext(args.displayName, args.dimensions, args.notes);
+    const userPrompt = `Generate an image prompt for this entity:\n${context}\n\nReference style template (adapt but prioritize the entity description above):\n${base}`;
+    let finalPrompt = await invoke<string>("llm_complete", { systemPrompt, userPrompt });
 
-export async function generateSpriteTemplate(
-  races: string[],
-  classes: string[],
-  _zoneVibe: string,
-): Promise<SpritePromptTemplate> {
-  if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
-  const raceList = races
-    .map((r) => `- ${r}: ${getRaceBodyDescription(r)}`)
-    .join("\n");
-
-  const classList = classes
-    .filter((c) => c !== "base")
-    .map((c) => `- ${c}: ${getClassOutfitDescription(c)}`)
-    .join("\n");
-
-  const toneDirective = buildToneDirective({ imageContext: true });
-  const toneBlock = toneDirective
-    ? `\n\nWorld context: ${toneDirective}\nDescriptions must match this tone.`
-    : "";
-
-  const systemPrompt = `You write short character descriptions for AI image generation. Keep each description to one concise phrase — just enough to identify the race or class visually. No prose, no storytelling.${toneBlock}
-
-Produce a JSON object with two fields:
-
-1. "raceDescriptions" — map each race key to a SHORT phrase describing physical appearance only (body type, skin, features). 10 words max. Only describe what makes this race visually distinct. For common races like "human", just use the race name.
-
-2. "classOutfits" — map each class key to a SHORT phrase describing outfit and weapon. 10 words max. Just the gear, not the character.
-
-Output ONLY valid JSON.`;
-
-  const userPrompt = `Races:
-${raceList}
-
-Classes:
-${classList}`;
-
-  const response = await invoke<string>("llm_complete", {
-    systemPrompt,
-    userPrompt,
-  });
-
-  const parsed = parseLlmJson<{
-    raceDescriptions?: Record<string, string>;
-    classOutfits?: Record<string, string>;
-  }>(response, "sprite-prompt-gen");
-  if (!parsed.raceDescriptions || !parsed.classOutfits) {
-    throw new Error("Invalid template response: missing required fields (raceDescriptions, classOutfits)");
+    const styleSuffix = getStyleSuffix("worldbuilding");
+    if (!finalPrompt.includes(styleSuffix.slice(0, 40))) {
+      finalPrompt = `${finalPrompt}\n\n${styleSuffix}`;
+    }
+    return finalPrompt;
+  } catch (error) {
+    console.warn("Sprite prompt enhancement failed, using base prompt.", error);
+    return base;
   }
-
-  return {
-    raceDescriptions: parsed.raceDescriptions,
-    classOutfits: parsed.classOutfits,
-    generatedAt: new Date().toISOString(),
-  };
 }
 
 // ─── Art direction generation ────────────────────────────────────────
@@ -230,4 +221,3 @@ Rules:
   });
   return result.trim();
 }
-


### PR DESCRIPTION
## Summary

Player sprites were the only entity art built by mechanical string concatenation (`buildSpritePrompt`) instead of the per-entity LLM enhancement pipeline used by mobs, items, and rooms. They skipped `getEnhanceSystemPrompt` entirely — losing the world visual style integration, tone directive, the lavender chroma-key sprite-safety rules that keep background removal clean, and the universal negative prompt — which is why sprite art looked markedly worse than the rest of Arcanum's generated art.

All three generation surfaces (single generate, prompt preview, Fill Gaps bulk scaffold) now go through `buildEnhancedSpritePrompt`: a `mobPrompt`-shaped base prompt plus a `spriteContext` entity block, run through the same enhancement pass as zone batch art, with the composed base prompt as the no-LLM fallback. The prompt preview modal now shows the final enhanced prompt. The `player_sprite` format spec and `ASSET_TEMPLATES` entry are rewritten for a full-body standing figure with a readable small-size silhouette, since sprites serve as "player is standing here" markers composited into room scenes.

The LLM-generated 10-word race/class fragment template (`generateSpriteTemplate`) is gone; race/class descriptions feed the enhancer's context directly. The `artDirection` field and its AI Suggest auto-generation are retained and flow into the enhancement context.

## Test plan

- [x] `spritePromptGen.test.ts` — new unit coverage for the enhanced prompt assembly
- [ ] Visual check: generate a player sprite and confirm style/quality parity with mob art

🤖 Generated with [Claude Code](https://claude.com/claude-code)