### PR TITLE
feat: KEEPSAKE item type for music-box souvenir lyric sheets

### DIFF
--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -418,7 +418,14 @@ export function ItemEditor({
                   min={0}
                 />
               </FieldRow>
-              <FieldRow label="Item Type">
+              <FieldRow
+                label="Item Type"
+                hint={
+                  item.itemType === "keepsake"
+                    ? "Keepsakes are soulbound souvenirs — locked like a quest item, but shelved under their own Keepsakes heading in the inventory."
+                    : undefined
+                }
+              >
                 <SelectInput
                   value={item.itemType ?? ""}
                   options={itemTypeOptions}

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -25,7 +25,7 @@ import { MediaPicker } from "@/components/ui/MediaPicker";
 import { AudioTrackPicker } from "@/components/ui/AudioTrackPicker";
 import { buildAudioMetaIndex, listAudioTracks, trackLabel } from "@/lib/audioLibrary";
 import { VideoGenerator } from "@/components/ui/VideoGenerator";
-import { roomPrompt, roomContext } from "@/lib/entityPrompts";
+import { roomPrompt, roomContext, musicBoxKeepsakePrompt, musicBoxKeepsakeContext } from "@/lib/entityPrompts";
 import { getTrainerClasses } from "@/lib/trainers";
 import { EnhanceDescriptionButton, MediaDisclosure, VideoVisionFields } from "@/components/editors/EditorShared";
 import { useVibeStore } from "@/stores/vibeStore";
@@ -1247,7 +1247,7 @@ export function RoomPanel({
             hint="Overrides the zone's default soundscape for this room."
           />
           <JukeboxEditor world={world} roomId={roomId} onWorldChange={onWorldChange} />
-          <MusicBoxEditor world={world} roomId={roomId} onWorldChange={onWorldChange} />
+          <MusicBoxEditor world={world} roomId={roomId} zoneId={zoneId} onWorldChange={onWorldChange} />
         </div>
       </Section>
       </>
@@ -1459,7 +1459,7 @@ function JukeboxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
  *  The song is a bare file ref; its title, artist, lyrics, and duration are
  *  denormalized from the audio library at save time, exactly like a jukebox song,
  *  minus the cost (the music box is always free). */
-function MusicBoxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
+function MusicBoxEditor({ world, roomId, zoneId, onWorldChange }: JukeboxEditorProps & { zoneId: string }) {
   const assets = useAssetStore((s) => s.assets);
   const metaIndex = useMemo(() => buildAudioMetaIndex(assets), [assets]);
   const musicTracks = useMemo(() => listAudioTracks(assets, "music"), [assets]);
@@ -1542,6 +1542,38 @@ function MusicBoxEditor({ world, roomId, onWorldChange }: JukeboxEditorProps) {
             Players use <code className="font-mono">musicbox play</code> — it's free and personal, and the
             song follows them out of the room. Title, artist, and lyrics come from the Audio Studio library.
           </p>
+          {box?.file && (
+            <div className="mt-1 flex flex-col gap-1.5 border-t border-border-default/60 pt-2">
+              <div className="flex items-center gap-1 text-2xs">
+                <span className="w-16 shrink-0 text-text-muted">Keepsake</span>
+                <span className="truncate text-text-secondary" title={box.image || undefined}>
+                  {box.image || "generic default"}
+                </span>
+              </div>
+              <EntityArtGenerator
+                getPrompt={(style) =>
+                  musicBoxKeepsakePrompt(
+                    meta?.name ?? box.title ?? "",
+                    meta?.artist ?? box.artist,
+                    style,
+                    useVibeStore.getState().getVibe(zoneId),
+                  )
+                }
+                entityContext={musicBoxKeepsakeContext(meta?.name ?? box.title ?? "", meta?.artist ?? box.artist)}
+                currentImage={box.image}
+                onAccept={(filePath) =>
+                  onWorldChange(updateRoom(world, roomId, { musicBox: { ...box, image: filePath } }))
+                }
+                assetType="item"
+                context={{ zone: zoneId, entity_type: "item", entity_id: `musicbox:${roomId}` }}
+                surface="worldbuilding"
+              />
+              <p className="text-3xs text-text-muted">
+                Art for the lyric-sheet keepsake minted on a player's first play. Optional — without it the
+                souvenir shows the client's generic item icon.
+              </p>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/creator/src/lib/__tests__/assetRefs.test.ts
+++ b/creator/src/lib/__tests__/assetRefs.test.ts
@@ -90,6 +90,37 @@ describe("normalizeWorldAssetRefs", () => {
     expect(world.puzzles?.sphinx?.reward.type).toBe("give_gold");
   });
 
+  it("normalizes a music box's audio file and keepsake image refs", () => {
+    const world = normalizeWorldAssetRefs({
+      zone: "tutorial_glade",
+      startRoom: "entrance",
+      rooms: {
+        parlor: {
+          title: "Parlor",
+          description: "",
+          musicBox: {
+            file: "C:/assets/audio/lullaby.mp3",
+            title: "Lullaby",
+            image: "C:\\assets\\images\\lyric-sheet.png",
+          },
+        },
+        bare: {
+          title: "Bare",
+          description: "",
+          musicBox: { file: "/audio/keeper.mp3" },
+        },
+      },
+    });
+
+    const box = world.rooms.parlor?.musicBox;
+    expect(box?.file).toBe("lullaby.mp3");
+    expect(box?.image).toBe("lyric-sheet.png");
+    // Untouched metadata survives the pass-through.
+    expect(box?.title).toBe("Lullaby");
+    // A box without an image never grows an undefined image key.
+    expect(world.rooms.bare?.musicBox).not.toHaveProperty("image");
+  });
+
   it("normalizes an exit door's frame/leaf refs", () => {
     const world = normalizeWorldAssetRefs({
       zone: "tutorial_glade",

--- a/creator/src/lib/__tests__/audioLibrary.test.ts
+++ b/creator/src/lib/__tests__/audioLibrary.test.ts
@@ -436,6 +436,26 @@ describe("enrichJukeboxSongs", () => {
     expect(Object.keys(box!)).not.toContain("cost");
   });
 
+  it("preserves the authored keepsake image through enrichment, before lyrics", () => {
+    const world = makeWorld({
+      rooms: {
+        parlor: {
+          title: "Parlor",
+          description: "",
+          // The image is zone-side authoring, not library metadata — it must
+          // survive the library rebuild and sit before lyrics in key order.
+          musicBox: { file: "song.mp3", title: "Stale", image: "items/lyric-sheet.png" },
+        },
+      } as WorldFile["rooms"],
+    });
+    const next = enrichJukeboxSongs(world, meta);
+    const box = next.rooms.parlor?.musicBox;
+    expect(box?.image).toBe("items/lyric-sheet.png");
+    expect(Object.keys(box!)).toEqual([
+      "title", "file", "durationSeconds", "artist", "description", "image", "lyrics",
+    ]);
+  });
+
   it("drops a blank-file music box during enrichment", () => {
     const world = makeWorld({
       rooms: {

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -1061,14 +1061,15 @@ describe("sanitizeZone — room music box", () => {
 });
 
 describe("sanitizeZone — keepsake items", () => {
-  it("round-trips a keepsake item through YAML with its type and soulbound flag", () => {
+  // Keepsakes bind via itemType alone server-side (Item.isBound = questItem ||
+  // itemType == KEEPSAKE), so a real keepsake carries no questItem flag.
+  it("round-trips a keepsake item through YAML with its type and multi-line lyrics", () => {
     const world = makeWorld({
       items: {
         lyric_sheet: {
           displayName: "a lyric sheet for \"The Word of Ambon\"",
-          description: "When the lanterns lean in low,\nthe teacups start to sway.",
+          description: "\"The Word of Ambon\"\n\nWhen the lanterns lean in low,\nthe teacups start to sway.",
           itemType: "keepsake",
-          questItem: true,
           basePrice: 0,
         },
       },
@@ -1079,7 +1080,6 @@ describe("sanitizeZone — keepsake items", () => {
     const item = reparsed.items!["lyric_sheet"] as ItemFile;
 
     expect(item.itemType).toBe("keepsake");
-    expect(item.questItem).toBe(true);
     expect(item.description).toContain("\n");
   });
 });

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -1040,6 +1040,38 @@ describe("sanitizeZone — room music box", () => {
     });
   });
 
+  it("serializes the keepsake image between description and lyrics, omitting a blank one", () => {
+    const world = makeWorld({
+      rooms: {
+        room_a: {
+          title: "A",
+          description: "A",
+          musicBox: {
+            file: "lullaby.mp3",
+            title: "Scuttlefish's Lullaby",
+            description: "A soft tune.",
+            image: "items/lyric-sheet-lullaby.png",
+            lyrics: ["the scuttlefish sings soft and slow"],
+          },
+        },
+        room_b: {
+          title: "B",
+          description: "B",
+          musicBox: { file: "keeper.mp3", image: "   " },
+        },
+      },
+    });
+
+    const result = sanitizeZone(world);
+    const boxA = result.rooms["room_a"]!.musicBox!;
+    expect(Object.keys(boxA)).toEqual([
+      "title", "file", "description", "image", "lyrics",
+    ]);
+    expect(boxA.image).toBe("items/lyric-sheet-lullaby.png");
+    // A blank image is dropped, never serialized as an empty key.
+    expect(result.rooms["room_b"]!.musicBox).toEqual({ file: "keeper.mp3" });
+  });
+
   it("drops a blank-file music box entirely", () => {
     const world = makeWorld({
       rooms: {

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
+import { parseDocument, stringify } from "yaml";
 import { sanitizeZone, sanitizeId, buildIdRemap } from "../sanitizeZone";
-import type { ExitValue, WorldFile } from "@/types/world";
+import type { ExitValue, ItemFile, WorldFile } from "@/types/world";
 
 // ─── sanitizeId ───────────────────────────────────────────────────
 
@@ -1056,5 +1057,29 @@ describe("sanitizeZone — room music box", () => {
     const world = makeWorld();
     const result = sanitizeZone(world);
     expect(result.rooms["room_a"]!.musicBox).toBeUndefined();
+  });
+});
+
+describe("sanitizeZone — keepsake items", () => {
+  it("round-trips a keepsake item through YAML with its type and soulbound flag", () => {
+    const world = makeWorld({
+      items: {
+        lyric_sheet: {
+          displayName: "a lyric sheet for \"The Word of Ambon\"",
+          description: "When the lanterns lean in low,\nthe teacups start to sway.",
+          itemType: "keepsake",
+          questItem: true,
+          basePrice: 0,
+        },
+      },
+    });
+
+    const sanitized = sanitizeZone(world);
+    const reparsed = parseDocument(stringify(sanitized)).toJS() as WorldFile;
+    const item = reparsed.items!["lyric_sheet"] as ItemFile;
+
+    expect(item.itemType).toBe("keepsake");
+    expect(item.questItem).toBe(true);
+    expect(item.description).toContain("\n");
   });
 });

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -844,4 +844,21 @@ describe("validateZone", () => {
       expect(issues).toHaveLength(0);
     });
   });
+
+  describe("item types", () => {
+    it("accepts the keepsake item type", () => {
+      const world = makeValidWorld();
+      world.items!.charm = { displayName: "Lyric Sheet", itemType: "keepsake", basePrice: 0 };
+      const issues = errors(validateZone(world));
+      expect(issues).toHaveLength(0);
+    });
+
+    it("errors on an unknown item type", () => {
+      const world = makeValidWorld();
+      // Cast through unknown: the union forbids this value, but authored YAML can.
+      world.items!.charm = { displayName: "Junk", itemType: "trinket" as unknown as never };
+      const issues = errors(validateZone(world));
+      expect(issues.some((i) => i.message.includes("is not a known type"))).toBe(true);
+    });
+  });
 });

--- a/creator/src/lib/assetRefs.ts
+++ b/creator/src/lib/assetRefs.ts
@@ -173,7 +173,12 @@ function normalizeJukeboxRefs(jukebox: JukeboxSongFile[] | undefined): JukeboxSo
 function normalizeMusicBoxRef(musicBox: MusicBoxFile | undefined): MusicBoxFile | undefined {
   if (!musicBox) return undefined;
   const file = normalizeAssetRef(musicBox.file);
-  return file ? { ...musicBox, file } : undefined;
+  if (!file) return undefined;
+  const image = normalizeAssetRef(musicBox.image);
+  const next = { ...musicBox, file };
+  if (image) next.image = image;
+  else delete next.image;
+  return next;
 }
 
 function mapEntries<T>(

--- a/creator/src/lib/audioLibrary.ts
+++ b/creator/src/lib/audioLibrary.ts
@@ -209,10 +209,18 @@ export function enrichJukeboxSongs(
     }
     if (room.musicBox) {
       const enriched = enrichSong(room.musicBox, meta);
-      // The music box never carries a cost — it's free; drop any stray one.
-      const box: MusicBoxFile | undefined = enriched
-        ? (({ cost: _cost, ...rest }) => rest)(enriched)
-        : undefined;
+      let box: MusicBoxFile | undefined;
+      if (enriched) {
+        // The music box never carries a cost — it's free; drop any stray one.
+        const { cost: _cost, lyrics, ...rest } = enriched;
+        box = rest;
+        // The keepsake image is zone-side authoring (not library metadata), so
+        // it survives enrichment like a jukebox song's cost — re-inserted before
+        // lyrics to match the server's authored key order.
+        const image = room.musicBox.image;
+        if (typeof image === "string" && image.trim()) box.image = image;
+        if (lyrics) box.lyrics = lyrics;
+      }
       nextRoom = box
         ? { ...nextRoom, musicBox: box }
         : { ...nextRoom, musicBox: undefined };

--- a/creator/src/lib/entityPrompts.ts
+++ b/creator/src/lib/entityPrompts.ts
@@ -476,6 +476,44 @@ Still life of ${typeHint} called "${item.displayName}"${slotDesc}.${desc} ${tail
   return withZoneVibe(inner, zoneVibe);
 }
 
+/** Build a context description for a music box's lyric-sheet keepsake. */
+export function musicBoxKeepsakeContext(title: string, artist?: string): string {
+  const named = title.trim() ? `"${title.trim()}"` : "an untitled tune";
+  const by = artist && artist.trim() ? ` by ${artist.trim()}` : "";
+  return [
+    `Lyric-sheet keepsake — a collectible souvenir of the song ${named}${by}, minted when a player winds the room's music box.`,
+    "A single printed sheet bearing the song's title and lyrics, kept as a memento.",
+    "Composition: centered, suitable for an inventory icon",
+  ].join("\n");
+}
+
+/** Build a full prompt for a music box's lyric-sheet keepsake image. */
+export function musicBoxKeepsakePrompt(
+  title: string,
+  artist?: string,
+  style: ArtStyle = "gentle_magic",
+  zoneVibe?: string | null,
+): string {
+  const opts = paletteOpts(zoneVibe);
+  const preamble = getPreamble(style, "worldbuilding", opts);
+  const named = title.trim() ? `"${title.trim()}"` : "an old tune";
+  const by = artist && artist.trim() ? ` by ${artist.trim()}` : "";
+  const subject = `a single lyric sheet — a worn sheet of paper printed with the title and lyrics of the song ${named}${by}, the keepsake a player keeps after winding a music box`;
+
+  const tail =
+    style === "gentle_magic"
+      ? `Rendered as a gently luminous object resting on a soft surface, ambient lavender and pale blue light diffusing around it, subtle floating motes of warm gold, dreamlike quality, painterly, centered composition suitable for an inventory icon`
+      : `Rendered as a glowing object floating in deep cosmic indigo void, aurum-gold light emanating from its edges, blue-violet ambient fill, ornate and detailed, painterly, centered composition suitable for an inventory icon`;
+
+  const inner = `${FORMAT_BY_TYPE.item}. ${preamble}
+
+Still life of ${subject}. ${tail}
+
+${getStyleSuffix("worldbuilding", opts)}`;
+
+  return withZoneVibe(inner, zoneVibe);
+}
+
 /** Build a full prompt for a shop image. */
 export function shopPrompt(_shopId: string, shop: ShopFile, style: ArtStyle = "gentle_magic"): string {
   const preamble = getPreamble(style, "worldbuilding");

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -183,8 +183,9 @@ function normalizeJukebox(jukebox?: JukeboxSongFile[]): JukeboxSongFile[] | unde
 }
 
 /** Rebuild the music box in the server contract's key order (title, file,
- *  durationSeconds, artist, description, lyrics — no cost; it's always free),
- *  omitting empty optional fields. A box with no audio file is dropped entirely. */
+ *  durationSeconds, artist, description, image, lyrics — no cost; it's always
+ *  free), omitting empty optional fields. A box with no audio file is dropped
+ *  entirely. */
 function normalizeMusicBox(box?: MusicBoxFile): MusicBoxFile | undefined {
   if (!box || !box.file || !box.file.trim()) return undefined;
   const out: MusicBoxFile =
@@ -196,6 +197,7 @@ function normalizeMusicBox(box?: MusicBoxFile): MusicBoxFile | undefined {
   }
   if (typeof box.artist === "string" && box.artist.trim()) out.artist = box.artist;
   if (typeof box.description === "string" && box.description.trim()) out.description = box.description;
+  if (typeof box.image === "string" && box.image.trim()) out.image = box.image;
   if (Array.isArray(box.lyrics)) {
     const lines = box.lyrics
       .map((line) => (typeof line === "string" ? line.trim() : ""))

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -168,6 +168,10 @@ export interface MusicBoxFile {
   durationSeconds?: number;
   artist?: string;
   description?: string;
+  /** Optional art for the lyric-sheet keepsake minted on the first play
+   *  (AmbonMUD #1341). An image filename resolved against the zone images base
+   *  (like room/item art); omit to fall back to the client's generic item default. */
+  image?: string;
   lyrics?: string[];
 }
 

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -478,8 +478,14 @@ export interface BtNodeFile {
  * Broad server-assigned item category. When omitted, the server infers it from
  * slot / consumable / basePrice. `questItem: true` always resolves to "quest"
  * regardless of this field.
+ *
+ * `keepsake` is a souvenir category: soulbound like a quest item (cannot be
+ * dropped, sold, traded, banked, or mailed) but shelved under its own
+ * "Keepsakes" heading in the inventory rather than "Quest". The server mints
+ * these automatically — e.g. a lyric sheet on the first play of a music-box
+ * song — but they can also be authored by hand here.
  */
-export type ItemType = "equipment" | "consumable" | "quest" | "treasure" | "misc";
+export type ItemType = "equipment" | "consumable" | "quest" | "treasure" | "misc" | "keepsake";
 
 export const ITEM_TYPES: readonly ItemType[] = [
   "equipment",
@@ -487,6 +493,7 @@ export const ITEM_TYPES: readonly ItemType[] = [
   "quest",
   "treasure",
   "misc",
+  "keepsake",
 ] as const;
 
 export interface ItemFile {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -485,15 +485,15 @@ export interface BtNodeFile {
  * these automatically — e.g. a lyric sheet on the first play of a music-box
  * song — but they can also be authored by hand here.
  */
-export type ItemType = "equipment" | "consumable" | "quest" | "treasure" | "misc" | "keepsake";
+export type ItemType = "equipment" | "consumable" | "quest" | "treasure" | "keepsake" | "misc";
 
 export const ITEM_TYPES: readonly ItemType[] = [
   "equipment",
   "consumable",
   "quest",
   "treasure",
-  "misc",
   "keepsake",
+  "misc",
 ] as const;
 
 export interface ItemFile {


### PR DESCRIPTION
## What

Arcanum-side support for the music-box lyric-sheet souvenir, the sibling of two AmbonMUD server changes:

1. **The KEEPSAKE item type** (server PR #1340) — a soulbound souvenir minted on the first play of a music-box song.
2. **Per-music-box keepsake art** (server PR #1341) — an optional `image` on a room's `musicBox` block that becomes the minted keepsake's picture.

Keepsakes are soulbound like quest items (can't be dropped, sold, traded, banked, or mailed) but live under their own "Keepsakes" heading in the inventory rather than "Quest". The server mints them automatically from the song's existing title/artist/lyrics metadata. The new `image` field is the one piece of per-song authoring: point a music box at its own lyric-sheet art, or omit it to fall back to the client's generic item default.

## Changes

### KEEPSAKE item type
- **`types/world.ts`** — add `"keepsake"` to the `ItemType` union and `ITEM_TYPES` array; document the soulbound-souvenir semantics. The item-type dropdown (data-driven) and `validateZone` (checks against `ITEM_TYPES`) both pick it up automatically.
- **`ItemEditor.tsx`** — contextual hint under the Item Type field when `keepsake` is selected, noting it's soulbound and gets its own inventory category.

### Per-music-box keepsake image (mirrors server #1341)
- **`types/world.ts`** — `MusicBoxFile` gains an optional `image` field.
- **`sanitizeZone.ts`** — serialize `image` in the server's authored key order (between `description` and `lyrics`); blank values omitted.
- **`assetRefs.ts`** — normalize the keepsake image ref (strip local filesystem paths, collect it for R2 sync) exactly like every other image.
- **`audioLibrary.ts`** — preserve the authored `image` through save-time library enrichment; it's zone-side authoring (like a jukebox song's `cost`), not library metadata, so it survives the rebuild and stays before `lyrics`.
- **`RoomPanel.tsx`** — the music-box editor shows an `EntityArtGenerator` for the keepsake art once a song is chosen, with a dedicated lyric-sheet prompt/context in `entityPrompts.ts`.

### Tests
- `validateZone` accepts `keepsake` and still rejects unknown types; `sanitizeZone` round-trips a keepsake item through YAML serialize→parse.
- `sanitizeZone` serializes the music-box `image` between `description` and `lyrics` and omits a blank one.
- `assetRefs` normalizes the music-box audio file + keepsake image refs and never grows an undefined `image` key.
- `audioLibrary` preserves the authored keepsake image through enrichment, in contract key order.

## Verification

- `bunx tsc --noEmit` — clean
- `bun run test` — 2209 passed

## Notes / scope

This is the **creator (authoring)** half. The server-side KEEPSAKE `ItemType`, the mint-on-first-play + dedup hook in `MusicBoxHandler`, the `image` threading through `WorldLoader.parseMusicBox()` / `lyricSheet()`, the web-v3 "Keepsakes" inventory category, and the `white-space: pre-line` lyric rendering live in the AmbonMUD repo (PRs #1340 and #1341).
