### PR TITLE
feat: one-click Enhance & Conjure button in the inline art forge

### DIFF
--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -296,7 +296,7 @@ export function EntityArtGenerator({
    *  before we read context props. */
   const flushPendingCommits = () => new Promise<void>((r) => setTimeout(r, 0));
 
-  const handleGenerate = async () => {
+  const runConjure = async (presetPrompt: string | null, presetEnhanced: boolean) => {
     setStage("generating");
     setError(null);
     try {
@@ -306,7 +306,7 @@ export function EntityArtGenerator({
       const ec = entityContextRef.current;
       const fh = framingHintRef.current;
       const freshBase = getPromptRef.current(artStyle);
-      const promptToUse = editedPrompt ?? freshBase;
+      const promptToUse = presetPrompt ?? editedPrompt ?? freshBase;
 
       const selectedModel = modelOverride === "__custom__"
         ? customModel.trim()
@@ -325,7 +325,7 @@ export function EntityArtGenerator({
         applyReferences(text, useReferenceStore.getState().resolver()).prompt;
 
       let finalPrompt = promptToUse;
-      if (enhanced) {
+      if (presetEnhanced || enhanced) {
         finalPrompt = expandLocal(promptToUse);
         setLastEnhancedPrompt(finalPrompt);
       } else if (hasLlmKey) {
@@ -370,7 +370,11 @@ export function EntityArtGenerator({
     }
   };
 
-  const handleEnhance = async () => {
+  const handleGenerate = () => {
+    void runConjure(null, false);
+  };
+
+  const runEnhance = async (): Promise<string | null> => {
     setEnhancing(true);
     setError(null);
     try {
@@ -382,11 +386,23 @@ export function EntityArtGenerator({
       const enhancedText = await enhancePromptWith(promptToEnhance, ec, fh);
       setEditedPrompt(enhancedText);
       setEnhanced(true);
+      return enhancedText;
     } catch (e) {
       setError(String(e));
+      return null;
     } finally {
       setEnhancing(false);
     }
+  };
+
+  const handleEnhance = () => {
+    void runEnhance();
+  };
+
+  const handleEnhanceAndConjure = async () => {
+    const enhancedText = await runEnhance();
+    if (enhancedText === null) return;
+    await runConjure(enhancedText, true);
   };
 
   const handlePickImage = async () => {
@@ -700,11 +716,23 @@ export function EntityArtGenerator({
               <button
                 className="art-btn art-btn--ember art-btn--big"
                 onClick={handleGenerate}
-                disabled={removingBg}
+                disabled={removingBg || enhancing}
               >
                 <span className="art-btn__rune">⚒</span>
                 <span>Conjure</span>
                 <span className="art-btn__sub">⌘↵</span>
+              </button>
+            )}
+
+            {AI_ENABLED && hasApiKey && hasLlmKey && stage === "idle" && (
+              <button
+                className="art-btn art-btn--ghost art-btn--big"
+                onClick={handleEnhanceAndConjure}
+                disabled={removingBg || enhancing}
+                title="Refine the prompt with AI, then conjure in one step"
+              >
+                <span className="art-btn__rune">✶</span>
+                <span>{enhancing ? "Enhancing…" : "Enhance & Conjure"}</span>
               </button>
             )}
 


### PR DESCRIPTION
## What

Adds an **Enhance & Conjure** button beneath the Conjure button in `EntityArtGenerator` — the integrated inline art forge that's reused across ~25 editors (zone rooms, lore articles, config classes/races/abilities/pets, player sprites, etc.). One click refines the prompt with the LLM and immediately generates, so the enhance → conjure flow no longer needs two clicks (and can't stall in between).

This mirrors the **Enhance & Render** button added to the modal asset generator in #301.

## Why it's not redundant with Conjure

A bare **Conjure** in this component *already* auto-enhances the prompt internally when an LLM key is present — but it does so silently and discards the enhanced text. The new combined button writes the enhanced prompt back into the editable prompt field, so you can **see it, tweak it, and it's reused on reroll**. It also closes the two-click gap for the explicit enhance-then-conjure workflow.

## How

- Refactored `handleGenerate`/`handleEnhance` into `runConjure(presetPrompt, presetEnhanced)` / `runEnhance()` cores.
- `runEnhance` returns the enhanced string so `handleEnhanceAndConjure` feeds it straight into `runConjure` — avoids reading stale React state when enhance and conjure run back-to-back.
- Thin `handleGenerate`/`handleEnhance` wrappers preserve all existing call sites (Conjure button, reroll, retry, ⌘↵ shortcut, Enhance button).
- Button gated on `hasLlmKey` (enhancement needs an LLM provider) and disabled during enhancing. Uses existing `art-btn--ghost art-btn--big` styling so it reads as a secondary action under the ember Conjure.

## Notes

- `bunx tsc --noEmit` clean.
- Branched fresh off `origin/main` (which had since merged #302 Reference Canon, touching this same file — the refactor sits cleanly on top of its reference-expansion logic).