### PR TITLE
Audio track metadata + jukebox authoring (descriptions, lyrics, durations, song picker)

### DIFF
--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -37,6 +37,12 @@ pub struct AssetEntry {
     pub is_active: bool,
     #[serde(default)]
     pub display_name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub lyrics: String,
+    #[serde(default)]
+    pub duration_seconds: f64,
 }
 
 fn default_sync_status() -> String {
@@ -139,6 +145,9 @@ pub async fn accept_asset(
         variant_group: vg.clone(),
         is_active: active,
         display_name: display_name.unwrap_or_default(),
+        description: String::new(),
+        lyrics: String::new(),
+        duration_seconds: 0.0,
     };
 
     let _lock = MANIFEST_LOCK.lock().await;
@@ -447,6 +456,14 @@ pub async fn import_asset(
     let vg = variant_group.unwrap_or_default();
     let active = is_active.unwrap_or(false);
 
+    let duration_seconds = if subdir == "audio" {
+        crate::ffmpeg::probe_media_duration_seconds(&app, &dest)
+            .await
+            .unwrap_or(0.0)
+    } else {
+        0.0
+    };
+
     let entry = AssetEntry {
         id: uuid::Uuid::new_v4().to_string(),
         hash,
@@ -463,6 +480,9 @@ pub async fn import_asset(
         variant_group: vg.clone(),
         is_active: active,
         display_name: display_name.unwrap_or_default(),
+        description: String::new(),
+        lyrics: String::new(),
+        duration_seconds,
     };
 
     let _lock = MANIFEST_LOCK.lock().await;
@@ -497,6 +517,74 @@ pub async fn rename_asset(
         .ok_or_else(|| format!("Asset not found: {asset_id}"))?;
     entry.display_name = display_name.trim().to_string();
     save_manifest(&app, &manifest).await
+}
+
+#[tauri::command]
+pub async fn update_asset_metadata(
+    app: AppHandle,
+    asset_id: String,
+    display_name: Option<String>,
+    description: Option<String>,
+    lyrics: Option<String>,
+) -> Result<(), String> {
+    let _lock = MANIFEST_LOCK.lock().await;
+    let mut manifest = load_manifest(&app).await?;
+    let entry = manifest
+        .assets
+        .iter_mut()
+        .find(|a| a.id == asset_id)
+        .ok_or_else(|| format!("Asset not found: {asset_id}"))?;
+    if let Some(name) = display_name {
+        entry.display_name = name.trim().to_string();
+    }
+    if let Some(text) = description {
+        entry.description = text.trim().to_string();
+    }
+    if let Some(text) = lyrics {
+        entry.lyrics = text.trim_end().to_string();
+    }
+    save_manifest(&app, &manifest).await
+}
+
+const AUDIO_ASSET_TYPES: [&str; 3] = ["music", "ambient", "audio"];
+const AUDIO_EXTENSIONS: [&str; 4] = ["mp3", "ogg", "flac", "wav"];
+
+/// Probe durations for audio library entries that don't have one yet.
+/// Best-effort: missing files and unprobeable tracks are skipped silently.
+#[tauri::command]
+pub async fn backfill_audio_meta(app: AppHandle) -> Result<u32, String> {
+    let audio_dir = assets_dir(&app)?.join("audio");
+    let _lock = MANIFEST_LOCK.lock().await;
+    let mut manifest = load_manifest(&app).await?;
+    let mut updated = 0u32;
+
+    for entry in manifest.assets.iter_mut() {
+        if !AUDIO_ASSET_TYPES.contains(&entry.asset_type.as_str()) {
+            continue;
+        }
+        if entry.duration_seconds > 0.0 {
+            continue;
+        }
+        let ext = extension_from_path(&entry.file_name)
+            .map(|e| e.to_lowercase())
+            .unwrap_or_default();
+        if !AUDIO_EXTENSIONS.contains(&ext.as_str()) {
+            continue;
+        }
+        let path = audio_dir.join(&entry.file_name);
+        if !path.exists() {
+            continue;
+        }
+        if let Some(seconds) = crate::ffmpeg::probe_media_duration_seconds(&app, &path).await {
+            entry.duration_seconds = seconds;
+            updated += 1;
+        }
+    }
+
+    if updated > 0 {
+        save_manifest(&app, &manifest).await?;
+    }
+    Ok(updated)
 }
 
 #[tauri::command]
@@ -601,6 +689,9 @@ pub async fn save_bytes_as_asset(
         variant_group: variant_group.unwrap_or_default(),
         is_active: false,
         display_name: String::new(),
+        description: String::new(),
+        lyrics: String::new(),
+        duration_seconds: 0.0,
     };
 
     manifest.assets.retain(|a| a.hash != entry.hash);
@@ -886,6 +977,9 @@ pub async fn import_player_sprites(
             variant_group,
             is_active: true,
             display_name: String::new(),
+            description: String::new(),
+            lyrics: String::new(),
+            duration_seconds: 0.0,
         };
 
         manifest.assets.push(entry);
@@ -1021,6 +1115,9 @@ pub async fn bulk_import_images(
             variant_group: format!("{entity_type}:{stem}"),
             is_active: true,
             display_name: String::new(),
+            description: String::new(),
+            lyrics: String::new(),
+            duration_seconds: 0.0,
         };
 
         manifest.assets.push(asset_entry);
@@ -1118,6 +1215,9 @@ pub async fn flip_image(app: AppHandle, image_ref: String) -> Result<String, Str
             variant_group: source.map_or_else(String::new, |s| s.variant_group.clone()),
             is_active: true,
             display_name: String::new(),
+            description: String::new(),
+            lyrics: String::new(),
+            duration_seconds: 0.0,
         };
 
         let vg = &entry.variant_group;

--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -40,6 +40,8 @@ pub struct AssetEntry {
     #[serde(default)]
     pub description: String,
     #[serde(default)]
+    pub artist: String,
+    #[serde(default)]
     pub lyrics: String,
     #[serde(default)]
     pub duration_seconds: f64,
@@ -146,6 +148,7 @@ pub async fn accept_asset(
         is_active: active,
         display_name: display_name.unwrap_or_default(),
         description: String::new(),
+        artist: String::new(),
         lyrics: String::new(),
         duration_seconds: 0.0,
     };
@@ -481,6 +484,7 @@ pub async fn import_asset(
         is_active: active,
         display_name: display_name.unwrap_or_default(),
         description: String::new(),
+        artist: String::new(),
         lyrics: String::new(),
         duration_seconds,
     };
@@ -525,7 +529,9 @@ pub async fn update_asset_metadata(
     asset_id: String,
     display_name: Option<String>,
     description: Option<String>,
+    artist: Option<String>,
     lyrics: Option<String>,
+    duration_seconds: Option<f64>,
 ) -> Result<(), String> {
     let _lock = MANIFEST_LOCK.lock().await;
     let mut manifest = load_manifest(&app).await?;
@@ -540,8 +546,14 @@ pub async fn update_asset_metadata(
     if let Some(text) = description {
         entry.description = text.trim().to_string();
     }
+    if let Some(text) = artist {
+        entry.artist = text.trim().to_string();
+    }
     if let Some(text) = lyrics {
         entry.lyrics = text.trim_end().to_string();
+    }
+    if let Some(seconds) = duration_seconds {
+        entry.duration_seconds = seconds.max(0.0);
     }
     save_manifest(&app, &manifest).await
 }
@@ -690,6 +702,7 @@ pub async fn save_bytes_as_asset(
         is_active: false,
         display_name: String::new(),
         description: String::new(),
+        artist: String::new(),
         lyrics: String::new(),
         duration_seconds: 0.0,
     };
@@ -978,6 +991,7 @@ pub async fn import_player_sprites(
             is_active: true,
             display_name: String::new(),
             description: String::new(),
+            artist: String::new(),
             lyrics: String::new(),
             duration_seconds: 0.0,
         };
@@ -1116,6 +1130,7 @@ pub async fn bulk_import_images(
             is_active: true,
             display_name: String::new(),
             description: String::new(),
+            artist: String::new(),
             lyrics: String::new(),
             duration_seconds: 0.0,
         };
@@ -1216,6 +1231,7 @@ pub async fn flip_image(app: AppHandle, image_ref: String) -> Result<String, Str
             is_active: true,
             display_name: String::new(),
             description: String::new(),
+            artist: String::new(),
             lyrics: String::new(),
             duration_seconds: 0.0,
         };

--- a/creator/src-tauri/src/ffmpeg.rs
+++ b/creator/src-tauri/src/ffmpeg.rs
@@ -107,6 +107,51 @@ fn parse_ffmpeg_version(text: &str) -> Option<String> {
     Some(token.to_string())
 }
 
+/// Probes a media file's duration by running `ffmpeg -i <path>` and
+/// parsing the `Duration: HH:MM:SS.cc` line from stderr. ffmpeg exits
+/// non-zero without an output file, so the exit status is ignored —
+/// only the stderr metadata matters. Returns `None` on any failure
+/// (ffmpeg unavailable, spawn error, unparseable output); duration is
+/// best-effort metadata, never a hard error.
+pub async fn probe_media_duration_seconds(app: &AppHandle, media_path: &Path) -> Option<f64> {
+    let status = resolve_ffmpeg(app).await;
+    if !status.available {
+        return None;
+    }
+    let bin = status.path?;
+    let output = tokio::process::Command::new(&bin)
+        .arg("-hide_banner")
+        .arg("-i")
+        .arg(media_path)
+        .output()
+        .await
+        .ok()?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    parse_duration_seconds(&stderr)
+}
+
+/// Parses `Duration: HH:MM:SS.cc` from ffmpeg's stderr metadata dump.
+/// Returns `None` when the line is missing, reads `N/A`, or yields a
+/// non-positive total.
+fn parse_duration_seconds(text: &str) -> Option<f64> {
+    for line in text.lines() {
+        let Some(rest) = line.trim().strip_prefix("Duration:") else {
+            continue;
+        };
+        let token = rest.split(',').next()?.trim();
+        let mut parts = token.split(':');
+        let hours: f64 = parts.next()?.trim().parse().ok()?;
+        let minutes: f64 = parts.next()?.trim().parse().ok()?;
+        let seconds: f64 = parts.next()?.trim().parse().ok()?;
+        if parts.next().is_some() {
+            return None;
+        }
+        let total = hours * 3600.0 + minutes * 60.0 + seconds;
+        return (total > 0.0).then_some(total);
+    }
+    None
+}
+
 // ─── Resolution ──────────────────────────────────────────────────
 
 /// Attempts to find ffmpeg in the bundled location first, then on
@@ -298,6 +343,32 @@ mod tests {
     fn ignores_lines_after_the_first() {
         let sample = "ffmpeg version 7.0.0 Copyright\nrandom second line\n6.1.1 trailing";
         assert_eq!(parse_ffmpeg_version(sample), Some("7.0.0".to_string()));
+    }
+
+    // ─── parse_duration_seconds ──────────────────────────────────
+
+    #[test]
+    fn parses_duration_line_from_stderr_dump() {
+        let sample = "Input #0, mp3, from 'song.mp3':\n\
+                      \x20 Duration: 00:01:36.05, start: 0.025057, bitrate: 192 kb/s\n\
+                      \x20 Stream #0:0: Audio: mp3, 44100 Hz, stereo";
+        let parsed = parse_duration_seconds(sample).expect("should parse");
+        assert!((parsed - 96.05).abs() < 0.001, "got {parsed}");
+    }
+
+    #[test]
+    fn parses_duration_with_hours() {
+        let sample = "  Duration: 01:02:03.50, bitrate: 128 kb/s";
+        let parsed = parse_duration_seconds(sample).expect("should parse");
+        assert!((parsed - 3723.5).abs() < 0.001, "got {parsed}");
+    }
+
+    #[test]
+    fn duration_returns_none_for_na_or_missing() {
+        assert_eq!(parse_duration_seconds("  Duration: N/A, bitrate: N/A"), None);
+        assert_eq!(parse_duration_seconds("no duration here"), None);
+        assert_eq!(parse_duration_seconds(""), None);
+        assert_eq!(parse_duration_seconds("  Duration: 00:00:00.00, start: 0"), None);
     }
 
     #[test]

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -88,6 +88,8 @@ macro_rules! base_handler {
             assets::read_media_data_url,
             assets::import_asset,
             assets::rename_asset,
+            assets::update_asset_metadata,
+            assets::backfill_audio_meta,
             assets::set_active_variant,
             assets::list_variants,
             assets::save_bytes_as_asset,

--- a/creator/src/components/AudioStudio.tsx
+++ b/creator/src/components/AudioStudio.tsx
@@ -18,6 +18,7 @@ import {
   listAudioTracks,
   setRoomTrack,
   setZoneDefaultTrack,
+  splitLyricsLines,
   trackLabel,
   usageSummary,
   type AudioTrackKind,
@@ -237,7 +238,9 @@ function TrackDetail({
   const settings = useAssetStore((s) => s.settings);
   const [name, setName] = useState(track.display_name);
   const [description, setDescription] = useState(track.description);
+  const [artist, setArtist] = useState(track.artist);
   const [lyrics, setLyrics] = useState(track.lyrics);
+  const [durationText, setDurationText] = useState(() => String(Math.round(track.duration_seconds)));
   const [composing, setComposing] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -246,6 +249,10 @@ function TrackDetail({
   const isMusic = track.asset_type === "music";
   const used = usage.zoneDefaults.length > 0 || usage.rooms.length > 0 || usage.jukeboxes.length > 0;
   const usedCount = usage.zoneDefaults.length + usage.rooms.length + usage.jukeboxes.length;
+
+  const durationSeconds = Math.max(0, Math.round(Number(durationText) || 0));
+  const lyricLineCount = splitLyricsLines(lyrics).length;
+  const lyricBudget = durationSeconds > 0 ? Math.floor(durationSeconds / 3) : null;
 
   const commitName = () => {
     const next = name.trim();
@@ -259,10 +266,22 @@ function TrackDetail({
     updateAssetMetadata(track.id, { description: next }).catch((e) => setError(String(e)));
   };
 
+  const commitArtist = () => {
+    const next = artist.trim();
+    if (next === track.artist) return;
+    updateAssetMetadata(track.id, { artist: next }).catch((e) => setError(String(e)));
+  };
+
   const commitLyrics = () => {
     const next = lyrics.trimEnd();
     if (next === track.lyrics) return;
     updateAssetMetadata(track.id, { lyrics: next }).catch((e) => setError(String(e)));
+  };
+
+  const commitDuration = () => {
+    setDurationText(String(durationSeconds));
+    if (durationSeconds === Math.round(track.duration_seconds)) return;
+    updateAssetMetadata(track.id, { durationSeconds }).catch((e) => setError(String(e)));
   };
 
   const handleCompose = async () => {
@@ -275,18 +294,26 @@ function TrackDetail({
           name: track.display_name || name.trim(),
           prompt: track.prompt,
           enhancedPrompt: track.enhanced_prompt,
+          durationSeconds,
         }),
       });
       const parsed = JSON.parse(stripJsonFences(raw)) as {
         title?: string;
+        artist?: string;
         description?: string;
         lyrics?: string;
       };
       const nextDescription = (parsed.description ?? "").trim();
+      const nextArtist = (parsed.artist ?? "").trim();
       const nextLyrics = (parsed.lyrics ?? "").trimEnd();
       setDescription(nextDescription);
+      setArtist(nextArtist);
       setLyrics(nextLyrics);
-      await updateAssetMetadata(track.id, { description: nextDescription, lyrics: nextLyrics });
+      await updateAssetMetadata(track.id, {
+        description: nextDescription,
+        artist: nextArtist,
+        lyrics: nextLyrics,
+      });
       const title = (parsed.title ?? "").trim();
       if (!track.display_name && title) {
         setName(title);
@@ -319,9 +346,20 @@ function TrackDetail({
           aria-label="Track name"
           className="ornate-input min-h-9 flex-1 px-2 py-1 text-xs text-text-primary"
         />
-        {track.duration_seconds > 0 && (
-          <span className="text-3xs text-text-muted">{formatDuration(track.duration_seconds)}</span>
-        )}
+        <label className="flex shrink-0 items-center gap-1 text-3xs text-text-muted">
+          <input
+            type="number"
+            min={0}
+            value={durationText}
+            onChange={(e) => setDurationText(e.target.value)}
+            onBlur={commitDuration}
+            onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+            aria-label="Track duration in seconds"
+            title="Play length in seconds — the jukebox needs this; edit it when audio probing fails"
+            className="w-14 rounded border border-border-default bg-bg-secondary px-1.5 py-0.5 text-right text-2xs text-text-secondary outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+          />
+          s{durationSeconds > 0 ? ` · ${formatDuration(durationSeconds)}` : ""}
+        </label>
         <span className="font-mono text-3xs text-text-muted" title={track.file_name}>
           {track.file_name.slice(0, 10)}…
         </span>
@@ -338,10 +376,27 @@ function TrackDetail({
       />
 
       {isMusic && (
+        <input
+          value={artist}
+          onChange={(e) => setArtist(e.target.value)}
+          onBlur={commitArtist}
+          onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+          placeholder="Artist — in-world performer or band, shown in jukebox listings"
+          aria-label="Track artist"
+          className="ornate-input min-h-9 w-full px-2 py-1 text-xs text-text-primary"
+        />
+      )}
+
+      {isMusic && (
         <div className="flex flex-col gap-1">
           <div className="flex items-center justify-between gap-2">
             <span className="text-2xs text-text-muted">
               Lyrics — broadcast line-by-line while a jukebox plays this song.
+              {lyricBudget !== null && (
+                <span className={lyricLineCount > lyricBudget ? "text-status-warning" : ""}>
+                  {" "}{lyricLineCount} line{lyricLineCount === 1 ? "" : "s"} · max {lyricBudget} for {formatDuration(durationSeconds)}
+                </span>
+              )}
             </span>
             {AI_ENABLED && hasLlmKey(settings) && (
               <button

--- a/creator/src/components/AudioStudio.tsx
+++ b/creator/src/components/AudioStudio.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -7,7 +7,12 @@ import { useZoneStore } from "@/stores/zoneStore";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 import { useMediaSrc } from "@/lib/useMediaSrc";
 import { AI_ENABLED } from "@/lib/featureFlags";
-import { getAudioSystemPrompt, getDefaultDuration } from "@/lib/musicPrompts";
+import {
+  SONG_METADATA_SYSTEM_PROMPT,
+  buildSongMetadataUserPrompt,
+  getAudioSystemPrompt,
+  getDefaultDuration,
+} from "@/lib/musicPrompts";
 import {
   buildUsageIndex,
   listAudioTracks,
@@ -18,7 +23,7 @@ import {
   type AudioTrackKind,
   type TrackUsage,
 } from "@/lib/audioLibrary";
-import type { AssetEntry, AssetContext } from "@/types/assets";
+import type { AssetEntry, AssetContext, Settings } from "@/types/assets";
 import { InlineError, Spinner } from "@/components/ui/FormWidgets";
 
 const AUDIO_EXTENSIONS = ["mp3", "ogg", "flac", "wav"];
@@ -43,10 +48,33 @@ function defaultTrackName(roomTitle: string, kind: AudioTrackKind): string {
   return `${roomTitle} ${kind === "music" ? "Theme" : "Ambience"}`;
 }
 
+function hasLlmKey(settings: Settings | null): boolean {
+  return !!settings && (
+    settings.deepinfra_api_key.length > 0 ||
+    settings.anthropic_api_key.length > 0 ||
+    settings.openrouter_api_key.length > 0 ||
+    (settings.use_hub_ai && settings.hub_api_key.length > 0)
+  );
+}
+
+function formatDuration(seconds: number): string {
+  const total = Math.round(seconds);
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
+}
+
+function stripJsonFences(raw: string): string {
+  return raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/```\s*$/, "");
+}
+
 export function AudioStudio() {
   const assets = useAssetStore((s) => s.assets);
   const importAsset = useAssetStore((s) => s.importAsset);
+  const backfillAudioMeta = useAssetStore((s) => s.backfillAudioMeta);
   const zones = useZoneStore((s) => s.zones);
+
+  useEffect(() => {
+    backfillAudioMeta().catch(() => {});
+  }, [backfillAudioMeta]);
 
   const [lane, setLane] = useState<AudioTrackKind>("music");
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -134,7 +162,7 @@ export function AudioStudio() {
                 <TrackRow
                   key={track.id}
                   track={track}
-                  usage={usageIndex.get(track.file_name) ?? { zoneDefaults: [], rooms: [] }}
+                  usage={usageIndex.get(track.file_name) ?? { zoneDefaults: [], rooms: [], jukeboxes: [] }}
                   expanded={selectedId === track.id}
                   onToggle={() => setSelectedId(selectedId === track.id ? null : track.id)}
                   onAssign={() => setAssignTrackId(track.id)}
@@ -172,7 +200,7 @@ function TrackRow({
   onToggle: () => void;
   onAssign: () => void;
 }) {
-  const used = usage.zoneDefaults.length > 0 || usage.rooms.length > 0;
+  const used = usage.zoneDefaults.length > 0 || usage.rooms.length > 0 || usage.jukeboxes.length > 0;
   return (
     <div
       className={`rounded-2xl border transition ${
@@ -204,18 +232,71 @@ function TrackDetail({
   onAssign: () => void;
 }) {
   const renameAsset = useAssetStore((s) => s.renameAsset);
+  const updateAssetMetadata = useAssetStore((s) => s.updateAssetMetadata);
   const deleteAsset = useAssetStore((s) => s.deleteAsset);
+  const settings = useAssetStore((s) => s.settings);
   const [name, setName] = useState(track.display_name);
+  const [description, setDescription] = useState(track.description);
+  const [lyrics, setLyrics] = useState(track.lyrics);
+  const [composing, setComposing] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const src = useMediaSrc(track.file_name);
 
-  const used = usage.zoneDefaults.length > 0 || usage.rooms.length > 0;
+  const isMusic = track.asset_type === "music";
+  const used = usage.zoneDefaults.length > 0 || usage.rooms.length > 0 || usage.jukeboxes.length > 0;
+  const usedCount = usage.zoneDefaults.length + usage.rooms.length + usage.jukeboxes.length;
 
   const commitName = () => {
     const next = name.trim();
     if (next === track.display_name) return;
     renameAsset(track.id, next).catch((e) => setError(String(e)));
+  };
+
+  const commitDescription = () => {
+    const next = description.trim();
+    if (next === track.description) return;
+    updateAssetMetadata(track.id, { description: next }).catch((e) => setError(String(e)));
+  };
+
+  const commitLyrics = () => {
+    const next = lyrics.trimEnd();
+    if (next === track.lyrics) return;
+    updateAssetMetadata(track.id, { lyrics: next }).catch((e) => setError(String(e)));
+  };
+
+  const handleCompose = async () => {
+    setComposing(true);
+    setError(null);
+    try {
+      const raw = await invoke<string>("llm_complete", {
+        systemPrompt: SONG_METADATA_SYSTEM_PROMPT,
+        userPrompt: buildSongMetadataUserPrompt({
+          name: track.display_name || name.trim(),
+          prompt: track.prompt,
+          enhancedPrompt: track.enhanced_prompt,
+        }),
+      });
+      const parsed = JSON.parse(stripJsonFences(raw)) as {
+        title?: string;
+        description?: string;
+        lyrics?: string;
+      };
+      const nextDescription = (parsed.description ?? "").trim();
+      const nextLyrics = (parsed.lyrics ?? "").trimEnd();
+      setDescription(nextDescription);
+      setLyrics(nextLyrics);
+      await updateAssetMetadata(track.id, { description: nextDescription, lyrics: nextLyrics });
+      const title = (parsed.title ?? "").trim();
+      if (!track.display_name && title) {
+        setName(title);
+        await renameAsset(track.id, title);
+      }
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setComposing(false);
+    }
   };
 
   const handleDelete = () => {
@@ -238,10 +319,51 @@ function TrackDetail({
           aria-label="Track name"
           className="ornate-input min-h-9 flex-1 px-2 py-1 text-xs text-text-primary"
         />
+        {track.duration_seconds > 0 && (
+          <span className="text-3xs text-text-muted">{formatDuration(track.duration_seconds)}</span>
+        )}
         <span className="font-mono text-3xs text-text-muted" title={track.file_name}>
           {track.file_name.slice(0, 10)}…
         </span>
       </div>
+
+      <input
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        onBlur={commitDescription}
+        onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+        placeholder={isMusic ? "Description — a songbook blurb for jukebox listings" : "Description"}
+        aria-label="Track description"
+        className="ornate-input min-h-9 w-full px-2 py-1 text-xs text-text-primary"
+      />
+
+      {isMusic && (
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-2xs text-text-muted">
+              Lyrics — broadcast line-by-line while a jukebox plays this song.
+            </span>
+            {AI_ENABLED && hasLlmKey(settings) && (
+              <button
+                onClick={handleCompose}
+                disabled={composing}
+                className="focus-ring shrink-0 rounded px-1.5 py-0.5 text-2xs text-accent transition-colors hover:bg-accent/10 disabled:opacity-50"
+              >
+                {composing ? <Spinner /> : "Compose details"}
+              </button>
+            )}
+          </div>
+          <textarea
+            value={lyrics}
+            onChange={(e) => setLyrics(e.target.value)}
+            onBlur={commitLyrics}
+            rows={6}
+            placeholder="When the lanterns lean in low…"
+            aria-label="Track lyrics"
+            className="w-full resize-y rounded border border-border-default bg-bg-secondary px-2 py-1 font-mono text-2xs leading-relaxed text-text-secondary placeholder:text-text-muted outline-none focus:border-accent/50 focus-visible:ring-2 focus-visible:ring-border-active"
+          />
+        </div>
+      )}
 
       {src ? <audio controls src={src} className="h-8 w-full" /> : <div className="text-2xs italic text-text-muted">Loading preview…</div>}
 
@@ -254,6 +376,10 @@ function TrackDetail({
             <span key={`${u.zoneId}:${u.roomId}:${u.kind}`}>{u.roomTitle} ({u.zoneId})</span>
           ))}
           {usage.rooms.length > 6 && <span>…and {usage.rooms.length - 6} more rooms</span>}
+          {usage.jukeboxes.slice(0, 6).map((u) => (
+            <span key={`${u.zoneId}:${u.roomId}:jukebox`}>Jukebox — {u.roomTitle} ({u.zoneId})</span>
+          ))}
+          {usage.jukeboxes.length > 6 && <span>…and {usage.jukeboxes.length - 6} more jukeboxes</span>}
         </div>
       )}
 
@@ -268,7 +394,7 @@ function TrackDetail({
             confirmDelete ? "bg-status-error/20 font-medium text-status-error" : "text-text-muted hover:text-status-error"
           }`}
         >
-          {confirmDelete ? (used ? `Used by ${usage.zoneDefaults.length + usage.rooms.length} — delete anyway?` : "Confirm delete") : "Delete"}
+          {confirmDelete ? (used ? `Used by ${usedCount} — delete anyway?` : "Confirm delete") : "Delete"}
         </button>
       </div>
 
@@ -286,12 +412,7 @@ function GenerateTrackCard({ kind, onCreated }: { kind: AudioTrackKind; onCreate
 
   const hasRunwareKey = !!settings && settings.runware_api_key.length > 0;
   const hasElevenKey = !!settings && settings.elevenlabs_api_key.length > 0;
-  const hasLlmKey = !!settings && (
-    settings.deepinfra_api_key.length > 0 ||
-    settings.anthropic_api_key.length > 0 ||
-    settings.openrouter_api_key.length > 0 ||
-    (settings.use_hub_ai && settings.hub_api_key.length > 0)
-  );
+  const llmReady = hasLlmKey(settings);
 
   // ElevenLabs sound effects suit ambience, not music.
   const providers: AudioProvider[] = kind === "ambient"
@@ -520,7 +641,7 @@ function GenerateTrackCard({ kind, onCreated }: { kind: AudioTrackKind; onCreate
           </label>
         )}
         <div className="ml-auto flex gap-1">
-          {hasLlmKey && (
+          {llmReady && (
             <button
               onClick={handleEnhance}
               disabled={enhancing}

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { WorldFile, ExitValue, DoorFile } from "@/types/world";
+import type { WorldFile, ExitValue, DoorFile, JukeboxSongFile } from "@/types/world";
 import {
   updateRoom,
   deleteRoom,
@@ -23,6 +23,7 @@ import { YamlPreview } from "@/components/ui/YamlPreview";
 import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
 import { MediaPicker } from "@/components/ui/MediaPicker";
 import { AudioTrackPicker } from "@/components/ui/AudioTrackPicker";
+import { buildAudioMetaIndex, listAudioTracks, trackLabel } from "@/lib/audioLibrary";
 import { VideoGenerator } from "@/components/ui/VideoGenerator";
 import { roomPrompt, roomContext } from "@/lib/entityPrompts";
 import { getTrainerClasses } from "@/lib/trainers";
@@ -1245,6 +1246,7 @@ export function RoomPanel({
             onChange={(v) => onWorldChange(updateRoom(world, roomId, { ambient: v }))}
             hint="Overrides the zone's default soundscape for this room."
           />
+          <JukeboxEditor world={world} roomId={roomId} onWorldChange={onWorldChange} />
         </div>
       </Section>
       </>
@@ -1276,6 +1278,134 @@ export function RoomPanel({
           }}
           onClose={() => setRenaming(false)}
         />
+      )}
+    </div>
+  );
+}
+
+interface JukeboxEditorProps {
+  world: WorldFile;
+  roomId: string;
+  onWorldChange: (world: WorldFile) => void;
+}
+
+/** Ordered song list for the room's jukebox. New songs are stored as bare
+ *  file refs — names, lyrics, and durations are denormalized from the audio
+ *  library at save time. */
+function JukeboxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
+  const assets = useAssetStore((s) => s.assets);
+  const metaIndex = useMemo(() => buildAudioMetaIndex(assets), [assets]);
+  const musicTracks = useMemo(() => listAudioTracks(assets, "music"), [assets]);
+
+  const room = world.rooms[roomId];
+  if (!room) return null;
+  const songs = room.jukebox?.songs ?? [];
+  const inList = new Set(songs.map((s) => s.file));
+  const addable = musicTracks.filter((t) => !inList.has(t.file_name));
+
+  const setSongs = (next: JukeboxSongFile[]) =>
+    onWorldChange(updateRoom(world, roomId, { jukebox: { songs: next } }));
+
+  const move = (index: number, delta: number) => {
+    const target = index + delta;
+    if (target < 0 || target >= songs.length) return;
+    const next = [...songs];
+    const a = next[index];
+    const b = next[target];
+    if (!a || !b) return;
+    next[index] = b;
+    next[target] = a;
+    setSongs(next);
+  };
+
+  const songButtonClass =
+    "focus-ring shrink-0 rounded px-1 text-2xs text-text-muted transition-colors hover:text-text-primary disabled:opacity-30";
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="flex cursor-pointer items-center gap-1.5 text-xs text-text-secondary">
+        <input
+          type="checkbox"
+          checked={!!room.jukebox}
+          onChange={(e) =>
+            onWorldChange(
+              updateRoom(world, roomId, { jukebox: e.target.checked ? { songs: [] } : undefined }),
+            )
+          }
+          className="accent-[rgb(var(--accent-rgb))]"
+        />
+        Jukebox in this room
+      </label>
+      {room.jukebox && (
+        <div className="flex flex-col gap-1 pl-5">
+          {songs.map((song, index) => {
+            const meta = metaIndex.get(song.file);
+            return (
+              <div key={`${song.file}:${index}`} className="flex items-center gap-1 text-2xs">
+                <span className="w-4 shrink-0 text-right text-text-muted">{index + 1}.</span>
+                <span className="min-w-0 flex-1 truncate text-text-secondary" title={song.file}>
+                  {meta?.name ?? song.name ?? song.file}
+                </span>
+                {!meta && (
+                  <span className="shrink-0 rounded bg-status-warning/15 px-1 py-0.5 text-3xs text-status-warning">
+                    unknown track
+                  </span>
+                )}
+                {meta && !meta.lyrics && (
+                  <span className="shrink-0 rounded bg-bg-secondary px-1 py-0.5 text-3xs text-text-muted">
+                    no lyrics
+                  </span>
+                )}
+                <button
+                  onClick={() => move(index, -1)}
+                  disabled={index === 0}
+                  title="Move up"
+                  aria-label={`Move song ${index + 1} up`}
+                  className={songButtonClass}
+                >
+                  ↑
+                </button>
+                <button
+                  onClick={() => move(index, 1)}
+                  disabled={index === songs.length - 1}
+                  title="Move down"
+                  aria-label={`Move song ${index + 1} down`}
+                  className={songButtonClass}
+                >
+                  ↓
+                </button>
+                <button
+                  onClick={() => setSongs(songs.filter((_, i) => i !== index))}
+                  title="Remove song"
+                  aria-label={`Remove song ${index + 1}`}
+                  className="focus-ring shrink-0 rounded px-1 text-2xs text-text-muted transition-colors hover:text-status-danger"
+                >
+                  ✕
+                </button>
+              </div>
+            );
+          })}
+          <select
+            value=""
+            onChange={(e) => {
+              if (!e.target.value) return;
+              setSongs([...songs, { file: e.target.value }]);
+            }}
+            aria-label="Add song to jukebox"
+            className="w-full rounded border border-border-default bg-bg-secondary px-2 py-1 text-2xs text-text-secondary outline-none focus-visible:ring-2 focus-visible:ring-border-active [&>option]:bg-bg-secondary"
+          >
+            <option value="">Add song…</option>
+            {addable.map((t) => (
+              <option key={t.id} value={t.file_name}>
+                {trackLabel(t)}
+              </option>
+            ))}
+          </select>
+          <p className="text-2xs text-text-muted">
+            Players use <code className="font-mono">jukebox play &lt;n&gt;</code> — lyrics and names
+            come from the Audio Studio library.
+          </p>
+        </div>
       )}
     </div>
   );

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -1289,9 +1289,15 @@ interface JukeboxEditorProps {
   onWorldChange: (world: WorldFile) => void;
 }
 
+function formatSongDuration(seconds: number): string {
+  const total = Math.round(seconds);
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
+}
+
 /** Ordered song list for the room's jukebox. New songs are stored as bare
- *  file refs — names, lyrics, and durations are denormalized from the audio
- *  library at save time. */
+ *  file refs — titles, artists, lyrics, and durations are denormalized from
+ *  the audio library at save time. Per-song cost is authored here because it
+ *  is zone content, not library metadata. */
 function JukeboxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
   const assets = useAssetStore((s) => s.assets);
   const metaIndex = useMemo(() => buildAudioMetaIndex(assets), [assets]);
@@ -1299,12 +1305,15 @@ function JukeboxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
 
   const room = world.rooms[roomId];
   if (!room) return null;
-  const songs = room.jukebox?.songs ?? [];
+  const songs = room.jukebox ?? [];
   const inList = new Set(songs.map((s) => s.file));
   const addable = musicTracks.filter((t) => !inList.has(t.file_name));
 
   const setSongs = (next: JukeboxSongFile[]) =>
-    onWorldChange(updateRoom(world, roomId, { jukebox: { songs: next } }));
+    onWorldChange(updateRoom(world, roomId, { jukebox: next }));
+
+  const setSong = (index: number, next: JukeboxSongFile) =>
+    setSongs(songs.map((s, i) => (i === index ? next : s)));
 
   const move = (index: number, delta: number) => {
     const target = index + delta;
@@ -1329,7 +1338,7 @@ function JukeboxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
           checked={!!room.jukebox}
           onChange={(e) =>
             onWorldChange(
-              updateRoom(world, roomId, { jukebox: e.target.checked ? { songs: [] } : undefined }),
+              updateRoom(world, roomId, { jukebox: e.target.checked ? [] : undefined }),
             )
           }
           className="accent-[rgb(var(--accent-rgb))]"
@@ -1340,15 +1349,31 @@ function JukeboxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
         <div className="flex flex-col gap-1 pl-5">
           {songs.map((song, index) => {
             const meta = metaIndex.get(song.file);
+            const songDuration =
+              typeof song.durationSeconds === "number" && song.durationSeconds > 0
+                ? Math.round(song.durationSeconds)
+                : 0;
+            const duration = meta && meta.durationSeconds > 0 ? meta.durationSeconds : songDuration;
             return (
               <div key={`${song.file}:${index}`} className="flex items-center gap-1 text-2xs">
                 <span className="w-4 shrink-0 text-right text-text-muted">{index + 1}.</span>
                 <span className="min-w-0 flex-1 truncate text-text-secondary" title={song.file}>
-                  {meta?.name ?? song.name ?? song.file}
+                  {meta?.name ?? song.title ?? song.file}
                 </span>
+                {duration > 0 && (
+                  <span className="shrink-0 text-3xs text-text-muted">{formatSongDuration(duration)}</span>
+                )}
                 {!meta && (
                   <span className="shrink-0 rounded bg-status-warning/15 px-1 py-0.5 text-3xs text-status-warning">
                     unknown track
+                  </span>
+                )}
+                {meta && duration <= 0 && (
+                  <span
+                    title="Saving is blocked until this song has a play length — set the track's duration in the Audio Studio."
+                    className="shrink-0 rounded bg-status-warning/15 px-1 py-0.5 text-3xs text-status-warning"
+                  >
+                    no duration
                   </span>
                 )}
                 {meta && !meta.lyrics && (
@@ -1356,6 +1381,24 @@ function JukeboxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
                     no lyrics
                   </span>
                 )}
+                <input
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={song.cost ?? ""}
+                  onChange={(e) => {
+                    if (e.target.value === "") {
+                      const { cost: _unused, ...rest } = song;
+                      setSong(index, rest);
+                    } else {
+                      setSong(index, { ...song, cost: Math.max(0, Math.round(Number(e.target.value))) });
+                    }
+                  }}
+                  placeholder="cost"
+                  title={`Gold cost to play song ${index + 1} — blank uses the server's default price`}
+                  aria-label={`Song ${index + 1} gold cost`}
+                  className="w-12 shrink-0 rounded border border-border-default bg-bg-secondary px-1 py-0.5 text-right text-2xs text-text-secondary placeholder:text-text-muted outline-none focus-visible:ring-2 focus-visible:ring-border-active"
+                />
                 <button
                   onClick={() => move(index, -1)}
                   disabled={index === 0}
@@ -1402,8 +1445,8 @@ function JukeboxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
             ))}
           </select>
           <p className="text-2xs text-text-muted">
-            Players use <code className="font-mono">jukebox play &lt;n&gt;</code> — lyrics and names
-            come from the Audio Studio library.
+            Players use <code className="font-mono">jukebox play &lt;n&gt;</code> — titles, artists, and
+            lyrics come from the Audio Studio library. A blank cost charges the server's default price.
           </p>
         </div>
       )}

--- a/creator/src/lib/__tests__/audioLibrary.test.ts
+++ b/creator/src/lib/__tests__/audioLibrary.test.ts
@@ -8,6 +8,7 @@ import {
   scanTrackUsage,
   setRoomTrack,
   setZoneDefaultTrack,
+  splitLyricsLines,
   trackLabel,
   usageSummary,
 } from "@/lib/audioLibrary";
@@ -33,6 +34,7 @@ function makeAsset(overrides: Partial<AssetEntry>): AssetEntry {
     is_active: false,
     display_name: "",
     description: "",
+    artist: "",
     lyrics: "",
     duration_seconds: 0,
     ...overrides,
@@ -123,7 +125,7 @@ describe("usage scanning", () => {
             parlor: {
               title: "Parlor",
               description: "",
-              jukebox: { songs: [{ file: "theme.mp3" }, { file: "waltz.mp3" }, { file: "theme.mp3" }] },
+              jukebox: [{ file: "theme.mp3" }, { file: "waltz.mp3" }, { file: "theme.mp3" }],
             },
           } as WorldFile["rooms"],
         }),
@@ -138,7 +140,7 @@ describe("usage scanning", () => {
               title: "Inn",
               description: "",
               ambient: "crickets.mp3",
-              jukebox: { songs: [{ file: "waltz.mp3" }] },
+              jukebox: [{ file: "waltz.mp3" }],
             },
           } as WorldFile["rooms"],
         }),
@@ -207,12 +209,33 @@ describe("assignment helpers", () => {
   });
 });
 
+describe("splitLyricsLines", () => {
+  it("splits on newlines, trims, and drops blank lines", () => {
+    expect(splitLyricsLines("When the lanterns lean in low,\n  the teacups start to sway.  \n\n   \nfinal line")).toEqual([
+      "When the lanterns lean in low,",
+      "the teacups start to sway.",
+      "final line",
+    ]);
+  });
+
+  it("handles CRLF, empty, and whitespace-only input", () => {
+    expect(splitLyricsLines("line one\r\nline two\r\n")).toEqual(["line one", "line two"]);
+    expect(splitLyricsLines("")).toEqual([]);
+    expect(splitLyricsLines("   \n\t\n")).toEqual([]);
+  });
+
+  it("passes a single line through", () => {
+    expect(splitLyricsLines("only line")).toEqual(["only line"]);
+  });
+});
+
 describe("buildAudioMetaIndex", () => {
   it("maps file names to label, metadata, and rounded duration", () => {
     const index = buildAudioMetaIndex([
       makeAsset({
         file_name: "song.mp3",
         display_name: "The Borrowed Song",
+        artist: "The Wandering Bards",
         description: "A waltz that remembers being hummed.",
         lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
         duration_seconds: 96.4,
@@ -221,12 +244,14 @@ describe("buildAudioMetaIndex", () => {
     ]);
     expect(index.get("song.mp3")).toEqual({
       name: "The Borrowed Song",
+      artist: "The Wandering Bards",
       description: "A waltz that remembers being hummed.",
       lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
       durationSeconds: 96,
     });
     expect(index.get("raw.mp3")).toEqual({
       name: "raw.mp3",
+      artist: "",
       description: "",
       lyrics: "",
       durationSeconds: 0,
@@ -239,6 +264,7 @@ describe("enrichJukeboxSongs", () => {
     makeAsset({
       file_name: "song.mp3",
       display_name: "The Borrowed Song",
+      artist: "The Wandering Bards",
       description: "A waltz that remembers being hummed.",
       lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
       duration_seconds: 96.4,
@@ -246,60 +272,113 @@ describe("enrichJukeboxSongs", () => {
     makeAsset({ id: "2", file_name: "bare.mp3", display_name: "Bare Bones" }),
   ]);
 
-  it("rewrites library-known songs entirely from the index", () => {
+  it("rewrites library-known songs from the index in the server key order", () => {
     const world = makeWorld({
       rooms: {
         parlor: {
           title: "Parlor",
           description: "",
-          jukebox: {
-            songs: [{ file: "song.mp3", name: "Stale Name", description: "stale", lyrics: "stale lines" }],
-          },
+          jukebox: [{ file: "song.mp3", title: "Stale Name", description: "stale", lyrics: ["stale lines"] }],
         },
       } as WorldFile["rooms"],
     });
     const next = enrichJukeboxSongs(world, meta);
-    expect(next.rooms.parlor?.jukebox?.songs).toEqual([
-      {
-        file: "song.mp3",
-        name: "The Borrowed Song",
-        description: "A waltz that remembers being hummed.",
-        lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
-        durationSeconds: 96,
-      },
+    const song = next.rooms.parlor?.jukebox?.[0];
+    expect(song).toEqual({
+      title: "The Borrowed Song",
+      file: "song.mp3",
+      durationSeconds: 96,
+      artist: "The Wandering Bards",
+      description: "A waltz that remembers being hummed.",
+      lyrics: ["When the lanterns lean in low,", "the teacups start to sway."],
+    });
+    expect(Object.keys(song!)).toEqual(["title", "file", "durationSeconds", "artist", "description", "lyrics"]);
+  });
+
+  it("converts the library's lyrics blob to a list of non-blank lines", () => {
+    const blobMeta = buildAudioMetaIndex([
+      makeAsset({
+        file_name: "song.mp3",
+        display_name: "The Borrowed Song",
+        lyrics: "first line\n\n  second line  \n\n",
+        duration_seconds: 30,
+      }),
+    ]);
+    const world = makeWorld({
+      rooms: {
+        parlor: { title: "Parlor", description: "", jukebox: [{ file: "song.mp3" }] },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, blobMeta);
+    expect(next.rooms.parlor?.jukebox?.[0]?.lyrics).toEqual(["first line", "second line"]);
+  });
+
+  it("keeps the zone-authored cost — it is not library metadata", () => {
+    const world = makeWorld({
+      rooms: {
+        parlor: {
+          title: "Parlor",
+          description: "",
+          jukebox: [
+            { file: "song.mp3", cost: 0 },
+            { file: "bare.mp3", cost: 12 },
+          ],
+        },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, meta);
+    expect(next.rooms.parlor?.jukebox?.[0]?.cost).toBe(0);
+    expect(next.rooms.parlor?.jukebox?.[1]?.cost).toBe(12);
+    expect(Object.keys(next.rooms.parlor!.jukebox![0]!)).toEqual([
+      "title", "file", "durationSeconds", "cost", "artist", "description", "lyrics",
     ]);
   });
 
-  it("clears stale description and lyrics when the library fields are empty", () => {
+  it("clears stale description and lyrics but keeps the song's own duration as fallback", () => {
     const world = makeWorld({
       rooms: {
         parlor: {
           title: "Parlor",
           description: "",
-          jukebox: {
-            songs: [{ file: "bare.mp3", description: "old blurb", lyrics: "old lines", durationSeconds: 30 }],
-          },
+          jukebox: [{ file: "bare.mp3", description: "old blurb", lyrics: ["old lines"], durationSeconds: 30 }],
         },
       } as WorldFile["rooms"],
     });
     const next = enrichJukeboxSongs(world, meta);
-    expect(next.rooms.parlor?.jukebox?.songs).toEqual([{ file: "bare.mp3", name: "Bare Bones" }]);
+    expect(next.rooms.parlor?.jukebox).toEqual([
+      { title: "Bare Bones", file: "bare.mp3", durationSeconds: 30 },
+    ]);
+  });
+
+  it("prefers the library duration over the song's stale one", () => {
+    const world = makeWorld({
+      rooms: {
+        parlor: {
+          title: "Parlor",
+          description: "",
+          jukebox: [{ file: "song.mp3", durationSeconds: 12 }],
+        },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, meta);
+    expect(next.rooms.parlor?.jukebox?.[0]?.durationSeconds).toBe(96);
   });
 
   it("preserves songs that are not in the library verbatim", () => {
     const foreign = {
+      title: "Foreign Tune",
       file: "elsewhere.mp3",
-      name: "Foreign Tune",
-      lyrics: "lines from another machine",
       durationSeconds: 42,
+      cost: 7,
+      lyrics: ["lines from another machine"],
     };
     const world = makeWorld({
       rooms: {
-        parlor: { title: "Parlor", description: "", jukebox: { songs: [foreign] } },
+        parlor: { title: "Parlor", description: "", jukebox: [foreign] },
       } as WorldFile["rooms"],
     });
     const next = enrichJukeboxSongs(world, meta);
-    expect(next.rooms.parlor?.jukebox?.songs?.[0]).toBe(foreign);
+    expect(next.rooms.parlor?.jukebox?.[0]).toBe(foreign);
   });
 
   it("drops blank-file songs and the jukebox itself when nothing remains", () => {
@@ -308,7 +387,7 @@ describe("enrichJukeboxSongs", () => {
         parlor: {
           title: "Parlor",
           description: "",
-          jukebox: { songs: [{ file: "" }, { file: "   " }] },
+          jukebox: [{ file: "" }, { file: "   " }],
         },
       } as WorldFile["rooms"],
     });
@@ -320,7 +399,7 @@ describe("enrichJukeboxSongs", () => {
     const world = makeWorld({
       rooms: {
         glade: { title: "Glade", description: "" },
-        parlor: { title: "Parlor", description: "", jukebox: { songs: [{ file: "song.mp3" }] } },
+        parlor: { title: "Parlor", description: "", jukebox: [{ file: "song.mp3" }] },
       } as WorldFile["rooms"],
     });
     const next = enrichJukeboxSongs(world, meta);
@@ -341,18 +420,18 @@ describe("jukebox YAML round-trip", () => {
         parlor: {
           title: "The Jukebox Parlor",
           description: "A parlor.",
-          jukebox: {
-            songs: [
-              {
-                file: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.mp3",
-                name: "The Borrowed Song",
-                description: "A waltz that remembers being hummed.",
-                lyrics: "When the lanterns lean in low,\nthe teacups start to sway.\n",
-                durationSeconds: 96,
-              },
-              { file: "plain.mp3", name: "Plain Tune" },
-            ],
-          },
+          jukebox: [
+            {
+              title: "The Borrowed Song",
+              file: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.mp3",
+              durationSeconds: 96,
+              cost: 5,
+              artist: "The Wandering Bards",
+              description: "A waltz that remembers being hummed.",
+              lyrics: ["When the lanterns lean in low,", "the teacups start to sway."],
+            },
+            { title: "Plain Tune", file: "plain.mp3", durationSeconds: 30 },
+          ],
         },
       } as WorldFile["rooms"],
     });

--- a/creator/src/lib/__tests__/audioLibrary.test.ts
+++ b/creator/src/lib/__tests__/audioLibrary.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { parseDocument, stringify } from "yaml";
 import {
+  buildAudioMetaIndex,
   buildUsageIndex,
+  enrichJukeboxSongs,
   listAudioTracks,
   scanTrackUsage,
   setRoomTrack,
@@ -8,6 +11,7 @@ import {
   trackLabel,
   usageSummary,
 } from "@/lib/audioLibrary";
+import { YAML_OPTS } from "@/lib/yamlOpts";
 import type { AssetEntry } from "@/types/assets";
 import type { WorldFile } from "@/types/world";
 
@@ -28,6 +32,9 @@ function makeAsset(overrides: Partial<AssetEntry>): AssetEntry {
     variant_group: "",
     is_active: false,
     display_name: "",
+    description: "",
+    lyrics: "",
+    duration_seconds: 0,
     ...overrides,
   };
 }
@@ -73,6 +80,28 @@ describe("trackLabel", () => {
     expect(trackLabel(makeAsset({ prompt: "Imported: night sounds" }))).toBe("night sounds");
     expect(trackLabel(makeAsset({ file_name: "abc123.mp3" }))).toBe("abc123.mp3");
   });
+
+  it("collapses content-addressed file names to an Untitled label", () => {
+    const hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    expect(trackLabel(makeAsset({ file_name: `${hash}.mp3` }))).toBe("Untitled (e3b0c442…)");
+  });
+
+  it("collapses hash-like prompts to an Untitled label", () => {
+    expect(trackLabel(makeAsset({ prompt: "Imported: deadbeefdeadbeefdeadbeef" }))).toBe(
+      "Untitled (deadbeef…)",
+    );
+  });
+
+  it("keeps short non-hash file names intact", () => {
+    expect(trackLabel(makeAsset({ file_name: "abcdef.mp3" }))).toBe("abcdef.mp3");
+  });
+
+  it("display name wins even when the file is content-addressed", () => {
+    const hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    expect(trackLabel(makeAsset({ display_name: "The Borrowed Song", file_name: `${hash}.mp3` }))).toBe(
+      "The Borrowed Song",
+    );
+  });
 });
 
 describe("usage scanning", () => {
@@ -85,6 +114,11 @@ describe("usage scanning", () => {
           rooms: {
             glade: { title: "Glade", description: "", music: "theme.mp3" },
             brook: { title: "Brook", description: "", ambient: "crickets.mp3" },
+            parlor: {
+              title: "Parlor",
+              description: "",
+              jukebox: { songs: [{ file: "theme.mp3" }, { file: "waltz.mp3" }, { file: "theme.mp3" }] },
+            },
           } as WorldFile["rooms"],
         }),
       },
@@ -94,7 +128,12 @@ describe("usage scanning", () => {
       {
         data: makeWorld({
           rooms: {
-            inn: { title: "Inn", description: "", ambient: "crickets.mp3" },
+            inn: {
+              title: "Inn",
+              description: "",
+              ambient: "crickets.mp3",
+              jukebox: { songs: [{ file: "waltz.mp3" }] },
+            },
           } as WorldFile["rooms"],
         }),
       },
@@ -112,14 +151,27 @@ describe("usage scanning", () => {
     ]);
   });
 
+  it("indexes jukebox references, deduped per room", () => {
+    const index = buildUsageIndex(zones);
+    expect(index.get("theme.mp3")!.jukeboxes).toEqual([
+      { zoneId: "forest", roomId: "parlor", roomTitle: "Parlor" },
+    ]);
+    expect(index.get("waltz.mp3")!.jukeboxes).toEqual([
+      { zoneId: "forest", roomId: "parlor", roomTitle: "Parlor" },
+      { zoneId: "village", roomId: "inn", roomTitle: "Inn" },
+    ]);
+  });
+
   it("scanTrackUsage returns empty usage for unknown files", () => {
-    expect(scanTrackUsage(zones, "nope.mp3")).toEqual({ zoneDefaults: [], rooms: [] });
+    expect(scanTrackUsage(zones, "nope.mp3")).toEqual({ zoneDefaults: [], rooms: [], jukeboxes: [] });
   });
 
   it("summarizes usage", () => {
     const index = buildUsageIndex(zones);
     expect(usageSummary(index.get("crickets.mp3")!)).toBe("1 zone default · 2 rooms in 2 zones");
-    expect(usageSummary({ zoneDefaults: [], rooms: [] })).toBe("Unused");
+    expect(usageSummary(index.get("waltz.mp3")!)).toBe("2 jukeboxes");
+    expect(usageSummary(index.get("theme.mp3")!)).toBe("1 room in 1 zone · 1 jukebox");
+    expect(usageSummary({ zoneDefaults: [], rooms: [], jukeboxes: [] })).toBe("Unused");
   });
 });
 
@@ -146,5 +198,160 @@ describe("assignment helpers", () => {
     expect(next.rooms.glade?.ambient).toBe("crickets.mp3");
     expect(world.rooms.glade?.ambient).toBeUndefined();
     expect(setRoomTrack(world, "missing", "music", "x.mp3")).toBe(world);
+  });
+});
+
+describe("buildAudioMetaIndex", () => {
+  it("maps file names to label, metadata, and rounded duration", () => {
+    const index = buildAudioMetaIndex([
+      makeAsset({
+        file_name: "song.mp3",
+        display_name: "The Borrowed Song",
+        description: "A waltz that remembers being hummed.",
+        lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
+        duration_seconds: 96.4,
+      }),
+      makeAsset({ id: "2", file_name: "raw.mp3" }),
+    ]);
+    expect(index.get("song.mp3")).toEqual({
+      name: "The Borrowed Song",
+      description: "A waltz that remembers being hummed.",
+      lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
+      durationSeconds: 96,
+    });
+    expect(index.get("raw.mp3")).toEqual({
+      name: "raw.mp3",
+      description: "",
+      lyrics: "",
+      durationSeconds: 0,
+    });
+  });
+});
+
+describe("enrichJukeboxSongs", () => {
+  const meta = buildAudioMetaIndex([
+    makeAsset({
+      file_name: "song.mp3",
+      display_name: "The Borrowed Song",
+      description: "A waltz that remembers being hummed.",
+      lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
+      duration_seconds: 96.4,
+    }),
+    makeAsset({ id: "2", file_name: "bare.mp3", display_name: "Bare Bones" }),
+  ]);
+
+  it("rewrites library-known songs entirely from the index", () => {
+    const world = makeWorld({
+      rooms: {
+        parlor: {
+          title: "Parlor",
+          description: "",
+          jukebox: {
+            songs: [{ file: "song.mp3", name: "Stale Name", description: "stale", lyrics: "stale lines" }],
+          },
+        },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, meta);
+    expect(next.rooms.parlor?.jukebox?.songs).toEqual([
+      {
+        file: "song.mp3",
+        name: "The Borrowed Song",
+        description: "A waltz that remembers being hummed.",
+        lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
+        durationSeconds: 96,
+      },
+    ]);
+  });
+
+  it("clears stale description and lyrics when the library fields are empty", () => {
+    const world = makeWorld({
+      rooms: {
+        parlor: {
+          title: "Parlor",
+          description: "",
+          jukebox: {
+            songs: [{ file: "bare.mp3", description: "old blurb", lyrics: "old lines", durationSeconds: 30 }],
+          },
+        },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, meta);
+    expect(next.rooms.parlor?.jukebox?.songs).toEqual([{ file: "bare.mp3", name: "Bare Bones" }]);
+  });
+
+  it("preserves songs that are not in the library verbatim", () => {
+    const foreign = {
+      file: "elsewhere.mp3",
+      name: "Foreign Tune",
+      lyrics: "lines from another machine",
+      durationSeconds: 42,
+    };
+    const world = makeWorld({
+      rooms: {
+        parlor: { title: "Parlor", description: "", jukebox: { songs: [foreign] } },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, meta);
+    expect(next.rooms.parlor?.jukebox?.songs?.[0]).toBe(foreign);
+  });
+
+  it("drops blank-file songs and the jukebox itself when nothing remains", () => {
+    const world = makeWorld({
+      rooms: {
+        parlor: {
+          title: "Parlor",
+          description: "",
+          jukebox: { songs: [{ file: "" }, { file: "   " }] },
+        },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, meta);
+    expect(next.rooms.parlor?.jukebox).toBeUndefined();
+  });
+
+  it("preserves identity for untouched rooms and jukebox-free worlds", () => {
+    const world = makeWorld({
+      rooms: {
+        glade: { title: "Glade", description: "" },
+        parlor: { title: "Parlor", description: "", jukebox: { songs: [{ file: "song.mp3" }] } },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, meta);
+    expect(next).not.toBe(world);
+    expect(next.rooms.glade).toBe(world.rooms.glade);
+
+    const noJukebox = makeWorld({
+      rooms: { glade: { title: "Glade", description: "" } } as WorldFile["rooms"],
+    });
+    expect(enrichJukeboxSongs(noJukebox, meta)).toBe(noJukebox);
+  });
+});
+
+describe("jukebox YAML round-trip", () => {
+  it("survives stringify + parse with songs deep-equal", () => {
+    const world = makeWorld({
+      rooms: {
+        parlor: {
+          title: "The Jukebox Parlor",
+          description: "A parlor.",
+          jukebox: {
+            songs: [
+              {
+                file: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.mp3",
+                name: "The Borrowed Song",
+                description: "A waltz that remembers being hummed.",
+                lyrics: "When the lanterns lean in low,\nthe teacups start to sway.\n",
+                durationSeconds: 96,
+              },
+              { file: "plain.mp3", name: "Plain Tune" },
+            ],
+          },
+        },
+      } as WorldFile["rooms"],
+    });
+    const yaml = stringify(world, YAML_OPTS);
+    const reparsed = parseDocument(yaml).toJS() as WorldFile;
+    expect(reparsed.rooms.parlor?.jukebox).toEqual(world.rooms.parlor?.jukebox);
   });
 });

--- a/creator/src/lib/__tests__/audioLibrary.test.ts
+++ b/creator/src/lib/__tests__/audioLibrary.test.ts
@@ -92,6 +92,12 @@ describe("trackLabel", () => {
     );
   });
 
+  it("collapses full sha256 prompts despite the 48-char truncation", () => {
+    const hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    expect(trackLabel(makeAsset({ prompt: `Imported: ${hash}` }))).toBe("Untitled (e3b0c442…)");
+    expect(trackLabel(makeAsset({ prompt: `Imported: ${hash}.mp3` }))).toBe("Untitled (e3b0c442…)");
+  });
+
   it("keeps short non-hash file names intact", () => {
     expect(trackLabel(makeAsset({ file_name: "abcdef.mp3" }))).toBe("abcdef.mp3");
   });

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -926,34 +926,53 @@ describe("sanitizeZone — room jukebox", () => {
         room_a: {
           title: "A",
           description: "A",
-          jukebox: {
-            songs: [
-              {
-                durationSeconds: 96.4,
-                lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
-                name: "The Borrowed Song",
-                file: "song.mp3",
-                description: "A waltz that remembers being hummed.",
-              },
-              { file: "plain.mp3", name: "", description: "  ", lyrics: "", durationSeconds: 0 },
-            ],
-          },
+          jukebox: [
+            {
+              durationSeconds: 96.4,
+              lyrics: ["  When the lanterns lean in low,  ", "", "the teacups start to sway."],
+              description: "A waltz that remembers being hummed.",
+              artist: "The Wandering Bards",
+              cost: 5.4,
+              file: "song.mp3",
+              title: "The Borrowed Song",
+            },
+            { file: "plain.mp3", title: "", artist: " ", description: "  ", lyrics: [], durationSeconds: 0, cost: -1 },
+          ],
         },
       },
     });
 
     const result = sanitizeZone(world);
-    const songs = result.rooms["room_a"]!.jukebox!.songs;
-    expect(Object.keys(songs[0]!)).toEqual(["file", "name", "description", "lyrics", "durationSeconds"]);
+    const songs = result.rooms["room_a"]!.jukebox!;
+    expect(Object.keys(songs[0]!)).toEqual([
+      "title", "file", "durationSeconds", "cost", "artist", "description", "lyrics",
+    ]);
     expect(songs[0]).toEqual({
+      title: "The Borrowed Song",
       file: "song.mp3",
-      name: "The Borrowed Song",
-      description: "A waltz that remembers being hummed.",
-      lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
       durationSeconds: 96,
+      cost: 5,
+      artist: "The Wandering Bards",
+      description: "A waltz that remembers being hummed.",
+      lyrics: ["When the lanterns lean in low,", "the teacups start to sway."],
     });
     expect(songs[1]).toEqual({ file: "plain.mp3" });
     expect(Object.keys(songs[1]!)).toEqual(["file"]);
+  });
+
+  it("keeps a zero cost — free songs are valid", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: {
+          title: "A",
+          description: "A",
+          jukebox: [{ title: "Free Tune", file: "free.mp3", durationSeconds: 20, cost: 0 }],
+        },
+      },
+    });
+
+    const result = sanitizeZone(world);
+    expect(result.rooms["room_a"]!.jukebox![0]!.cost).toBe(0);
   });
 
   it("drops blank-file songs and removes the jukebox when none survive", () => {
@@ -962,19 +981,19 @@ describe("sanitizeZone — room jukebox", () => {
         room_a: {
           title: "A",
           description: "A",
-          jukebox: { songs: [{ file: "" }, { file: "   ", name: "Ghost" }] },
+          jukebox: [{ file: "" }, { file: "   ", title: "Ghost" }],
         },
         room_b: {
           title: "B",
           description: "B",
-          jukebox: { songs: [{ file: "" }, { file: "keeper.mp3" }] },
+          jukebox: [{ file: "" }, { file: "keeper.mp3" }],
         },
       },
     });
 
     const result = sanitizeZone(world);
     expect(result.rooms["room_a"]!.jukebox).toBeUndefined();
-    expect(result.rooms["room_b"]!.jukebox!.songs).toEqual([{ file: "keeper.mp3" }]);
+    expect(result.rooms["room_b"]!.jukebox).toEqual([{ file: "keeper.mp3" }]);
   });
 
   it("leaves rooms without a jukebox alone", () => {

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -918,3 +918,68 @@ describe("sanitizeZone — videoText / videoTextSeconds", () => {
     expect(result.items!["orb"]!.videoText).toBe("The orb pulses with trapped light.");
   });
 });
+
+describe("sanitizeZone — room jukebox", () => {
+  it("rebuilds songs in contract key order with empty optionals omitted", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: {
+          title: "A",
+          description: "A",
+          jukebox: {
+            songs: [
+              {
+                durationSeconds: 96.4,
+                lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
+                name: "The Borrowed Song",
+                file: "song.mp3",
+                description: "A waltz that remembers being hummed.",
+              },
+              { file: "plain.mp3", name: "", description: "  ", lyrics: "", durationSeconds: 0 },
+            ],
+          },
+        },
+      },
+    });
+
+    const result = sanitizeZone(world);
+    const songs = result.rooms["room_a"]!.jukebox!.songs;
+    expect(Object.keys(songs[0]!)).toEqual(["file", "name", "description", "lyrics", "durationSeconds"]);
+    expect(songs[0]).toEqual({
+      file: "song.mp3",
+      name: "The Borrowed Song",
+      description: "A waltz that remembers being hummed.",
+      lyrics: "When the lanterns lean in low,\nthe teacups start to sway.",
+      durationSeconds: 96,
+    });
+    expect(songs[1]).toEqual({ file: "plain.mp3" });
+    expect(Object.keys(songs[1]!)).toEqual(["file"]);
+  });
+
+  it("drops blank-file songs and removes the jukebox when none survive", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: {
+          title: "A",
+          description: "A",
+          jukebox: { songs: [{ file: "" }, { file: "   ", name: "Ghost" }] },
+        },
+        room_b: {
+          title: "B",
+          description: "B",
+          jukebox: { songs: [{ file: "" }, { file: "keeper.mp3" }] },
+        },
+      },
+    });
+
+    const result = sanitizeZone(world);
+    expect(result.rooms["room_a"]!.jukebox).toBeUndefined();
+    expect(result.rooms["room_b"]!.jukebox!.songs).toEqual([{ file: "keeper.mp3" }]);
+  });
+
+  it("leaves rooms without a jukebox alone", () => {
+    const world = makeWorld();
+    const result = sanitizeZone(world);
+    expect(result.rooms["room_a"]!.jukebox).toBeUndefined();
+  });
+});

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -86,6 +86,30 @@ describe("validateZone", () => {
     expect(issues).toHaveLength(0);
   });
 
+  // ─── Room jukebox ────────────────────────────────────────────
+  it("errors on a jukebox song with a blank file", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.jukebox = { songs: [{ file: "song.mp3" }, { file: "   " }] };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.entity === "room:room1" && i.message.includes("Jukebox song #2"))).toBe(true);
+  });
+
+  it("warns on a jukebox with no songs", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.jukebox = { songs: [] };
+    const issues = validateZone(world);
+    expect(errors(issues)).toHaveLength(0);
+    expect(warnings(issues).some((i) => i.entity === "room:room1" && i.message.includes("Jukebox has no songs"))).toBe(true);
+  });
+
+  it("accepts a populated jukebox without issues", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.jukebox = {
+      songs: [{ file: "song.mp3", name: "Tune", lyrics: "la\nla", durationSeconds: 30 }],
+    };
+    expect(validateZone(world)).toHaveLength(0);
+  });
+
   it("warns on door key that is not a known item", () => {
     const world = makeValidWorld();
     world.rooms.room1.exits = {

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -87,16 +87,21 @@ describe("validateZone", () => {
   });
 
   // ─── Room jukebox ────────────────────────────────────────────
+  const JUKEBOX_OUTPUT = [
+    undefined, undefined, undefined, undefined, undefined, undefined, undefined,
+    { jukeboxOutput: true },
+  ] as const;
+
   it("errors on a jukebox song with a blank file", () => {
     const world = makeValidWorld();
-    world.rooms.room1.jukebox = { songs: [{ file: "song.mp3" }, { file: "   " }] };
+    world.rooms.room1.jukebox = [{ file: "song.mp3" }, { file: "   " }];
     const issues = errors(validateZone(world));
     expect(issues.some((i) => i.entity === "room:room1" && i.message.includes("Jukebox song #2"))).toBe(true);
   });
 
   it("warns on a jukebox with no songs", () => {
     const world = makeValidWorld();
-    world.rooms.room1.jukebox = { songs: [] };
+    world.rooms.room1.jukebox = [];
     const issues = validateZone(world);
     expect(errors(issues)).toHaveLength(0);
     expect(warnings(issues).some((i) => i.entity === "room:room1" && i.message.includes("Jukebox has no songs"))).toBe(true);
@@ -104,10 +109,82 @@ describe("validateZone", () => {
 
   it("accepts a populated jukebox without issues", () => {
     const world = makeValidWorld();
-    world.rooms.room1.jukebox = {
-      songs: [{ file: "song.mp3", name: "Tune", lyrics: "la\nla", durationSeconds: 30 }],
-    };
+    world.rooms.room1.jukebox = [
+      { title: "Tune", file: "song.mp3", durationSeconds: 30, lyrics: ["la", "la"] },
+    ];
     expect(validateZone(world)).toHaveLength(0);
+  });
+
+  it("errors on a negative cost but accepts zero", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.jukebox = [
+      { file: "a.mp3", cost: -1 },
+      { file: "b.mp3", cost: 0 },
+    ];
+    const issues = errors(validateZone(world));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("Jukebox song #1");
+    expect(issues[0].message).toContain("negative cost");
+  });
+
+  it("errors on a blank lyric line", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.jukebox = [{ file: "a.mp3", lyrics: ["fine line", "   "] }];
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.message.includes("blank lyric line"))).toBe(true);
+  });
+
+  it("errors when lyrics exceed one line per 3 seconds of duration", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.jukebox = [
+      { file: "a.mp3", durationSeconds: 10, lyrics: ["one", "two", "three", "four"] },
+    ];
+    const issues = errors(validateZone(world));
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("at most one lyric line per 3 seconds");
+    expect(issues[0].message).toContain("at most 3");
+  });
+
+  it("accepts lyrics exactly at the density limit", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.jukebox = [
+      { title: "Tune", file: "a.mp3", durationSeconds: 9, lyrics: ["one", "two", "three"] },
+    ];
+    expect(validateZone(world)).toHaveLength(0);
+  });
+
+  it("skips the density check while the duration is still unknown", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.jukebox = [{ file: "a.mp3", lyrics: ["one", "two", "three", "four"] }];
+    expect(errors(validateZone(world))).toHaveLength(0);
+  });
+
+  it("requires title and duration only when validating enriched output", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.jukebox = [{ file: "song.mp3" }];
+
+    expect(validateZone(world)).toHaveLength(0);
+
+    const issues = errors(validateZone(world, ...JUKEBOX_OUTPUT));
+    expect(issues).toHaveLength(2);
+    expect(issues.some((i) => i.message.includes("no title"))).toBe(true);
+    expect(issues.some((i) => i.message.includes("set the track's duration in the Audio Studio"))).toBe(true);
+  });
+
+  it("passes the strict output check for a fully enriched song", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.jukebox = [
+      {
+        title: "The Borrowed Song",
+        file: "song.mp3",
+        durationSeconds: 96,
+        cost: 5,
+        artist: "The Wandering Bards",
+        description: "A waltz that remembers being hummed.",
+        lyrics: ["When the lanterns lean in low,", "the teacups start to sway."],
+      },
+    ];
+    expect(validateZone(world, ...JUKEBOX_OUTPUT)).toHaveLength(0);
   });
 
   it("warns on door key that is not a known item", () => {

--- a/creator/src/lib/assetRefs.ts
+++ b/creator/src/lib/assetRefs.ts
@@ -1,5 +1,5 @@
 import type { AppConfig } from "@/types/config";
-import type { JukeboxFile, WorldFile } from "@/types/world";
+import type { JukeboxSongFile, WorldFile } from "@/types/world";
 
 const REMOTE_URL_RE = /^(?:https?:)?\/\//i;
 const ENGINE_MEDIA_PATH_RE = /^\/(?:images?|videos?|audio)\//i;
@@ -160,13 +160,13 @@ export function normalizeWorldAssetRefs(world: WorldFile): WorldFile {
   };
 }
 
-function normalizeJukeboxRefs(jukebox: JukeboxFile | undefined): JukeboxFile | undefined {
+function normalizeJukeboxRefs(jukebox: JukeboxSongFile[] | undefined): JukeboxSongFile[] | undefined {
   if (!jukebox) return undefined;
-  const songs = (jukebox.songs ?? []).flatMap((song) => {
+  const songs = jukebox.flatMap((song) => {
     const file = normalizeAssetRef(song.file);
     return file ? [{ ...song, file }] : [];
   });
-  return { songs };
+  return songs.length > 0 ? songs : undefined;
 }
 
 function mapEntries<T>(

--- a/creator/src/lib/assetRefs.ts
+++ b/creator/src/lib/assetRefs.ts
@@ -1,5 +1,5 @@
 import type { AppConfig } from "@/types/config";
-import type { WorldFile } from "@/types/world";
+import type { JukeboxFile, WorldFile } from "@/types/world";
 
 const REMOTE_URL_RE = /^(?:https?:)?\/\//i;
 const ENGINE_MEDIA_PATH_RE = /^\/(?:images?|videos?|audio)\//i;
@@ -97,6 +97,7 @@ export function normalizeWorldAssetRefs(world: WorldFile): WorldFile {
         music: normalizeAssetRef(room.music),
         ambient: normalizeAssetRef(room.ambient),
         audio: normalizeAssetRef(room.audio),
+        jukebox: normalizeJukeboxRefs(room.jukebox),
         features: room.features
           ? mapEntries(room.features, (feature) =>
               feature.plateImage || feature.handleImage || feature.backgroundImage
@@ -157,6 +158,15 @@ export function normalizeWorldAssetRefs(world: WorldFile): WorldFile {
           })
         : puzzle),
   };
+}
+
+function normalizeJukeboxRefs(jukebox: JukeboxFile | undefined): JukeboxFile | undefined {
+  if (!jukebox) return undefined;
+  const songs = (jukebox.songs ?? []).flatMap((song) => {
+    const file = normalizeAssetRef(song.file);
+    return file ? [{ ...song, file }] : [];
+  });
+  return { songs };
 }
 
 function mapEntries<T>(

--- a/creator/src/lib/audioLibrary.ts
+++ b/creator/src/lib/audioLibrary.ts
@@ -72,7 +72,7 @@ export function buildUsageIndex(
       if (room.ambient) entry(room.ambient).rooms.push({ zoneId, roomId, roomTitle: room.title, kind: "ambient" });
       if (room.jukebox) {
         const seen = new Set<string>();
-        for (const song of room.jukebox.songs ?? []) {
+        for (const song of room.jukebox) {
           if (!song.file || seen.has(song.file)) continue;
           seen.add(song.file);
           entry(song.file).jukeboxes.push({ zoneId, roomId, roomTitle: room.title });
@@ -127,6 +127,7 @@ export function setRoomTrack(
 
 export interface AudioTrackMeta {
   name: string;
+  artist: string;
   description: string;
   lyrics: string;
   durationSeconds: number;
@@ -137,6 +138,7 @@ export function buildAudioMetaIndex(assets: AssetEntry[]): Map<string, AudioTrac
   for (const entry of assets) {
     index.set(entry.file_name, {
       name: trackLabel(entry),
+      artist: entry.artist,
       description: entry.description,
       lyrics: entry.lyrics,
       durationSeconds: Math.round(entry.duration_seconds),
@@ -145,12 +147,23 @@ export function buildAudioMetaIndex(assets: AssetEntry[]): Map<string, AudioTrac
   return index;
 }
 
+/** Lyrics are edited as one text blob but the server contract is a list of
+ *  non-blank lines. */
+export function splitLyricsLines(lyrics: string): string[] {
+  return lyrics
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
 /**
  * Denormalize library metadata into jukebox song entries at save time.
- * Songs whose file is in the index are rewritten entirely from it (so stale
- * descriptions and lyrics clear when the library entry empties); songs from
- * other machines stay verbatim. Blank-file songs are dropped, and a jukebox
- * with no surviving songs disappears.
+ * Songs whose file is in the index are rebuilt from it in the server
+ * contract's key order (so stale titles, descriptions, and lyrics clear when
+ * the library entry empties); songs from other machines stay verbatim. The
+ * per-song `cost` is zone-side authoring, not library metadata, so it always
+ * survives. Blank-file songs are dropped, and a jukebox with no surviving
+ * songs disappears.
  */
 export function enrichJukeboxSongs(
   world: WorldFile,
@@ -164,21 +177,28 @@ export function enrichJukeboxSongs(
       continue;
     }
     const songs: JukeboxSongFile[] = [];
-    for (const song of room.jukebox.songs ?? []) {
+    for (const song of room.jukebox) {
       if (!song.file || !song.file.trim()) continue;
       const track = meta.get(song.file);
       if (!track) {
         songs.push(song);
         continue;
       }
-      const enriched: JukeboxSongFile = { file: song.file, name: track.name };
+      const enriched: JukeboxSongFile = { title: track.name, file: song.file };
+      if (track.durationSeconds > 0) {
+        enriched.durationSeconds = track.durationSeconds;
+      } else if (typeof song.durationSeconds === "number" && song.durationSeconds > 0) {
+        enriched.durationSeconds = Math.round(song.durationSeconds);
+      }
+      if (typeof song.cost === "number" && song.cost >= 0) enriched.cost = song.cost;
+      if (track.artist) enriched.artist = track.artist;
       if (track.description) enriched.description = track.description;
-      if (track.lyrics) enriched.lyrics = track.lyrics;
-      if (track.durationSeconds > 0) enriched.durationSeconds = track.durationSeconds;
+      const lyrics = splitLyricsLines(track.lyrics);
+      if (lyrics.length > 0) enriched.lyrics = lyrics;
       songs.push(enriched);
     }
     rooms[roomId] = songs.length > 0
-      ? { ...room, jukebox: { songs } }
+      ? { ...room, jukebox: songs }
       : { ...room, jukebox: undefined };
     changed = true;
   }

--- a/creator/src/lib/audioLibrary.ts
+++ b/creator/src/lib/audioLibrary.ts
@@ -1,9 +1,10 @@
 import type { AssetEntry } from "@/types/assets";
-import type { WorldFile } from "@/types/world";
+import type { JukeboxSongFile, RoomFile, WorldFile } from "@/types/world";
 
 export type AudioTrackKind = "music" | "ambient";
 
 const AUDIO_EXTENSION = /\.(mp3|ogg|flac|wav)$/i;
+const HASH_LIKE_RE = /^[0-9a-f]{16,}$/i;
 
 /** Asset types surfaced in each studio lane. Legacy untyped "audio" imports
  *  (the old room foley slot) land in the ambient lane so they stay reachable. */
@@ -26,8 +27,13 @@ export function listAudioTracks(assets: AssetEntry[], kind: AudioTrackKind): Ass
 export function trackLabel(entry: AssetEntry): string {
   if (entry.display_name) return entry.display_name;
   const prompt = entry.prompt.replace(/^Imported:\s*/, "").trim();
-  if (prompt) return prompt.length > 48 ? `${prompt.slice(0, 48)}…` : prompt;
-  return entry.file_name;
+  const label = prompt
+    ? prompt.length > 48 ? `${prompt.slice(0, 48)}…` : prompt
+    : entry.file_name;
+  // Content-addressed file names make terrible labels — collapse them.
+  const stem = label === entry.file_name ? label.replace(/\.[^.]+$/, "") : label;
+  if (HASH_LIKE_RE.test(stem)) return `Untitled (${stem.slice(0, 8)}…)`;
+  return label;
 }
 
 export interface TrackUsage {
@@ -35,13 +41,15 @@ export interface TrackUsage {
   zoneDefaults: { zoneId: string; kind: AudioTrackKind }[];
   /** Rooms referencing the track directly. */
   rooms: { zoneId: string; roomId: string; roomTitle: string; kind: AudioTrackKind }[];
+  /** Room jukeboxes whose song list includes the track. */
+  jukeboxes: { zoneId: string; roomId: string; roomTitle: string }[];
 }
 
 export function scanTrackUsage(
   zones: Iterable<[string, { data: WorldFile }]>,
   fileName: string,
 ): TrackUsage {
-  return buildUsageIndex(zones).get(fileName) ?? { zoneDefaults: [], rooms: [] };
+  return buildUsageIndex(zones).get(fileName) ?? { zoneDefaults: [], rooms: [], jukeboxes: [] };
 }
 
 /** Single pass over all loaded zones: file name → everywhere it's referenced. */
@@ -52,7 +60,7 @@ export function buildUsageIndex(
   const entry = (fileName: string): TrackUsage => {
     let usage = index.get(fileName);
     if (!usage) {
-      usage = { zoneDefaults: [], rooms: [] };
+      usage = { zoneDefaults: [], rooms: [], jukeboxes: [] };
       index.set(fileName, usage);
     }
     return usage;
@@ -63,13 +71,23 @@ export function buildUsageIndex(
     for (const [roomId, room] of Object.entries(data.rooms)) {
       if (room.music) entry(room.music).rooms.push({ zoneId, roomId, roomTitle: room.title, kind: "music" });
       if (room.ambient) entry(room.ambient).rooms.push({ zoneId, roomId, roomTitle: room.title, kind: "ambient" });
+      if (room.jukebox) {
+        const seen = new Set<string>();
+        for (const song of room.jukebox.songs ?? []) {
+          if (!song.file || seen.has(song.file)) continue;
+          seen.add(song.file);
+          entry(song.file).jukeboxes.push({ zoneId, roomId, roomTitle: room.title });
+        }
+      }
     }
   }
   return index;
 }
 
 export function usageSummary(usage: TrackUsage): string {
-  if (usage.zoneDefaults.length === 0 && usage.rooms.length === 0) return "Unused";
+  if (usage.zoneDefaults.length === 0 && usage.rooms.length === 0 && usage.jukeboxes.length === 0) {
+    return "Unused";
+  }
   const parts: string[] = [];
   if (usage.zoneDefaults.length > 0) {
     parts.push(`${usage.zoneDefaults.length} zone default${usage.zoneDefaults.length === 1 ? "" : "s"}`);
@@ -77,6 +95,9 @@ export function usageSummary(usage: TrackUsage): string {
   if (usage.rooms.length > 0) {
     const zoneCount = new Set(usage.rooms.map((r) => r.zoneId)).size;
     parts.push(`${usage.rooms.length} room${usage.rooms.length === 1 ? "" : "s"} in ${zoneCount} zone${zoneCount === 1 ? "" : "s"}`);
+  }
+  if (usage.jukeboxes.length > 0) {
+    parts.push(`${usage.jukeboxes.length} jukebox${usage.jukeboxes.length === 1 ? "" : "es"}`);
   }
   return parts.join(" · ");
 }
@@ -103,4 +124,64 @@ export function setRoomTrack(
     ...world,
     rooms: { ...world.rooms, [roomId]: { ...room, [kind]: fileName } },
   };
+}
+
+export interface AudioTrackMeta {
+  name: string;
+  description: string;
+  lyrics: string;
+  durationSeconds: number;
+}
+
+export function buildAudioMetaIndex(assets: AssetEntry[]): Map<string, AudioTrackMeta> {
+  const index = new Map<string, AudioTrackMeta>();
+  for (const entry of assets) {
+    index.set(entry.file_name, {
+      name: trackLabel(entry),
+      description: entry.description,
+      lyrics: entry.lyrics,
+      durationSeconds: Math.round(entry.duration_seconds),
+    });
+  }
+  return index;
+}
+
+/**
+ * Denormalize library metadata into jukebox song entries at save time.
+ * Songs whose file is in the index are rewritten entirely from it (so stale
+ * descriptions and lyrics clear when the library entry empties); songs from
+ * other machines stay verbatim. Blank-file songs are dropped, and a jukebox
+ * with no surviving songs disappears.
+ */
+export function enrichJukeboxSongs(
+  world: WorldFile,
+  meta: Map<string, AudioTrackMeta>,
+): WorldFile {
+  let changed = false;
+  const rooms: Record<string, RoomFile> = {};
+  for (const [roomId, room] of Object.entries(world.rooms)) {
+    if (!room.jukebox) {
+      rooms[roomId] = room;
+      continue;
+    }
+    const songs: JukeboxSongFile[] = [];
+    for (const song of room.jukebox.songs ?? []) {
+      if (!song.file || !song.file.trim()) continue;
+      const track = meta.get(song.file);
+      if (!track) {
+        songs.push(song);
+        continue;
+      }
+      const enriched: JukeboxSongFile = { file: song.file, name: track.name };
+      if (track.description) enriched.description = track.description;
+      if (track.lyrics) enriched.lyrics = track.lyrics;
+      if (track.durationSeconds > 0) enriched.durationSeconds = track.durationSeconds;
+      songs.push(enriched);
+    }
+    rooms[roomId] = songs.length > 0
+      ? { ...room, jukebox: { songs } }
+      : { ...room, jukebox: undefined };
+    changed = true;
+  }
+  return changed ? { ...world, rooms } : world;
 }

--- a/creator/src/lib/audioLibrary.ts
+++ b/creator/src/lib/audioLibrary.ts
@@ -27,13 +27,12 @@ export function listAudioTracks(assets: AssetEntry[], kind: AudioTrackKind): Ass
 export function trackLabel(entry: AssetEntry): string {
   if (entry.display_name) return entry.display_name;
   const prompt = entry.prompt.replace(/^Imported:\s*/, "").trim();
-  const label = prompt
-    ? prompt.length > 48 ? `${prompt.slice(0, 48)}…` : prompt
-    : entry.file_name;
-  // Content-addressed file names make terrible labels — collapse them.
-  const stem = label === entry.file_name ? label.replace(/\.[^.]+$/, "") : label;
+  // Content-addressed hashes make terrible labels — collapse them before the
+  // 48-char truncation below can disguise a full sha256 as ordinary text.
+  const stem = (prompt || entry.file_name).replace(/\.[^.]+$/, "");
   if (HASH_LIKE_RE.test(stem)) return `Untitled (${stem.slice(0, 8)}…)`;
-  return label;
+  if (prompt) return prompt.length > 48 ? `${prompt.slice(0, 48)}…` : prompt;
+  return entry.file_name;
 }
 
 export interface TrackUsage {

--- a/creator/src/lib/musicPrompts.ts
+++ b/creator/src/lib/musicPrompts.ts
@@ -40,14 +40,15 @@ Guidelines:
 
 Output ONLY the prompt text — no labels, no markdown, no commentary. Keep it under 150 words.`;
 
-/** System prompt for composing jukebox-facing song metadata (title, blurb, lyrics) */
+/** System prompt for composing jukebox-facing song metadata (title, artist, blurb, lyrics) */
 export const SONG_METADATA_SYSTEM_PROMPT = `You are a music director for a fantasy RPG. Given an audio track's generation prompt and its current name, invent in-world song metadata for the game's jukebox listings.
 
 Return STRICT JSON only — no markdown, no commentary — with exactly these keys:
-{"title": string, "description": string, "lyrics": string}
+{"title": string, "artist": string, "description": string, "lyrics": string}
 
 Rules:
 - title: 5 words or fewer, evocative, no quotation marks
+- artist: an in-world band or performer name, 1 to 4 words
 - description: one sentence — a songbook blurb players read in a jukebox listing
 - lyrics: 6 to 14 short lines separated by \\n, with a singable verse/chorus feel; no timestamps, no stage directions, no markdown`;
 
@@ -55,6 +56,12 @@ interface SongMetadataTrack {
   name: string;
   prompt: string;
   enhancedPrompt: string;
+  durationSeconds?: number;
+}
+
+function formatTrackLength(seconds: number): string {
+  const total = Math.round(seconds);
+  return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
 }
 
 export function buildSongMetadataUserPrompt(track: SongMetadataTrack): string {
@@ -63,7 +70,15 @@ export function buildSongMetadataUserPrompt(track: SongMetadataTrack): string {
     track.prompt && `Generation prompt: ${track.prompt}`,
     track.enhancedPrompt && `Enhanced prompt: ${track.enhancedPrompt}`,
   ].filter(Boolean);
-  return parts.length > 0 ? parts.join("\n") : "An instrumental fantasy melody.";
+  if (parts.length === 0) parts.push("An instrumental fantasy melody.");
+  const duration = track.durationSeconds ?? 0;
+  if (duration > 0) {
+    const maxLines = Math.min(14, Math.floor(duration / 3));
+    parts.push(
+      `Track length: ${formatTrackLength(duration)}. Lyrics must have at most ${maxLines} lines (one line per 3 seconds of music).`,
+    );
+  }
+  return parts.join("\n");
 }
 
 /** Get the system prompt for a given audio track type */

--- a/creator/src/lib/musicPrompts.ts
+++ b/creator/src/lib/musicPrompts.ts
@@ -40,6 +40,32 @@ Guidelines:
 
 Output ONLY the prompt text — no labels, no markdown, no commentary. Keep it under 150 words.`;
 
+/** System prompt for composing jukebox-facing song metadata (title, blurb, lyrics) */
+export const SONG_METADATA_SYSTEM_PROMPT = `You are a music director for a fantasy RPG. Given an audio track's generation prompt and its current name, invent in-world song metadata for the game's jukebox listings.
+
+Return STRICT JSON only — no markdown, no commentary — with exactly these keys:
+{"title": string, "description": string, "lyrics": string}
+
+Rules:
+- title: 5 words or fewer, evocative, no quotation marks
+- description: one sentence — a songbook blurb players read in a jukebox listing
+- lyrics: 6 to 14 short lines separated by \\n, with a singable verse/chorus feel; no timestamps, no stage directions, no markdown`;
+
+interface SongMetadataTrack {
+  name: string;
+  prompt: string;
+  enhancedPrompt: string;
+}
+
+export function buildSongMetadataUserPrompt(track: SongMetadataTrack): string {
+  const parts = [
+    track.name && `Current name: ${track.name}`,
+    track.prompt && `Generation prompt: ${track.prompt}`,
+    track.enhancedPrompt && `Enhanced prompt: ${track.enhancedPrompt}`,
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join("\n") : "An instrumental fantasy melody.";
+}
+
 /** Get the system prompt for a given audio track type */
 export function getAudioSystemPrompt(trackType: AudioTrackType): string {
   return trackType === "music" ? MUSIC_SYSTEM_PROMPT : AMBIENT_SYSTEM_PROMPT;

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -13,6 +13,8 @@ import type {
   FeatureFile,
   DoorFile,
   DungeonLootTable,
+  JukeboxFile,
+  JukeboxSongFile,
 } from "@/types/world";
 import { resolveDoorKeyId } from "./doorHelpers";
 import { getTrainerClasses } from "./trainers";
@@ -151,8 +153,27 @@ function normalizeFeatureFile(feature: FeatureFile): FeatureFile {
   return out;
 }
 
+/** Rebuild each song in the server contract's key order, omitting empty
+ *  optional fields. A jukebox with no valid songs is dropped entirely. */
+function normalizeJukebox(jukebox?: JukeboxFile): JukeboxFile | undefined {
+  if (!jukebox) return undefined;
+  const songs: JukeboxSongFile[] = [];
+  for (const song of jukebox.songs ?? []) {
+    if (!song.file || !song.file.trim()) continue;
+    const out: JukeboxSongFile = { file: song.file };
+    if (typeof song.name === "string" && song.name.trim()) out.name = song.name;
+    if (typeof song.description === "string" && song.description.trim()) out.description = song.description;
+    if (typeof song.lyrics === "string" && song.lyrics.trim()) out.lyrics = song.lyrics;
+    if (typeof song.durationSeconds === "number" && song.durationSeconds > 0) {
+      out.durationSeconds = Math.round(song.durationSeconds);
+    }
+    songs.push(out);
+  }
+  return songs.length > 0 ? { songs } : undefined;
+}
+
 function normalizeRoomOutput(room: RoomFile): RoomFile {
-  let next: RoomFile = { ...room, audio: undefined };
+  let next: RoomFile = { ...room, audio: undefined, jukebox: normalizeJukebox(room.jukebox) };
   if (room.exits) {
     const exits: Record<string, string | ExitValue> = {};
     for (const [dir, exit] of Object.entries(room.exits)) {

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -13,7 +13,6 @@ import type {
   FeatureFile,
   DoorFile,
   DungeonLootTable,
-  JukeboxFile,
   JukeboxSongFile,
 } from "@/types/world";
 import { resolveDoorKeyId } from "./doorHelpers";
@@ -153,23 +152,33 @@ function normalizeFeatureFile(feature: FeatureFile): FeatureFile {
   return out;
 }
 
-/** Rebuild each song in the server contract's key order, omitting empty
+/** Rebuild each song in the server contract's key order (title, file,
+ *  durationSeconds, cost, artist, description, lyrics), omitting empty
  *  optional fields. A jukebox with no valid songs is dropped entirely. */
-function normalizeJukebox(jukebox?: JukeboxFile): JukeboxFile | undefined {
+function normalizeJukebox(jukebox?: JukeboxSongFile[]): JukeboxSongFile[] | undefined {
   if (!jukebox) return undefined;
   const songs: JukeboxSongFile[] = [];
-  for (const song of jukebox.songs ?? []) {
+  for (const song of jukebox) {
     if (!song.file || !song.file.trim()) continue;
-    const out: JukeboxSongFile = { file: song.file };
-    if (typeof song.name === "string" && song.name.trim()) out.name = song.name;
-    if (typeof song.description === "string" && song.description.trim()) out.description = song.description;
-    if (typeof song.lyrics === "string" && song.lyrics.trim()) out.lyrics = song.lyrics;
+    const out: JukeboxSongFile =
+      typeof song.title === "string" && song.title.trim()
+        ? { title: song.title, file: song.file }
+        : { file: song.file };
     if (typeof song.durationSeconds === "number" && song.durationSeconds > 0) {
       out.durationSeconds = Math.round(song.durationSeconds);
     }
+    if (typeof song.cost === "number" && song.cost >= 0) out.cost = Math.round(song.cost);
+    if (typeof song.artist === "string" && song.artist.trim()) out.artist = song.artist;
+    if (typeof song.description === "string" && song.description.trim()) out.description = song.description;
+    if (Array.isArray(song.lyrics)) {
+      const lines = song.lyrics
+        .map((line) => (typeof line === "string" ? line.trim() : ""))
+        .filter((line) => line.length > 0);
+      if (lines.length > 0) out.lyrics = lines;
+    }
     songs.push(out);
   }
-  return songs.length > 0 ? { songs } : undefined;
+  return songs.length > 0 ? songs : undefined;
 }
 
 function normalizeRoomOutput(room: RoomFile): RoomFile {

--- a/creator/src/lib/saveZone.ts
+++ b/creator/src/lib/saveZone.ts
@@ -1,8 +1,10 @@
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { stringify } from "yaml";
 import { normalizeWorldAssetRefs } from "@/lib/assetRefs";
+import { buildAudioMetaIndex, enrichJukeboxSongs } from "@/lib/audioLibrary";
 import { sanitizeZone } from "@/lib/sanitizeZone";
 import { validateZone } from "@/lib/validateZone";
+import { useAssetStore } from "@/stores/assetStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { YAML_OPTS } from "@/lib/yamlOpts";
@@ -14,7 +16,10 @@ import { YAML_OPTS } from "@/lib/yamlOpts";
 export function serializeZone(zoneId: string): string {
   const zone = useZoneStore.getState().zones.get(zoneId);
   if (!zone) throw new Error(`Zone "${zoneId}" not found`);
-  const sanitized = normalizeWorldAssetRefs(sanitizeZone(zone.data));
+  const sanitized = enrichJukeboxSongs(
+    normalizeWorldAssetRefs(sanitizeZone(zone.data)),
+    buildAudioMetaIndex(useAssetStore.getState().assets),
+  );
   const config = useConfigStore.getState().config;
   const validClasses = config ? new Set(Object.keys(config.classes).map((id) => id.toUpperCase())) : undefined;
   const knownFactions = config?.factions?.definitions

--- a/creator/src/lib/saveZone.ts
+++ b/creator/src/lib/saveZone.ts
@@ -44,6 +44,7 @@ export function serializeZone(zoneId: string): string {
     config?.mobTiers,
     config?.progression.quests,
     classStatPriorities,
+    { jukeboxOutput: true },
   );
   const errors = issues.filter((issue) => issue.severity === "error");
   if (errors.length > 0) {

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -527,6 +527,18 @@ export function validateZone(
     for (const [featureId, feature] of Object.entries(room.features ?? {})) {
       validateFeature(issues, entity, featureId, feature, itemIds);
     }
+
+    if (room.jukebox) {
+      const songs = room.jukebox.songs ?? [];
+      if (songs.length === 0) {
+        addIssue(issues, "warning", entity, "Jukebox has no songs — add tracks or remove it");
+      }
+      for (const [index, song] of songs.entries()) {
+        if (!song.file?.trim()) {
+          addIssue(issues, "error", entity, `Jukebox song #${index + 1} has no audio file`);
+        }
+      }
+    }
   }
 
   for (const [mobId, mob] of Object.entries(world.mobs ?? {})) {

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -427,6 +427,9 @@ export function validateZone(
   /** Class id -> ordered statPriorities. Used to warn when an item uses an
    *  archetypal stat slot that no class fills (the bonus would silently drop). */
   classStatPriorities?: Record<string, string[]>,
+  /** `jukeboxOutput` enables the server's strict title/duration checks, which
+   *  only hold after save-time enrichment — in-editor songs are bare file refs. */
+  opts?: { jukeboxOutput?: boolean },
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const roomIds = new Set(Object.keys(world.rooms));
@@ -529,13 +532,46 @@ export function validateZone(
     }
 
     if (room.jukebox) {
-      const songs = room.jukebox.songs ?? [];
-      if (songs.length === 0) {
+      if (room.jukebox.length === 0) {
         addIssue(issues, "warning", entity, "Jukebox has no songs — add tracks or remove it");
       }
-      for (const [index, song] of songs.entries()) {
+      for (const [index, song] of room.jukebox.entries()) {
+        const where = `Jukebox song #${index + 1}`;
         if (!song.file?.trim()) {
-          addIssue(issues, "error", entity, `Jukebox song #${index + 1} has no audio file`);
+          addIssue(issues, "error", entity, `${where} has no audio file`);
+        }
+        if (song.cost != null && song.cost < 0) {
+          addIssue(issues, "error", entity, `${where} has a negative cost (${song.cost})`);
+        }
+        if (song.lyrics) {
+          if (song.lyrics.some((line) => typeof line !== "string" || !line.trim())) {
+            addIssue(issues, "error", entity, `${where} has a blank lyric line`);
+          }
+          const duration = song.durationSeconds;
+          if (typeof duration === "number" && duration > 0) {
+            const maxLines = Math.floor(duration / 3);
+            if (song.lyrics.length > maxLines) {
+              addIssue(
+                issues,
+                "error",
+                entity,
+                `${where} has ${song.lyrics.length} lyric lines but durationSeconds=${duration} allows at most ${maxLines} — at most one lyric line per 3 seconds`,
+              );
+            }
+          }
+        }
+        if (opts?.jukeboxOutput) {
+          if (!song.title?.trim()) {
+            addIssue(issues, "error", entity, `${where} has no title — name the track in the Audio Studio`);
+          }
+          if (typeof song.durationSeconds !== "number" || song.durationSeconds <= 0) {
+            addIssue(
+              issues,
+              "error",
+              entity,
+              `${where} has no playable duration — set the track's duration in the Audio Studio`,
+            );
+          }
         }
       }
     }

--- a/creator/src/stores/__tests__/zoneStore.test.ts
+++ b/creator/src/stores/__tests__/zoneStore.test.ts
@@ -134,4 +134,21 @@ describe("zoneStore undo/redo", () => {
     useZoneStore.getState().undo("test");
     expect(useZoneStore.getState().zones.get("test")!.dirty).toBe(true);
   });
+
+  it("markDirty flags the zone without data changes or history entries", () => {
+    const store = useZoneStore.getState();
+    store.loadZone("test", "/path/test.yaml", makeWorld());
+    const before = useZoneStore.getState().zones.get("test")!.data;
+
+    useZoneStore.getState().markDirty("test");
+
+    const zone = useZoneStore.getState().zones.get("test")!;
+    expect(zone.dirty).toBe(true);
+    expect(zone.data).toBe(before);
+    expect(useZoneStore.getState().canUndo("test")).toBe(false);
+    expect(useZoneStore.getState().canRedo("test")).toBe(false);
+
+    useZoneStore.getState().markDirty("missing");
+    expect(useZoneStore.getState().zones.get("missing")).toBeUndefined();
+  });
 });

--- a/creator/src/stores/assetStore.ts
+++ b/creator/src/stores/assetStore.ts
@@ -15,7 +15,9 @@ interface BatchProgress {
 interface AssetMetadataPatch {
   displayName?: string;
   description?: string;
+  artist?: string;
   lyrics?: string;
+  durationSeconds?: number;
 }
 
 /** Saved zone YAML denormalizes jukebox song metadata, so a metadata edit
@@ -25,7 +27,7 @@ function markJukeboxZonesDirty(fileName: string | undefined): void {
   const zoneStore = useZoneStore.getState();
   for (const [zoneId, zone] of zoneStore.zones) {
     const referenced = Object.values(zone.data.rooms).some((room) =>
-      (room.jukebox?.songs ?? []).some((song) => song.file === fileName),
+      (room.jukebox ?? []).some((song) => song.file === fileName),
     );
     if (referenced) zoneStore.markDirty(zoneId);
   }
@@ -182,7 +184,9 @@ export const useAssetStore = create<AssetState>((set, get) => ({
       assetId,
       displayName: patch.displayName ?? null,
       description: patch.description ?? null,
+      artist: patch.artist ?? null,
       lyrics: patch.lyrics ?? null,
+      durationSeconds: patch.durationSeconds ?? null,
     });
     await get().loadAssets();
     markJukeboxZonesDirty(fileName);

--- a/creator/src/stores/assetStore.ts
+++ b/creator/src/stores/assetStore.ts
@@ -3,12 +3,32 @@ import { invoke } from "@tauri-apps/api/core";
 import type { AssetContext, AssetEntry, GeneratedImage, ProjectSettings, Settings, SyncProgress, SyncScope } from "@/types/assets";
 import type { ArtStyle } from "@/lib/arcanumPrompts";
 import { useProjectStore } from "@/stores/projectStore";
+import { useZoneStore } from "@/stores/zoneStore";
 
 interface BatchProgress {
   total: number;
   completed: number;
   failed: number;
   errors: string[];
+}
+
+interface AssetMetadataPatch {
+  displayName?: string;
+  description?: string;
+  lyrics?: string;
+}
+
+/** Saved zone YAML denormalizes jukebox song metadata, so a metadata edit
+ *  means every zone whose jukeboxes reference the track needs a re-save. */
+function markJukeboxZonesDirty(fileName: string | undefined): void {
+  if (!fileName) return;
+  const zoneStore = useZoneStore.getState();
+  for (const [zoneId, zone] of zoneStore.zones) {
+    const referenced = Object.values(zone.data.rooms).some((room) =>
+      (room.jukebox?.songs ?? []).some((song) => song.file === fileName),
+    );
+    if (referenced) zoneStore.markDirty(zoneId);
+  }
 }
 
 interface AssetState {
@@ -22,6 +42,7 @@ interface AssetState {
   syncing: boolean;
   lastSyncResult: SyncProgress | null;
   batchProgress: BatchProgress | null;
+  audioMetaBackfilled: boolean;
 
   loadSettings: () => Promise<void>;
   saveSettings: (settings: Settings) => Promise<void>;
@@ -39,6 +60,8 @@ interface AssetState {
     displayName?: string,
   ) => Promise<AssetEntry>;
   renameAsset: (assetId: string, displayName: string) => Promise<void>;
+  updateAssetMetadata: (assetId: string, patch: AssetMetadataPatch) => Promise<void>;
+  backfillAudioMeta: () => Promise<void>;
   deleteAsset: (id: string) => Promise<void>;
   deleteAssets: (ids: string[]) => Promise<void>;
 
@@ -71,6 +94,7 @@ export const useAssetStore = create<AssetState>((set, get) => ({
   syncing: false,
   lastSyncResult: null,
   batchProgress: null,
+  audioMetaBackfilled: false,
 
   loadSettings: async () => {
     const projectDir = useProjectStore.getState().project?.mudDir;
@@ -146,8 +170,29 @@ export const useAssetStore = create<AssetState>((set, get) => ({
   },
 
   renameAsset: async (assetId, displayName) => {
+    const fileName = get().assets.find((a) => a.id === assetId)?.file_name;
     await invoke("rename_asset", { assetId, displayName });
     await get().loadAssets();
+    markJukeboxZonesDirty(fileName);
+  },
+
+  updateAssetMetadata: async (assetId, patch) => {
+    const fileName = get().assets.find((a) => a.id === assetId)?.file_name;
+    await invoke("update_asset_metadata", {
+      assetId,
+      displayName: patch.displayName ?? null,
+      description: patch.description ?? null,
+      lyrics: patch.lyrics ?? null,
+    });
+    await get().loadAssets();
+    markJukeboxZonesDirty(fileName);
+  },
+
+  backfillAudioMeta: async () => {
+    if (get().audioMetaBackfilled) return;
+    set({ audioMetaBackfilled: true });
+    const count = await invoke<number>("backfill_audio_meta");
+    if (count > 0) await get().loadAssets();
   },
 
   deleteAsset: async (id: string) => {

--- a/creator/src/stores/zoneStore.ts
+++ b/creator/src/stores/zoneStore.ts
@@ -18,6 +18,8 @@ interface ZoneStore {
   loadZone: (zoneId: string, filePath: string, data: WorldFile) => void;
   updateZone: (zoneId: string, data: WorldFile) => void;
   markClean: (zoneId: string) => void;
+  /** Flag a zone as needing a save without touching its data or undo history. */
+  markDirty: (zoneId: string) => void;
   /**
    * Re-key a loaded zone from `oldId` to `newId`, updating its file path and
    * the `zone` field inside its data. Preserves undo/redo history. No-op if
@@ -76,6 +78,15 @@ export const useZoneStore = create<ZoneStore>((set, get) => ({
       if (existing) {
         zones.set(zoneId, { ...existing, dirty: false });
       }
+      return { zones };
+    }),
+
+  markDirty: (zoneId) =>
+    set((state) => {
+      const existing = state.zones.get(zoneId);
+      if (!existing || existing.dirty) return state;
+      const zones = new Map(state.zones);
+      zones.set(zoneId, { ...existing, dirty: true });
       return { zones };
     }),
 

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -28,6 +28,7 @@ export interface AssetEntry {
   is_active: boolean;
   display_name: string;
   description: string;
+  artist: string;
   lyrics: string;
   duration_seconds: number;
 }

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -27,6 +27,9 @@ export interface AssetEntry {
   variant_group: string;
   is_active: boolean;
   display_name: string;
+  description: string;
+  lyrics: string;
+  duration_seconds: number;
 }
 
 export interface AssetContext {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -137,21 +137,23 @@ export interface RoomFile {
   videoTextSeconds?: number;
   music?: string;
   ambient?: string;
-  jukebox?: JukeboxFile;
+  /** Bare song list — non-empty means the room has a jukebox. */
+  jukebox?: JukeboxSongFile[];
   /** Legacy Arcanum-only alias; stripped on output. */
   audio?: string;
 }
 
+/** Server contract (AmbonMUD #1316). `title` and `durationSeconds` are
+ *  required by the server loader but optional here because in-editor
+ *  entries are bare `{ file }` refs until save-time enrichment. */
 export interface JukeboxSongFile {
+  title?: string;
   file: string;
-  name?: string;
-  description?: string;
-  lyrics?: string;
   durationSeconds?: number;
-}
-
-export interface JukeboxFile {
-  songs: JukeboxSongFile[];
+  cost?: number;
+  artist?: string;
+  description?: string;
+  lyrics?: string[];
 }
 
 export interface ExitValue {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -137,8 +137,21 @@ export interface RoomFile {
   videoTextSeconds?: number;
   music?: string;
   ambient?: string;
+  jukebox?: JukeboxFile;
   /** Legacy Arcanum-only alias; stripped on output. */
   audio?: string;
+}
+
+export interface JukeboxSongFile {
+  file: string;
+  name?: string;
+  description?: string;
+  lyrics?: string;
+  durationSeconds?: number;
+}
+
+export interface JukeboxFile {
+  songs: JukeboxSongFile[];
 }
 
 export interface ExitValue {


### PR DESCRIPTION
## What

Makes the Audio Studio the source of truth for song metadata and gives rooms a jukebox editor, emitting the zone YAML schema implemented server-side in jnoecker/AmbonMUD#1316.

### Track library (Audio Studio)
- `AssetEntry` gains `description`, `artist`, `lyrics`, and `duration_seconds` (probed via `ffmpeg -i` at import; `backfill_audio_meta` fills existing libraries on studio mount; duration is also editable for probe failures).
- Track detail: description + artist inputs, lyrics textarea with a live line budget (`N lines · max M for m:ss`, mirroring the server cap), duration field, and a **Compose details** AI button returning strict JSON `{title, artist, description, lyrics}` sized to the track length.
- `trackLabel` collapses content-addressed hashes (file names *and* pre-#296 `Imported: <sha256>` prompts) to `Untitled (xxxxxxxx…)`.
- Usage tracking, delete warnings, and the usage summary now include jukebox references.

### Jukebox authoring (Room editor)
- "Jukebox in this room" toggle + ordered song picker from the music library, with reorder/remove, optional per-song gold cost (blank = server default), duration chips, and `unknown track` / `no lyrics` / `no duration` badges.
- Songs are stored as bare file refs while editing; `serializeZone` denormalizes title/artist/description/lyrics/duration from the library at save time (`enrichJukeboxSongs`), so library edits propagate (referencing zones are auto-marked dirty). Songs not in the local library pass through verbatim for cross-machine sharing.

### Contract (canonical, from AmbonMUD#1316)
```yaml
jukebox:
  - title: The Borrowed Song
    file: <sha256>.mp3
    durationSeconds: 96
    cost: 5            # optional, omit for server default
    artist: The Wandering Bards
    description: A waltz that remembers being hummed.
    lyrics:
      - When the lanterns lean in low,
      - the teacups start to sway.
```
Validation mirrors the server loader: blank file/title, missing or non-positive duration (save path), negative cost, blank lyric lines, and the at-most-one-lyric-line-per-3-seconds density rule are all surfaced before YAML that the server would refuse to load can be written.

## Test plan
- `bunx tsc --noEmit` clean
- `bun run test` — 2193 tests, 68 files, all passing (enrichment, sanitize ordering/omission, validation incl. density + strict output mode, YAML round-trip)
- `cargo check` + `cargo test --lib` clean
