### PR TITLE
Load server's built-in rare-variant palette into the editor

### DIFF
--- a/creator/src/components/config/panels/WeatherEnvironmentPanel.tsx
+++ b/creator/src/components/config/panels/WeatherEnvironmentPanel.tsx
@@ -18,6 +18,7 @@ import {
   IconButton,
 } from "@/components/ui/FormWidgets";
 import { RegistryPanel } from "./RegistryPanel";
+import { BUILTIN_MOB_VARIANTS } from "@/lib/mobVariantDefaults";
 import { useZoneStore } from "@/stores/zoneStore";
 
 // ─── Constants ────────────────────────────────────────────────────
@@ -383,6 +384,16 @@ function MobVariantsTab({
     [mv.variants, patchVariants],
   );
 
+  const missingBuiltins = useMemo(
+    () => Object.keys(BUILTIN_MOB_VARIANTS).filter((id) => !(id in mv.variants)),
+    [mv.variants],
+  );
+
+  const loadBuiltins = useCallback(() => {
+    // Built-ins first, then existing entries so the author's edits win on ID clash.
+    patchVariants({ ...BUILTIN_MOB_VARIANTS, ...mv.variants });
+  }, [mv.variants, patchVariants]);
+
   return (
     <>
       <Section
@@ -397,7 +408,7 @@ function MobVariantsTab({
           />
           <FieldRow
             label="Base Chance"
-            hint="Probability an eligible mob rolls as a rare variant on each dynamic spawn (zone reset, respawn, conditional spawn). 0–1; default 0.04."
+            hint="Probability an eligible mob rolls as a rare variant on each spawn opportunity (cold start, zone reset, respawn, conditional spawn). 0–1; default 0.04."
           >
             <NumberInput
               value={mv.chance}
@@ -407,13 +418,20 @@ function MobVariantsTab({
               step={0.01}
             />
           </FieldRow>
-          {!hasCustom && (
-            <p className="text-2xs text-text-muted">
-              No custom archetypes defined — the server's built-in palette
-              (albino, verdant, shadow-touched, ember, glimmering, frostbound,
-              spectral, ancient) is used. Add archetypes below to define your own
-              palette; once any exist, only your archetypes spawn.
-            </p>
+          <p className="text-2xs text-text-muted">
+            {hasCustom
+              ? "This palette replaces the server's built-ins entirely — only the archetypes below can spawn. Load the built-ins to combine them with your own."
+              : "No custom archetypes defined — the server's built-in palette (albino, verdant, shadow-touched, ember, glimmering, frostbound, spectral, ancient) is used and tracks future server updates. Load it below to tweak or extend it; once the palette is non-empty it fully replaces the built-ins, so include any you still want."}
+          </p>
+          {missingBuiltins.length > 0 && (
+            <button
+              onClick={loadBuiltins}
+              className="self-start rounded bg-accent/20 px-2.5 py-1 text-xs text-accent hover:bg-accent/30"
+            >
+              {hasCustom
+                ? `Add ${missingBuiltins.length} built-in archetype${missingBuiltins.length === 1 ? "" : "s"}`
+                : "Load built-in palette"}
+            </button>
           )}
         </div>
       </Section>

--- a/creator/src/lib/mobVariantDefaults.ts
+++ b/creator/src/lib/mobVariantDefaults.ts
@@ -1,0 +1,106 @@
+import type { MobVariantDefinition } from "@/types/config";
+
+/**
+ * Faithful mirror of the AmbonMUD server's built-in rare-variant palette
+ * (`MobVariantsConfig.DEFAULT_VARIANTS` in `AppConfig.kt`). The server uses this
+ * set whenever a world omits `mobVariants.variants`; supplying a non-empty map
+ * replaces it entirely. Surfaced in the Rare Variants config tab so authors can
+ * load the defaults as a starting point and extend them. Keep in sync with the
+ * server if its defaults change.
+ */
+export const BUILTIN_MOB_VARIANTS: Record<string, MobVariantDefinition> = {
+  albino: {
+    displayName: "Albino",
+    namePrefix: "Albino ",
+    tint: "#f5f0ff",
+    rarity: "uncommon",
+    weight: 3.0,
+    hpMultiplier: 1.2,
+    xpMultiplier: 1.3,
+    lootMultiplier: 1.2,
+    announce: "ZONE",
+  },
+  verdant: {
+    displayName: "Verdant",
+    namePrefix: "Verdant ",
+    tint: "#5fd17a",
+    rarity: "uncommon",
+    weight: 2.5,
+    hpMultiplier: 1.2,
+    xpMultiplier: 1.3,
+    lootMultiplier: 1.2,
+    announce: "ZONE",
+  },
+  shadow: {
+    displayName: "Shadow-touched",
+    namePrefix: "Shadow-touched ",
+    tint: "#6a4aa0",
+    overlay: "swirl",
+    rarity: "uncommon",
+    weight: 2.5,
+    hpMultiplier: 1.25,
+    xpMultiplier: 1.4,
+    lootMultiplier: 1.25,
+    announce: "ZONE",
+  },
+  ember: {
+    displayName: "Ember",
+    namePrefix: "Ember ",
+    tint: "#ff6a3c",
+    overlay: "embers",
+    rarity: "rare",
+    weight: 1.4,
+    hpMultiplier: 1.5,
+    xpMultiplier: 1.7,
+    lootMultiplier: 1.5,
+    announce: "ZONE",
+  },
+  glimmering: {
+    displayName: "Glimmering",
+    namePrefix: "Glimmering ",
+    tint: "#ffe8a3",
+    overlay: "sparkle",
+    rarity: "rare",
+    weight: 1.2,
+    hpMultiplier: 1.5,
+    xpMultiplier: 1.8,
+    lootMultiplier: 1.6,
+    announce: "ZONE",
+  },
+  frostbound: {
+    displayName: "Frostbound",
+    namePrefix: "Frostbound ",
+    tint: "#a3e4ff",
+    overlay: "frost",
+    rarity: "rare",
+    weight: 1.2,
+    hpMultiplier: 1.5,
+    xpMultiplier: 1.7,
+    lootMultiplier: 1.5,
+    announce: "ZONE",
+  },
+  spectral: {
+    displayName: "Spectral",
+    namePrefix: "Spectral ",
+    tint: "#bfeaff",
+    overlay: "mist",
+    rarity: "legendary",
+    weight: 0.4,
+    hpMultiplier: 2.0,
+    xpMultiplier: 2.5,
+    lootMultiplier: 2.0,
+    announce: "SERVER",
+  },
+  ancient: {
+    displayName: "Ancient",
+    namePrefix: "Ancient ",
+    tint: "#caa86a",
+    overlay: "swirl",
+    rarity: "legendary",
+    weight: 0.3,
+    hpMultiplier: 2.2,
+    xpMultiplier: 2.6,
+    lootMultiplier: 2.2,
+    announce: "SERVER",
+  },
+};


### PR DESCRIPTION
## What

Lets authors **combine custom rare-mob variants with the server's built-in palette** — a follow-up to #293.

## Why it works this way

I traced the server contract in AmbonMUD (`MobVariantsConfig` / `MobVariantRoller.kt`): a world's `mobVariants.variants` map **replaces** the server's defaults entirely once it's non-empty — there is no merge, and the roller has no fallback to built-ins. So the only way to "combine" without a server change is to physically include the built-in archetypes in the map you send.

## Changes

- **`creator/src/lib/mobVariantDefaults.ts`** — `BUILTIN_MOB_VARIANTS`, a faithful mirror of the server's `MobVariantsConfig.DEFAULT_VARIANTS` (`AppConfig.kt`): all 8 archetypes (albino, verdant, shadow, ember, glimmering, frostbound, spectral, ancient) with their exact tints, overlays, weights, and HP/XP/loot multipliers. Documented as a keep-in-sync mirror.
- **Rare Variants tab** — a **Load built-in palette** button:
  - On an empty palette it seeds all 8 built-ins so you can tweak/extend them.
  - With customs already present it shows **Add N built-in archetypes**, merging in only the missing ones (existing edits win on ID clash).
  - Hidden once all 8 built-ins are present.
- Clarified the explanatory copy for both states (empty = inherit server defaults & auto-update; non-empty = fully replaces built-ins).
- Corrected the **Base Chance** hint to match the current server — cold-start spawns are rolled too.

## Behavior preserved

Leaving the palette empty still means "inherit the server's built-ins (auto-updating)" — the button is opt-in, so nothing is frozen unless the author chooses to load it.

## Verification

- `bunx tsc --noEmit` clean
- `bun run test` — 2147 passed