### PR TITLE
Add WebSocket connection-limit + admin host config fields

### DIFF
--- a/creator/src/components/config/panels/AdminConfigPanel.tsx
+++ b/creator/src/components/config/panels/AdminConfigPanel.tsx
@@ -20,6 +20,13 @@ export function AdminConfigPanel({ config, onChange }: ConfigPanelProps) {
               label="Enable admin server"
             />
           </FieldRow>
+          <FieldRow label="Host" hint="Bind address for the admin API. Defaults to 127.0.0.1 (loopback) so the privileged API is not network-reachable. Set to 0.0.0.0 only behind a reverse proxy.">
+            <TextInput
+              value={a.host}
+              onCommit={(v) => patch({ host: v || "127.0.0.1" })}
+              placeholder="127.0.0.1"
+            />
+          </FieldRow>
           <FieldRow label="Port" hint="HTTP port for the admin API. Default 9091 avoids conflicts with the game's web port.">
             <NumberInput
               value={a.port}

--- a/creator/src/components/config/panels/InfrastructurePanel.tsx
+++ b/creator/src/components/config/panels/InfrastructurePanel.tsx
@@ -300,6 +300,60 @@ function WebsocketBody({ config, onChange }: ConfigPanelProps) {
       </div>
 
       <div className="ornate-divider" aria-hidden />
+      <SubLabel>Connection limits</SubLabel>
+      <div className="flex flex-col gap-1.5">
+        <FieldRow label="Max connections" hint="Global cap on concurrent WebSocket connections before new ones are rejected.">
+          <NumberInput
+            value={t.websocket.maxConnections}
+            onCommit={(v) => patchWs({ maxConnections: v ?? 5000 })}
+            min={1}
+            max={1000000}
+            dense
+          />
+        </FieldRow>
+        <FieldRow label="Max per IP" hint="Concurrent connections allowed from a single remote IP. 0 disables the per-IP cap.">
+          <NumberInput
+            value={t.websocket.maxConnectionsPerIp}
+            onCommit={(v) => patchWs({ maxConnectionsPerIp: v ?? 30 })}
+            min={0}
+            max={100000}
+            dense
+          />
+        </FieldRow>
+        <FieldRow label="Max frame (bytes)" hint="Largest inbound WebSocket frame accepted. Bigger frames are rejected.">
+          <NumberInput
+            value={t.websocket.maxFrameBytes}
+            onCommit={(v) => patchWs({ maxFrameBytes: v ?? 65536 })}
+            min={1024}
+            dense
+          />
+        </FieldRow>
+      </div>
+
+      <div className="ornate-divider" aria-hidden />
+      <SubLabel>Keepalive</SubLabel>
+      <div className="flex flex-col gap-1.5">
+        <FieldRow label="Ping period (ms)" hint="Server→client ping interval; also drives dead-peer detection. 0 disables pings.">
+          <NumberInput
+            value={t.websocket.pingPeriodMillis}
+            onCommit={(v) => patchWs({ pingPeriodMillis: v ?? 15000 })}
+            min={0}
+            max={600000}
+            dense
+          />
+        </FieldRow>
+        <FieldRow label="Pong timeout (ms)" hint="Time to wait for a pong before closing. Defends against slow-loris holds.">
+          <NumberInput
+            value={t.websocket.pongTimeoutMillis}
+            onCommit={(v) => patchWs({ pongTimeoutMillis: v ?? 30000 })}
+            min={0}
+            max={600000}
+            dense
+          />
+        </FieldRow>
+      </div>
+
+      <div className="ornate-divider" aria-hidden />
       <SubLabel>Backpressure</SubLabel>
       <div className="flex flex-col gap-1.5">
         <FieldRow label="Max failures" hint="Outbound buffer overflows before drop.">

--- a/creator/src/lib/__tests__/exportMud.test.ts
+++ b/creator/src/lib/__tests__/exportMud.test.ts
@@ -150,6 +150,7 @@ const BASE_CONFIG: AppConfig = {
   },
   admin: {
     enabled: false,
+    host: "127.0.0.1",
     port: 8081,
     token: "",
     basePath: "/admin",
@@ -168,7 +169,7 @@ const BASE_CONFIG: AppConfig = {
   emotePresets: { presets: [] },
   persistence: { backend: "YAML", rootDir: "data/players", worker: { enabled: true, flushIntervalMs: 5000 } },
   login: { maxWrongPasswordRetries: 3, maxFailedAttemptsBeforeDisconnect: 3, maxConcurrentLogins: 50, authThreads: 8 },
-  transport: { telnet: { maxLineLen: 1024, maxNonPrintablePerLine: 32, socketBacklog: 256, maxConnections: 5000 }, websocket: { host: "0.0.0.0", stopGraceMillis: 1000, stopTimeoutMillis: 2000 }, maxInboundBackpressureFailures: 3 },
+  transport: { telnet: { maxLineLen: 1024, maxNonPrintablePerLine: 32, socketBacklog: 256, maxConnections: 5000 }, websocket: { host: "0.0.0.0", stopGraceMillis: 1000, stopTimeoutMillis: 2000, maxConnections: 5000, maxConnectionsPerIp: 30, pingPeriodMillis: 15000, pongTimeoutMillis: 30000, maxFrameBytes: 65536 }, maxInboundBackpressureFailures: 3 },
   demo: { autoLaunchBrowser: false, webClientHost: "localhost", webClientUrl: null },
   database: { jdbcUrl: "jdbc:postgresql://localhost:5432/ambonmud", username: "ambon", password: "ambon", maxPoolSize: 5, minimumIdle: 1 },
   redis: { enabled: false, uri: "redis://localhost:6379", cacheTtlSeconds: 3600, bus: { enabled: false, inboundChannel: "ambon:inbound", outboundChannel: "ambon:outbound", instanceId: "", sharedSecret: "" } },

--- a/creator/src/lib/__tests__/validateConfig.test.ts
+++ b/creator/src/lib/__tests__/validateConfig.test.ts
@@ -6,7 +6,7 @@ import type { AppConfig } from "@/types/config";
 const BASE_CONFIG: AppConfig = {
   mode: "STANDALONE",
   server: { telnetPort: 4000, webPort: 8080, inboundChannelCapacity: 10000, outboundChannelCapacity: 10000, sessionOutboundQueueCapacity: 200, maxInboundEventsPerTick: 1000, tickMillis: 100, inboundBudgetMs: 30 },
-  admin: { enabled: false, port: 9091, token: "", basePath: "/", grafanaUrl: "", corsOrigins: [] },
+  admin: { enabled: false, host: "127.0.0.1", port: 9091, token: "", basePath: "/", grafanaUrl: "", corsOrigins: [] },
   observability: { metricsEnabled: true, metricsEndpoint: "/metrics", metricsHttpPort: 9099, metricsHttpHost: "0.0.0.0", staticTags: {} },
   logging: { level: "INFO", packageLevels: {} },
   world: { startRoom: "" },
@@ -237,7 +237,7 @@ const BASE_CONFIG: AppConfig = {
   },
   persistence: { backend: "YAML", rootDir: "data/players", worker: { enabled: true, flushIntervalMs: 5000 } },
   login: { maxWrongPasswordRetries: 3, maxFailedAttemptsBeforeDisconnect: 3, maxConcurrentLogins: 50, authThreads: 8 },
-  transport: { telnet: { maxLineLen: 1024, maxNonPrintablePerLine: 32, socketBacklog: 256, maxConnections: 5000 }, websocket: { host: "0.0.0.0", stopGraceMillis: 1000, stopTimeoutMillis: 2000 }, maxInboundBackpressureFailures: 3 },
+  transport: { telnet: { maxLineLen: 1024, maxNonPrintablePerLine: 32, socketBacklog: 256, maxConnections: 5000 }, websocket: { host: "0.0.0.0", stopGraceMillis: 1000, stopTimeoutMillis: 2000, maxConnections: 5000, maxConnectionsPerIp: 30, pingPeriodMillis: 15000, pongTimeoutMillis: 30000, maxFrameBytes: 65536 }, maxInboundBackpressureFailures: 3 },
   demo: { autoLaunchBrowser: false, webClientHost: "localhost", webClientUrl: null },
   database: { jdbcUrl: "jdbc:postgresql://localhost:5432/ambonmud", username: "ambon", password: "ambon", maxPoolSize: 5, minimumIdle: 1 },
   redis: { enabled: false, uri: "redis://localhost:6379", cacheTtlSeconds: 3600, bus: { enabled: false, inboundChannel: "ambon:inbound", outboundChannel: "ambon:outbound", instanceId: "", sharedSecret: "" } },

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -57,6 +57,7 @@ function voicesBaseUrl(imagesBaseUrl: string): string {
 function sanitizeAdminConfigForRuntime(admin: AppConfig["admin"] | undefined): AppConfig["admin"] {
   return {
     enabled: admin?.enabled ?? false,
+    host: admin?.host ?? "127.0.0.1",
     port: admin?.port ?? 9091,
     // The runtime token is injected by the mud deployment layer via env/SSM.
     // Arcanum should never persist it into project config.
@@ -533,6 +534,7 @@ export function buildMonolithicConfigObject(
     },
     admin: {
       enabled: adminConfig.enabled,
+      host: adminConfig.host || undefined,
       port: adminConfig.port,
       token: adminConfig.token,
       basePath: adminConfig.basePath || undefined,

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -261,6 +261,11 @@ function parseTransportConfig(raw: unknown): AppConfig["transport"] {
       host: asString(ws.host, "0.0.0.0"),
       stopGraceMillis: asNumber(ws.stopGraceMillis, 1000),
       stopTimeoutMillis: asNumber(ws.stopTimeoutMillis, 2000),
+      maxConnections: asNumber(ws.maxConnections, 5000),
+      maxConnectionsPerIp: asNumber(ws.maxConnectionsPerIp, 30),
+      pingPeriodMillis: asNumber(ws.pingPeriodMillis, 15000),
+      pongTimeoutMillis: asNumber(ws.pongTimeoutMillis, 30000),
+      maxFrameBytes: asNumber(ws.maxFrameBytes, 65536),
     },
     maxInboundBackpressureFailures: asNumber(s.maxInboundBackpressureFailures, 3),
   };
@@ -388,6 +393,7 @@ function parseAdminConfig(raw: unknown): AppConfig["admin"] {
   const s = (raw ?? {}) as Record<string, unknown>;
   return {
     enabled: s.enabled === true,
+    host: asString(s.host, "127.0.0.1"),
     port: asNumber(s.port, 9091),
     token: asString(s.token, ""),
     basePath: asString(s.basePath, "/"),

--- a/creator/src/lib/tuning/__tests__/presets.test.ts
+++ b/creator/src/lib/tuning/__tests__/presets.test.ts
@@ -15,7 +15,7 @@ import type { AppConfig } from "@/types/config";
 const FULL_MOCK_CONFIG: AppConfig = {
   mode: "STANDALONE",
   server: { telnetPort: 4000, webPort: 8080, inboundChannelCapacity: 10000, outboundChannelCapacity: 10000, sessionOutboundQueueCapacity: 200, maxInboundEventsPerTick: 1000, tickMillis: 100, inboundBudgetMs: 30 },
-  admin: { enabled: false, port: 9090, token: "test", basePath: "/admin", grafanaUrl: "" },
+  admin: { enabled: false, host: "127.0.0.1", port: 9090, token: "test", basePath: "/admin", grafanaUrl: "" },
   observability: { metricsEnabled: false, metricsEndpoint: "/metrics", metricsHttpPort: 9100 },
   logging: { level: "INFO", packageLevels: {} },
   world: { startRoom: "town:center", resources: [] },
@@ -141,7 +141,7 @@ const FULL_MOCK_CONFIG: AppConfig = {
   globalAssets: {},
   persistence: { backend: "YAML", rootDir: "data/players", worker: { enabled: true, flushIntervalMs: 5000 } },
   login: { maxWrongPasswordRetries: 3, maxFailedAttemptsBeforeDisconnect: 3, maxConcurrentLogins: 50, authThreads: 8 },
-  transport: { telnet: { maxLineLen: 1024, maxNonPrintablePerLine: 32, socketBacklog: 256, maxConnections: 5000 }, websocket: { host: "0.0.0.0", stopGraceMillis: 1000, stopTimeoutMillis: 2000 }, maxInboundBackpressureFailures: 3 },
+  transport: { telnet: { maxLineLen: 1024, maxNonPrintablePerLine: 32, socketBacklog: 256, maxConnections: 5000 }, websocket: { host: "0.0.0.0", stopGraceMillis: 1000, stopTimeoutMillis: 2000, maxConnections: 5000, maxConnectionsPerIp: 30, pingPeriodMillis: 15000, pongTimeoutMillis: 30000, maxFrameBytes: 65536 }, maxInboundBackpressureFailures: 3 },
   demo: { autoLaunchBrowser: false, webClientHost: "localhost", webClientUrl: null },
   database: { jdbcUrl: "jdbc:postgresql://localhost:5432/ambonmud", username: "ambon", password: "ambon", maxPoolSize: 5, minimumIdle: 1 },
   redis: { enabled: false, uri: "redis://localhost:6379", cacheTtlSeconds: 3600, bus: { enabled: false, inboundChannel: "ambon:inbound", outboundChannel: "ambon:outbound", instanceId: "", sharedSecret: "" } },

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -1019,6 +1019,11 @@ export interface WebSocketTransportConfig {
   host: string;
   stopGraceMillis: number;
   stopTimeoutMillis: number;
+  maxConnections: number;
+  maxConnectionsPerIp: number;
+  pingPeriodMillis: number;
+  pongTimeoutMillis: number;
+  maxFrameBytes: number;
 }
 
 export interface TransportConfig {
@@ -1158,6 +1163,7 @@ export interface ShardingConfig {
 
 export interface AdminServerConfig {
   enabled: boolean;
+  host: string;
   port: number;
   token: string;
   basePath: string;


### PR DESCRIPTION
## Summary

[AmbonMUD PR #1300](https://github.com/jnoecker/AmbonMUD/pull/1300) (security hardening) added six new fields to the server's `application.yaml`. This makes them editable in Arcanum so they round-trip cleanly instead of being silently dropped on save.

**WebSocket transport** (`ambonmud.transports.websocket`):
- `maxConnections` (5000) — global cap on concurrent WS connections
- `maxConnectionsPerIp` (30) — per-IP cap (0 disables)
- `pingPeriodMillis` (15000) — server→client ping interval / dead-peer detection
- `pongTimeoutMillis` (30000) — slow-loris defense
- `maxFrameBytes` (65536) — max inbound frame size

**Admin** (`ambonmud.admin`):
- `host` (`127.0.0.1`) — bind address; loopback by default so the privileged admin API isn't network-reachable

## Changes
- `types/config.ts` — new fields on `WebSocketTransportConfig` and `AdminServerConfig`
- `lib/loader.ts` — parse the new keys with the server's defaults
- `lib/exportMud.ts` — emit `admin.host` in both export builders (websocket already passes through as a whole object)
- `components/config/panels/InfrastructurePanel.tsx` — "Connection limits" + "Keepalive" subsections in the WebSocket editor
- `components/config/panels/AdminConfigPanel.tsx` — Host field with a hint explaining the loopback default
- test fixtures updated for the new required fields

Defaults match the server exactly, so existing YAML loads with the same values the server would use and new keys are written on save.

## Testing
- `bunx tsc --noEmit` — clean
- `bun run test` — 2133 passed