### PR TITLE
Player sprites: full art generator, faster deletes, retire variants

### DIFF
--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -187,6 +187,33 @@ pub async fn delete_asset(app: AppHandle, id: String) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub async fn delete_assets(app: AppHandle, ids: Vec<String>) -> Result<(), String> {
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let _lock = MANIFEST_LOCK.lock().await;
+    let mut manifest = load_manifest(&app).await?;
+    let id_set: std::collections::HashSet<&str> = ids.iter().map(|s| s.as_str()).collect();
+    let base = assets_dir(&app)?;
+
+    for entry in manifest.assets.iter().filter(|a| id_set.contains(a.id.as_str())) {
+        for subdir in &["images", "video", "audio"] {
+            let file_path = base.join(subdir).join(&entry.file_name);
+            if file_path.exists() {
+                tokio::fs::remove_file(&file_path)
+                    .await
+                    .map_err(|e| format!("Failed to delete file: {e}"))?;
+                break;
+            }
+        }
+    }
+
+    manifest.assets.retain(|a| !id_set.contains(a.id.as_str()));
+    save_manifest(&app, &manifest).await?;
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn get_assets_dir(app: AppHandle) -> Result<String, String> {
     let dir = assets_dir(&app)?;
     Ok(dir.to_string_lossy().to_string())

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -82,6 +82,7 @@ macro_rules! base_handler {
             assets::accept_asset,
             assets::list_assets,
             assets::delete_asset,
+            assets::delete_assets,
             assets::get_assets_dir,
             assets::resolve_media_path,
             assets::read_media_data_url,

--- a/creator/src/components/PlayerSpriteHelpers.tsx
+++ b/creator/src/components/PlayerSpriteHelpers.tsx
@@ -1,18 +1,15 @@
 import { memo, useState, useCallback } from "react";
-import { invoke } from "@tauri-apps/api/core";
-import { useImageSrc, isR2HashPath } from "@/lib/useImageSrc";
-import { useFocusTrap } from "@/lib/useFocusTrap";
-import { removeBgAndSave } from "@/lib/useBackgroundRemoval";
+import { useImageSrc } from "@/lib/useImageSrc";
 import { generateArtDirection } from "@/lib/spritePromptGen";
 import { AI_ENABLED } from "@/lib/featureFlags";
 import type { BulkBgTarget } from "@/components/ui/BulkBgRemoval";
 import type {
   SpriteDefinition,
-  SpriteVariant,
   SpriteRequirement,
   RequirementType,
 } from "@/types/sprites";
 import { ActionButton } from "./ui/FormWidgets";
+import { SpriteArtGenerator } from "./SpriteArtGenerator";
 
 // ─── Helpers ────────────────────────────────────────────────────────
 
@@ -75,129 +72,6 @@ export const SpriteThumbnail = memo(function SpriteThumbnail({
     />
   );
 });
-
-// ─── Lightbox ───────────────────────────────────────────────────────
-
-export function SpriteLightbox({
-  spriteKey: key,
-  fileName,
-  variantGroup,
-  canRegenerate,
-  canDelete,
-  onRegenerate,
-  onDelete,
-  onRemoveBg,
-  onFlip,
-  onClose,
-}: {
-  spriteKey: string;
-  fileName: string;
-  variantGroup: string;
-  canRegenerate: boolean;
-  canDelete: boolean;
-  onRegenerate: () => void;
-  onDelete: () => void;
-  onRemoveBg: () => void;
-  onFlip?: (newFileName: string) => void;
-  onClose: () => void;
-}) {
-  const src = useImageSrc(fileName);
-  const [removingBg, setRemovingBg] = useState(false);
-  const [flipping, setFlipping] = useState(false);
-  const lightboxTrapRef = useFocusTrap<HTMLDivElement>(onClose);
-
-  const handleRemoveBg = async () => {
-    if (!src) return;
-    setRemovingBg(true);
-    try {
-      const context = { zone: "sprites", entity_type: "player_sprite", entity_id: key };
-      const entry = await removeBgAndSave(src, "player_sprite", context, variantGroup);
-      if (entry) onRemoveBg();
-    } catch (err) {
-      console.error("[player sprite] bg removal failed:", err);
-    } finally {
-      setRemovingBg(false);
-    }
-  };
-
-  return (
-    <div
-      ref={lightboxTrapRef}
-      className="modal-overlay"
-      onClick={onClose}
-    >
-      <div
-        className="relative flex max-h-[90vh] max-w-[90vw] flex-col items-center gap-3"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {src ? (
-          <img
-            src={src}
-            alt={`Sprite: ${key}`}
-            className="max-h-[80vh] max-w-[80vw] rounded border border-border-default object-contain"
-            style={{ imageRendering: "auto" }}
-          />
-        ) : (
-          <div className="flex h-64 w-64 items-center justify-center rounded border border-border-default bg-bg-tertiary text-text-muted">
-            Rendering preview...
-          </div>
-        )}
-        <span className="font-mono text-xs text-text-secondary">{key}</span>
-        <div className="flex gap-2">
-          <ActionButton
-            onClick={onRegenerate}
-            disabled={!canRegenerate}
-            variant="primary"
-          >
-            Regenerate
-          </ActionButton>
-          <ActionButton
-            onClick={handleRemoveBg}
-            disabled={removingBg || !src}
-            variant="secondary"
-          >
-            {removingBg ? "Removing BG..." : "Remove BG"}
-          </ActionButton>
-          {isR2HashPath(fileName) && onFlip && (
-            <ActionButton
-              onClick={async () => {
-                setFlipping(true);
-                try {
-                  const newFileName = await invoke<string>("flip_image", { imageRef: fileName });
-                  onFlip(newFileName);
-                } catch (e) {
-                  console.error("Flip failed:", e);
-                } finally {
-                  setFlipping(false);
-                }
-              }}
-              disabled={flipping}
-              variant="secondary"
-            >
-              {flipping ? "Flipping..." : "\u21C4 Flip"}
-            </ActionButton>
-          )}
-          <ActionButton
-            onClick={onDelete}
-            disabled={!canDelete}
-            variant="danger"
-          >
-            Delete
-          </ActionButton>
-        </div>
-        <ActionButton
-          aria-label="Close"
-          onClick={onClose}
-          variant="ghost"
-          size="icon"
-          className="absolute -right-4 -top-4"
-        >
-          x
-        </ActionButton>
-      </div>
-    </div>
-  );
-}
 
 // ─── Art direction field ────────────────────────────────────────────
 
@@ -267,82 +141,6 @@ export function ArtDirectionField({
           {error.length > 60 ? `${error.slice(0, 60)}…` : error}
         </span>
       )}
-    </div>
-  );
-}
-
-// ─── Prompt preview modal ──────────────────────────────────────────
-
-interface PromptPreviewModalProps {
-  prompt: string;
-  imageId: string;
-  onGenerate: (editedPrompt: string) => void;
-  onClose: () => void;
-}
-
-export function PromptPreviewModal({
-  prompt,
-  imageId,
-  onGenerate,
-  onClose,
-}: PromptPreviewModalProps) {
-  const [editedPrompt, setEditedPrompt] = useState(prompt);
-  const trapRef = useFocusTrap<HTMLDivElement>(onClose);
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-bg-abyss/70"
-      onClick={onClose}
-    >
-      <div
-        ref={trapRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="prompt-preview-title"
-        className="mx-4 flex max-h-[85vh] w-full max-w-2xl flex-col rounded-lg border border-border-default bg-bg-secondary shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between border-b border-border-default px-5 py-3">
-          <div>
-            <h2 id="prompt-preview-title" className="font-display text-sm tracking-wide text-text-primary">
-              Preview & Generate
-            </h2>
-            <p className="mt-0.5 text-2xs text-text-muted">
-              Review and tweak the AI-enhanced prompt before generating &mdash; {imageId}
-            </p>
-          </div>
-          <ActionButton onClick={onClose} variant="ghost" size="icon">x</ActionButton>
-        </div>
-
-        <div className="flex-1 overflow-y-auto px-5 py-4">
-          <textarea
-            className="ornate-input min-h-[20rem] w-full resize-y rounded-3xl px-4 py-3 text-sm leading-relaxed text-text-primary"
-            value={editedPrompt}
-            onChange={(e) => setEditedPrompt(e.target.value)}
-          />
-        </div>
-
-        <div className="flex items-center justify-between border-t border-border-default px-5 py-3">
-          <button
-            onClick={() => setEditedPrompt(prompt)}
-            className="text-2xs text-text-muted hover:text-text-secondary"
-          >
-            Reset to original
-          </button>
-          <div className="flex gap-2">
-            <ActionButton onClick={onClose} variant="secondary" size="sm">
-              Cancel
-            </ActionButton>
-            <ActionButton
-              onClick={() => onGenerate(editedPrompt)}
-              variant="primary"
-              size="sm"
-            >
-              Generate
-            </ActionButton>
-          </div>
-        </div>
-      </div>
     </div>
   );
 }
@@ -440,141 +238,6 @@ export function RequirementRow({
   );
 }
 
-// ─── Variant editor ─────────────────────────────────────────────────
-
-interface VariantRowProps {
-  variant: SpriteVariant;
-  index: number;
-  races: string[];
-  classes: string[];
-  assetFileName: string | undefined;
-  generating: boolean;
-  hasApiKey: boolean;
-  onPatch: (index: number, patch: Partial<SpriteVariant>) => void;
-  onRemove: (index: number) => void;
-  onGenerate: (variant: SpriteVariant) => void;
-  onPreview: (variant: SpriteVariant) => void;
-  onClickThumbnail?: () => void;
-}
-
-export function VariantRow({
-  variant,
-  index,
-  races,
-  classes,
-  assetFileName,
-  generating,
-  hasApiKey,
-  onPatch,
-  onRemove,
-  onGenerate,
-  onPreview,
-  onClickThumbnail,
-}: VariantRowProps) {
-  return (
-    <div className="flex items-start gap-3 rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-3">
-      <SpriteThumbnail fileName={assetFileName} label={variant.imageId} onClick={onClickThumbnail} />
-
-      <div className="flex min-w-0 flex-1 flex-col gap-2">
-        <div className="grid grid-cols-2 gap-2">
-          <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
-            Image ID
-            <input
-              className="ornate-input min-h-11 rounded-2xl px-3 py-3 text-sm text-text-primary"
-              value={variant.imageId}
-              onChange={(e) => {
-                const imageId = e.target.value;
-                onPatch(index, { imageId, imagePath: `player_sprites/${imageId}.png` });
-              }}
-            />
-          </label>
-          <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
-            Display Name
-            <input
-              className="ornate-input min-h-11 rounded-2xl px-3 py-3 text-sm text-text-primary"
-              placeholder="(inherits parent)"
-              value={variant.displayName ?? ""}
-              onChange={(e) => onPatch(index, { displayName: e.target.value || undefined })}
-            />
-          </label>
-        </div>
-
-        <div className="grid grid-cols-3 gap-2">
-          <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
-            Race Filter
-            <select
-              className="ornate-input min-h-11 rounded-2xl px-3 py-3 text-sm text-text-primary"
-              value={variant.race ?? ""}
-              onChange={(e) => onPatch(index, { race: e.target.value || undefined })}
-            >
-              <option value="">Any</option>
-              {races.map((r) => (
-                <option key={r} value={r}>{r}</option>
-              ))}
-            </select>
-          </label>
-          <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
-            Class Filter
-            <select
-              className="ornate-input min-h-11 rounded-2xl px-3 py-3 text-sm text-text-primary"
-              value={variant.playerClass ?? ""}
-              onChange={(e) => onPatch(index, { playerClass: e.target.value || undefined })}
-            >
-              <option value="">Any</option>
-              {classes.map((c) => (
-                <option key={c} value={c}>{c}</option>
-              ))}
-            </select>
-          </label>
-          <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
-            Gender
-            <select
-              className="ornate-input min-h-11 rounded-2xl px-3 py-3 text-sm text-text-primary"
-              value={variant.gender ?? ""}
-              onChange={(e) => onPatch(index, { gender: e.target.value || undefined })}
-            >
-              <option value="">Any</option>
-              <option value="male">Male</option>
-              <option value="female">Female</option>
-              <option value="nonbinary">Nonbinary</option>
-            </select>
-          </label>
-        </div>
-      </div>
-
-      <div className="flex shrink-0 flex-col gap-1">
-        {AI_ENABLED && (
-          <>
-            <ActionButton
-              onClick={() => onGenerate(variant)}
-              disabled={!hasApiKey || generating}
-              variant="secondary"
-              size="sm"
-            >
-              {generating ? "..." : "Render"}
-            </ActionButton>
-            <ActionButton
-              onClick={() => onPreview(variant)}
-              disabled={!hasApiKey || generating}
-              variant="ghost"
-              size="sm"
-            >
-              Preview
-            </ActionButton>
-          </>
-        )}
-        <ActionButton
-          onClick={() => onRemove(index)}
-          variant="danger"
-          size="sm"
-        >
-          Remove
-        </ActionButton>
-      </div>
-    </div>
-  );
-}
-
 // ─── Sprite detail editor ───────────────────────────────────────────
 
 interface SpriteDetailEditorProps {
@@ -583,14 +246,9 @@ interface SpriteDetailEditorProps {
   races: string[];
   classes: string[];
   spriteAssetMap: Map<string, { fileName: string; assetId: string }>;
-  hasApiKey: boolean;
   hasLlmKey: boolean;
-  generating: string | null;
   onPatch: (patch: Partial<SpriteDefinition>) => void;
   onDelete: () => void;
-  onGenerateImage: (imageId: string) => void;
-  onPreviewGenerate: (imageId: string) => void;
-  onViewSprite: (imageId: string) => void;
 }
 
 export function SpriteDetailEditor({
@@ -599,17 +257,10 @@ export function SpriteDetailEditor({
   races,
   classes,
   spriteAssetMap,
-  hasApiKey,
   hasLlmKey,
-  generating,
   onPatch,
   onDelete,
-  onGenerateImage,
-  onPreviewGenerate,
-  onViewSprite,
 }: SpriteDetailEditorProps) {
-  const useVariants = (def.variants && def.variants.length > 0) || false;
-
   const handleAddRequirement = useCallback(() => {
     onPatch({ requirements: [...def.requirements, emptyRequirement("minLevel")] });
   }, [def.requirements, onPatch]);
@@ -623,47 +274,6 @@ export function SpriteDetailEditor({
   const handleRemoveRequirement = useCallback((index: number) => {
     onPatch({ requirements: def.requirements.filter((_, i) => i !== index) });
   }, [def.requirements, onPatch]);
-
-  const handleSwitchToVariants = useCallback(() => {
-    const variants: SpriteVariant[] = [{
-      imageId: id,
-      imagePath: def.image || `player_sprites/${id}.png`,
-    }];
-    onPatch({ variants, image: undefined });
-  }, [id, def.image, onPatch]);
-
-  const handleSwitchToSingleImage = useCallback(() => {
-    const image = def.variants?.[0]?.imagePath || `player_sprites/${id}.png`;
-    onPatch({ image, variants: undefined });
-  }, [id, def.variants, onPatch]);
-
-  const handlePatchVariant = useCallback((index: number, patch: Partial<SpriteVariant>) => {
-    if (!def.variants) return;
-    const variants = def.variants.map((v, i) => (i === index ? { ...v, ...patch } : v));
-    onPatch({ variants });
-  }, [def.variants, onPatch]);
-
-  const handleRemoveVariant = useCallback((index: number) => {
-    if (!def.variants) return;
-    onPatch({ variants: def.variants.filter((_, i) => i !== index) });
-  }, [def.variants, onPatch]);
-
-  const handleAddVariant = useCallback(() => {
-    const suffix = def.variants ? def.variants.length : 0;
-    const newVariant: SpriteVariant = {
-      imageId: `${id}_v${suffix}`,
-      imagePath: `player_sprites/${id}_v${suffix}.png`,
-    };
-    onPatch({ variants: [...(def.variants ?? []), newVariant] });
-  }, [id, def.variants, onPatch]);
-
-  const handleGenerateForVariant = useCallback((variant: SpriteVariant) => {
-    onGenerateImage(variant.imageId);
-  }, [onGenerateImage]);
-
-  const handlePreviewForVariant = useCallback((variant: SpriteVariant) => {
-    onPreviewGenerate(variant.imageId);
-  }, [onPreviewGenerate]);
 
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-5">
@@ -771,104 +381,14 @@ export function SpriteDetailEditor({
         </div>
       </div>
 
-      {/* Image / Variants */}
+      {/* Image */}
       <div>
-        <div className="mb-2 flex items-center justify-between">
-          <h4 className="font-display text-sm text-text-primary">
-            {useVariants ? `Variants (${def.variants?.length ?? 0})` : "Image"}
-          </h4>
-          <div className="flex gap-2">
-            {useVariants ? (
-              <>
-                <ActionButton
-                  onClick={handleAddVariant}
-                  variant="secondary"
-                  size="sm"
-                >
-                  Add Variant
-                </ActionButton>
-                {(def.variants?.length ?? 0) <= 1 && (
-                  <ActionButton
-                    onClick={handleSwitchToSingleImage}
-                    variant="ghost"
-                    size="sm"
-                  >
-                    Use Single Image
-                  </ActionButton>
-                )}
-              </>
-            ) : (
-              <ActionButton
-                onClick={handleSwitchToVariants}
-                variant="ghost"
-                size="sm"
-              >
-                Use Variants
-              </ActionButton>
-            )}
-          </div>
-        </div>
-
-        {useVariants ? (
-          <div className="flex flex-col gap-3">
-            {def.variants?.map((variant, idx) => (
-              <VariantRow
-                key={variant.imageId}
-                variant={variant}
-                index={idx}
-                races={races}
-                classes={classes}
-                assetFileName={spriteAssetMap.get(variant.imageId)?.fileName}
-                generating={generating === variant.imageId}
-                hasApiKey={hasApiKey}
-                onPatch={handlePatchVariant}
-                onRemove={handleRemoveVariant}
-                onGenerate={handleGenerateForVariant}
-                onPreview={handlePreviewForVariant}
-                onClickThumbnail={() => onViewSprite(variant.imageId)}
-              />
-            ))}
-          </div>
-        ) : (
-          <div className="flex items-center gap-3 rounded-xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-3">
-            <SpriteThumbnail
-              fileName={spriteAssetMap.get(id)?.fileName}
-              label={id}
-              size="h-16 w-16"
-              onClick={() => onViewSprite(id)}
-            />
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-              <label className="flex flex-col gap-0.5 text-2xs text-text-muted">
-                Image Path
-                <input
-                  className="ornate-input min-h-11 rounded-2xl px-3 py-3 text-sm text-text-primary"
-                  value={def.image ?? `player_sprites/${id}.png`}
-                  onChange={(e) => onPatch({ image: e.target.value })}
-                />
-              </label>
-            </div>
-            {AI_ENABLED && (
-              <div className="flex shrink-0 flex-col gap-1">
-                <ActionButton
-                  onClick={() => onGenerateImage(id)}
-                  disabled={!hasApiKey || generating === id}
-                  variant="primary"
-                  size="sm"
-                >
-                  {generating === id ? "Generating..." : "Generate"}
-                </ActionButton>
-                <ActionButton
-                  onClick={() => onPreviewGenerate(id)}
-                  disabled={!hasApiKey || generating === id}
-                  variant="secondary"
-                  size="sm"
-                >
-                  Preview
-                </ActionButton>
-              </div>
-            )}
-          </div>
-        )}
+        <h4 className="mb-2 font-display text-sm text-text-primary">Image</h4>
+        <SpriteArtGenerator
+          id={id}
+          def={def}
+          currentImage={spriteAssetMap.get(id)?.fileName}
+        />
       </div>
     </div>
   );

--- a/creator/src/components/PlayerSpriteManager.tsx
+++ b/creator/src/components/PlayerSpriteManager.tsx
@@ -4,33 +4,20 @@ import { useSpriteDefinitionStore } from "@/stores/spriteDefinitionStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { useAssetStore } from "@/stores/assetStore";
-import { removeBgAndSave } from "@/lib/useBackgroundRemoval";
 import { resolveImageDataUrl } from "@/lib/useImageSrc";
 import { save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { writeFile } from "@tauri-apps/plugin-fs";
 import { BulkBgRemoval } from "@/components/ui/BulkBgRemoval";
-import { AI_ENABLED } from "@/lib/featureFlags";
-import { ENTITY_DIMENSIONS, modelNativelyTransparent, resolveImageModel } from "@/types/assets";
-import { generateAssetImage } from "@/lib/imageGen";
-import { getNegativePrompt } from "@/lib/arcanumPrompts";
-import {
-  buildEnhancedSpritePrompt,
-  type SpriteDimensions,
-} from "@/lib/spritePromptGen";
 import type {
   SpriteDefinition,
-  SpriteVariant,
   SpriteRequirement,
-  RequirementType,
 } from "@/types/sprites";
-import type { AssetContext, SyncProgress } from "@/types/assets";
+import type { SyncProgress } from "@/types/assets";
 import { ActionButton } from "./ui/FormWidgets";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { SpriteScaffold } from "./SpriteScaffold";
 import {
   SpriteThumbnail,
-  SpriteLightbox,
-  PromptPreviewModal,
   SpriteDetailEditor,
   collectSpriteBgTargets,
   requirementLabel,
@@ -47,55 +34,6 @@ function primaryImageId(id: string, def: SpriteDefinition): string {
 /** Get the effective image path for asset lookup. */
 function primaryAssetKey(id: string, def: SpriteDefinition): string {
   return primaryImageId(id, def);
-}
-
-function findRequirement<T extends RequirementType>(
-  requirements: SpriteRequirement[],
-  type: T,
-): Extract<SpriteRequirement, { type: T }> | undefined {
-  return requirements.find(
-    (requirement): requirement is Extract<SpriteRequirement, { type: T }> => requirement.type === type,
-  );
-}
-
-function resolveSpriteDimensions(
-  definition: SpriteDefinition,
-  variant: SpriteVariant | undefined,
-): SpriteDimensions {
-  const race = variant?.race
-    || findRequirement(definition.requirements, "race")?.race
-    || undefined;
-  const playerClass = variant?.playerClass
-    || findRequirement(definition.requirements, "class")?.playerClass
-    || undefined;
-  const gender = variant?.gender || definition.gender || undefined;
-
-  return { race, playerClass, gender };
-}
-
-function findSpriteEntry(
-  definitions: Record<string, SpriteDefinition>,
-  imageId: string,
-): { definitionId: string; definition: SpriteDefinition; variant?: SpriteVariant } | null {
-  for (const [definitionId, definition] of Object.entries(definitions)) {
-    const variant = definition.variants?.find((entry) => entry.imageId === imageId);
-    if (variant) return { definitionId, definition, variant };
-    if ((!definition.variants || definition.variants.length === 0) && definitionId === imageId) {
-      return { definitionId, definition };
-    }
-  }
-  return null;
-}
-
-function spritePromptNotes(definition: SpriteDefinition, variant?: SpriteVariant): string | undefined {
-  const notes = [
-    variant?.displayName && variant.displayName !== definition.displayName
-      ? `Variant label: ${variant.displayName}`
-      : null,
-    definition.artDirection?.trim() || definition.description?.trim() || null,
-  ].filter(Boolean);
-
-  return notes.length > 0 ? notes.join(". ") : undefined;
 }
 
 function hasAnyImage(
@@ -189,10 +127,8 @@ export function PlayerSpriteManager() {
   const assets = useAssetStore((s) => s.assets);
   const assetsDir = useAssetStore((s) => s.assetsDir);
   const settings = useAssetStore((s) => s.settings);
-  const artStyle = useAssetStore((s) => s.artStyle);
   const loadAssets = useAssetStore((s) => s.loadAssets);
-  const acceptAsset = useAssetStore((s) => s.acceptAsset);
-  const deleteAsset = useAssetStore((s) => s.deleteAsset);
+  const deleteAssets = useAssetStore((s) => s.deleteAssets);
 
   useEffect(() => { loadAssets(); }, [loadAssets]);
 
@@ -205,27 +141,19 @@ export function PlayerSpriteManager() {
   const [filterGender, setFilterGender] = useState<string>("all");
   const [filterImage, setFilterImage] = useState<"all" | "with" | "without">("all");
   const [filterStale, setFilterStale] = useState<"all" | "race" | "class" | "any">("all");
-  const [generating, setGenerating] = useState<string | null>(null);
   const [deploying, setDeploying] = useState(false);
   const [exportingSheet, setExportingSheet] = useState(false);
   const [deployResult, setDeployResult] = useState<SyncProgress | null>(null);
-  const [viewSprite, setViewSprite] = useState<{ key: string; fileName: string; assetId: string } | null>(null);
   const [generationError, setGenerationError] = useState<string | null>(null);
   const [showScaffold, setShowScaffold] = useState(false);
   const [showBulkBgRemoval, setShowBulkBgRemoval] = useState(false);
   const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
   const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
-  const [promptPreview, setPromptPreview] = useState<{ imageId: string; prompt: string } | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const races = useMemo(() => config ? Object.keys(config.races) : [], [config]);
   const classes = useMemo(() => config ? Object.keys(config.classes).filter((c) => c !== "base") : [], [config]);
 
-  const imageProvider = settings?.image_provider ?? "deepinfra";
-  const hasApiKey = !!(settings && (
-    (imageProvider === "deepinfra" && settings.deepinfra_api_key.length > 0) ||
-    (imageProvider === "runware" && settings.runware_api_key.length > 0) ||
-    (imageProvider === "openai" && settings.openai_api_key.length > 0)
-  ));
   const hasLlmKey = !!(
     settings?.deepinfra_api_key ||
     settings?.anthropic_api_key ||
@@ -352,76 +280,38 @@ export function PlayerSpriteManager() {
     [selectedId, selectedDef, setDefinition],
   );
 
+  // Gather the asset ids backing a set of sprite definitions, so deletes can
+  // clean up the generated images in one batched pass.
+  const collectAssetIds = useCallback(
+    (ids: string[]) => {
+      const assetIds: string[] = [];
+      for (const id of ids) {
+        const def = definitions[id];
+        if (!def) continue;
+        const imageIds = def.variants?.length ? def.variants.map((v) => v.imageId) : [id];
+        for (const imageId of imageIds) {
+          const asset = spriteAssetMap.get(imageId);
+          if (asset) assetIds.push(asset.assetId);
+        }
+      }
+      return assetIds;
+    },
+    [definitions, spriteAssetMap],
+  );
+
   const handleDeleteSelected = useCallback(() => {
     if (!selectedId) return;
+    setShowDeleteConfirm(true);
+  }, [selectedId]);
+
+  const confirmDeleteSelected = useCallback(async () => {
+    if (!selectedId) return;
+    const assetIds = collectAssetIds([selectedId]);
     deleteDefinition(selectedId);
     setSelectedId(null);
-  }, [selectedId, deleteDefinition]);
-
-  const handleViewSprite = useCallback(
-    (imageId: string) => {
-      const entry = spriteAssetMap.get(imageId);
-      if (!entry) return;
-      setViewSprite({ key: imageId, fileName: entry.fileName, assetId: entry.assetId });
-    },
-    [spriteAssetMap],
-  );
-
-  const handleGenerateImage = useCallback(
-    async (imageId: string) => {
-      if (!AI_ENABLED || !hasApiKey || !settings) return;
-      setGenerating(imageId);
-      setGenerationError(null);
-
-      try {
-        const resolved = findSpriteEntry(definitions, imageId);
-        if (!resolved) throw new Error(`Unable to resolve sprite definition for "${imageId}".`);
-
-        const model = resolveImageModel(imageProvider, settings?.image_model);
-        if (!model) throw new Error("No image model available");
-
-        const dimensions = resolveSpriteDimensions(resolved.definition, resolved.variant);
-        const finalPrompt = await buildEnhancedSpritePrompt({
-          displayName: resolved.variant?.displayName || resolved.definition.displayName,
-          dimensions,
-          notes: spritePromptNotes(resolved.definition, resolved.variant),
-          style: artStyle,
-          nativeTransparency: modelNativelyTransparent(imageProvider, model.id),
-          enhance: hasLlmKey,
-        });
-
-        const dims = ENTITY_DIMENSIONS.player_sprite ?? { width: 512, height: 512 };
-
-        const image = await generateAssetImage({
-          provider: imageProvider,
-          model,
-          prompt: finalPrompt,
-          width: dims.width,
-          height: dims.height,
-          assetType: "player_sprite",
-          negativePrompt: getNegativePrompt("player_sprite"),
-        });
-
-        const assetContext: AssetContext = { zone: "sprites", entity_type: "player_sprite", entity_id: imageId };
-        const variantGroup = `player_sprite:${imageId}`;
-
-        await acceptAsset(image, "player_sprite", finalPrompt, assetContext, variantGroup, true);
-
-        if (settings.auto_remove_bg && image.data_url) {
-          await removeBgAndSave(image.data_url, "player_sprite", assetContext, variantGroup).catch(() => {});
-        }
-
-        await loadAssets();
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        setGenerationError(message);
-        console.error("Failed to generate sprite:", err);
-      } finally {
-        setGenerating(null);
-      }
-    },
-    [acceptAsset, artStyle, definitions, hasApiKey, hasLlmKey, imageProvider, loadAssets, settings],
-  );
+    setShowDeleteConfirm(false);
+    await deleteAssets(assetIds);
+  }, [selectedId, collectAssetIds, deleteDefinition, deleteAssets]);
 
   const handleExportSheet = useCallback(async () => {
     if (filteredDefs.length === 0 || exportingSheet) return;
@@ -575,106 +465,22 @@ export function PlayerSpriteManager() {
   }, [filteredDefs]);
 
   const handleBulkDelete = useCallback(async () => {
-    for (const id of checkedIds) {
-      // Delete associated generated images
-      const def = definitions[id];
-      if (def) {
-        const imageIds: string[] = [];
-        if (def.variants && def.variants.length > 0) {
-          for (const v of def.variants) imageIds.push(v.imageId);
-        } else {
-          imageIds.push(id);
-        }
-        for (const imageId of imageIds) {
-          const asset = spriteAssetMap.get(imageId);
-          if (asset) {
-            await deleteAsset(asset.assetId).catch(() => {});
-          }
-        }
-      }
-      deleteDefinition(id);
-    }
+    const ids = Array.from(checkedIds);
+
+    // Gather every associated asset up front, then remove the definitions and
+    // dismiss the dialog immediately so the UI stays responsive while the
+    // (network-bound) asset deletion runs in a single batched pass.
+    const assetIds = collectAssetIds(ids);
+
+    for (const id of ids) deleteDefinition(id);
     if (selectedId && checkedIds.has(selectedId)) {
       setSelectedId(null);
     }
     setCheckedIds(new Set());
     setShowBulkDeleteConfirm(false);
-    await loadAssets();
-  }, [checkedIds, definitions, spriteAssetMap, selectedId, deleteDefinition, deleteAsset, loadAssets]);
 
-  // ─── Prompt preview ────────────────────────────────────────────────
-
-  const handlePreviewGenerate = useCallback(
-    async (imageId: string) => {
-      const resolved = findSpriteEntry(definitions, imageId);
-      if (!resolved) return;
-
-      const model = resolveImageModel(imageProvider, settings?.image_model);
-      const dimensions = resolveSpriteDimensions(resolved.definition, resolved.variant);
-
-      setGenerating(imageId);
-      try {
-        const prompt = await buildEnhancedSpritePrompt({
-          displayName: resolved.variant?.displayName || resolved.definition.displayName,
-          dimensions,
-          notes: spritePromptNotes(resolved.definition, resolved.variant),
-          style: artStyle,
-          nativeTransparency: model ? modelNativelyTransparent(imageProvider, model.id) : false,
-          enhance: hasLlmKey,
-        });
-        setPromptPreview({ imageId, prompt });
-      } finally {
-        setGenerating(null);
-      }
-    },
-    [artStyle, definitions, hasLlmKey, imageProvider, settings],
-  );
-
-  const handleGenerateWithPrompt = useCallback(
-    async (editedPrompt: string) => {
-      if (!promptPreview || !hasApiKey || !settings) return;
-      const { imageId } = promptPreview;
-      setPromptPreview(null);
-      setGenerating(imageId);
-      setGenerationError(null);
-
-      try {
-        const finalPrompt = editedPrompt;
-        const model = resolveImageModel(imageProvider, settings?.image_model);
-        if (!model) throw new Error("No image model available");
-
-        const dims = ENTITY_DIMENSIONS.player_sprite ?? { width: 512, height: 512 };
-
-        const image = await generateAssetImage({
-          provider: imageProvider,
-          model,
-          prompt: finalPrompt,
-          width: dims.width,
-          height: dims.height,
-          assetType: "player_sprite",
-          negativePrompt: getNegativePrompt("player_sprite"),
-        });
-
-        const assetContext: AssetContext = { zone: "sprites", entity_type: "player_sprite", entity_id: imageId };
-        const variantGroup = `player_sprite:${imageId}`;
-
-        await acceptAsset(image, "player_sprite", finalPrompt, assetContext, variantGroup, true);
-
-        if (settings.auto_remove_bg && image.data_url) {
-          await removeBgAndSave(image.data_url, "player_sprite", assetContext, variantGroup).catch(() => {});
-        }
-
-        await loadAssets();
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        setGenerationError(message);
-        console.error("Failed to generate sprite:", err);
-      } finally {
-        setGenerating(null);
-      }
-    },
-    [promptPreview, acceptAsset, hasApiKey, imageProvider, loadAssets, settings],
-  );
+    await deleteAssets(assetIds);
+  }, [checkedIds, collectAssetIds, selectedId, deleteDefinition, deleteAssets]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -953,14 +759,9 @@ export function PlayerSpriteManager() {
               races={races}
               classes={classes}
               spriteAssetMap={spriteAssetMap}
-              hasApiKey={hasApiKey}
               hasLlmKey={hasLlmKey}
-              generating={generating}
               onPatch={handlePatchSelected}
               onDelete={handleDeleteSelected}
-              onGenerateImage={handleGenerateImage}
-              onPreviewGenerate={handlePreviewGenerate}
-              onViewSprite={handleViewSprite}
             />
           ) : (
             <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-sm text-text-muted">
@@ -992,43 +793,15 @@ export function PlayerSpriteManager() {
         />
       )}
 
-      {/* Sprite lightbox */}
-      {viewSprite && (
-        <SpriteLightbox
-          spriteKey={viewSprite.key}
-          fileName={viewSprite.fileName}
-          variantGroup={`player_sprite:${viewSprite.key}`}
-          canRegenerate={!generating}
-          canDelete={!generating}
-          onRegenerate={() => {
-            const key = viewSprite.key;
-            setViewSprite(null);
-            void handleGenerateImage(key);
-          }}
-          onDelete={() => {
-            const assetId = viewSprite.assetId;
-            setViewSprite(null);
-            void deleteAsset(assetId);
-          }}
-          onRemoveBg={() => {
-            setViewSprite(null);
-            void loadAssets();
-          }}
-          onFlip={() => {
-            setViewSprite(null);
-            void loadAssets();
-          }}
-          onClose={() => setViewSprite(null)}
-        />
-      )}
-
-      {/* Prompt preview modal */}
-      {promptPreview && (
-        <PromptPreviewModal
-          prompt={promptPreview.prompt}
-          imageId={promptPreview.imageId}
-          onGenerate={handleGenerateWithPrompt}
-          onClose={() => setPromptPreview(null)}
+      {/* Single delete confirmation */}
+      {showDeleteConfirm && selectedDef && (
+        <ConfirmDialog
+          title="Delete Sprite"
+          message={`Delete "${selectedDef.displayName}" and its generated image? This cannot be undone.`}
+          confirmLabel="Delete"
+          destructive
+          onConfirm={() => void confirmDeleteSelected()}
+          onCancel={() => setShowDeleteConfirm(false)}
         />
       )}
 

--- a/creator/src/components/SpriteArtGenerator.tsx
+++ b/creator/src/components/SpriteArtGenerator.tsx
@@ -1,0 +1,49 @@
+import { useCallback } from "react";
+import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
+import { getFormatForAssetType, type ArtStyle } from "@/lib/arcanumPrompts";
+import {
+  spriteBasePrompt,
+  spriteContext,
+  resolveSpriteDimensions,
+  spritePromptNotes,
+} from "@/lib/spritePromptGen";
+import type { AssetContext } from "@/types/assets";
+import type { SpriteDefinition } from "@/types/sprites";
+
+interface SpriteArtGeneratorProps {
+  /** Sprite definition key — also the asset variant-group key. */
+  id: string;
+  def: SpriteDefinition;
+  /** Currently-associated asset file name, if any. */
+  currentImage?: string;
+}
+
+/**
+ * The full art studio (prompt editing, enhance, conjure, pick/sketch/gallery,
+ * variant rerolls) wired for a single player sprite. Reuses the standard
+ * sprite prompt pipeline (`spriteBasePrompt` fallback + `spriteContext` for the
+ * LLM enhancer) and pins the asset variant group to `player_sprite:<id>` so the
+ * R2 deploy can resolve the canonical `player_sprites/<id>.png` path.
+ */
+export function SpriteArtGenerator({ id, def, currentImage }: SpriteArtGeneratorProps) {
+  const getPrompt = useCallback(
+    (style: ArtStyle) => spriteBasePrompt(resolveSpriteDimensions(def), style, spritePromptNotes(def)),
+    [def],
+  );
+
+  const context: AssetContext = { zone: "sprites", entity_type: "player_sprite", entity_id: id };
+
+  return (
+    <EntityArtGenerator
+      getPrompt={getPrompt}
+      entityContext={spriteContext(def.displayName, resolveSpriteDimensions(def), spritePromptNotes(def))}
+      framingHint={getFormatForAssetType("player_sprite")}
+      currentImage={currentImage}
+      onAccept={() => {}}
+      assetType="player_sprite"
+      context={context}
+      variantGroupOverride={`player_sprite:${id}`}
+      surface="worldbuilding"
+    />
+  );
+}

--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -45,6 +45,12 @@ interface EntityArtGeneratorProps {
   vibe?: string;
   /** Which art-style surface to apply — "worldbuilding" for zone/entity/game art, "lore" for lore article illustrations */
   surface?: ArtStyleSurface;
+  /**
+   * Explicit variant-group key, overriding the `entity_type:zone:entity_id`
+   * derivation from `context`. Required for callers (e.g. player sprites) whose
+   * downstream contract expects a specific group format.
+   */
+  variantGroupOverride?: string;
 }
 
 function computeVariantGroup(context?: AssetContext): string {
@@ -61,13 +67,13 @@ function autoAcceptImage(
   onAccept: (filePath: string) => void,
   assetType: string | undefined,
   context: AssetContext | undefined,
+  variantGroup: string,
 ) {
   const fileName = img.file_path.split(/[\\/]/).pop() ?? img.hash;
   onAccept(fileName);
   if (assetType) {
-    const vg = computeVariantGroup(context);
     useAssetStore.getState().acceptAsset(
-      img, assetType, prompt ?? undefined, context, vg, true,
+      img, assetType, prompt ?? undefined, context, variantGroup, true,
     ).catch(() => {});
   }
 }
@@ -101,6 +107,7 @@ export function EntityArtGenerator({
   context,
   vibe: _vibe,
   surface,
+  variantGroupOverride,
 }: EntityArtGeneratorProps) {
   const settings = useAssetStore((s) => s.settings);
   const artStyle = useAssetStore((s) => s.artStyle);
@@ -145,6 +152,7 @@ export function EntityArtGenerator({
   assetTypeRef.current = assetType;
   const contextRef = useRef(context);
   contextRef.current = context;
+  const variantGroupRef = useRef("");
 
   // Mirror context-shaping props in refs so handleGenerate/handleEnhance can read
   // the latest values *after* yielding a tick — necessary because commit-on-blur
@@ -165,7 +173,7 @@ export function EntityArtGenerator({
       mountedRef.current = false;
       const img = pendingResultRef.current;
       if (!img) return;
-      autoAcceptImage(img, pendingPromptRef.current, onAcceptRef.current, assetTypeRef.current, contextRef.current);
+      autoAcceptImage(img, pendingPromptRef.current, onAcceptRef.current, assetTypeRef.current, contextRef.current, variantGroupRef.current);
     };
   }, []);
 
@@ -182,7 +190,8 @@ export function EntityArtGenerator({
   );
   const basePrompt = getPrompt(artStyle);
   const activePrompt = editedPrompt ?? basePrompt;
-  const variantGroup = computeVariantGroup(context);
+  const variantGroup = variantGroupOverride ?? computeVariantGroup(context);
+  variantGroupRef.current = variantGroup;
 
   const entityType = context?.entity_type ?? "";
   const defaultDims = ENTITY_DIMENSIONS[entityType] ?? { width: 1024, height: 1024, label: "1024×1024" };
@@ -310,7 +319,7 @@ export function EntityArtGenerator({
         negativePrompt: getNegativePrompt(assetType),
       });
       if (!mountedRef.current) {
-        autoAcceptImage(image, finalPrompt, onAcceptRef.current, assetTypeRef.current, contextRef.current);
+        autoAcceptImage(image, finalPrompt, onAcceptRef.current, assetTypeRef.current, contextRef.current, variantGroupRef.current);
         return;
       }
       pendingResultRef.current = image;
@@ -414,6 +423,10 @@ export function EntityArtGenerator({
     try {
       const newFileName = await invoke<string>("flip_image", { imageRef: currentImage });
       onAccept(newFileName);
+      // flip_image already registers the flipped asset under the source's
+      // variant group and marks it active; refresh so grouped consumers
+      // (e.g. player sprites, whose onAccept is a no-op) reflect it.
+      if (variantGroup) await useAssetStore.getState().loadAssets();
     } catch (e) {
       console.error("Flip failed:", e);
     } finally {
@@ -724,9 +737,16 @@ export function EntityArtGenerator({
         height={1024}
         initialDataUrl={savedImageSrc || null}
         assetType={assetType ?? "background"}
+        context={context}
+        variantGroup={variantGroup}
         onClose={() => setShowSketch(false)}
         onSave={(entry) => {
           onAccept(entry.file_name);
+          // For grouped callers (e.g. player sprites) the path field isn't the
+          // source of truth — the asset's variant group is. Promote the sketch
+          // to the active entry so it shows and deploys; setActiveVariant
+          // refreshes the asset list.
+          if (variantGroup) void setActiveVariant(variantGroup, entry.id);
         }}
       />
 

--- a/creator/src/components/ui/SketchCanvas.tsx
+++ b/creator/src/components/ui/SketchCanvas.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { ActionButton } from "./FormWidgets";
+import type { AssetContext } from "@/types/assets";
+
+export interface SketchSavedEntry {
+  id: string;
+  file_name: string;
+  width: number;
+  height: number;
+}
 
 type Tool = "pen" | "eraser" | "fill";
 
@@ -24,8 +32,10 @@ interface Props {
   height?: number;
   initialDataUrl?: string | null;
   onCancel: () => void;
-  onSave: (entry: { file_name: string; width: number; height: number }) => void;
+  onSave: (entry: SketchSavedEntry) => void;
   assetType?: string;
+  context?: AssetContext;
+  variantGroup?: string;
 }
 
 export function SketchCanvas({
@@ -35,6 +45,8 @@ export function SketchCanvas({
   onCancel,
   onSave,
   assetType = "lore_map",
+  context,
+  variantGroup,
 }: Props) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [tool, setTool] = useState<Tool>("pen");
@@ -194,11 +206,13 @@ export function SketchCanvas({
     try {
       const dataUrl = canvas.toDataURL("image/png");
       const bytesB64 = dataUrl.replace(/^data:image\/png;base64,/, "");
-      const entry = await invoke<{ file_name: string; width: number; height: number }>(
+      const entry = await invoke<SketchSavedEntry>(
         "save_bytes_as_asset",
         {
           bytesB64,
           assetType,
+          context: context ?? null,
+          variantGroup: variantGroup ?? null,
         },
       );
       onSave(entry);

--- a/creator/src/components/ui/SketchDialog.tsx
+++ b/creator/src/components/ui/SketchDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
-import { SketchCanvas } from "./SketchCanvas";
+import { SketchCanvas, type SketchSavedEntry } from "./SketchCanvas";
+import type { AssetContext } from "@/types/assets";
 
 interface Props {
   open: boolean;
@@ -8,8 +9,10 @@ interface Props {
   height?: number;
   initialDataUrl?: string | null;
   assetType?: string;
+  context?: AssetContext;
+  variantGroup?: string;
   onClose: () => void;
-  onSave: (entry: { file_name: string; width: number; height: number }) => void;
+  onSave: (entry: SketchSavedEntry) => void;
 }
 
 export function SketchDialog({
@@ -19,6 +22,8 @@ export function SketchDialog({
   height,
   initialDataUrl,
   assetType,
+  context,
+  variantGroup,
   onClose,
   onSave,
 }: Props) {
@@ -70,6 +75,8 @@ export function SketchDialog({
           height={height}
           initialDataUrl={initialDataUrl}
           assetType={assetType}
+          context={context}
+          variantGroup={variantGroup}
           onCancel={onClose}
           onSave={(entry) => {
             onSave(entry);

--- a/creator/src/lib/spritePromptGen.ts
+++ b/creator/src/lib/spritePromptGen.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_CLASS_OUTFIT_DESCRIPTIONS,
 } from "./defaultSpriteData";
 import { AI_ENABLED } from "@/lib/featureFlags";
+import type { SpriteDefinition, SpriteRequirement } from "@/types/sprites";
 
 // ─── Types ───────────────────────────────────────────────────────────
 
@@ -62,6 +63,30 @@ export function getClassOutfitDescription(cls: string): string {
   return config?.classes[cls]?.outfitDescription
     ?? DEFAULT_CLASS_OUTFIT_DESCRIPTIONS[cls]
     ?? cls;
+}
+
+function findReq<T extends SpriteRequirement["type"]>(
+  requirements: SpriteRequirement[],
+  type: T,
+): Extract<SpriteRequirement, { type: T }> | undefined {
+  return requirements.find(
+    (r): r is Extract<SpriteRequirement, { type: T }> => r.type === type,
+  );
+}
+
+/** Resolve race/class/gender for a sprite definition from its requirements + gender. */
+export function resolveSpriteDimensions(def: SpriteDefinition): SpriteDimensions {
+  return {
+    race: findReq(def.requirements, "race")?.race || undefined,
+    playerClass: findReq(def.requirements, "class")?.playerClass || undefined,
+    gender: def.gender || undefined,
+  };
+}
+
+/** Free-text steering (art direction / description) for a sprite definition. */
+export function spritePromptNotes(def: SpriteDefinition): string | undefined {
+  const notes = def.artDirection?.trim() || def.description?.trim();
+  return notes || undefined;
 }
 
 // ─── Prompt assembly ─────────────────────────────────────────────────

--- a/creator/src/stores/assetStore.ts
+++ b/creator/src/stores/assetStore.ts
@@ -38,6 +38,7 @@ interface AssetState {
     isActive?: boolean,
   ) => Promise<AssetEntry>;
   deleteAsset: (id: string) => Promise<void>;
+  deleteAssets: (ids: string[]) => Promise<void>;
 
   setActiveVariant: (variantGroup: string, assetId: string) => Promise<void>;
   listVariants: (variantGroup: string) => Promise<AssetEntry[]>;
@@ -147,6 +148,17 @@ export const useAssetStore = create<AssetState>((set, get) => ({
       await invoke("delete_from_r2", { fileName: asset.file_name }).catch(() => {});
     }
     await invoke("delete_asset", { id });
+    await get().loadAssets();
+  },
+
+  deleteAssets: async (ids: string[]) => {
+    if (ids.length === 0) return;
+    const idSet = new Set(ids);
+    const synced = get().assets.filter((a) => idSet.has(a.id) && a.sync_status === "synced");
+    await Promise.allSettled(
+      synced.map((a) => invoke("delete_from_r2", { fileName: a.file_name })),
+    );
+    await invoke("delete_assets", { ids });
     await get().loadAssets();
   },
 

--- a/creator/src/stores/spriteDefinitionStore.ts
+++ b/creator/src/stores/spriteDefinitionStore.ts
@@ -28,6 +28,58 @@ function parseRequirement(raw: Record<string, unknown>): SpriteRequirement | nul
   }
 }
 
+/**
+ * Flatten legacy multi-variant definitions into one definition per variant.
+ * Each sprite is now itself a variant, so a def carrying a `variants[]` array
+ * is exploded into sibling definitions keyed by each variant's imageId — which
+ * is also the asset's variant-group key, so generated images stay associated.
+ * Variant race/class filters become requirements; gender/displayName carry over.
+ * Returns whether any definition was rewritten so the caller can mark dirty.
+ */
+function flattenVariantDefinitions(
+  defs: Record<string, SpriteDefinition>,
+): { defs: Record<string, SpriteDefinition>; changed: boolean } {
+  const out: Record<string, SpriteDefinition> = {};
+  let changed = false;
+
+  const claim = (preferred: string): string => {
+    if (!out[preferred]) return preferred;
+    let n = 1;
+    while (out[`${preferred}_${n}`]) n += 1;
+    return `${preferred}_${n}`;
+  };
+
+  for (const [id, def] of Object.entries(defs)) {
+    if (!def.variants || def.variants.length === 0) {
+      out[claim(id)] = def;
+      continue;
+    }
+    changed = true;
+    def.variants.forEach((variant, index) => {
+      const newId = claim(variant.imageId || (index === 0 ? id : `${id}_v${index}`));
+      const requirements: SpriteRequirement[] = [...def.requirements];
+      if (variant.race && !requirements.some((r) => r.type === "race")) {
+        requirements.push({ type: "race", race: variant.race });
+      }
+      if (variant.playerClass && !requirements.some((r) => r.type === "class")) {
+        requirements.push({ type: "class", playerClass: variant.playerClass });
+      }
+      out[newId] = {
+        displayName: variant.displayName ?? def.displayName,
+        description: def.description,
+        artDirection: def.artDirection,
+        category: def.category,
+        gender: variant.gender ?? def.gender,
+        sortOrder: def.sortOrder + index,
+        requirements,
+        image: variant.imagePath || `player_sprites/${newId}.png`,
+      };
+    });
+  }
+
+  return { defs: out, changed };
+}
+
 /** Parse a raw YAML entry into a SpriteDefinition. */
 function parseDefinition(id: string, entry: Record<string, unknown>): SpriteDefinition {
   const requirements: SpriteRequirement[] = [];
@@ -136,7 +188,8 @@ export const useSpriteDefinitionStore = create<SpriteDefinitionStore>((set, get)
           defs[id] = parseDefinition(id, entry as Record<string, unknown>);
         }
       }
-      set({ definitions: defs, dirty: false });
+      const flattened = flattenVariantDefinitions(defs);
+      set({ definitions: flattened.defs, dirty: flattened.changed });
     } catch {
       set({ definitions: {}, dirty: false });
     }


### PR DESCRIPTION
## Summary

Three related improvements to the Player Sprites panel, plus the slow-delete fix that started this.

### Deletes (the original report: bulk delete "just sits there")
- New batched `delete_assets(ids)` Rust command + `assetStore.deleteAssets`: one manifest lock/load/save and a single asset-list reload for the whole set, with R2 deletes fired in parallel. The old bulk delete rewrote the entire manifest **and** reloaded the full asset list once per sprite-variant (N×M serial round-trips), and only closed the confirmation modal after everything finished — hence the unresponsive "nothing happens" feel. The modal now dismisses immediately.
- **Single-sprite delete** now also deletes its generated image (previously orphaned) and goes through a confirmation dialog.

### Full art generator in the sprite editor
- Replaces the short *Image Path / Generate / Preview* panel with the full `EntityArtGenerator` — prompt editing, Enhance, Conjure, hero preview + zoom, reroll rail, Pick file / Sketch / Gallery, and forge settings.
- Added a `variantGroupOverride` prop to `EntityArtGenerator`: sprites must keep the `player_sprite:<id>` group that `deploy_sprites_to_r2` strips to derive the canonical `player_sprites/<id>.png` path. The generator's default 3-part `entity_type:zone:entity_id` group would have broken the deploy.
- Threaded `context`/`variantGroup` through `SketchDialog`/`SketchCanvas` and promote sketches to the active group entry; refresh assets after flip. So **Sketch** and **Flip** now associate with the sprite (both backend commands already supported it — this was frontend-only).

### Retire in-sprite variants
Each sprite is now itself a variant, so the per-definition variant sub-system is gone:
- Removed the variant UI (toggle, variant rows, add/switch).
- Legacy `variants[]` arrays are **flattened on load** into sibling definitions keyed by each variant's `imageId` — which is also the asset's variant-group key, so existing generated images stay associated. Variant race/class become requirements; gender/label carry over. The `SpriteVariant` type and YAML/server contract are untouched; the flatten marks the store dirty so it persists on the next Save.

Also removes the now-dead `SpriteLightbox` / `PromptPreviewModal` and the old template-based sprite generation path.

## Testing
- `bunx tsc --noEmit` clean
- `bun run test` — 2125 passed
- `cargo check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)