### PR TITLE
Add monster_manual_portrait_frame global asset

### DIFF
--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -808,6 +808,19 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     aspect: "landscape",
   },
   {
+    key: "monster_manual_portrait_frame",
+    defaultFilename: "monster_manual_portrait_frame.png",
+    label: "Monster Manual Portrait Frame",
+    description:
+      "Ornamental border overlaid on top of the bestiary portrait box in the monster-manual (mob inspect) card. Its opaque painted edge hides the obvious seam left by the rare-mob colorize filter, so the center must be fully transparent for the creature to show through. Falls back to no overlay when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "A 2:3 portrait ornamental picture frame with a fully transparent empty center window, the painted border occupying only the outer tenth of each edge, hand-painted parchment-and-vine style matching an illuminated bestiary, lush twining vines with colorful butterflies, speckled mushrooms, and blooming flowers in jewel tones, no fill in the center, no creature, no figures, no readable text, transparent PNG suitable as a frame overlaid on top of a creature portrait.",
+    transparent: false,
+    aspect: "portrait",
+    optional: true,
+  },
+  {
     key: "inventory_satchel_bg",
     defaultFilename: "inventory_satchel_bg.png",
     label: "Inventory Satchel Texture",


### PR DESCRIPTION
## Summary

Registers a new global asset `monster_manual_portrait_frame` in `creator/src/lib/requiredGlobalAssets.ts` — the canonical registry driving the Shared Assets panel, the AI generator modal, validation, and the `globalAssets` key→filename export into `application.yaml`.

Rare mobs apply colorize filters whose edges are obvious; this asset is a painted ornamental border (butterflies, mushrooms, blooms) overlaid on top of the bestiary portrait box so its opaque edge hides the seam.

## Details

- **`aspect: "portrait"`** → generator renders at 1024×1536 (2:3), matching the spec (816×1224 is the same ratio).
- **`transparent: false`** (deliberate) — the `transparent` flag enables edge-flood background *removal*, which is the inverse of what this asset needs (opaque edges, transparent center). The alpha center must come from a hand-made PNG or manual edit; the prompt/description call this out.
- **`optional: true`** — when absent the client simply renders no overlay, so it shouldn't trigger a validation warning on every project.

## Out of scope

Client-side overlay rendering (the MUD client that reads this key and draws the frame over rare-mob portraits) lives outside this repo. This change makes the asset authorable, generatable, and publishable from Arcanum.

## Verification

- `bunx tsc --noEmit` passes.