### PR TITLE
feat: batch art covers music-box keepsake images

### DIFF
--- a/creator/src/components/zone/BatchArtGenerator.tsx
+++ b/creator/src/components/zone/BatchArtGenerator.tsx
@@ -1,9 +1,10 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useMemo } from "react";
 import { AI_ENABLED } from "@/lib/featureFlags";
 import type { WorldFile } from "@/types/world";
 import { ART_STYLE_LABELS } from "@/lib/arcanumPrompts";
 import { useAssetStore } from "@/stores/assetStore";
 import { useVibeStore } from "@/stores/vibeStore";
+import { buildAudioMetaIndex } from "@/lib/audioLibrary";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 import { ActionButton } from "@/components/ui/FormWidgets";
 import {
@@ -26,8 +27,10 @@ export function BatchArtGenerator({
 }: BatchArtGeneratorProps) {
   const artStyle = useAssetStore((s) => s.artStyle);
   const settings = useAssetStore((s) => s.settings);
+  const assets = useAssetStore((s) => s.assets);
   const vibe = useVibeStore((s) => s.vibes.get(zoneId) ?? "");
-  const [targets, setTargets] = useState(() => collectTargets(world));
+  const audioMeta = useMemo(() => buildAudioMetaIndex(assets), [assets]);
+  const [targets, setTargets] = useState(() => collectTargets(world, audioMeta));
   const [running, setRunning] = useState(false);
   const [bgRemoval, setBgRemoval] = useState<{ done: number; total: number } | null>(null);
   const [concurrency, setConcurrency] = useState(settings?.batch_concurrency ?? 5);

--- a/creator/src/lib/__tests__/batchArt.test.ts
+++ b/creator/src/lib/__tests__/batchArt.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import type { WorldFile } from "@/types/world";
+import type { AudioTrackMeta } from "@/lib/audioLibrary";
+import { collectTargets, getTargetPrompt, getTargetContext, assetTypeForKind } from "@/lib/batchArt";
+
+function makeWorld(rooms: WorldFile["rooms"]): WorldFile {
+  return { zone: "parlor_zone", startRoom: "parlor_a", rooms };
+}
+
+const meta: Map<string, AudioTrackMeta> = new Map([
+  [
+    "lullaby.mp3",
+    { name: "Scuttlefish's Lullaby", artist: "Scuttlefish", description: "", lyrics: "", durationSeconds: 60 },
+  ],
+]);
+
+describe("collectTargets — music box keepsakes", () => {
+  it("adds a keepsake target per music box, resolving the song from the audio library", () => {
+    const world = makeWorld({
+      parlor_a: { title: "Parlor A", description: "", musicBox: { file: "lullaby.mp3" } },
+      parlor_b: { title: "Parlor B", description: "", musicBox: { file: "waltz.mp3", image: "items/sheet.png" } },
+      study: { title: "Study", description: "" },
+      ghost: { title: "Ghost", description: "", musicBox: { file: "   " } },
+    });
+
+    const keepsakes = collectTargets(world, meta).filter((t) => t.kind === "musicBoxKeepsake");
+    expect(keepsakes.map((t) => t.id)).toEqual(["parlor_a", "parlor_b"]);
+
+    const a = keepsakes.find((t) => t.id === "parlor_a")!;
+    // Library metadata names the keepsake and seeds the prompt.
+    expect(a.label).toBe("Keepsake: Scuttlefish's Lullaby");
+    expect(a.song).toEqual({ title: "Scuttlefish's Lullaby", artist: "Scuttlefish" });
+    // No authored image yet → selected by default as "missing".
+    expect(a.hasExisting).toBe(false);
+    expect(a.checked).toBe(true);
+
+    const b = keepsakes.find((t) => t.id === "parlor_b")!;
+    // Not in the library → label falls back to the filename, and an existing
+    // image means it isn't selected by default.
+    expect(b.label).toBe("Keepsake: waltz.mp3");
+    expect(b.hasExisting).toBe(true);
+    expect(b.checked).toBe(false);
+  });
+
+  it("falls back to the authored title when the library has no entry", () => {
+    const world = makeWorld({
+      parlor: { title: "Parlor", description: "", musicBox: { file: "waltz.mp3", title: "A Borrowed Waltz" } },
+    });
+    const keepsake = collectTargets(world).find((t) => t.kind === "musicBoxKeepsake")!;
+    expect(keepsake.label).toBe("Keepsake: A Borrowed Waltz");
+    expect(keepsake.song?.title).toBe("A Borrowed Waltz");
+  });
+
+  it("routes keepsake prompt/context through the lyric-sheet helpers", () => {
+    const world = makeWorld({
+      parlor_a: { title: "Parlor A", description: "", musicBox: { file: "lullaby.mp3" } },
+    });
+    const target = collectTargets(world, meta).find((t) => t.kind === "musicBoxKeepsake")!;
+    expect(getTargetPrompt(target, world, "gentle_magic")).toContain("Scuttlefish's Lullaby");
+    expect(getTargetContext(target, world)).toContain("Scuttlefish's Lullaby");
+    expect(assetTypeForKind("musicBoxKeepsake")).toBe("item");
+  });
+});

--- a/creator/src/lib/batchArt.ts
+++ b/creator/src/lib/batchArt.ts
@@ -9,7 +9,10 @@ import {
   dungeonContext,
   dungeonRoomTemplatePrompt,
   dungeonRoomTemplateContext,
+  musicBoxKeepsakePrompt,
+  musicBoxKeepsakeContext,
 } from "@/lib/entityPrompts";
+import type { AudioTrackMeta } from "@/lib/audioLibrary";
 import {
   getNegativePrompt,
   getEnhanceSystemPrompt,
@@ -30,6 +33,7 @@ export function assetTypeForKind(kind: string): string {
   if (kind === "shop") return "background";
   if (kind === "dungeon") return "background";
   if (kind === "dungeonRoom") return "background";
+  if (kind === "musicBoxKeepsake") return "item";
   return "background";
 }
 
@@ -42,9 +46,16 @@ export interface BatchTarget {
   status: "pending" | "generating" | "done" | "error";
   result?: GeneratedImage;
   error?: string;
+  /** For `musicBoxKeepsake` targets: the song the lyric-sheet commemorates,
+   *  resolved from the audio library at collect time (the prompt needs it, and
+   *  an in-editor music box is a bare `{ file }` until save-time enrichment). */
+  song?: { title: string; artist?: string };
 }
 
-export function collectTargets(world: WorldFile): BatchTarget[] {
+export function collectTargets(
+  world: WorldFile,
+  audioMeta?: Map<string, AudioTrackMeta>,
+): BatchTarget[] {
   const targets: BatchTarget[] = [];
 
   for (const [id, room] of Object.entries(world.rooms)) {
@@ -56,6 +67,24 @@ export function collectTargets(world: WorldFile): BatchTarget[] {
       checked: !hasImage,
       hasExisting: hasImage,
       status: "pending",
+    });
+  }
+
+  for (const [id, room] of Object.entries(world.rooms)) {
+    const box = room.musicBox;
+    if (!box?.file?.trim()) continue;
+    const meta = audioMeta?.get(box.file);
+    const title = meta?.name ?? box.title ?? "";
+    const songLabel = title.trim() || box.file;
+    const hasImage = !!box.image;
+    targets.push({
+      kind: "musicBoxKeepsake",
+      id,
+      label: `Keepsake: ${songLabel}`,
+      checked: !hasImage,
+      hasExisting: hasImage,
+      status: "pending",
+      song: { title, artist: meta?.artist ?? box.artist },
     });
   }
 
@@ -158,6 +187,9 @@ export function getTargetPrompt(
   if (kind === "room") {
     return roomPrompt(id, world.rooms[id]!, style, zoneVibe);
   }
+  if (kind === "musicBoxKeepsake") {
+    return musicBoxKeepsakePrompt(target.song?.title ?? "", target.song?.artist, style, zoneVibe);
+  }
   if (kind === "dungeon" && world.dungeon) {
     return dungeonPrompt(world.dungeon, style);
   }
@@ -180,6 +212,9 @@ export function getTargetContext(
   const { kind, id } = target;
   if (kind === "room") {
     return roomContext(id, world.rooms[id]!);
+  }
+  if (kind === "musicBoxKeepsake") {
+    return musicBoxKeepsakeContext(target.song?.title ?? "", target.song?.artist);
   }
   if (kind === "dungeon" && world.dungeon) {
     return dungeonContext(world.dungeon, world.zone);
@@ -294,12 +329,14 @@ export async function runBatchArtGeneration(
 
         callbacks.onTargetUpdate(idx, { status: "done", result: image });
 
-        const variantGroup = `${target.kind}:${zoneId}:${target.id}`;
-        const batchContext = {
-          zone: zoneId,
-          entity_type: target.kind,
-          entity_id: target.id,
-        };
+        // Keepsakes share the per-room music-box editor's manifest identity
+        // (entity_type "item", entity_id "musicbox:<roomId>") so variants from
+        // either authoring path land in the same group.
+        const batchContext =
+          target.kind === "musicBoxKeepsake"
+            ? { zone: zoneId, entity_type: "item", entity_id: `musicbox:${target.id}` }
+            : { zone: zoneId, entity_type: target.kind, entity_id: target.id };
+        const variantGroup = `${batchContext.entity_type}:${zoneId}:${batchContext.entity_id}`;
         await callbacks
           .acceptAsset(
             image,
@@ -333,6 +370,18 @@ export async function runBatchArtGeneration(
               [id]: { ...cur.rooms[id]!, image: fileName },
             },
           };
+        } else if (kind === "musicBoxKeepsake") {
+          const room = cur.rooms[id];
+          if (room?.musicBox) {
+            const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
+            worldRef.current = {
+              ...cur,
+              rooms: {
+                ...cur.rooms,
+                [id]: { ...room, musicBox: { ...room.musicBox, image: fileName } },
+              },
+            };
+          }
         } else if (kind === "dungeon" && cur.dungeon) {
           const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
           worldRef.current = {
@@ -400,19 +449,32 @@ export async function runBatchArtGeneration(
       const entry = await promise;
       if (entry) {
         const cur = worldRef.current;
-        const collection =
-          kind === "mob" ? "mobs" : kind === "item" ? "items" : kind === "shop" ? "shops" : null;
-        if (collection) {
-          const entities = (cur as Record<string, unknown>)[collection] as
-            Record<string, Record<string, unknown>> | undefined;
-          if (entities?.[id]) {
+        if (kind === "musicBoxKeepsake") {
+          const room = cur.rooms[id];
+          if (room?.musicBox) {
             worldRef.current = {
               ...cur,
-              [collection]: {
-                ...entities,
-                [id]: { ...entities[id], image: entry.file_name },
+              rooms: {
+                ...cur.rooms,
+                [id]: { ...room, musicBox: { ...room.musicBox, image: entry.file_name } },
               },
             };
+          }
+        } else {
+          const collection =
+            kind === "mob" ? "mobs" : kind === "item" ? "items" : kind === "shop" ? "shops" : null;
+          if (collection) {
+            const entities = (cur as Record<string, unknown>)[collection] as
+              Record<string, Record<string, unknown>> | undefined;
+            if (entities?.[id]) {
+              worldRef.current = {
+                ...cur,
+                [collection]: {
+                  ...entities,
+                  [id]: { ...entities[id], image: entry.file_name },
+                },
+              };
+            }
           }
         }
       }

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -298,6 +298,7 @@ export const ENTITY_DIMENSIONS: Record<string, { width: number; height: number; 
   mob: { width: 1024, height: 1024, label: "1024×1024 (Portrait)" },
   pet: { width: 1024, height: 1024, label: "1024×1024 (Portrait)" },
   item: { width: 1024, height: 1024, label: "1024×1024 (Icon)" },
+  musicBoxKeepsake: { width: 1024, height: 1024, label: "1024×1024 (Icon)" },
   gathering_node: { width: 1024, height: 1024, label: "1024×1024 (Sprite)" },
   lever_plate: { width: 1024, height: 1024, label: "1024×1024 (Sprite)" },
   lever_handle: { width: 1024, height: 1024, label: "1024×1024 (Sprite)" },


### PR DESCRIPTION
## What

Teach the **Batch Art** generator to fill missing music-box **keepsake** images. Follow-up to the per-song keepsake art landed in #300.

Before this, `collectTargets` only enumerated rooms, mobs, items, gathering nodes, shops, and dungeon art — music boxes were absent. So an author who bulk-generated a zone's art got everything filled *except* the lyric-sheet souvenirs, which kept falling back to the client's generic item icon until each room was visited and generated by hand.

## Changes

- **`batchArt.ts`**
  - New `musicBoxKeepsake` target kind: one per room that has a music box, selected by default when `musicBox.image` is empty (the existing "missing art" rule).
  - The song title/artist are resolved from the audio library **at collect time** and stashed on the target. An in-editor music box is a bare `{ file }` until save-time enrichment, so its `title`/`artist` aren't on the world object yet — resolving here means batch-generated sheets are song-specific, not generic. Falls back to the authored `title`, then the filename.
  - Prompt/context route through the `musicBoxKeepsakePrompt` / `musicBoxKeepsakeContext` helpers from #300; asset type is `item`.
  - Generated art writes back to `room.musicBox.image` in both the main pass and the post-background-removal pass.
  - Manifest identity matches the per-room editor (`entity_type: "item"`, `entity_id: "musicbox:<roomId>"`) so variants generated from either authoring path share one group.
- **`BatchArtGenerator.tsx`** — builds the audio-meta index from the asset store and passes it to `collectTargets`.
- **`types/assets.ts`** — `musicBoxKeepsake` dimensions entry (1024×1024 icon).
- **Tests** — new `batchArt.test.ts`: target collection (present/missing/blank-file/no-box), library-vs-authored title fallback, and prompt/context routing.

## Verification

- `bunx tsc --noEmit` — clean
- `bun run test` — 2238 passed (3 new)

## Notes

Purely the creator authoring side; no server contract change. The keepsake image still resolves against the zone images base on the server (AmbonMUD #1341) and only appears in-game once the zone is published and the image syncs to R2.
