### PR TITLE
R2 Cache-Control headers + force re-upload backfill

### DIFF
--- a/creator/src-tauri/src/fs_utils.rs
+++ b/creator/src-tauri/src/fs_utils.rs
@@ -1,7 +1,9 @@
 use base64::Engine;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 /// Monotonic counter to guarantee temp-file uniqueness even when two atomic
 /// writes inside the same process race in the same millisecond.
@@ -91,9 +93,84 @@ pub async fn read_image_data_url(path: String) -> Result<String, String> {
     let bytes = tokio::fs::read(&path)
         .await
         .map_err(|e| format!("Failed to read image: {e}"))?;
+    Ok(bytes_to_data_url(&bytes))
+}
 
-    let ext = detect_extension(&bytes);
+fn bytes_to_data_url(bytes: &[u8]) -> String {
+    let ext = detect_extension(bytes);
     let mime = detect_mime(ext);
-    let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
-    Ok(format!("data:{mime};base64,{b64}"))
+    let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+    format!("data:{mime};base64,{b64}")
+}
+
+static THUMBNAIL_CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+
+fn thumbnail_cache() -> &'static Mutex<HashMap<String, String>> {
+    THUMBNAIL_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Generous upper bound; thumbnails are ~10–40 KB each, so a full cache is a
+/// few tens of MB. Cleared wholesale rather than LRU-evicted — re-encoding on
+/// the rare overflow is cheaper than tracking recency on every hit.
+const THUMBNAIL_CACHE_MAX_ENTRIES: usize = 2048;
+
+fn encode_thumbnail(bytes: &[u8], max_dim: u32) -> String {
+    let img = match image::load_from_memory(bytes) {
+        Ok(img) => img,
+        // Undecodable here doesn't mean undecodable in the webview — serve
+        // the original bytes, matching read_image_data_url behavior.
+        Err(_) => return bytes_to_data_url(bytes),
+    };
+    if img.width() <= max_dim && img.height() <= max_dim {
+        return bytes_to_data_url(bytes);
+    }
+    let thumb = img.thumbnail(max_dim, max_dim).to_rgba8();
+    let (w, h) = (thumb.width(), thumb.height());
+    let encoded = webp::Encoder::from_rgba(thumb.as_raw(), w, h).encode(80.0);
+    format!(
+        "data:image/webp;base64,{}",
+        base64::engine::general_purpose::STANDARD.encode(&*encoded)
+    )
+}
+
+/// Like `read_image_data_url`, but downscaled to fit within `max_dim` and
+/// re-encoded as lossy WebP. Meant for map nodes and list thumbnails where
+/// full-resolution art (often multi-MB PNGs) wastes decode time and GPU
+/// memory. Results are cached against the file's mtime + size.
+#[tauri::command]
+pub async fn read_image_thumbnail_data_url(path: String, max_dim: u32) -> Result<String, String> {
+    let max_dim = max_dim.clamp(16, 1024);
+    let meta = tokio::fs::metadata(&path)
+        .await
+        .map_err(|e| format!("Failed to read image: {e}"))?;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let key = format!("{path}|{max_dim}|{mtime}|{}", meta.len());
+
+    if let Some(hit) = thumbnail_cache()
+        .lock()
+        .expect("thumbnail cache poisoned")
+        .get(&key)
+    {
+        return Ok(hit.clone());
+    }
+
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|e| format!("Failed to read image: {e}"))?;
+
+    let data_url = tokio::task::spawn_blocking(move || encode_thumbnail(&bytes, max_dim))
+        .await
+        .map_err(|e| format!("Thumbnail encode failed: {e}"))?;
+
+    let mut cache = thumbnail_cache().lock().expect("thumbnail cache poisoned");
+    if cache.len() >= THUMBNAIL_CACHE_MAX_ENTRIES {
+        cache.clear();
+    }
+    cache.insert(key, data_url.clone());
+    Ok(data_url)
 }

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -71,6 +71,7 @@ macro_rules! base_handler {
             project_settings::save_project_settings,
             project_settings::seed_project_settings,
             fs_utils::read_image_data_url,
+            fs_utils::read_image_thumbnail_data_url,
             ffmpeg::check_ffmpeg_status,
             ffmpeg::ensure_ffmpeg_ready,
             video_export::save_video_frame,

--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -13,6 +13,21 @@ use crate::settings;
 
 type HmacSha256 = Hmac<Sha256>;
 
+// ─── Cache-Control policies ─────────────────────────────────────────
+// Stored as R2 object metadata and returned verbatim on every GET, so the
+// MUD client (and the showcase CDN) can cache art instead of re-downloading
+// it on each game load. The three tiers map to how the object key behaves.
+
+/// Content-addressed objects — the filename IS a hash of the bytes, so a given
+/// URL can never change meaning. Safe to cache for a year and skip revalidation.
+const CACHE_IMMUTABLE: &str = "public, max-age=31536000, immutable";
+/// Stable-path media (sprites, global assets, cinematics) that lives at a fixed
+/// URL but can be regenerated. Cache for a day so a regen still propagates.
+const CACHE_ASSET: &str = "public, max-age=86400";
+/// Manifests and configs that decide which assets the client loads. Keep these
+/// fresh — a short TTL still spares the origin a full transfer via 304s.
+const CACHE_MANIFEST: &str = "public, max-age=60";
+
 // ─── Types ──────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -76,6 +91,7 @@ fn build_signed_put(
     object_key: &str,
     body: &[u8],
     content_type: &str,
+    cache_control: &str,
 ) -> Result<(String, Vec<(String, String)>), String> {
     let host = format!("{bucket}.{account_id}.r2.cloudflarestorage.com");
     let url = format!("https://{host}/{object_key}");
@@ -88,11 +104,12 @@ fn build_signed_put(
     let payload_hash = sha256_hex(body);
     let content_length = body.len().to_string();
 
-    // Canonical request
+    // Canonical request. Header lines must be sorted lexicographically by
+    // lowercase name, so `cache-control` sorts ahead of `content-length`.
     let canonical_headers = format!(
-        "content-length:{content_length}\ncontent-type:{content_type}\nhost:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n"
+        "cache-control:{cache_control}\ncontent-length:{content_length}\ncontent-type:{content_type}\nhost:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n"
     );
-    let signed_headers = "content-length;content-type;host;x-amz-content-sha256;x-amz-date";
+    let signed_headers = "cache-control;content-length;content-type;host;x-amz-content-sha256;x-amz-date";
     let canonical_request = format!(
         "PUT\n/{object_key}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
     );
@@ -111,6 +128,7 @@ fn build_signed_put(
     );
 
     let headers = vec![
+        ("Cache-Control".to_string(), cache_control.to_string()),
         ("Content-Length".to_string(), content_length),
         ("Content-Type".to_string(), content_type.to_string()),
         ("Host".to_string(), host),
@@ -386,13 +404,14 @@ async fn upload_object(
     object_key: &str,
     body: Vec<u8>,
     content_type: &str,
+    cache_control: &str,
 ) -> Result<(), String> {
     const MAX_ATTEMPTS: u32 = 4;
     let mut last_err = String::new();
 
     for attempt in 1..=MAX_ATTEMPTS {
         let (url, headers) = build_signed_put(
-            account_id, bucket, access_key, secret_key, object_key, &body, content_type,
+            account_id, bucket, access_key, secret_key, object_key, &body, content_type, cache_control,
         )?;
 
         let mut req = client.put(&url).body(body.clone());
@@ -525,12 +544,17 @@ fn should_sync_asset(asset: &AssetEntry, scope: &str, active_set: &std::collecti
 }
 
 #[tauri::command]
-pub async fn sync_assets(app: AppHandle, scope: Option<String>) -> Result<SyncProgress, String> {
+pub async fn sync_assets(
+    app: AppHandle,
+    scope: Option<String>,
+    force: Option<bool>,
+) -> Result<SyncProgress, String> {
     let s = settings::get_settings(app.clone()).await?;
     if s.r2_account_id.is_empty() || s.r2_access_key_id.is_empty() || s.r2_secret_access_key.is_empty() || s.r2_bucket.is_empty() {
         return Err("R2 credentials not configured. Set them in Settings.".to_string());
     }
 
+    let force = force.unwrap_or(false);
     let sync_scope = scope.unwrap_or_else(|| "approved".to_string());
     let assets = assets::list_assets(app.clone()).await?;
 
@@ -541,9 +565,11 @@ pub async fn sync_assets(app: AppHandle, scope: Option<String>) -> Result<SyncPr
         .map(|a| a.variant_group.clone())
         .collect();
 
+    // A forced run re-uploads already-synced assets too, so a Cache-Control
+    // backfill reaches everything — not just the not-yet-synced tail.
     let unsynced: Vec<&AssetEntry> = assets
         .iter()
-        .filter(|a| a.sync_status != "synced" && should_sync_asset(a, &sync_scope, &active_set))
+        .filter(|a| (force || a.sync_status != "synced") && should_sync_asset(a, &sync_scope, &active_set))
         .collect();
     let base_dir = assets_base_dir(&app)?;
     let client = crate::http::shared_client();
@@ -559,19 +585,23 @@ pub async fn sync_assets(app: AppHandle, scope: Option<String>) -> Result<SyncPr
     for asset in &unsynced {
         let object_key = &asset.file_name;
 
-        // Check if already exists in R2 (dedup by content hash)
-        match object_exists(&client, &s.r2_account_id, &s.r2_bucket, &s.r2_access_key_id, &s.r2_secret_access_key, object_key).await {
-            Ok(true) => {
-                // Already in R2, just mark as synced
-                assets::update_sync_status(app.clone(), &asset.id, "synced").await?;
-                progress.skipped += 1;
-                continue;
-            }
-            Ok(false) => {}
-            Err(e) => {
-                progress.failed += 1;
-                progress.errors.push(format!("{}: {e}", asset.file_name));
-                continue;
+        // Check if already exists in R2 (dedup by content hash). A forced run
+        // skips the probe and always re-PUTs so existing objects pick up the
+        // current Cache-Control header.
+        if !force {
+            match object_exists(&client, &s.r2_account_id, &s.r2_bucket, &s.r2_access_key_id, &s.r2_secret_access_key, object_key).await {
+                Ok(true) => {
+                    // Already in R2, just mark as synced
+                    assets::update_sync_status(app.clone(), &asset.id, "synced").await?;
+                    progress.skipped += 1;
+                    continue;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    progress.failed += 1;
+                    progress.errors.push(format!("{}: {e}", asset.file_name));
+                    continue;
+                }
             }
         }
 
@@ -606,6 +636,7 @@ pub async fn sync_assets(app: AppHandle, scope: Option<String>) -> Result<SyncPr
             object_key,
             body,
             content_type,
+            CACHE_IMMUTABLE,
         ).await {
             Ok(()) => {
                 assets::update_sync_status(app.clone(), &asset.id, "synced").await?;
@@ -686,7 +717,12 @@ pub async fn delete_from_r2(app: AppHandle, file_name: String) -> Result<(), Str
 /// Each sprite asset with variant_group "player_sprite:{key}" gets uploaded
 /// as "player_sprites/{key}.png" so the game server can find them.
 #[tauri::command]
-pub async fn deploy_sprites_to_r2(app: AppHandle, sprites_yaml: Option<String>) -> Result<SyncProgress, String> {
+pub async fn deploy_sprites_to_r2(
+    app: AppHandle,
+    sprites_yaml: Option<String>,
+    force: Option<bool>,
+) -> Result<SyncProgress, String> {
+    let force = force.unwrap_or(false);
     let s = settings::get_settings(app.clone()).await?;
     if s.r2_account_id.is_empty()
         || s.r2_access_key_id.is_empty()
@@ -742,8 +778,9 @@ pub async fn deploy_sprites_to_r2(app: AppHandle, sprites_yaml: Option<String>) 
         };
 
         // Skip re-upload if the source bytes match what we uploaded last time.
+        // A forced run ignores the cache so existing objects refresh their headers.
         let src_hash = sha256_hex(&body);
-        if sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
+        if !force && sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
             progress.skipped += 1;
             continue;
         }
@@ -760,6 +797,7 @@ pub async fn deploy_sprites_to_r2(app: AppHandle, sprites_yaml: Option<String>) 
             &object_key,
             optimized,
             "image/png",
+            CACHE_ASSET,
         )
         .await
         {
@@ -779,7 +817,7 @@ pub async fn deploy_sprites_to_r2(app: AppHandle, sprites_yaml: Option<String>) 
         progress.total += 1;
         let yaml_bytes = yaml.into_bytes();
         let src_hash = sha256_hex(&yaml_bytes);
-        if sync_state.get("sprites.yaml").map(|h| h.as_str()) == Some(src_hash.as_str()) {
+        if !force && sync_state.get("sprites.yaml").map(|h| h.as_str()) == Some(src_hash.as_str()) {
             progress.skipped += 1;
         } else {
             match upload_object(
@@ -791,6 +829,7 @@ pub async fn deploy_sprites_to_r2(app: AppHandle, sprites_yaml: Option<String>) 
                 "sprites.yaml",
                 yaml_bytes,
                 "application/x-yaml",
+                CACHE_MANIFEST,
             )
             .await
             {
@@ -817,7 +856,9 @@ pub async fn deploy_sprites_to_r2(app: AppHandle, sprites_yaml: Option<String>) 
 pub async fn deploy_global_assets_to_r2(
     app: AppHandle,
     global_assets: std::collections::HashMap<String, String>,
+    force: Option<bool>,
 ) -> Result<SyncProgress, String> {
+    let force = force.unwrap_or(false);
     let s = settings::get_settings(app.clone()).await?;
     if s.r2_account_id.is_empty()
         || s.r2_access_key_id.is_empty()
@@ -878,8 +919,9 @@ pub async fn deploy_global_assets_to_r2(
         };
 
         // Skip re-upload if the source bytes match what we uploaded last time.
+        // A forced run ignores the cache so existing objects refresh their headers.
         let src_hash = sha256_hex(&body);
-        if sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
+        if !force && sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
             progress.skipped += 1;
             continue;
         }
@@ -903,6 +945,7 @@ pub async fn deploy_global_assets_to_r2(
             &object_key,
             optimized,
             content_type,
+            CACHE_ASSET,
         )
         .await
         {
@@ -962,6 +1005,7 @@ pub async fn deploy_config_to_r2(
         object_key,
         body,
         "application/x-yaml",
+        CACHE_MANIFEST,
     )
     .await?;
 
@@ -996,6 +1040,7 @@ pub async fn deploy_achievements_to_r2(
         object_key,
         achievements_content.into_bytes(),
         "application/x-yaml",
+        CACHE_MANIFEST,
     )
     .await?;
 
@@ -1109,6 +1154,7 @@ pub async fn deploy_zones_to_r2(
             &object_key,
             body,
             "application/x-yaml",
+            CACHE_MANIFEST,
         )
         .await
         {
@@ -1143,7 +1189,9 @@ fn voice_object_key(zone: &str, template_key: &str, node_id: &str, text_sha8: &s
 pub async fn deploy_voices_to_r2(
     app: AppHandle,
     jobs: Vec<VoiceUploadJob>,
+    force: Option<bool>,
 ) -> Result<SyncProgress, String> {
+    let force = force.unwrap_or(false);
     let s = settings::get_settings(app.clone()).await?;
     if s.r2_account_id.is_empty()
         || s.r2_access_key_id.is_empty()
@@ -1190,8 +1238,9 @@ pub async fn deploy_voices_to_r2(
         };
 
         // Skip re-upload when the source bytes match the last publish.
+        // A forced run ignores the cache so existing objects refresh their headers.
         let src_hash = sha256_hex(&body);
-        if sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
+        if !force && sync_state.get(&object_key).map(|h| h.as_str()) == Some(src_hash.as_str()) {
             progress.skipped += 1;
             continue;
         }
@@ -1205,6 +1254,7 @@ pub async fn deploy_voices_to_r2(
             &object_key,
             body,
             "audio/mpeg",
+            CACHE_IMMUTABLE,
         )
         .await
         {
@@ -1393,6 +1443,7 @@ pub async fn deploy_story_video_to_r2(
         &object_key,
         bytes,
         "video/mp4",
+        CACHE_ASSET,
     )
     .await?;
 
@@ -1427,6 +1478,7 @@ pub async fn deploy_showcase_to_r2(
         object_key,
         json_content.into_bytes(),
         "application/json",
+        CACHE_MANIFEST,
     )
     .await?;
 

--- a/creator/src/components/PublishWorldModal.tsx
+++ b/creator/src/components/PublishWorldModal.tsx
@@ -12,6 +12,7 @@ import {
   publishCuratedAssets,
   publishGlobalAssets,
   publishPlayerSprites,
+  publishVoices,
   runWorkspaceValidation,
   saveWorkspace,
 } from "@/lib/runtimeHandoff";
@@ -31,6 +32,7 @@ type StepKey =
   | "assets"
   | "globals"
   | "sprites"
+  | "voices"
   | "config"
   | "achievements"
   | "zones";
@@ -55,6 +57,7 @@ const STEP_ORDER: { key: StepKey; title: string; idleDetail: string }[] = [
   { key: "assets", title: "Publish assets", idleDetail: "Upload approved gallery assets to R2." },
   { key: "globals", title: "Publish globals", idleDetail: "Upload changed global assets to R2." },
   { key: "sprites", title: "Publish sprites", idleDetail: "Upload changed player sprites to R2." },
+  { key: "voices", title: "Publish voices", idleDetail: "Upload synthesized dialogue clips to R2." },
 ];
 
 const STATUS_STYLES: Record<StepStatus, string> = {
@@ -307,6 +310,21 @@ export function PublishWorldModal({ onClose }: PublishWorldModalProps) {
         });
       } catch (error) {
         setStep("sprites", { status: "error", detail: "Sprite publish failed.", errors: [String(error)] });
+        throw error;
+      }
+
+      // ── 10. Voices ────────────────────────────────────────────────
+      setStep("voices", { status: "running", detail: "Publishing dialogue voice-over to R2..." });
+      try {
+        const result = await publishVoices();
+        const nothing = result.total === 0 && result.uploaded === 0 && result.failed === 0;
+        setStep("voices", {
+          status: nothing ? "skipped" : result.failed > 0 ? "warning" : "success",
+          detail: nothing ? "No synthesized dialogue clips to publish." : formatSyncResult(result, "clips"),
+          errors: result.errors,
+        });
+      } catch (error) {
+        setStep("voices", { status: "error", detail: "Voice publish failed.", errors: [String(error)] });
         throw error;
       }
 

--- a/creator/src/components/VoiceOverPanel.tsx
+++ b/creator/src/components/VoiceOverPanel.tsx
@@ -107,6 +107,7 @@ export default function VoiceOverPanel() {
 
   const [savingMap, setSavingMap] = useState(false);
   const [savedMap, setSavedMap] = useState(false);
+  const [forceReupload, setForceReupload] = useState(false);
   const [sha8Map, setSha8Map] = useState<Record<string, string>>({});
 
   const hasKey = !!settings?.elevenlabs_api_key;
@@ -438,8 +439,20 @@ export default function VoiceOverPanel() {
             >
               {generating ? "Generating…" : "Generate all"}
             </button>
+            <label
+              className="flex cursor-pointer items-center gap-1.5 text-2xs text-text-muted"
+              title="Re-upload clips already on R2 so they pick up the latest cache headers. Use when seeding a new bucket or after a caching change."
+            >
+              <input
+                type="checkbox"
+                checked={forceReupload}
+                onChange={(event) => setForceReupload(event.target.checked)}
+                className="accent-[var(--accent)]"
+              />
+              Force re-upload
+            </label>
             <button
-              onClick={() => publishToR2(lines)}
+              onClick={() => publishToR2(lines, forceReupload)}
               disabled={!r2Configured || publishing || doneCount === 0}
               title={r2Configured ? undefined : "Configure Cloudflare R2 in Settings to publish."}
               className="action-button action-button-secondary action-button-sm focus-ring"

--- a/creator/src/components/VoiceOverPanel.tsx
+++ b/creator/src/components/VoiceOverPanel.tsx
@@ -4,6 +4,7 @@ import { useProjectStore } from "@/stores/projectStore";
 import { useAssetStore } from "@/stores/assetStore";
 import { useVoiceStore } from "@/stores/voiceStore";
 import { panelTab } from "@/lib/panelRegistry";
+import { collectDialogueLines } from "@/lib/dialogueLines";
 import {
   ELEVENLABS_DEFAULT_SETTINGS,
   ELEVENLABS_MODELS,
@@ -12,7 +13,6 @@ import {
   settingsAreEmpty,
   sha8,
   VOICE_SETTING_FIELDS,
-  type DialogueLine,
   type ElevenLabsVoice,
   type VoiceMap,
   type VoiceSettings,
@@ -40,31 +40,6 @@ function fillRequired(
     speed: s.speed ?? base.speed,
     sentencePause: s.sentencePause ?? base.sentencePause,
   };
-}
-
-/** Flatten every voiceable NPC dialogue line across all loaded zones. */
-function collectLines(zones: Map<string, { data: import("@/types/world").WorldFile }>): DialogueLine[] {
-  const lines: DialogueLine[] = [];
-  for (const { data } of zones.values()) {
-    const zone = data.zone;
-    const mobs = data.mobs ?? {};
-    for (const [templateKey, mob] of Object.entries(mobs)) {
-      const dialogue = mob.dialogue;
-      if (!dialogue) continue;
-      for (const [nodeId, node] of Object.entries(dialogue)) {
-        if (!node.text || !node.text.trim()) continue;
-        lines.push({ zone, templateKey, mobName: mob.name ?? templateKey, nodeId, text: node.text });
-      }
-    }
-  }
-  lines.sort((a, b) => {
-    if (a.zone !== b.zone) return a.zone.localeCompare(b.zone);
-    if (a.templateKey !== b.templateKey) return a.templateKey.localeCompare(b.templateKey);
-    if (a.nodeId === "root") return -1;
-    if (b.nodeId === "root") return 1;
-    return a.nodeId.localeCompare(b.nodeId);
-  });
-  return lines;
 }
 
 export default function VoiceOverPanel() {
@@ -132,7 +107,7 @@ export default function VoiceOverPanel() {
     }
   }, [hasKey, voices.length, loadingVoices, voicesError, fetchVoices]);
 
-  const lines = useMemo(() => collectLines(zones), [zones]);
+  const lines = useMemo(() => collectDialogueLines(zones), [zones]);
 
   const mobGroups = useMemo<MobGroup[]>(() => {
     const map = new Map<string, MobGroup>();

--- a/creator/src/components/config/RuntimeHandoffStudio.tsx
+++ b/creator/src/components/config/RuntimeHandoffStudio.tsx
@@ -143,6 +143,7 @@ export function RuntimeHandoffStudio() {
     }
   });
   const [runningAll, setRunningAll] = useState(false);
+  const [forceReupload, setForceReupload] = useState(false);
   const [workflowMessage, setWorkflowMessage] = useState<string | null>(null);
   const [deployCommitMsg, setDeployCommitMsg] = useState(() =>
     `Deploy: ${new Date().toISOString().slice(0, 16).replace("T", " ")}`,
@@ -326,7 +327,7 @@ export function RuntimeHandoffStudio() {
       errors: [],
     });
     try {
-      const result = await publishCuratedAssets(syncScope);
+      const result = await publishCuratedAssets(syncScope, forceReupload);
       setStepState("assets", {
         status: result.failed > 0 ? "warning" : "success",
         detail: formatSyncResult(result, "assets"),
@@ -349,7 +350,7 @@ export function RuntimeHandoffStudio() {
       errors: [],
     });
     try {
-      const result = await publishGlobalAssets();
+      const result = await publishGlobalAssets(forceReupload);
       setStepState("globals", {
         status: result.failed > 0 ? "warning" : "success",
         detail: formatSyncResult(result, "globals"),
@@ -372,7 +373,7 @@ export function RuntimeHandoffStudio() {
       errors: [],
     });
     try {
-      const result = await publishPlayerSprites();
+      const result = await publishPlayerSprites(forceReupload);
       setStepState("sprites", {
         status: result.failed > 0 ? "warning" : "success",
         detail: formatSyncResult(result, "sprites"),
@@ -565,6 +566,18 @@ export function RuntimeHandoffStudio() {
             >
               Open validation
             </button>
+            <label
+              className="flex cursor-pointer items-center gap-2 rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-2 text-xs font-medium text-text-secondary transition hover:bg-[var(--chrome-highlight-strong)]"
+              title="Re-upload assets that are already on R2 so they pick up the latest cache headers. Slower — use after a caching change."
+            >
+              <input
+                type="checkbox"
+                checked={forceReupload}
+                onChange={(event) => setForceReupload(event.target.checked)}
+                className="accent-[var(--accent)]"
+              />
+              Force re-upload
+            </label>
           </div>
         </div>
 

--- a/creator/src/components/config/RuntimeHandoffStudio.tsx
+++ b/creator/src/components/config/RuntimeHandoffStudio.tsx
@@ -15,6 +15,7 @@ import {
   publishCuratedAssets,
   publishGlobalAssets,
   publishPlayerSprites,
+  publishVoices,
   runWorkspaceValidation,
   saveWorkspace,
 } from "@/lib/runtimeHandoff";
@@ -30,6 +31,7 @@ type StepKey =
   | "assets"
   | "globals"
   | "sprites"
+  | "voices"
   | "config"
   | "achievements"
   | "zones";
@@ -159,6 +161,7 @@ export function RuntimeHandoffStudio() {
     assets: { status: "idle", detail: "Upload approved gallery assets to R2.", errors: [] },
     globals: { status: "idle", detail: "Upload global asset files to R2.", errors: [] },
     sprites: { status: "idle", detail: "Upload player sprite files to R2.", errors: [] },
+    voices: { status: "idle", detail: "Upload synthesized dialogue clips to R2.", errors: [] },
     config: { status: "idle", detail: "Upload runtime config to R2.", errors: [] },
     achievements: { status: "idle", detail: "Upload achievements.yaml to R2.", errors: [] },
     zones: { status: "idle", detail: "Upload zone YAML files to R2.", errors: [] },
@@ -389,6 +392,30 @@ export function RuntimeHandoffStudio() {
     }
   };
 
+  const runVoicesStep = async () => {
+    setStepState("voices", {
+      status: "running",
+      detail: "Publishing dialogue voice-over to R2...",
+      errors: [],
+    });
+    try {
+      const result = await publishVoices(forceReupload);
+      const nothing = result.total === 0 && result.uploaded === 0 && result.failed === 0;
+      setStepState("voices", {
+        status: result.failed > 0 ? "warning" : "success",
+        detail: nothing ? "No synthesized dialogue clips to publish." : formatSyncResult(result, "clips"),
+        errors: result.errors,
+      });
+    } catch (error) {
+      setStepState("voices", {
+        status: "error",
+        detail: "Voice publish failed.",
+        errors: [String(error)],
+      });
+      throw error;
+    }
+  };
+
   const runConfigStep = async () => {
     if (!project) return;
     setStepState("config", {
@@ -520,6 +547,7 @@ export function RuntimeHandoffStudio() {
         await runAssetsStep();
         await runGlobalsStep();
         await runSpritesStep();
+        await runVoicesStep();
         await runConfigStep();
         await runAchievementsStep();
         await runZonesStep();
@@ -749,6 +777,16 @@ export function RuntimeHandoffStudio() {
 
         <StepCard
           number={8}
+          title="Publish dialogue voices"
+          description="Upload synthesized voice-over clips to R2."
+          state={steps.voices}
+          actionLabel="Publish voices"
+          disabled={!hasR2}
+          onAction={runVoicesStep}
+        />
+
+        <StepCard
+          number={9}
           title="Deploy runtime config"
           description="Upload the assembled runtime config the MUD server pulls from R2."
           state={steps.config}
@@ -758,7 +796,7 @@ export function RuntimeHandoffStudio() {
         />
 
         <StepCard
-          number={9}
+          number={10}
           title="Deploy achievements"
           description="Upload achievements.yaml to R2."
           state={steps.achievements}
@@ -768,7 +806,7 @@ export function RuntimeHandoffStudio() {
         />
 
         <StepCard
-          number={10}
+          number={11}
           title="Deploy zone YAML"
           description="Upload zone files to R2."
           state={steps.zones}

--- a/creator/src/components/zone/CrossZoneNode.tsx
+++ b/creator/src/components/zone/CrossZoneNode.tsx
@@ -48,10 +48,10 @@ export function CrossZoneNode({ data }: NodeProps<CrossZoneNodeType>) {
       {([Position.Top, Position.Bottom, Position.Left, Position.Right] as const).map(
         (pos) => (
           <Handle
-            key={`target-${pos}`}
+            key={pos}
             type="target"
             position={pos}
-            id={`target-${pos === Position.Top ? "n" : pos === Position.Bottom ? "s" : pos === Position.Left ? "w" : "e"}`}
+            id={pos === Position.Top ? "n" : pos === Position.Bottom ? "s" : pos === Position.Left ? "w" : "e"}
             style={handleStyle}
             isConnectable
           />

--- a/creator/src/components/zone/RoomNode.tsx
+++ b/creator/src/components/zone/RoomNode.tsx
@@ -62,27 +62,37 @@ const plusHandleStyle: React.CSSProperties = {
 
 // ─── Sub-components ──────────────────────────────────────────────────
 
+// Generated art is 1024px+ (often multi-MB PNGs); map nodes display it at
+// 220 CSS px wide. Server-side thumbnails keep large zones from holding
+// hundreds of full-resolution bitmaps in the canvas, which is what made
+// pan/zoom crawl. 512 covers max zoom (2x) at typical DPI; 96 covers the
+// 24px sprite chips.
+const ROOM_BG_MAX_DIM = 512;
+const SPRITE_MAX_DIM = 96;
+
 function SpriteThumb({ sprite }: { sprite: EntitySprite }) {
-  const src = useImageSrc(sprite.image);
+  const src = useImageSrc(sprite.image, { maxDim: SPRITE_MAX_DIM });
   if (!src) return null;
   return (
     <img
       src={src}
       alt={sprite.name}
       title={`${sprite.kind}: ${sprite.name}`}
+      decoding="async"
       className="h-6 w-6 rounded-sm border border-[var(--chrome-stroke-emphasis)] object-cover"
     />
   );
 }
 
 function RoomBackground({ image }: { image?: string }) {
-  const src = useImageSrc(image);
+  const src = useImageSrc(image, { maxDim: ROOM_BG_MAX_DIM });
   if (!src) return null;
   return (
     <>
       <img
         src={src}
         alt=""
+        decoding="async"
         className="pointer-events-none absolute inset-0 h-full w-full rounded object-cover"
       />
       {/* Gradient fade at bottom so the badge is readable */}
@@ -211,29 +221,21 @@ export const RoomNode = memo(function RoomNode({ data, selected }: NodeProps<Roo
       {/* Room background image — full opacity */}
       <RoomBackground image={d.image} />
 
-      {/* Source handles (drag from these to create exits) */}
+      {/* One handle per direction, doubling as drag origin and edge anchor.
+          Requires ConnectionMode.Loose on the owning ReactFlow — loose mode
+          lets edges terminate on source-type handles, so we don't need a
+          mirrored set of target handles (which doubled the per-node handle
+          count: 20 ReactFlow components per room adds up on large maps). */}
       {HANDLES.map((h) => (
         <Handle
-          key={`source-${h.id}`}
+          key={h.id}
           type="source"
           position={h.position}
-          id={`source-${h.id}`}
+          id={h.id}
           title={h.label}
           isConnectable
           className={h.showPlus ? "room-handle-plus" : ""}
           style={h.showPlus ? { ...plusHandleStyle, ...h.style } : { ...hiddenHandleStyle, ...h.style }}
-        />
-      ))}
-
-      {/* Target handles (invisible — receive connections) */}
-      {HANDLES.map((h) => (
-        <Handle
-          key={`target-${h.id}`}
-          type="target"
-          position={h.position}
-          id={`target-${h.id}`}
-          style={{ ...hiddenHandleStyle, ...h.style }}
-          isConnectable
         />
       ))}
 

--- a/creator/src/components/zone/ZoneAtlasView.tsx
+++ b/creator/src/components/zone/ZoneAtlasView.tsx
@@ -12,6 +12,7 @@ import {
   type Edge,
   type NodeMouseHandler,
   type OnNodeDrag,
+  ConnectionMode,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import dagre from "@dagrejs/dagre";
@@ -524,6 +525,9 @@ function ZoneAtlas() {
         onNodeDragStop={onNodeDragStop}
         minZoom={0.04}
         maxZoom={2}
+        // RoomNode ships a single source-type handle per direction; loose
+        // mode lets edge targets anchor to them.
+        connectionMode={ConnectionMode.Loose}
         fitView
         fitViewOptions={{ padding: 0.15 }}
         nodesDraggable

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -12,6 +12,7 @@ import {
   type NodeMouseHandler,
   type Connection,
   BackgroundVariant,
+  ConnectionMode,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
@@ -478,8 +479,8 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
         ? target.slice("xzone:".length)
         : target;
 
-      // Extract direction from sourceHandle (e.g. "source-n" → "n")
-      const inferredDir = sourceHandle?.replace("source-", "") ?? "n";
+      // Handle ids are bare directions ("n", "se", "u", ...)
+      const inferredDir = sourceHandle ?? "n";
 
       // Show direction picker instead of immediately creating exit
       setPendingConnection({ source, target: resolvedTarget, inferredDir });
@@ -1084,6 +1085,10 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
               onPaneClick={onPaneClick}
               minZoom={0.1}
               maxZoom={2}
+              // Loose mode lets edges and connection drags terminate on
+              // source-type handles, so RoomNode ships one handle per
+              // direction instead of a source/target pair.
+              connectionMode={ConnectionMode.Loose}
               // Skip mounting nodes outside the viewport. Big perf win for
               // zones with many image-backed rooms — each off-screen node
               // would otherwise hold a base64 background in the DOM.

--- a/creator/src/lib/dialogueLines.ts
+++ b/creator/src/lib/dialogueLines.ts
@@ -1,0 +1,31 @@
+import type { WorldFile } from "@/types/world";
+import type { DialogueLine } from "@/types/voiceover";
+
+/** Flatten every voiceable NPC dialogue line across the given zones, sorted by
+ *  zone, then mob, then node (root first). Shared by the Voice-Over panel and
+ *  the world publish flow so both enumerate the same lines. */
+export function collectDialogueLines(
+  zones: Map<string, { data: WorldFile }>,
+): DialogueLine[] {
+  const lines: DialogueLine[] = [];
+  for (const { data } of zones.values()) {
+    const zone = data.zone;
+    const mobs = data.mobs ?? {};
+    for (const [templateKey, mob] of Object.entries(mobs)) {
+      const dialogue = mob.dialogue;
+      if (!dialogue) continue;
+      for (const [nodeId, node] of Object.entries(dialogue)) {
+        if (!node.text || !node.text.trim()) continue;
+        lines.push({ zone, templateKey, mobName: mob.name ?? templateKey, nodeId, text: node.text });
+      }
+    }
+  }
+  lines.sort((a, b) => {
+    if (a.zone !== b.zone) return a.zone.localeCompare(b.zone);
+    if (a.templateKey !== b.templateKey) return a.templateKey.localeCompare(b.templateKey);
+    if (a.nodeId === "root") return -1;
+    if (b.nodeId === "root") return 1;
+    return a.nodeId.localeCompare(b.nodeId);
+  });
+  return lines;
+}

--- a/creator/src/lib/runtimeHandoff.ts
+++ b/creator/src/lib/runtimeHandoff.ts
@@ -9,6 +9,7 @@ import { validateAllZones, type ValidationIssue } from "@/lib/validateZone";
 import { useAssetStore } from "@/stores/assetStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useValidationStore } from "@/stores/validationStore";
+import { useVoiceStore } from "@/stores/voiceStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import type { Project } from "@/types/project";
 import type { SyncProgress, SyncScope } from "@/types/assets";
@@ -167,6 +168,11 @@ export async function publishGlobalAssets(force = false): Promise<SyncProgress> 
 export async function publishPlayerSprites(force = false): Promise<SyncProgress> {
   const spritesYaml = generateSpritesYaml();
   return invoke<SyncProgress>("deploy_sprites_to_r2", { spritesYaml, force });
+}
+
+export async function publishVoices(force = false): Promise<SyncProgress> {
+  const result = await useVoiceStore.getState().publishWorldVoices(force);
+  return result ?? { total: 0, uploaded: 0, skipped: 0, failed: 0, errors: [] };
 }
 
 export async function deployRuntimeAchievements(): Promise<string> {

--- a/creator/src/lib/runtimeHandoff.ts
+++ b/creator/src/lib/runtimeHandoff.ts
@@ -149,20 +149,24 @@ export async function exportRuntimeBundle(outputDir: string) {
   return exportMudFormat(outputDir);
 }
 
-export async function publishCuratedAssets(scope: SyncScope = "approved"): Promise<SyncProgress> {
-  return useAssetStore.getState().syncToR2(scope);
+export async function publishCuratedAssets(
+  scope: SyncScope = "approved",
+  force = false,
+): Promise<SyncProgress> {
+  return useAssetStore.getState().syncToR2(scope, force);
 }
 
-export async function publishGlobalAssets(): Promise<SyncProgress> {
+export async function publishGlobalAssets(force = false): Promise<SyncProgress> {
   const config = useConfigStore.getState().config;
   return invoke<SyncProgress>("deploy_global_assets_to_r2", {
     globalAssets: config?.globalAssets ?? {},
+    force,
   });
 }
 
-export async function publishPlayerSprites(): Promise<SyncProgress> {
+export async function publishPlayerSprites(force = false): Promise<SyncProgress> {
   const spritesYaml = generateSpritesYaml();
-  return invoke<SyncProgress>("deploy_sprites_to_r2", { spritesYaml });
+  return invoke<SyncProgress>("deploy_sprites_to_r2", { spritesYaml, force });
 }
 
 export async function deployRuntimeAchievements(): Promise<string> {

--- a/creator/src/lib/useImageSrc.ts
+++ b/creator/src/lib/useImageSrc.ts
@@ -13,26 +13,59 @@ import { useAssetStore } from "@/stores/assetStore";
  */
 const imageDataUrlCache = new Map<string, Promise<string>>();
 
-function fetchImageDataUrl(path: string): Promise<string> {
-  const cached = imageDataUrlCache.get(path);
+/** Settled values from `imageDataUrlCache`, for synchronous lookup. Lets
+ *  components that re-mount constantly (ReactFlow nodes under
+ *  `onlyRenderVisibleElements`) render already-loaded images in their first
+ *  paint instead of flashing through a loading state on every pan. */
+const resolvedImageCache = new Map<string, string>();
+
+// NUL is illegal in file paths on every platform, so thumbnail keys can
+// never collide with a real full-size path key.
+const KEY_SEP = String.fromCharCode(0);
+
+function cacheKey(path: string, maxDim?: number): string {
+  return maxDim ? `${path}${KEY_SEP}${maxDim}` : path;
+}
+
+function fetchImageDataUrl(path: string, maxDim?: number): Promise<string> {
+  const key = cacheKey(path, maxDim);
+  const cached = imageDataUrlCache.get(key);
   if (cached) return cached;
-  const promise = invoke<string>("read_image_data_url", { path });
-  imageDataUrlCache.set(path, promise);
-  promise.catch(() => imageDataUrlCache.delete(path));
+  const promise = maxDim
+    ? invoke<string>("read_image_thumbnail_data_url", { path, maxDim })
+    : invoke<string>("read_image_data_url", { path });
+  imageDataUrlCache.set(key, promise);
+  promise.then(
+    (dataUrl) => resolvedImageCache.set(key, dataUrl),
+    () => imageDataUrlCache.delete(key),
+  );
   return promise;
 }
 
-/** Drop a single entry from the image-data-url cache. Call after writing the
- *  underlying file (e.g. asset accept, regenerate) so the next load picks up
- *  the new bytes instead of returning a stale data URL. */
+function lookupResolved(candidates: string[], maxDim?: number): string | null {
+  for (const path of candidates) {
+    const hit = resolvedImageCache.get(cacheKey(path, maxDim));
+    if (hit) return hit;
+  }
+  return null;
+}
+
+/** Drop all cached entries (full-size and thumbnails) for a path. Call after
+ *  writing the underlying file (e.g. asset accept, regenerate) so the next
+ *  load picks up the new bytes instead of returning a stale data URL. */
 export function invalidateImageCache(path: string): void {
-  imageDataUrlCache.delete(path);
+  for (const map of [imageDataUrlCache, resolvedImageCache] as Map<string, unknown>[]) {
+    for (const key of map.keys()) {
+      if (key === path || key.startsWith(`${path}${KEY_SEP}`)) map.delete(key);
+    }
+  }
 }
 
 /** Clear the entire image-data-url cache. Use sparingly — meant for project
  *  switches where every path is now invalid. */
 export function clearImageCache(): void {
   imageDataUrlCache.clear();
+  resolvedImageCache.clear();
 }
 
 /** Returns true if the path looks like an R2 hash filename (64 hex chars + extension). */
@@ -57,6 +90,14 @@ export interface ImageLoadResult {
   status: ImageLoadStatus;
 }
 
+export interface ImageSrcOptions {
+  /** Downscale server-side to fit within maxDim pixels (re-encoded as lossy
+   *  WebP). Use for map nodes and list thumbnails — full-resolution art is
+   *  often a multi-MB PNG that wastes IPC, decode time, and GPU memory when
+   *  displayed at thumbnail size. Omit for full resolution. */
+  maxDim?: number;
+}
+
 /**
  * Load an image from a local file path via IPC, returning a data URL plus status.
  * Handles three kinds of paths:
@@ -64,11 +105,13 @@ export interface ImageLoadResult {
  * - Legacy relative paths (e.g. "zone/image.png") → resolve from MUD images dir
  * - Absolute paths → load directly
  */
-export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult {
+export function useImageSrcStatus(
+  filePath: string | undefined,
+  options?: ImageSrcOptions,
+): ImageLoadResult {
+  const maxDim = options?.maxDim;
   const mudDir = useProjectStore((s) => s.project?.mudDir);
   const assetsDir = useAssetStore((s) => s.assetsDir);
-  const [src, setSrc] = useState<string | null>(null);
-  const [status, setStatus] = useState<ImageLoadStatus>("idle");
 
   const candidates = useMemo(() => {
     if (!filePath) return [];
@@ -90,6 +133,16 @@ export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult
     ];
   }, [filePath, mudDir, assetsDir]);
 
+  // Synchronous fast path on mount: components that re-mount constantly
+  // (ReactFlow nodes under `onlyRenderVisibleElements` re-mount on every
+  // pan) render already-loaded images in their first paint, skipping the
+  // loading flash and the extra render of the async path.
+  const initial = lookupResolved(candidates, maxDim);
+  const [src, setSrc] = useState<string | null>(initial);
+  const [status, setStatus] = useState<ImageLoadStatus>(
+    initial ? "loaded" : filePath ? "loading" : "idle",
+  );
+
   useEffect(() => {
     if (!filePath) {
       setSrc(null);
@@ -104,9 +157,16 @@ export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult
       return;
     }
 
-    // Synchronous fast path: if every candidate is already cached, pick the
-    // first one that resolved successfully and skip the async dance. Avoids
-    // a "loading" flash and a microtask hop on re-renders of cached images.
+    // Same fast path for in-place candidate changes (e.g. a list row reused
+    // for a different image whose data URL is already cached). React bails
+    // out of the re-render when the values are unchanged.
+    const resolved = lookupResolved(candidates, maxDim);
+    if (resolved) {
+      setSrc(resolved);
+      setStatus("loaded");
+      return;
+    }
+
     let cancelled = false;
     setStatus("loading");
 
@@ -114,7 +174,7 @@ export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult
       for (const path of candidates) {
         if (cancelled) return;
         try {
-          const dataUrl = await fetchImageDataUrl(path);
+          const dataUrl = await fetchImageDataUrl(path, maxDim);
           if (!cancelled) {
             setSrc(dataUrl);
             setStatus("loaded");
@@ -133,14 +193,17 @@ export function useImageSrcStatus(filePath: string | undefined): ImageLoadResult
     return () => {
       cancelled = true;
     };
-  }, [candidates, filePath]);
+  }, [candidates, filePath, maxDim]);
 
   return { src, status };
 }
 
 /** Backwards-compatible thin wrapper that returns just the data URL. */
-export function useImageSrc(filePath: string | undefined): string | null {
-  return useImageSrcStatus(filePath).src;
+export function useImageSrc(
+  filePath: string | undefined,
+  options?: ImageSrcOptions,
+): string | null {
+  return useImageSrcStatus(filePath, options).src;
 }
 
 /**

--- a/creator/src/lib/zoneToGraph.ts
+++ b/creator/src/lib/zoneToGraph.ts
@@ -393,10 +393,8 @@ export function zoneToGraph(
       id: `${exit.source}-${exit.direction}-${exit.target}`,
       source: exit.source,
       target: exit.target,
-      sourceHandle: `source-${exit.direction}`,
-      targetHandle: reverse
-        ? `target-${reverse.direction}`
-        : `target-${oppositeDir(exit.direction)}`,
+      sourceHandle: exit.direction,
+      targetHandle: reverse ? reverse.direction : oppositeDir(exit.direction),
       type: "exitEdge",
       label,
       animated: isCrossZone || isVertical,

--- a/creator/src/stores/assetStore.ts
+++ b/creator/src/stores/assetStore.ts
@@ -42,7 +42,7 @@ interface AssetState {
   setActiveVariant: (variantGroup: string, assetId: string) => Promise<void>;
   listVariants: (variantGroup: string) => Promise<AssetEntry[]>;
 
-  syncToR2: (scope?: SyncScope) => Promise<SyncProgress>;
+  syncToR2: (scope?: SyncScope, force?: boolean) => Promise<SyncProgress>;
   getSyncStatus: () => Promise<SyncProgress>;
 
   startBatch: (progress: BatchProgress) => void;
@@ -159,10 +159,10 @@ export const useAssetStore = create<AssetState>((set, get) => ({
     return invoke<AssetEntry[]>("list_variants", { variantGroup });
   },
 
-  syncToR2: async (scope = "approved") => {
+  syncToR2: async (scope = "approved", force = false) => {
     set({ syncing: true });
     try {
-      const result = await invoke<SyncProgress>("sync_assets", { scope });
+      const result = await invoke<SyncProgress>("sync_assets", { scope, force });
       set({ lastSyncResult: result, syncing: false });
       await get().loadAssets();
       return result;

--- a/creator/src/stores/voiceStore.ts
+++ b/creator/src/stores/voiceStore.ts
@@ -1,6 +1,8 @@
 import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
 import { useProjectStore } from "@/stores/projectStore";
+import { useZoneStore } from "@/stores/zoneStore";
+import { collectDialogueLines } from "@/lib/dialogueLines";
 import type { SyncProgress } from "@/types/assets";
 import {
   DEFAULT_ELEVENLABS_MODEL,
@@ -98,6 +100,10 @@ interface VoiceStore {
   synthesizeLine: (line: DialogueLine) => Promise<void>;
   generateAll: (lines: DialogueLine[]) => Promise<void>;
   publishToR2: (lines: DialogueLine[], force?: boolean) => Promise<SyncProgress | null>;
+  /** Self-contained publish for the world handoff flow: loads the voice map,
+   *  enumerates every dialogue line, rehydrates on-disk clips, then uploads.
+   *  Works without the Voice-Over panel ever being opened. */
+  publishWorldVoices: (force?: boolean) => Promise<SyncProgress | null>;
   reset: () => void;
 }
 
@@ -412,6 +418,22 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
       set({ lastPublish: progress, publishing: false });
       return progress;
     }
+  },
+
+  publishWorldVoices: async (force = false) => {
+    const dir = projectDir();
+    if (!dir) return null;
+    await get().loadVoiceMap();
+    const lines = collectDialogueLines(useZoneStore.getState().zones);
+    if (lines.length === 0) {
+      const empty: SyncProgress = { total: 0, uploaded: 0, skipped: 0, failed: 0, errors: [] };
+      set({ lastPublish: empty });
+      return empty;
+    }
+    // Discover which clips are already synthesized on disk for the current
+    // voice/model/settings — the panel may never have been opened this session.
+    await get().rehydrate(lines);
+    return get().publishToR2(lines, force);
   },
 
   reset: () =>

--- a/creator/src/stores/voiceStore.ts
+++ b/creator/src/stores/voiceStore.ts
@@ -97,7 +97,7 @@ interface VoiceStore {
 
   synthesizeLine: (line: DialogueLine) => Promise<void>;
   generateAll: (lines: DialogueLine[]) => Promise<void>;
-  publishToR2: (lines: DialogueLine[]) => Promise<SyncProgress | null>;
+  publishToR2: (lines: DialogueLine[], force?: boolean) => Promise<SyncProgress | null>;
   reset: () => void;
 }
 
@@ -380,7 +380,7 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
     }
   },
 
-  publishToR2: async (lines) => {
+  publishToR2: async (lines, force = false) => {
     if (get().publishing) return null;
     set({ publishing: true, lastPublish: null });
     try {
@@ -398,7 +398,7 @@ export const useVoiceStore = create<VoiceStore>((set, get) => ({
           });
         }
       }
-      const progress = await invoke<SyncProgress>("deploy_voices_to_r2", { jobs });
+      const progress = await invoke<SyncProgress>("deploy_voices_to_r2", { jobs, force });
       set({ lastPublish: progress, publishing: false });
       return progress;
     } catch (e) {

--- a/hub-worker/src/handlers/publish.ts
+++ b/hub-worker/src/handlers/publish.ts
@@ -80,8 +80,14 @@ export async function uploadImage(req: Request, env: Env, user: UserRow): Promis
   }
 
   const key = `worlds/${slug}/images/${last}`;
+  // Content-addressed (filename is the SHA-256), so the bytes behind a URL can
+  // never change — store an immutable Cache-Control alongside the object so it
+  // travels with any direct-R2 access, matching what serveImage sets on GET.
   await env.BUCKET.put(key, bytes, {
-    httpMetadata: { contentType: "image/webp" },
+    httpMetadata: {
+      contentType: "image/webp",
+      cacheControl: "public, max-age=31536000, immutable",
+    },
   });
 
   return json({ ok: true, size: bytes.byteLength }, {}, { origin: "*" });
@@ -127,8 +133,13 @@ export async function uploadManifest(req: Request, env: Env, user: UserRow): Pro
   const json_text = JSON.stringify(body.showcase);
   const bytes = new TextEncoder().encode(json_text);
 
+  // Mutable at a stable key — keep it short so a republish shows up quickly.
+  // serveShowcaseJson sets the authoritative header on GET; this just mirrors it.
   await env.BUCKET.put(`worlds/${slug}/showcase.json`, bytes, {
-    httpMetadata: { contentType: "application/json" },
+    httpMetadata: {
+      contentType: "application/json",
+      cacheControl: "public, max-age=60, s-maxage=300",
+    },
   });
 
   // Discovery metadata is derived from the manifest we just stored,


### PR DESCRIPTION
## Why

MUD game clients (and the showcase CDN) re-downloaded painted scenes, sprites, and other art on **every** game load because R2 objects shipped with no `Cache-Control` header. On slow connections that's the dominant cost of loading the game.

## What

**1. Cache-Control on every self-hosted R2 upload** (`creator/src-tauri/src/r2.rs`)

Threaded a `cache_control` value through the SigV4 signer (it's a *signed* header so R2 stores it as object metadata and returns it on GET), tiered by how each object key behaves:

| Tier | Value | Applies to |
|------|-------|-----------|
| Immutable | `public, max-age=31536000, immutable` | Content-addressed art (`sync_assets`) + voice clips (`text_sha8` path) |
| Asset | `public, max-age=86400` | Stable-path media: sprites, global assets, cinematics |
| Manifest | `public, max-age=60` | `.yaml` configs + `showcase.json` |

The heavy art is content-addressed, so it gets the full year-long immutable treatment — returning players and zone transitions re-fetch nothing.

**2. Hub Worker** (`hub-worker/src/handlers/publish.ts`)

The Worker's GET path already set ideal headers (`serveImage` → immutable, `serveShowcaseJson` → short). Mirrored those onto the `BUCKET.put` httpMetadata so they travel with the stored object for any direct-R2 access.

**3. Force re-upload / bucket backfill** (Rust + UI)

The four skip-tracking commands (`sync_assets`, `deploy_sprites_to_r2`, `deploy_global_assets_to_r2`, `deploy_voices_to_r2`) now accept a `force` flag that bypasses their dedup checks (remote HEAD probe / local `runtime_sync_state` cache). This:
- backfills the new headers onto objects already in R2, and
- seeds a **brand-new bucket** — the skip state is local, not per-bucket, so without `force` a fresh bucket would be wrongly skipped.

Surfaced as a **"Force re-upload"** toggle in:
- the Runtime Handoff Studio header (covers assets / globals / sprites; use "Everything" scope + Publish all for a full bucket)
- the Voice-Over panel (dialogue clips)

All `force` params are `Option<bool>` defaulting to false, so every existing caller is unchanged.

## Notes / usage

- To initialize a new bucket: point R2 settings at it → tick **Force re-upload** → set scope to **Everything** → **Publish all**. The always-upload steps (config, achievements, zones, showcase.json) need no force.
- A forced run re-uploads everything, so it's slower/bandwidth-heavy — meant as a one-time backfill or bucket seed, not for routine publishes.

## Verification

- `cargo check` ✅
- creator `tsc --noEmit` ✅
- hub-worker `tsc --noEmit` ✅
- `bun run test` — 2125 tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)