### PR TITLE
Cinematic text alternatives: videoText / videoTextSeconds (issue 1240)

### DIFF
--- a/creator/src/components/editors/EditorShared.tsx
+++ b/creator/src/components/editors/EditorShared.tsx
@@ -1,6 +1,6 @@
 import { useState, type ReactNode } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { Section, FieldRow, TextInput } from "@/components/ui/FormWidgets";
+import { Section, FieldRow, TextInput, CommitTextarea, NumberInput } from "@/components/ui/FormWidgets";
 import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
 import { MediaPicker } from "@/components/ui/MediaPicker";
 import { MusicGenerator } from "@/components/ui/MusicGenerator";
@@ -207,11 +207,58 @@ export function EnhanceDescriptionButton({
   );
 }
 
+/**
+ * Text alternative for a cinematic — narrated as a vision to text and
+ * screen-reader clients in place of the video, and shown verbatim as the
+ * transcript under the video in the web client. Valid without a `video`
+ * (a text-only vision). Pairs everywhere a `video` field exists.
+ */
+export function VideoVisionFields({
+  videoText,
+  onVideoTextChange,
+  videoTextSeconds,
+  onVideoTextSecondsChange,
+}: {
+  videoText?: string;
+  onVideoTextChange: (v: string | undefined) => void;
+  videoTextSeconds?: number;
+  onVideoTextSecondsChange: (v: number | undefined) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <CommitTextarea
+        label="Vision text"
+        value={videoText ?? ""}
+        onCommit={(v) => onVideoTextChange(v.trim() ? v : undefined)}
+        rows={3}
+        placeholder="A hawk's-eye sweep over slate rooftops and lantern-lit lanes…"
+      />
+      <p className="text-2xs text-text-muted">
+        Narrated to text & screen-reader players as a vision, and shown as the
+        video transcript. Write the content of the vision, not the file.
+      </p>
+      <FieldRow label="Vision seconds">
+        <NumberInput
+          value={videoTextSeconds}
+          onCommit={onVideoTextSecondsChange}
+          min={0}
+          placeholder="All at once"
+          dense
+        />
+      </FieldRow>
+    </div>
+  );
+}
+
 export function MediaSection({
   image,
   onImageChange,
   video,
   onVideoChange,
+  videoText,
+  onVideoTextChange,
+  videoTextSeconds,
+  onVideoTextSecondsChange,
   getPrompt,
   entityContext,
   assetType,
@@ -222,6 +269,10 @@ export function MediaSection({
   onImageChange: (v: string | undefined) => void;
   video?: string;
   onVideoChange?: (v: string | undefined) => void;
+  videoText?: string;
+  onVideoTextChange?: (v: string | undefined) => void;
+  videoTextSeconds?: number;
+  onVideoTextSecondsChange?: (v: number | undefined) => void;
   getPrompt?: (style: ArtStyle) => string;
   entityContext?: string;
   assetType?: string;
@@ -253,7 +304,7 @@ export function MediaSection({
           )}
         </div>
         {onVideoChange && (
-          <MediaDisclosure label="Video" hasValue={!!video}>
+          <MediaDisclosure label="Video" hasValue={!!video || !!videoText}>
             <FieldRow label="Video">
               <TextInput
                 value={video ?? ""}
@@ -271,6 +322,14 @@ export function MediaSection({
               <VideoGenerator
                 imagePath={image}
                 onAccept={(filePath) => onVideoChange(filePath)}
+              />
+            )}
+            {onVideoTextChange && onVideoTextSecondsChange && (
+              <VideoVisionFields
+                videoText={videoText}
+                onVideoTextChange={onVideoTextChange}
+                videoTextSeconds={videoTextSeconds}
+                onVideoTextSecondsChange={onVideoTextSecondsChange}
               />
             )}
           </MediaDisclosure>

--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -582,6 +582,10 @@ export function ItemEditor({
           onImageChange={(v) => patch({ image: v })}
           video={item.video}
           onVideoChange={(v) => patch({ video: v })}
+          videoText={item.videoText}
+          onVideoTextChange={(v) => patch({ videoText: v })}
+          videoTextSeconds={item.videoTextSeconds}
+          onVideoTextSecondsChange={(v) => patch({ videoTextSeconds: v })}
           getPrompt={(style) => itemPrompt(itemId, item, style, zoneId ? useVibeStore.getState().getVibe(zoneId) : undefined)}
           entityContext={itemContext(itemId, item)}
           assetType="entity_portrait"

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -1037,6 +1037,10 @@ export function MobEditor({
           onImageChange={(v) => patch({ image: v })}
           video={mob.video}
           onVideoChange={(v) => patch({ video: v })}
+          videoText={mob.videoText}
+          onVideoTextChange={(v) => patch({ videoText: v })}
+          videoTextSeconds={mob.videoTextSeconds}
+          onVideoTextSecondsChange={(v) => patch({ videoTextSeconds: v })}
           getPrompt={(style) => mobPrompt(mobId, mob, style, zoneId ? useVibeStore.getState().getVibe(zoneId) : undefined)}
           entityContext={mobContext(mobId, mob)}
           assetType="entity_portrait"

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -26,7 +26,7 @@ import { MusicGenerator } from "@/components/ui/MusicGenerator";
 import { VideoGenerator } from "@/components/ui/VideoGenerator";
 import { roomPrompt, roomContext } from "@/lib/entityPrompts";
 import { getTrainerClasses } from "@/lib/trainers";
-import { EnhanceDescriptionButton, MediaDisclosure } from "@/components/editors/EditorShared";
+import { EnhanceDescriptionButton, MediaDisclosure, VideoVisionFields } from "@/components/editors/EditorShared";
 import { useVibeStore } from "@/stores/vibeStore";
 import { useAssetStore } from "@/stores/assetStore";
 import { useZoneStore } from "@/stores/zoneStore";
@@ -1185,7 +1185,7 @@ export function RoomPanel({
               surface="worldbuilding"
             />
           </div>
-          <MediaDisclosure label="Video" hasValue={!!room.video}>
+          <MediaDisclosure label="Video" hasValue={!!room.video || !!room.videoText}>
             <FieldRow label="Video">
               <TextInput
                 value={room.video ?? ""}
@@ -1214,6 +1214,14 @@ export function RoomPanel({
               onAccept={(fileName) => {
                 onWorldChange(updateRoom(world, roomId, { video: fileName }));
               }}
+            />
+            <VideoVisionFields
+              videoText={room.videoText}
+              onVideoTextChange={(v) => onWorldChange(updateRoom(world, roomId, { videoText: v }))}
+              videoTextSeconds={room.videoTextSeconds}
+              onVideoTextSecondsChange={(v) =>
+                onWorldChange(updateRoom(world, roomId, { videoTextSeconds: v }))
+              }
             />
           </MediaDisclosure>
         </div>

--- a/creator/src/components/zone/ZoneMediaPanel.tsx
+++ b/creator/src/components/zone/ZoneMediaPanel.tsx
@@ -4,6 +4,7 @@ import { FieldRow, TextInput } from "@/components/ui/FormWidgets";
 import { MusicGenerator } from "@/components/ui/MusicGenerator";
 import { VideoGenerator } from "@/components/ui/VideoGenerator";
 import { MediaPicker } from "@/components/ui/MediaPicker";
+import { VideoVisionFields } from "@/components/editors/EditorShared";
 import { useVibeStore } from "@/stores/vibeStore";
 import { useAssetStore } from "@/stores/assetStore";
 import sidebarBg from "@/assets/sidebar-bg.png";
@@ -183,6 +184,14 @@ export function ZoneMediaPanel({ zoneId, world, onWorldChange }: ZoneMediaPanelP
                   Generate a room image first — zone intro video needs a source frame.
                 </p>
               )}
+              <div className="mt-3 border-t border-border-muted pt-3">
+                <VideoVisionFields
+                  videoText={world.videoText}
+                  onVideoTextChange={(v) => onWorldChange({ ...world, videoText: v })}
+                  videoTextSeconds={world.videoTextSeconds}
+                  onVideoTextSecondsChange={(v) => onWorldChange({ ...world, videoTextSeconds: v })}
+                />
+              </div>
             </MediaCard>
           </div>
 

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -819,3 +819,72 @@ describe("sanitizeZone — end-to-end", () => {
     expect(result.shops!["shop_301"]).toBeUndefined();
   });
 });
+
+// ─── sanitizeZone — cinematic text alternatives (videoText) ────────
+
+describe("sanitizeZone — videoText / videoTextSeconds", () => {
+  it("serializes zone-level videoText and a positive videoTextSeconds", () => {
+    const world = makeWorld({
+      video: "intro.mp4",
+      videoText: "A hawk's-eye sweep over slate rooftops.\nThe view dives toward a quiet keep.",
+      videoTextSeconds: 30,
+    });
+
+    const result = sanitizeZone(world) as WorldFile;
+    expect(result.video).toBe("intro.mp4");
+    expect(result.videoText).toBe(
+      "A hawk's-eye sweep over slate rooftops.\nThe view dives toward a quiet keep.",
+    );
+    expect(result.videoTextSeconds).toBe(30);
+  });
+
+  it("preserves the block-literal text verbatim without trimming internal lines", () => {
+    const world = makeWorld({ videoText: "Line one\nLine two\nLine three" });
+    const result = sanitizeZone(world) as WorldFile;
+    expect(result.videoText).toBe("Line one\nLine two\nLine three");
+  });
+
+  it("allows a text-only vision (videoText without video)", () => {
+    const world = makeWorld({ videoText: "Glyphs flare to life, tracing a hidden door." });
+    const result = sanitizeZone(world) as WorldFile;
+    expect(result.video).toBeUndefined();
+    expect(result.videoText).toBe("Glyphs flare to life, tracing a hidden door.");
+  });
+
+  it("drops blank videoText and non-positive videoTextSeconds", () => {
+    const world = makeWorld({ videoText: "   ", videoTextSeconds: 0 });
+    const result = sanitizeZone(world) as WorldFile;
+    expect(result.videoText).toBeUndefined();
+    expect(result.videoTextSeconds).toBeUndefined();
+  });
+
+  it("carries room, mob, and item videoText through serialization", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: {
+          title: "A",
+          description: "A",
+          video: "glyphs.mp4",
+          videoText: "Glyphs along the wall flare to life.",
+          videoTextSeconds: 10,
+        },
+      },
+      mobs: {
+        seer: {
+          name: "Seer",
+          spawns: [{ room: "room_a" }],
+          videoText: "The seer's eyes cloud with prophecy.",
+        },
+      },
+      items: {
+        orb: { displayName: "Orb", videoText: "The orb pulses with trapped light." },
+      },
+    });
+
+    const result = sanitizeZone(world);
+    expect(result.rooms["room_a"]!.videoText).toBe("Glyphs along the wall flare to life.");
+    expect(result.rooms["room_a"]!.videoTextSeconds).toBe(10);
+    expect(result.mobs!["seer"]!.videoText).toBe("The seer's eyes cloud with prophecy.");
+    expect(result.items!["orb"]!.videoText).toBe("The orb pulses with trapped light.");
+  });
+});

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -814,6 +814,10 @@ function cleanOutput(world: WorldFile): WorldFile {
   }
   if (world.audio) result.audio = world.audio;
   if (world.video?.trim()) result.video = world.video.trim();
+  if (world.videoText?.trim()) result.videoText = world.videoText;
+  if (typeof world.videoTextSeconds === "number" && world.videoTextSeconds > 0) {
+    result.videoTextSeconds = world.videoTextSeconds;
+  }
   if (hasEntries(mobsOut)) result.mobs = mobsOut;
   if (hasEntries(items)) result.items = items;
   if (hasEntries(world.shops)) result.shops = world.shops;

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -71,6 +71,15 @@ export interface WorldFile {
    *  resolves under the videos base URL. Auto-plays on a player's first entry
    *  to the zone and is replayable from the World Map. */
   video?: string;
+  /** Prose vision narrated to text/screen-reader clients in place of the video.
+   *  The server frames it as a vision ("a vision rises before your eyes…") and
+   *  shows it verbatim as the transcript under the video in the web client.
+   *  Valid without a `video` — that makes a text-only vision. */
+  videoText?: string;
+  /** Total seconds the text vision plays out over for text clients. With a block
+   *  literal `videoText`, each line is revealed evenly across this window. Omit or
+   *  ≤ 0 shows it all at once. Sensible default: the video's runtime. */
+  videoTextSeconds?: number;
   rooms: Record<string, RoomFile>;
   mobs?: Record<string, MobFile>;
   items?: Record<string, ItemFile>;
@@ -117,6 +126,12 @@ export interface RoomFile {
   inn?: boolean;
   image?: string;
   video?: string;
+  /** Prose vision narrated to text/screen-reader clients in place of the video.
+   *  Valid without a `video` — that makes a text-only vision. */
+  videoText?: string;
+  /** Seconds the text vision plays out over; lines of a block literal reveal
+   *  evenly across this window. Omit or ≤ 0 shows it all at once. */
+  videoTextSeconds?: number;
   music?: string;
   ambient?: string;
   /** Legacy Arcanum-only alias; stripped on output. */
@@ -317,6 +332,12 @@ export interface MobFile {
   defaultAttack?: string;
   image?: string;
   video?: string;
+  /** Prose vision narrated to text/screen-reader clients in place of the video.
+   *  Valid without a `video` — that makes a text-only vision. */
+  videoText?: string;
+  /** Seconds the text vision plays out over; lines of a block literal reveal
+   *  evenly across this window. Omit or ≤ 0 shows it all at once. */
+  videoTextSeconds?: number;
   /**
    * When `role === "trainer"`, the class IDs this NPC teaches. One entry =
    * single-class trainer; two or more = multi-class trainer. Each spawn room
@@ -419,6 +440,12 @@ export interface ItemFile {
   basePrice?: number;
   image?: string;
   video?: string;
+  /** Prose vision narrated to text/screen-reader clients in place of the video.
+   *  Valid without a `video` — that makes a text-only vision. */
+  videoText?: string;
+  /** Seconds the text vision plays out over; lines of a block literal reveal
+   *  evenly across this window. Omit or ≤ 0 shows it all at once. */
+  videoTextSeconds?: number;
   /**
    * Explicit server-side category. Leave unset to let the server infer from
    * other fields. Values are lowercase to match the server's `ItemType.label()`.


### PR DESCRIPTION
## Summary

Adds authoring support for the four new optional cinematic-text-alternative YAML fields from the AmbonMUD sync (issue 1240). They pair with every existing `video:` field — on **zones**, **rooms**, **mobs**, and **items**. No changes to existing fields, no migration; zones without them behave exactly as before.

- **`videoText`** — plain prose narrated to text/screen-reader clients as a vision (the engine frames it with "a vision rises before your eyes…"), and shown verbatim as the transcript under the video in the web client. Valid without a `video` — that makes a text-only vision.
- **`videoTextSeconds`** — total seconds the text vision plays out over; with a block-literal `videoText`, lines reveal evenly across the window. Omit or ≤ 0 to show it all at once.

## Changes

- **Types** (`types/world.ts`) — added the pair to `WorldFile`, `RoomFile`, `MobFile`, `ItemFile`, each documented next to `video`.
- **Serialization** (`sanitizeZone.ts`) — zone-level fields written right after `video`; rooms/mobs/items pass through their existing spread. Blank `videoText` and non-positive `videoTextSeconds` are dropped. Block-literal text is preserved verbatim (untrimmed internal lines). MUD export inherits this via `serializeZone`.
- **UI** — new shared `VideoVisionFields` component (in `EditorShared.tsx`) wired into:
  - Mob & Item editors (via `MediaSection`)
  - Room panel (`RoomPanel.tsx`)
  - Zone intro media (`ZoneMediaPanel.tsx`)
  
  Video disclosures now open when *either* a video or a vision text is set, so text-only visions are reachable.
- **Tests** — round-trip coverage in `sanitizeZone.test.ts` for all four entity types, text-only visions, block-literal preservation, and blank/zero stripping.

## Verification

- `bunx tsc --noEmit` clean
- `bun run test` — 2138 passed

## Notes for review

- Authoring priority per the sync: every Auringold zone/room/mob/item that currently has a `video:` should get a `videoText` to reach parity. This PR delivers the authoring surface; content backfill is separate.