### PR TITLE
Room jukebox authoring

### DIFF
--- a/creator/src/components/zone/JukeboxEditor.tsx
+++ b/creator/src/components/zone/JukeboxEditor.tsx
@@ -11,7 +11,6 @@ const EMPTY_SONG: JukeboxSong = {
   title: "",
   file: "",
   durationSeconds: 0,
-  cost: 0,
 };
 
 export function JukeboxEditor({ songs, onChange }: JukeboxEditorProps) {
@@ -102,6 +101,15 @@ export function JukeboxEditor({ songs, onChange }: JukeboxEditorProps) {
                 />
               </FieldRow>
 
+              <FieldRow label="Description">
+                <TextInput
+                  value={song.description ?? ""}
+                  onCommit={(v) => update(index, { description: v || undefined })}
+                  placeholder="Optional lore flavour"
+                  dense
+                />
+              </FieldRow>
+
               <AudioTrackPicker
                 kind="music"
                 label="Track"
@@ -123,9 +131,10 @@ export function JukeboxEditor({ songs, onChange }: JukeboxEditorProps) {
                 <FieldRow label="Cost (gold)">
                   <NumberInput
                     value={song.cost}
-                    onCommit={(v) => update(index, { cost: v ?? 0 })}
-                    placeholder="0"
+                    onCommit={(v) => update(index, { cost: v })}
+                    placeholder="default"
                     min={0}
+                    step={1}
                     dense
                   />
                 </FieldRow>

--- a/creator/src/components/zone/JukeboxEditor.tsx
+++ b/creator/src/components/zone/JukeboxEditor.tsx
@@ -1,0 +1,147 @@
+import type { JukeboxSong } from "@/types/world";
+import { FieldRow, TextInput, NumberInput } from "@/components/ui/FormWidgets";
+import { AudioTrackPicker } from "@/components/ui/AudioTrackPicker";
+
+interface JukeboxEditorProps {
+  songs: JukeboxSong[];
+  onChange: (songs: JukeboxSong[]) => void;
+}
+
+const EMPTY_SONG: JukeboxSong = {
+  title: "",
+  file: "",
+  durationSeconds: 0,
+  cost: 0,
+};
+
+export function JukeboxEditor({ songs, onChange }: JukeboxEditorProps) {
+  const update = (index: number, patch: Partial<JukeboxSong>) => {
+    onChange(songs.map((song, i) => (i === index ? { ...song, ...patch } : song)));
+  };
+
+  const add = () => onChange([...songs, { ...EMPTY_SONG }]);
+
+  const remove = (index: number) => onChange(songs.filter((_, i) => i !== index));
+
+  const move = (index: number, delta: number) => {
+    const target = index + delta;
+    if (target < 0 || target >= songs.length) return;
+    const next = [...songs];
+    const picked = next[index];
+    if (!picked) return;
+    next.splice(index, 1);
+    next.splice(target, 0, picked);
+    onChange(next);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs text-text-muted">
+        Players pay gold to play a song; the room's music locks to that track for its duration,
+        then reverts. An empty playlist means the room has no jukebox.
+      </p>
+
+      {songs.length === 0 ? (
+        <p className="empty-placeholder">No songs in this jukebox</p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {songs.map((song, index) => (
+            <li
+              key={index}
+              className="flex flex-col gap-2 rounded-md border border-border-default bg-bg-tertiary/40 p-2"
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-xs text-text-muted">{index + 1}.</span>
+                <div className="flex-1">
+                  <TextInput
+                    value={song.title}
+                    onCommit={(v) => update(index, { title: v })}
+                    placeholder="Song title"
+                    dense
+                  />
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <button
+                    type="button"
+                    className="rounded px-1.5 py-0.5 text-text-muted transition-colors hover:bg-bg-hover hover:text-text-secondary disabled:opacity-30 disabled:hover:bg-transparent"
+                    onClick={() => move(index, -1)}
+                    disabled={index === 0}
+                    title="Move up"
+                    aria-label={`Move ${song.title || `song ${index + 1}`} up`}
+                  >
+                    ↑
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded px-1.5 py-0.5 text-text-muted transition-colors hover:bg-bg-hover hover:text-text-secondary disabled:opacity-30 disabled:hover:bg-transparent"
+                    onClick={() => move(index, 1)}
+                    disabled={index === songs.length - 1}
+                    title="Move down"
+                    aria-label={`Move ${song.title || `song ${index + 1}`} down`}
+                  >
+                    ↓
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded px-1.5 py-0.5 text-status-danger transition-colors hover:bg-status-danger/10"
+                    onClick={() => remove(index)}
+                    title="Remove song"
+                    aria-label={`Remove ${song.title || `song ${index + 1}`}`}
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+
+              <FieldRow label="Artist">
+                <TextInput
+                  value={song.artist ?? ""}
+                  onCommit={(v) => update(index, { artist: v || undefined })}
+                  placeholder="Optional"
+                  dense
+                />
+              </FieldRow>
+
+              <AudioTrackPicker
+                kind="music"
+                label="Track"
+                value={song.file || undefined}
+                onChange={(v) => update(index, { file: v ?? "" })}
+                hint="Picked from the music library in the Audio Studio."
+              />
+
+              <div className="flex gap-2">
+                <FieldRow label="Duration (s)">
+                  <NumberInput
+                    value={song.durationSeconds || undefined}
+                    onCommit={(v) => update(index, { durationSeconds: v ?? 0 })}
+                    placeholder="0"
+                    min={1}
+                    dense
+                  />
+                </FieldRow>
+                <FieldRow label="Cost (gold)">
+                  <NumberInput
+                    value={song.cost}
+                    onCommit={(v) => update(index, { cost: v ?? 0 })}
+                    placeholder="0"
+                    min={0}
+                    dense
+                  />
+                </FieldRow>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <button
+        type="button"
+        className="self-start rounded border border-border-default px-2 py-1 text-xs text-text-secondary transition-colors hover:bg-bg-hover hover:text-accent"
+        onClick={add}
+      >
+        + Add song
+      </button>
+    </div>
+  );
+}

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/zoneEdits";
 import { ExitDoorEditor } from "./ExitDoorEditor";
 import { RoomFeaturesEditor } from "./RoomFeaturesEditor";
+import { JukeboxEditor } from "./JukeboxEditor";
 import { EditableField, EditableTextArea, Section, IconButton, FieldRow, TextInput, SelectInput, TabBar } from "@/components/ui/FormWidgets";
 import { YamlPreview } from "@/components/ui/YamlPreview";
 import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
@@ -1245,6 +1246,19 @@ export function RoomPanel({
             onChange={(v) => onWorldChange(updateRoom(world, roomId, { ambient: v }))}
             hint="Overrides the zone's default soundscape for this room."
           />
+          <MediaDisclosure
+            label={`Jukebox${room.jukebox?.length ? ` (${room.jukebox.length})` : ""}`}
+            hasValue={!!room.jukebox?.length}
+          >
+            <JukeboxEditor
+              songs={room.jukebox ?? []}
+              onChange={(songs) =>
+                onWorldChange(
+                  updateRoom(world, roomId, { jukebox: songs.length ? songs : undefined }),
+                )
+              }
+            />
+          </MediaDisclosure>
         </div>
       </Section>
       </>

--- a/creator/src/components/zone/ZoneMediaPanel.tsx
+++ b/creator/src/components/zone/ZoneMediaPanel.tsx
@@ -38,6 +38,14 @@ const VideoIcon = () => (
   </svg>
 );
 
+const JukeboxIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5">
+    <path d="M6 3h12a2 2 0 0 1 2 2v16H4V5a2 2 0 0 1 2-2Z" />
+    <circle cx="12" cy="13" r="3" />
+    <path d="M8 7h8" />
+  </svg>
+);
+
 export function ZoneMediaPanel({ zoneId, world, onWorldChange }: ZoneMediaPanelProps) {
   const assetsDir = useAssetStore((s) => s.assetsDir);
 
@@ -48,6 +56,7 @@ export function ZoneMediaPanel({ zoneId, world, onWorldChange }: ZoneMediaPanelP
     const musicCount = Object.values(rooms).filter((r) => r.music).length;
     const ambientCount = Object.values(rooms).filter((r) => r.ambient).length;
     const videoCount = Object.values(rooms).filter((r) => r.video).length;
+    const jukeboxCount = Object.values(rooms).filter((r) => r.jukebox?.length).length;
     return {
       zoneImagePath: firstWithImage?.image && assetsDir
         ? `${assetsDir}\\images\\${firstWithImage.image}`
@@ -55,7 +64,7 @@ export function ZoneMediaPanel({ zoneId, world, onWorldChange }: ZoneMediaPanelP
       roomNames: Object.entries(rooms)
         .map(([id, r]) => `- ${r.title} (${id})`)
         .join("\n"),
-      stats: { music: musicCount, ambient: ambientCount, video: videoCount },
+      stats: { music: musicCount, ambient: ambientCount, video: videoCount, jukebox: jukeboxCount },
       totalRooms: total,
     };
   }, [world.rooms, assetsDir]);
@@ -87,6 +96,7 @@ export function ZoneMediaPanel({ zoneId, world, onWorldChange }: ZoneMediaPanelP
               <StatsPill icon={<MusicIcon />} label="music" count={stats.music} total={totalRooms} />
               <StatsPill icon={<AmbientIcon />} label="ambient" count={stats.ambient} total={totalRooms} />
               <StatsPill icon={<VideoIcon />} label="video" count={stats.video} total={totalRooms} />
+              <StatsPill icon={<JukeboxIcon />} label="jukebox" count={stats.jukebox} total={totalRooms} />
             </div>
           </div>
 

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -326,6 +326,81 @@ describe("sanitizeZone — invalid entity stripping", () => {
   });
 });
 
+describe("sanitizeZone — jukebox", () => {
+  it("preserves a valid jukebox playlist and trims fields", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: {
+          title: "Tavern",
+          description: "A cozy tavern.",
+          jukebox: [
+            { title: "  Hearth Song  ", artist: "  The Bards  ", file: " hearth.mp3 ", durationSeconds: 90, cost: 5 },
+          ],
+        },
+      },
+    });
+
+    const result = sanitizeZone(world);
+    const songs = result.rooms["room_a"]!.jukebox!;
+    expect(songs).toHaveLength(1);
+    expect(songs[0]).toEqual({
+      title: "Hearth Song",
+      artist: "The Bards",
+      file: "hearth.mp3",
+      durationSeconds: 90,
+      cost: 5,
+    });
+  });
+
+  it("drops the artist key when empty and keeps a free (cost 0) song", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: {
+          title: "Tavern",
+          description: "A cozy tavern.",
+          jukebox: [{ title: "Anthem", artist: "   ", file: "anthem.mp3", durationSeconds: 60, cost: 0 }],
+        },
+      },
+    });
+
+    const songs = sanitizeZone(world).rooms["room_a"]!.jukebox!;
+    expect(songs).toHaveLength(1);
+    expect(songs[0]!.cost).toBe(0);
+    expect("artist" in songs[0]!).toBe(false);
+  });
+
+  it("drops songs missing a title or file", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: {
+          title: "Tavern",
+          description: "A cozy tavern.",
+          jukebox: [
+            { title: "", file: "good.mp3", durationSeconds: 30, cost: 1 },
+            { title: "No File", file: "  ", durationSeconds: 30, cost: 1 },
+            { title: "Keeper", file: "keep.mp3", durationSeconds: 30, cost: 1 },
+          ],
+        },
+      },
+    });
+
+    const songs = sanitizeZone(world).rooms["room_a"]!.jukebox!;
+    expect(songs).toHaveLength(1);
+    expect(songs[0]!.title).toBe("Keeper");
+  });
+
+  it("omits the jukebox key entirely when the playlist is empty", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: { title: "Tavern", description: "A cozy tavern.", jukebox: [] },
+      },
+    });
+
+    const room = sanitizeZone(world).rooms["room_a"]!;
+    expect(room.jukebox).toBeUndefined();
+  });
+});
+
 // ─── sanitizeZone — dangling reference cleanup ────────────────────
 
 describe("sanitizeZone — dangling reference cleanup", () => {

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -334,7 +334,14 @@ describe("sanitizeZone — jukebox", () => {
           title: "Tavern",
           description: "A cozy tavern.",
           jukebox: [
-            { title: "  Hearth Song  ", artist: "  The Bards  ", file: " hearth.mp3 ", durationSeconds: 90, cost: 5 },
+            {
+              title: "  Hearth Song  ",
+              artist: "  The Bards  ",
+              file: " hearth.mp3 ",
+              durationSeconds: 90,
+              cost: 5,
+              description: "  A foot-stomping reel.  ",
+            },
           ],
         },
       },
@@ -349,16 +356,17 @@ describe("sanitizeZone — jukebox", () => {
       file: "hearth.mp3",
       durationSeconds: 90,
       cost: 5,
+      description: "A foot-stomping reel.",
     });
   });
 
-  it("drops the artist key when empty and keeps a free (cost 0) song", () => {
+  it("drops empty artist/description and keeps a free (cost 0) song", () => {
     const world = makeWorld({
       rooms: {
         room_a: {
           title: "Tavern",
           description: "A cozy tavern.",
-          jukebox: [{ title: "Anthem", artist: "   ", file: "anthem.mp3", durationSeconds: 60, cost: 0 }],
+          jukebox: [{ title: "Anthem", artist: "   ", description: "  ", file: "anthem.mp3", durationSeconds: 60, cost: 0 }],
         },
       },
     });
@@ -367,6 +375,23 @@ describe("sanitizeZone — jukebox", () => {
     expect(songs).toHaveLength(1);
     expect(songs[0]!.cost).toBe(0);
     expect("artist" in songs[0]!).toBe(false);
+    expect("description" in songs[0]!).toBe(false);
+  });
+
+  it("omits cost entirely when unset so the server applies its default", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: {
+          title: "Tavern",
+          description: "A cozy tavern.",
+          jukebox: [{ title: "Anthem", file: "anthem.mp3", durationSeconds: 60 }],
+        },
+      },
+    });
+
+    const songs = sanitizeZone(world).rooms["room_a"]!.jukebox!;
+    expect(songs).toHaveLength(1);
+    expect("cost" in songs[0]!).toBe(false);
   });
 
   it("drops songs missing a title or file", () => {

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -717,6 +717,23 @@ describe("validateZone", () => {
       expect(errors(validateZone(world))).toHaveLength(0);
     });
 
+    it("accepts a song with no cost (server applies its default)", () => {
+      const world = makeValidWorld();
+      world.rooms.room1!.jukebox = [
+        { title: "Anthem", file: "anthem.mp3", durationSeconds: 60 },
+      ];
+      expect(errors(validateZone(world))).toHaveLength(0);
+    });
+
+    it("errors on a fractional cost", () => {
+      const world = makeValidWorld();
+      world.rooms.room1!.jukebox = [
+        { title: "Hearth Song", file: "hearth.mp3", durationSeconds: 90, cost: 5.5 },
+      ];
+      const errs = errors(validateZone(world));
+      expect(errs.some((e) => /invalid cost/i.test(e.message))).toBe(true);
+    });
+
     it("errors on a missing audio file", () => {
       const world = makeValidWorld();
       world.rooms.room1!.jukebox = [

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -698,4 +698,60 @@ describe("validateZone", () => {
       expect(issues).toHaveLength(0);
     });
   });
+
+  // ─── Jukebox ─────────────────────────────────────────────────
+  describe("jukebox", () => {
+    it("accepts a valid jukebox song", () => {
+      const world = makeValidWorld();
+      world.rooms.room1!.jukebox = [
+        { title: "Hearth Song", file: "hearth.mp3", durationSeconds: 90, cost: 5 },
+      ];
+      expect(validateZone(world)).toHaveLength(0);
+    });
+
+    it("accepts a free song (cost 0)", () => {
+      const world = makeValidWorld();
+      world.rooms.room1!.jukebox = [
+        { title: "Anthem", file: "anthem.mp3", durationSeconds: 60, cost: 0 },
+      ];
+      expect(errors(validateZone(world))).toHaveLength(0);
+    });
+
+    it("errors on a missing audio file", () => {
+      const world = makeValidWorld();
+      world.rooms.room1!.jukebox = [
+        { title: "Hearth Song", file: "", durationSeconds: 90, cost: 5 },
+      ];
+      const errs = errors(validateZone(world));
+      expect(errs).toHaveLength(1);
+      expect(errs[0]!.message).toMatch(/no audio file/i);
+    });
+
+    it("errors on a non-positive duration", () => {
+      const world = makeValidWorld();
+      world.rooms.room1!.jukebox = [
+        { title: "Hearth Song", file: "hearth.mp3", durationSeconds: 0, cost: 5 },
+      ];
+      const errs = errors(validateZone(world));
+      expect(errs.some((e) => /positive duration/i.test(e.message))).toBe(true);
+    });
+
+    it("errors on a negative cost", () => {
+      const world = makeValidWorld();
+      world.rooms.room1!.jukebox = [
+        { title: "Hearth Song", file: "hearth.mp3", durationSeconds: 90, cost: -1 },
+      ];
+      const errs = errors(validateZone(world));
+      expect(errs.some((e) => /invalid cost/i.test(e.message))).toBe(true);
+    });
+
+    it("warns on a missing title", () => {
+      const world = makeValidWorld();
+      world.rooms.room1!.jukebox = [
+        { title: "", file: "hearth.mp3", durationSeconds: 90, cost: 5 },
+      ];
+      const warns = warnings(validateZone(world));
+      expect(warns.some((w) => /no title/i.test(w.message))).toBe(true);
+    });
+  });
 });

--- a/creator/src/lib/audioLibrary.ts
+++ b/creator/src/lib/audioLibrary.ts
@@ -63,6 +63,9 @@ export function buildUsageIndex(
     for (const [roomId, room] of Object.entries(data.rooms)) {
       if (room.music) entry(room.music).rooms.push({ zoneId, roomId, roomTitle: room.title, kind: "music" });
       if (room.ambient) entry(room.ambient).rooms.push({ zoneId, roomId, roomTitle: room.title, kind: "ambient" });
+      for (const song of room.jukebox ?? []) {
+        if (song.file) entry(song.file).rooms.push({ zoneId, roomId, roomTitle: room.title, kind: "music" });
+      }
     }
   }
   return index;

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -339,6 +339,16 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     transparent: true,
   },
   {
+    key: "jukebox_widget",
+    defaultFilename: "jukebox_widget.png",
+    label: "Jukebox",
+    description: "Badge shown on rooms with a jukebox; opens the song-picker panel.",
+    assetType: "ability_icon",
+    defaultPrompt: "A single ornate fantasy jukebox cabinet glowing with warm light, centered, brass and stained-glass accents.",
+    transparent: true,
+    optional: true,
+  },
+  {
     key: "duel_arena_widget",
     defaultFilename: "duel_arena_widget.png",
     label: "Duel Arena",
@@ -848,6 +858,18 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     assetType: "background",
     defaultPrompt:
       "A dim treasury vault interior filling the frame edge to edge — polished marble walls and floor, gleaming brass fittings and a great round vault door suggested in the background, rows of safety-deposit drawers along one side, warm aurum-gold light pooling softly, deep secure atmosphere, no coins in focus, no figures, no readable text, suitable as a backdrop behind a bank panel.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
+  {
+    key: "jukebox_bg",
+    defaultFilename: "jukebox_bg.png",
+    label: "Jukebox Panel Background",
+    description: "Backdrop behind the jukebox song-picker panel. The playlist and now-playing countdown render on top. Falls back to the procedural panel when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "A warm tavern corner filling the frame edge to edge — an ornate fantasy jukebox cabinet glowing with stained-glass light, worn wooden floorboards, hanging lanterns casting amber pools, faint motes of music in the air, cozy intimate atmosphere, no figures, no readable text, suitable as a backdrop behind a song-list panel.",
     transparent: false,
     aspect: "landscape",
     optional: true,

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -152,9 +152,11 @@ function normalizeFeatureFile(feature: FeatureFile): FeatureFile {
   return out;
 }
 
-/** Clean a jukebox playlist for output: trim text, drop empty `artist`, drop
- *  songs missing a title or file, coerce numbers. Returns undefined when the
- *  result is empty so the `jukebox` key is omitted entirely. */
+/** Clean a jukebox playlist for output: trim text, drop empty optional fields,
+ *  drop songs missing a title or file. `cost` is preserved only when it's a real
+ *  number (an explicit 0 stays; an unset cost is omitted so the server applies
+ *  its configured default). Returns undefined when the result is empty so the
+ *  `jukebox` key is omitted entirely. Key order mirrors the server DTO. */
 function normalizeJukebox(songs?: JukeboxSong[]): JukeboxSong[] | undefined {
   if (!songs || songs.length === 0) return undefined;
   const cleaned: JukeboxSong[] = [];
@@ -166,10 +168,14 @@ function normalizeJukebox(songs?: JukeboxSong[]): JukeboxSong[] | undefined {
       title,
       file,
       durationSeconds: Number(song.durationSeconds) || 0,
-      cost: Number(song.cost) || 0,
     };
+    if (typeof song.cost === "number" && Number.isFinite(song.cost)) {
+      out.cost = song.cost;
+    }
     const artist = song.artist?.trim();
     if (artist) out.artist = artist;
+    const description = song.description?.trim();
+    if (description) out.description = description;
     cleaned.push(out);
   }
   return cleaned.length > 0 ? cleaned : undefined;

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -13,6 +13,7 @@ import type {
   FeatureFile,
   DoorFile,
   DungeonLootTable,
+  JukeboxSong,
 } from "@/types/world";
 import { resolveDoorKeyId } from "./doorHelpers";
 import { getTrainerClasses } from "./trainers";
@@ -151,8 +152,31 @@ function normalizeFeatureFile(feature: FeatureFile): FeatureFile {
   return out;
 }
 
+/** Clean a jukebox playlist for output: trim text, drop empty `artist`, drop
+ *  songs missing a title or file, coerce numbers. Returns undefined when the
+ *  result is empty so the `jukebox` key is omitted entirely. */
+function normalizeJukebox(songs?: JukeboxSong[]): JukeboxSong[] | undefined {
+  if (!songs || songs.length === 0) return undefined;
+  const cleaned: JukeboxSong[] = [];
+  for (const song of songs) {
+    const title = song.title?.trim() ?? "";
+    const file = song.file?.trim() ?? "";
+    if (!title || !file) continue;
+    const out: JukeboxSong = {
+      title,
+      file,
+      durationSeconds: Number(song.durationSeconds) || 0,
+      cost: Number(song.cost) || 0,
+    };
+    const artist = song.artist?.trim();
+    if (artist) out.artist = artist;
+    cleaned.push(out);
+  }
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
 function normalizeRoomOutput(room: RoomFile): RoomFile {
-  let next: RoomFile = { ...room, audio: undefined };
+  let next: RoomFile = { ...room, audio: undefined, jukebox: normalizeJukebox(room.jukebox) };
   if (room.exits) {
     const exits: Record<string, string | ExitValue> = {};
     for (const [dir, exit] of Object.entries(room.exits)) {

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -539,8 +539,10 @@ export function validateZone(
       if (!isPositiveInteger(song.durationSeconds)) {
         addIssue(issues, "error", entity, `Jukebox song ${label} needs a positive duration in seconds`);
       }
-      if (typeof song.cost !== "number" || song.cost < 0 || !Number.isFinite(song.cost)) {
-        addIssue(issues, "error", entity, `Jukebox song ${label} has an invalid cost (must be 0 or more)`);
+      // cost is optional — omitted means the server's configured default. When
+      // present it must be a whole, non-negative number of gold.
+      if (song.cost != null && (!Number.isInteger(song.cost) || song.cost < 0)) {
+        addIssue(issues, "error", entity, `Jukebox song ${label} has an invalid cost (whole gold, 0 or more)`);
       }
     });
   }

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -527,6 +527,22 @@ export function validateZone(
     for (const [featureId, feature] of Object.entries(room.features ?? {})) {
       validateFeature(issues, entity, featureId, feature, itemIds);
     }
+
+    (room.jukebox ?? []).forEach((song, index) => {
+      const label = song.title?.trim() || `#${index + 1}`;
+      if (!song.title?.trim()) {
+        addIssue(issues, "warning", entity, `Jukebox song ${label} has no title`);
+      }
+      if (!song.file?.trim()) {
+        addIssue(issues, "error", entity, `Jukebox song ${label} has no audio file`);
+      }
+      if (!isPositiveInteger(song.durationSeconds)) {
+        addIssue(issues, "error", entity, `Jukebox song ${label} needs a positive duration in seconds`);
+      }
+      if (typeof song.cost !== "number" || song.cost < 0 || !Number.isFinite(song.cost)) {
+        addIssue(issues, "error", entity, `Jukebox song ${label} has an invalid cost (must be 0 or more)`);
+      }
+    });
   }
 
   for (const [mobId, mob] of Object.entries(world.mobs ?? {})) {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -109,6 +109,20 @@ export interface ZoneAudioDefaults {
   ambient?: string;
 }
 
+/** A single jukebox track a player can pay to play in a room. The `file` is an
+ *  audio asset filename resolved against the zone's audio base (same as
+ *  `RoomFile.music` / `ambient`). Playing locks the room's music to this track
+ *  for `durationSeconds`, then it reverts to the room default. */
+export interface JukeboxSong {
+  title: string;
+  artist?: string;
+  file: string;
+  /** Length of the track in seconds; also the room's music-lock window. */
+  durationSeconds: number;
+  /** Gold cost to play. 0 is a valid (free) song. */
+  cost: number;
+}
+
 export interface RoomFile {
   title: string;
   description: string;
@@ -139,6 +153,10 @@ export interface RoomFile {
   ambient?: string;
   /** Legacy Arcanum-only alias; stripped on output. */
   audio?: string;
+  /** Player-playable jukebox playlist. Empty/omitted means the room has no
+   *  jukebox. Each song is paid for in gold and locks the room's music for its
+   *  `durationSeconds` before reverting to the room default. */
+  jukebox?: JukeboxSong[];
 }
 
 export interface ExitValue {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -112,15 +112,19 @@ export interface ZoneAudioDefaults {
 /** A single jukebox track a player can pay to play in a room. The `file` is an
  *  audio asset filename resolved against the zone's audio base (same as
  *  `RoomFile.music` / `ambient`). Playing locks the room's music to this track
- *  for `durationSeconds`, then it reverts to the room default. */
+ *  for `durationSeconds`, then it reverts to the room default. Mirrors the
+ *  server's `JukeboxSongFile` authoring DTO. */
 export interface JukeboxSong {
   title: string;
-  artist?: string;
   file: string;
-  /** Length of the track in seconds; also the room's music-lock window. */
+  /** Length of the track in seconds; also the room's music-lock window. Integer > 0. */
   durationSeconds: number;
-  /** Gold cost to play. 0 is a valid (free) song. */
-  cost: number;
+  /** Gold cost to play (integer). Omitted means the server's configured default
+   *  cost; an explicit 0 is a free song. */
+  cost?: number;
+  artist?: string;
+  /** Optional lore flavour shown in the song list / web panel. */
+  description?: string;
 }
 
 export interface RoomFile {


### PR DESCRIPTION
## Arcanum side of the Room Jukebox feature

Authoring support so creators can build a room's jukebox playlist in the world editor. The **server + web-v3 work is separate** — this PR only adds the data + UI that produces the YAML the server will consume.

### Data shape (per song, matches the server plan)
`title`, `artist?`, `file` (audio asset, resolved against the zone `audioBase` like `music`/`ambient`), `durationSeconds`, `cost`. An empty/omitted `jukebox` means the room has no jukebox.

### Changes
- **types/world.ts** — `JukeboxSong` + `RoomFile.jukebox?: JukeboxSong[]`
- **sanitizeZone.ts** — `normalizeJukebox`: trims text, drops empty `artist`, drops songs missing a title/file, omits the key entirely when the list is empty (clean round-trip via the existing `toJS()`/stringify path)
- **validateZone.ts** — per song: non-empty title (warn) + file (error), `durationSeconds > 0` (error), `cost >= 0` (error)
- **JukeboxEditor.tsx** — new editor: add/remove/reorder songs; `file` uses the same music `AudioTrackPicker` as room Music/Ambient (library-backed, with preview)
- **RoomPanel.tsx** — Jukebox disclosure in the Audio section
- **ZoneMediaPanel.tsx** — jukebox usage stat pill; `audioLibrary.ts` usage index now counts jukebox tracks so the Audio Studio shows where they're used

### Tests
- `sanitizeZone.test.ts` — trim/drop-empty/omit-empty round-trip
- `validateZone.test.ts` — valid song, free song, missing file, bad duration, negative cost, missing title

`bunx tsc --noEmit` clean · `bun run test` green (2169 passed).

Draft until you've had a look at the editor placement and the song field shape.