### PR TITLE
feat: author a room's music box (sibling of AmbonMUD #1336)

### DIFF
--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -1247,6 +1247,7 @@ export function RoomPanel({
             hint="Overrides the zone's default soundscape for this room."
           />
           <JukeboxEditor world={world} roomId={roomId} onWorldChange={onWorldChange} />
+          <MusicBoxEditor world={world} roomId={roomId} onWorldChange={onWorldChange} />
         </div>
       </Section>
       </>
@@ -1447,6 +1448,99 @@ function JukeboxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
           <p className="text-2xs text-text-muted">
             Players use <code className="font-mono">jukebox play &lt;n&gt;</code> — titles, artists, and
             lyrics come from the Audio Studio library. A blank cost charges the server's default price.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A room's one-song music box — a free, player-scoped miniature of the jukebox.
+ *  The song is a bare file ref; its title, artist, lyrics, and duration are
+ *  denormalized from the audio library at save time, exactly like a jukebox song,
+ *  minus the cost (the music box is always free). */
+function MusicBoxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
+  const assets = useAssetStore((s) => s.assets);
+  const metaIndex = useMemo(() => buildAudioMetaIndex(assets), [assets]);
+  const musicTracks = useMemo(() => listAudioTracks(assets, "music"), [assets]);
+
+  const room = world.rooms[roomId];
+  if (!room) return null;
+  const box = room.musicBox;
+  const meta = box ? metaIndex.get(box.file) : undefined;
+  const boxDuration =
+    box && typeof box.durationSeconds === "number" && box.durationSeconds > 0
+      ? Math.round(box.durationSeconds)
+      : 0;
+  const duration = meta && meta.durationSeconds > 0 ? meta.durationSeconds : boxDuration;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="flex cursor-pointer items-center gap-1.5 text-xs text-text-secondary">
+        <input
+          type="checkbox"
+          checked={!!room.musicBox}
+          onChange={(e) =>
+            onWorldChange(
+              updateRoom(world, roomId, { musicBox: e.target.checked ? { file: "" } : undefined }),
+            )
+          }
+          className="accent-[rgb(var(--accent-rgb))]"
+        />
+        Music box in this room
+      </label>
+      {room.musicBox && (
+        <div className="flex flex-col gap-1 pl-5">
+          {box?.file ? (
+            <div className="flex items-center gap-1 text-2xs">
+              <span className="min-w-0 flex-1 truncate text-text-secondary" title={box.file}>
+                {meta?.name ?? box.title ?? box.file}
+              </span>
+              {duration > 0 && (
+                <span className="shrink-0 text-3xs text-text-muted">{formatSongDuration(duration)}</span>
+              )}
+              {!meta && (
+                <span className="shrink-0 rounded bg-status-warning/15 px-1 py-0.5 text-3xs text-status-warning">
+                  unknown track
+                </span>
+              )}
+              {meta && duration <= 0 && (
+                <span
+                  title="Saving is blocked until this song has a play length — set the track's duration in the Audio Studio."
+                  className="shrink-0 rounded bg-status-warning/15 px-1 py-0.5 text-3xs text-status-warning"
+                >
+                  no duration
+                </span>
+              )}
+              {meta && !meta.lyrics && (
+                <span className="shrink-0 rounded bg-bg-secondary px-1 py-0.5 text-3xs text-text-muted">
+                  no lyrics
+                </span>
+              )}
+            </div>
+          ) : null}
+          <select
+            value={box?.file ?? ""}
+            onChange={(e) =>
+              onWorldChange(
+                updateRoom(world, roomId, {
+                  musicBox: e.target.value ? { file: e.target.value } : { file: "" },
+                }),
+              )
+            }
+            aria-label="Music box song"
+            className="w-full rounded border border-border-default bg-bg-secondary px-2 py-1 text-2xs text-text-secondary outline-none focus-visible:ring-2 focus-visible:ring-border-active [&>option]:bg-bg-secondary"
+          >
+            <option value="">Choose song…</option>
+            {musicTracks.map((t) => (
+              <option key={t.id} value={t.file_name}>
+                {trackLabel(t)}
+              </option>
+            ))}
+          </select>
+          <p className="text-2xs text-text-muted">
+            Players use <code className="font-mono">musicbox play</code> — it's free and personal, and the
+            song follows them out of the room. Title, artist, and lyrics come from the Audio Studio library.
           </p>
         </div>
       )}

--- a/creator/src/lib/__tests__/audioLibrary.test.ts
+++ b/creator/src/lib/__tests__/audioLibrary.test.ts
@@ -411,6 +411,40 @@ describe("enrichJukeboxSongs", () => {
     });
     expect(enrichJukeboxSongs(noJukebox, meta)).toBe(noJukebox);
   });
+
+  it("enriches a room's music box from the library and never gives it a cost", () => {
+    const world = makeWorld({
+      rooms: {
+        parlor: {
+          title: "Parlor",
+          description: "",
+          // A stray cost on the box must be stripped — the music box is always free.
+          musicBox: { file: "song.mp3", title: "Stale", cost: 9 },
+        },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, meta);
+    const box = next.rooms.parlor?.musicBox;
+    expect(box).toEqual({
+      title: "The Borrowed Song",
+      file: "song.mp3",
+      durationSeconds: 96,
+      artist: "The Wandering Bards",
+      description: "A waltz that remembers being hummed.",
+      lyrics: ["When the lanterns lean in low,", "the teacups start to sway."],
+    });
+    expect(Object.keys(box!)).not.toContain("cost");
+  });
+
+  it("drops a blank-file music box during enrichment", () => {
+    const world = makeWorld({
+      rooms: {
+        parlor: { title: "Parlor", description: "", musicBox: { file: "   " } },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, meta);
+    expect(next.rooms.parlor?.musicBox).toBeUndefined();
+  });
 });
 
 describe("jukebox YAML round-trip", () => {

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -1002,3 +1002,59 @@ describe("sanitizeZone — room jukebox", () => {
     expect(result.rooms["room_a"]!.jukebox).toBeUndefined();
   });
 });
+
+describe("sanitizeZone — room music box", () => {
+  it("rebuilds the box in contract key order with empty optionals omitted and no cost", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: {
+          title: "A",
+          description: "A",
+          musicBox: {
+            durationSeconds: 60.6,
+            lyrics: ["  Down where the lantern-light is low  ", "", "the scuttlefish sings soft and slow"],
+            description: "A soft tune.",
+            artist: "Scuttlefish",
+            // A stray cost must not survive — the music box is always free.
+            cost: 5,
+            file: "lullaby.mp3",
+            title: "Scuttlefish's Lullaby",
+          } as never,
+        },
+      },
+    });
+
+    const result = sanitizeZone(world);
+    const box = result.rooms["room_a"]!.musicBox!;
+    expect(Object.keys(box)).toEqual([
+      "title", "file", "durationSeconds", "artist", "description", "lyrics",
+    ]);
+    expect(box).toEqual({
+      title: "Scuttlefish's Lullaby",
+      file: "lullaby.mp3",
+      durationSeconds: 61,
+      artist: "Scuttlefish",
+      description: "A soft tune.",
+      lyrics: ["Down where the lantern-light is low", "the scuttlefish sings soft and slow"],
+    });
+  });
+
+  it("drops a blank-file music box entirely", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: { title: "A", description: "A", musicBox: { file: "   ", title: "Ghost" } },
+        room_b: { title: "B", description: "B", musicBox: { file: "keeper.mp3" } },
+      },
+    });
+
+    const result = sanitizeZone(world);
+    expect(result.rooms["room_a"]!.musicBox).toBeUndefined();
+    expect(result.rooms["room_b"]!.musicBox).toEqual({ file: "keeper.mp3" });
+  });
+
+  it("leaves rooms without a music box alone", () => {
+    const world = makeWorld();
+    const result = sanitizeZone(world);
+    expect(result.rooms["room_a"]!.musicBox).toBeUndefined();
+  });
+});

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -187,6 +187,51 @@ describe("validateZone", () => {
     expect(validateZone(world, ...JUKEBOX_OUTPUT)).toHaveLength(0);
   });
 
+  // ─── Room music box ──────────────────────────────────────────
+  it("errors on a music box with a blank file", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.musicBox = { file: "   " };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.entity === "room:room1" && i.message.includes("Music box has no audio file"))).toBe(true);
+  });
+
+  it("accepts a populated music box without issues", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.musicBox = {
+      title: "Lullaby",
+      file: "box.mp3",
+      durationSeconds: 30,
+      lyrics: ["soft", "and", "slow"],
+    };
+    expect(validateZone(world)).toHaveLength(0);
+  });
+
+  it("errors on a music box blank lyric line", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.musicBox = { file: "box.mp3", lyrics: ["fine", "   "] };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.message.includes("Music box has a blank lyric line"))).toBe(true);
+  });
+
+  it("errors when music box lyrics exceed one line per 3 seconds", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.musicBox = { file: "box.mp3", durationSeconds: 9, lyrics: ["a", "b", "c", "d"] };
+    const issues = errors(validateZone(world));
+    expect(issues.some((i) => i.message.includes("Music box") && i.message.includes("at most 3"))).toBe(true);
+  });
+
+  it("requires music box title and duration only when validating enriched output", () => {
+    const world = makeValidWorld();
+    world.rooms.room1.musicBox = { file: "box.mp3" };
+
+    expect(validateZone(world)).toHaveLength(0);
+
+    const issues = errors(validateZone(world, ...JUKEBOX_OUTPUT));
+    expect(issues).toHaveLength(2);
+    expect(issues.some((i) => i.message.includes("Music box has no title"))).toBe(true);
+    expect(issues.some((i) => i.message.includes("Music box has no playable duration"))).toBe(true);
+  });
+
   it("warns on door key that is not a known item", () => {
     const world = makeValidWorld();
     world.rooms.room1.exits = {

--- a/creator/src/lib/assetRefs.ts
+++ b/creator/src/lib/assetRefs.ts
@@ -1,5 +1,5 @@
 import type { AppConfig } from "@/types/config";
-import type { JukeboxSongFile, WorldFile } from "@/types/world";
+import type { JukeboxSongFile, MusicBoxFile, WorldFile } from "@/types/world";
 
 const REMOTE_URL_RE = /^(?:https?:)?\/\//i;
 const ENGINE_MEDIA_PATH_RE = /^\/(?:images?|videos?|audio)\//i;
@@ -98,6 +98,7 @@ export function normalizeWorldAssetRefs(world: WorldFile): WorldFile {
         ambient: normalizeAssetRef(room.ambient),
         audio: normalizeAssetRef(room.audio),
         jukebox: normalizeJukeboxRefs(room.jukebox),
+        musicBox: normalizeMusicBoxRef(room.musicBox),
         features: room.features
           ? mapEntries(room.features, (feature) =>
               feature.plateImage || feature.handleImage || feature.backgroundImage
@@ -167,6 +168,12 @@ function normalizeJukeboxRefs(jukebox: JukeboxSongFile[] | undefined): JukeboxSo
     return file ? [{ ...song, file }] : [];
   });
   return songs.length > 0 ? songs : undefined;
+}
+
+function normalizeMusicBoxRef(musicBox: MusicBoxFile | undefined): MusicBoxFile | undefined {
+  if (!musicBox) return undefined;
+  const file = normalizeAssetRef(musicBox.file);
+  return file ? { ...musicBox, file } : undefined;
 }
 
 function mapEntries<T>(

--- a/creator/src/lib/audioLibrary.ts
+++ b/creator/src/lib/audioLibrary.ts
@@ -1,5 +1,5 @@
 import type { AssetEntry } from "@/types/assets";
-import type { JukeboxSongFile, RoomFile, WorldFile } from "@/types/world";
+import type { JukeboxSongFile, MusicBoxFile, RoomFile, WorldFile } from "@/types/world";
 
 export type AudioTrackKind = "music" | "ambient";
 
@@ -157,13 +157,36 @@ export function splitLyricsLines(lyrics: string): string[] {
 }
 
 /**
- * Denormalize library metadata into jukebox song entries at save time.
- * Songs whose file is in the index are rebuilt from it in the server
+ * Denormalize library metadata into a single jukebox song from its file's
+ * library entry, rebuilt in the server contract's key order. Returns null for a
+ * blank file. A track not in the index stays verbatim.
+ */
+function enrichSong(song: JukeboxSongFile, meta: Map<string, AudioTrackMeta>): JukeboxSongFile | null {
+  if (!song.file || !song.file.trim()) return null;
+  const track = meta.get(song.file);
+  if (!track) return song;
+  const enriched: JukeboxSongFile = { title: track.name, file: song.file };
+  if (track.durationSeconds > 0) {
+    enriched.durationSeconds = track.durationSeconds;
+  } else if (typeof song.durationSeconds === "number" && song.durationSeconds > 0) {
+    enriched.durationSeconds = Math.round(song.durationSeconds);
+  }
+  if (typeof song.cost === "number" && song.cost >= 0) enriched.cost = song.cost;
+  if (track.artist) enriched.artist = track.artist;
+  if (track.description) enriched.description = track.description;
+  const lyrics = splitLyricsLines(track.lyrics);
+  if (lyrics.length > 0) enriched.lyrics = lyrics;
+  return enriched;
+}
+
+/**
+ * Denormalize library metadata into jukebox + music-box entries at save time.
+ * Entries whose file is in the index are rebuilt from it in the server
  * contract's key order (so stale titles, descriptions, and lyrics clear when
- * the library entry empties); songs from other machines stay verbatim. The
- * per-song `cost` is zone-side authoring, not library metadata, so it always
- * survives. Blank-file songs are dropped, and a jukebox with no surviving
- * songs disappears.
+ * the library entry empties); entries from other machines stay verbatim. A
+ * jukebox song's `cost` is zone-side authoring and always survives; the music
+ * box is always free, so it carries none. Blank-file entries are dropped, and a
+ * jukebox / music box with nothing left disappears.
  */
 export function enrichJukeboxSongs(
   world: WorldFile,
@@ -172,35 +195,30 @@ export function enrichJukeboxSongs(
   let changed = false;
   const rooms: Record<string, RoomFile> = {};
   for (const [roomId, room] of Object.entries(world.rooms)) {
-    if (!room.jukebox) {
-      rooms[roomId] = room;
-      continue;
-    }
-    const songs: JukeboxSongFile[] = [];
-    for (const song of room.jukebox) {
-      if (!song.file || !song.file.trim()) continue;
-      const track = meta.get(song.file);
-      if (!track) {
-        songs.push(song);
-        continue;
+    let nextRoom = room;
+    if (room.jukebox) {
+      const songs: JukeboxSongFile[] = [];
+      for (const song of room.jukebox) {
+        const enriched = enrichSong(song, meta);
+        if (enriched) songs.push(enriched);
       }
-      const enriched: JukeboxSongFile = { title: track.name, file: song.file };
-      if (track.durationSeconds > 0) {
-        enriched.durationSeconds = track.durationSeconds;
-      } else if (typeof song.durationSeconds === "number" && song.durationSeconds > 0) {
-        enriched.durationSeconds = Math.round(song.durationSeconds);
-      }
-      if (typeof song.cost === "number" && song.cost >= 0) enriched.cost = song.cost;
-      if (track.artist) enriched.artist = track.artist;
-      if (track.description) enriched.description = track.description;
-      const lyrics = splitLyricsLines(track.lyrics);
-      if (lyrics.length > 0) enriched.lyrics = lyrics;
-      songs.push(enriched);
+      nextRoom = songs.length > 0
+        ? { ...nextRoom, jukebox: songs }
+        : { ...nextRoom, jukebox: undefined };
+      changed = true;
     }
-    rooms[roomId] = songs.length > 0
-      ? { ...room, jukebox: songs }
-      : { ...room, jukebox: undefined };
-    changed = true;
+    if (room.musicBox) {
+      const enriched = enrichSong(room.musicBox, meta);
+      // The music box never carries a cost — it's free; drop any stray one.
+      const box: MusicBoxFile | undefined = enriched
+        ? (({ cost: _cost, ...rest }) => rest)(enriched)
+        : undefined;
+      nextRoom = box
+        ? { ...nextRoom, musicBox: box }
+        : { ...nextRoom, musicBox: undefined };
+      changed = true;
+    }
+    rooms[roomId] = nextRoom;
   }
   return changed ? { ...world, rooms } : world;
 }

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -349,6 +349,16 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     optional: true,
   },
   {
+    key: "music_box_widget",
+    defaultFilename: "music_box_widget.png",
+    label: "Music Box",
+    description: "Badge shown on rooms with a music box (and while a song follows the player); opens the music-box device.",
+    assetType: "ability_icon",
+    defaultPrompt: "A single small ornate fantasy wind-up music box, walnut and brass with a winding crank, glowing with warm light, centered.",
+    transparent: true,
+    optional: true,
+  },
+  {
     key: "duel_arena_widget",
     defaultFilename: "duel_arena_widget.png",
     label: "Duel Arena",
@@ -884,6 +894,32 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     assetType: "background",
     defaultPrompt:
       "A tall ornate fantasy music-box jukebox cabinet facade filling the frame edge to edge — dark carved wood with brass fittings, filigree, and clockwork details, a blank ornate title plaque centered at the top, a stack of five wide blank parchment scroll rollers as horizontal rows in the center where song titles overlay, a long blank parchment strip along the bottom where the now-playing bar overlays, slender side columns with a small clock face, a brass bell, winding keys, and tiny carved musician automaton figurines in lantern-lit alcoves, a twilight starfield behind the cabinet, warm magical lantern glow, portrait composition, no living figures, no readable text, suitable as a backdrop behind a song-picker panel on a narrow screen.",
+    transparent: false,
+    aspect: "portrait",
+    optional: true,
+  },
+  {
+    key: "musicbox_bg",
+    defaultFilename: "musicbox_bg.png",
+    label: "Music Box Device Background",
+    description:
+      "Fully painted device frame for the music-box panel — a small wind-up music box. The title overlays the blank parchment plaque at the top, the scrolling lyrics overlay the large blank central parchment, and the play/stop crank controls overlay the base plaque. Falls back to the procedural panel when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "A small ornate fantasy wind-up music box facade filling a tall portrait frame edge to edge — dark carved walnut with brass fittings, filigree, and clockwork details, a blank ornate title plaque centered near the top, a pinned brass cylinder drum below it, one large blank central parchment panel where scrolling lyrics overlay, flanked by tiny carved musician automaton figurines (cello, harp, singer) in lantern-lit alcoves, a small clock face in the upper corner and a brass winding crank on the side, a blank decorative base plaque along the bottom where the play controls overlay, warm magical lantern glow, no living figures, no readable text, suitable as a device frame behind a music-box panel.",
+    transparent: false,
+    aspect: "portrait",
+    optional: true,
+  },
+  {
+    key: "musicbox_bg_portrait",
+    defaultFilename: "musicbox_bg_portrait.png",
+    label: "Music Box Device Background (Portrait)",
+    description:
+      "Portrait variant of the music-box device frame served to mobile / narrow viewports. The title overlays the top plaque, the lyrics overlay the central parchment, and the crank controls overlay the base plaque. Falls back to the main device art when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "A small ornate fantasy wind-up music box facade filling a tall portrait frame edge to edge — dark carved walnut with brass fittings, filigree, and clockwork details, a blank ornate title plaque centered near the top, a pinned brass cylinder drum below it, one large blank central parchment panel where scrolling lyrics overlay, flanked by tiny carved musician automaton figurines in lantern-lit alcoves, a small clock face in the upper corner and a brass winding crank on the side, a blank decorative base plaque along the bottom where the play controls overlay, warm magical lantern glow, portrait composition, no living figures, no readable text, suitable as a device frame behind a music-box panel on a narrow screen.",
     transparent: false,
     aspect: "portrait",
     optional: true,

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -14,6 +14,7 @@ import type {
   DoorFile,
   DungeonLootTable,
   JukeboxSongFile,
+  MusicBoxFile,
 } from "@/types/world";
 import { resolveDoorKeyId } from "./doorHelpers";
 import { getTrainerClasses } from "./trainers";
@@ -181,8 +182,36 @@ function normalizeJukebox(jukebox?: JukeboxSongFile[]): JukeboxSongFile[] | unde
   return songs.length > 0 ? songs : undefined;
 }
 
+/** Rebuild the music box in the server contract's key order (title, file,
+ *  durationSeconds, artist, description, lyrics — no cost; it's always free),
+ *  omitting empty optional fields. A box with no audio file is dropped entirely. */
+function normalizeMusicBox(box?: MusicBoxFile): MusicBoxFile | undefined {
+  if (!box || !box.file || !box.file.trim()) return undefined;
+  const out: MusicBoxFile =
+    typeof box.title === "string" && box.title.trim()
+      ? { title: box.title, file: box.file }
+      : { file: box.file };
+  if (typeof box.durationSeconds === "number" && box.durationSeconds > 0) {
+    out.durationSeconds = Math.round(box.durationSeconds);
+  }
+  if (typeof box.artist === "string" && box.artist.trim()) out.artist = box.artist;
+  if (typeof box.description === "string" && box.description.trim()) out.description = box.description;
+  if (Array.isArray(box.lyrics)) {
+    const lines = box.lyrics
+      .map((line) => (typeof line === "string" ? line.trim() : ""))
+      .filter((line) => line.length > 0);
+    if (lines.length > 0) out.lyrics = lines;
+  }
+  return out;
+}
+
 function normalizeRoomOutput(room: RoomFile): RoomFile {
-  let next: RoomFile = { ...room, audio: undefined, jukebox: normalizeJukebox(room.jukebox) };
+  let next: RoomFile = {
+    ...room,
+    audio: undefined,
+    jukebox: normalizeJukebox(room.jukebox),
+    musicBox: normalizeMusicBox(room.musicBox),
+  };
   if (room.exits) {
     const exits: Record<string, string | ExitValue> = {};
     for (const [dir, exit] of Object.entries(room.exits)) {

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -575,6 +575,44 @@ export function validateZone(
         }
       }
     }
+
+    if (room.musicBox) {
+      const box = room.musicBox;
+      const where = "Music box";
+      if (!box.file?.trim()) {
+        addIssue(issues, "error", entity, `${where} has no audio file`);
+      }
+      if (box.lyrics) {
+        if (box.lyrics.some((line) => typeof line !== "string" || !line.trim())) {
+          addIssue(issues, "error", entity, `${where} has a blank lyric line`);
+        }
+        const duration = box.durationSeconds;
+        if (typeof duration === "number" && duration > 0) {
+          const maxLines = Math.floor(duration / 3);
+          if (box.lyrics.length > maxLines) {
+            addIssue(
+              issues,
+              "error",
+              entity,
+              `${where} has ${box.lyrics.length} lyric lines but durationSeconds=${duration} allows at most ${maxLines} — at most one lyric line per 3 seconds`,
+            );
+          }
+        }
+      }
+      if (opts?.jukeboxOutput) {
+        if (!box.title?.trim()) {
+          addIssue(issues, "error", entity, `${where} has no title — name the track in the Audio Studio`);
+        }
+        if (typeof box.durationSeconds !== "number" || box.durationSeconds <= 0) {
+          addIssue(
+            issues,
+            "error",
+            entity,
+            `${where} has no playable duration — set the track's duration in the Audio Studio`,
+          );
+        }
+      }
+    }
   }
 
   for (const [mobId, mob] of Object.entries(world.mobs ?? {})) {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -139,6 +139,9 @@ export interface RoomFile {
   ambient?: string;
   /** Bare song list — non-empty means the room has a jukebox. */
   jukebox?: JukeboxSongFile[];
+  /** A single song — present means the room has a music box (a free, player-scoped
+   *  one-song miniature of the jukebox). */
+  musicBox?: MusicBoxFile;
   /** Legacy Arcanum-only alias; stripped on output. */
   audio?: string;
 }
@@ -151,6 +154,18 @@ export interface JukeboxSongFile {
   file: string;
   durationSeconds?: number;
   cost?: number;
+  artist?: string;
+  description?: string;
+  lyrics?: string[];
+}
+
+/** Server contract (AmbonMUD #1336). A room's one-song music box — like a
+ *  {@link JukeboxSongFile} but always free (no `cost`). `title`/`durationSeconds`
+ *  are required by the server loader but optional here until save-time enrichment. */
+export interface MusicBoxFile {
+  title?: string;
+  file: string;
+  durationSeconds?: number;
   artist?: string;
   description?: string;
   lyrics?: string[];


### PR DESCRIPTION
Mirrors the new **music box** room feature from AmbonMUD PR #1336 so worldbuilders can author it in the creator.

A music box is a free, player-scoped one-song miniature of the jukebox: winding it up starts the song for *you* only, and it follows you out of the room until it ends or you stop it. On the web client it's a painted wind-up device with a play/stop crank and a central parchment that scrolls the song's lyrics (and 🎵 lyric toasts while the device is closed).

## What's here
- **Type** — `MusicBoxFile` mirror DTO (`creator/src/types/world.ts`), plus `room.musicBox`.
- **Editor** — a "Music box in this room" section in the Room panel: a single music-track picker (no cost — the box is always free), with the same unknown-track / no-duration / no-lyrics badges as the jukebox.
- **Validation** — `validateZone.ts`: blank file, blank lyric line, the one-line-per-3-seconds density cap, and strict title+duration on enriched output.
- **Serialization** — `sanitizeZone.ts` rebuilds the box in the server's key order (no `cost`); `audioLibrary.ts` denormalizes title/artist/lyrics/duration from the Audio Studio library at save time (stripping any stray cost); `assetRefs.ts` tracks the box's audio file.
- **Global assets** — `music_box_widget` (rail kiosk badge) and `musicbox_bg` (+ portrait) device frame registered in `requiredGlobalAssets.ts`.

## Tests
New coverage in `validateZone`, `sanitizeZone`, and `audioLibrary` suites (170 pass). `bunx tsc --noEmit` clean.

## Sibling
- AmbonMUD: jnoecker/AmbonMUD#1336 (server schema + engine + GMCP + web device). Land together.