### PR TITLE
feat: edit racial passive abilities on race definitions

### DIFF
--- a/creator/src/components/config/races/RaceEditor.tsx
+++ b/creator/src/components/config/races/RaceEditor.tsx
@@ -1,12 +1,20 @@
 ﻿import { useState } from "react";
-import type { RaceDefinitionConfig } from "@/types/config";
+import type { RaceDefinitionConfig, RacialAbilityConfig, RacialAbilityKind } from "@/types/config";
+import { RACIAL_ABILITY_KINDS, RACIAL_ABILITY_TRIGGERS } from "@/types/config";
 import type { StatMap } from "@/types/world";
-import { TextInput, CommitTextarea, cx } from "@/components/ui/FormWidgets";
+import {
+  TextInput,
+  CommitTextarea,
+  NumberInput,
+  SelectInput,
+  cx,
+} from "@/components/ui/FormWidgets";
 import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
 import { EnhanceDescriptionButton } from "@/components/editors/EditorShared";
 import { getBackstoryEnhancePrompt } from "@/lib/lorePrompts";
 import { composePrompt, type ArtStyle } from "@/lib/arcanumPrompts";
 import { useAssetStore } from "@/stores/assetStore";
+import { useConfigStore } from "@/stores/configStore";
 import { useImageSrc } from "@/lib/useImageSrc";
 import { useStatMods } from "@/lib/useStatMods";
 import { SectionCard } from "@/components/ui/SectionCard";
@@ -97,10 +105,337 @@ export function RaceEditor({
         </div>
       </div>
 
+      <RacialAbilityCard
+        ability={race.racialAbility}
+        onChange={(racialAbility) => patch({ racialAbility })}
+      />
+
       <SectionCard title="Concept Art">
         <ConceptArt id={id} race={race} patch={patch} buildContext={buildContext} />
       </SectionCard>
     </div>
+  );
+}
+
+// ─── Racial Passive Ability ────────────────────────────────────────
+
+const ABILITY_KIND_LABELS: Record<RacialAbilityKind, string> = {
+  PYRAE_IMMOLATE: "Pyrae · Immolation — AoE flame on low HP",
+  AURELIA_DAZZLE: "Aurelia · Dazzling Burst — stun enemies on low HP",
+  MYCORAE_SPORES: "Mycorae · Spore Burst — summon tank mushrooms on low HP",
+  ARCHAE_DRENGARIAE: "Archae · Call the Drengariae — summon a DPS soldier on low HP",
+  OPHIRAE_WRATH: "Ophirae · Draconic Wrath — damage buff on low HP",
+  KITSARAE_REVERSAL: "Kitsarae · Reversal — nullify a lethal blow and heal",
+  LUSTRIAE_TIMESLIP: "Lustriae · Timeslip — extra attack on a lethal blow",
+  LITHAE_STONEFORM: "Lithae · Stone Form — petrify on a lethal blow",
+  AETHERAE_PHASE: "Aetherae · Phase Shift — phase out of a lethal blow",
+};
+
+interface KindFields {
+  triggerHealthPct?: boolean;
+  aoeDamagePctOfMaxHp?: boolean;
+  damageMultiplier?: boolean;
+  buffDurationMs?: boolean;
+  stunStatusId?: boolean;
+  petTemplateKey?: boolean;
+  petCounts?: boolean;
+  petDurationMs?: boolean;
+  regenPctOfMaxHp?: boolean;
+  stoneStatusId?: boolean;
+  stoneDurationMs?: boolean;
+  phaseTicks?: boolean;
+}
+
+const KIND_FIELDS: Record<RacialAbilityKind, KindFields> = {
+  PYRAE_IMMOLATE: { triggerHealthPct: true, aoeDamagePctOfMaxHp: true },
+  AURELIA_DAZZLE: { triggerHealthPct: true, stunStatusId: true },
+  MYCORAE_SPORES: { triggerHealthPct: true, petTemplateKey: true, petCounts: true, petDurationMs: true },
+  ARCHAE_DRENGARIAE: { triggerHealthPct: true, petTemplateKey: true, petDurationMs: true },
+  OPHIRAE_WRATH: { triggerHealthPct: true, damageMultiplier: true, buffDurationMs: true },
+  KITSARAE_REVERSAL: {},
+  LUSTRIAE_TIMESLIP: {},
+  LITHAE_STONEFORM: { regenPctOfMaxHp: true, stoneStatusId: true, stoneDurationMs: true },
+  AETHERAE_PHASE: { phaseTicks: true },
+};
+
+function RacialAbilityCard({
+  ability,
+  onChange,
+}: {
+  ability: RacialAbilityConfig | undefined;
+  onChange: (ability: RacialAbilityConfig | undefined) => void;
+}) {
+  const config = useConfigStore((s) => s.config);
+  const statusEffects = config?.statusEffects ?? {};
+  const pets = config?.pets ?? {};
+
+  const stunOptions = Object.entries(statusEffects)
+    .filter(([, def]) => def.effectType === "stun")
+    .map(([key]) => ({ value: key, label: key }));
+  const rootOptions = Object.entries(statusEffects)
+    .filter(([, def]) => def.effectType === "root")
+    .map(([key]) => ({ value: key, label: key }));
+  const petOptions = Object.entries(pets).map(([key, def]) => ({
+    value: key,
+    label: def.name ? `${key} (${def.name})` : key,
+  }));
+
+  if (!ability) {
+    return (
+      <SectionCard title="Racial Passive Ability">
+        <div className="flex flex-col items-start gap-2">
+          <p className="text-2xs italic text-text-muted/80">
+            No passive ability. Racial passives fire from combat hooks (a low-health threshold or a
+            would-be-lethal blow) on a long, persisted cooldown.
+          </p>
+          <button
+            type="button"
+            onClick={() =>
+              onChange({ kind: "PYRAE_IMMOLATE", cooldownMs: 120000, triggerHealthPct: 10 })
+            }
+            className="focus-ring inline-flex items-center gap-1 rounded-lg border border-accent/40 bg-accent/10 px-3 py-1.5 text-2xs font-medium text-accent transition hover:bg-accent/20"
+          >
+            <PlusIcon />
+            Add racial ability
+          </button>
+        </div>
+      </SectionCard>
+    );
+  }
+
+  const fields = KIND_FIELDS[ability.kind] ?? {};
+  const trigger = RACIAL_ABILITY_TRIGGERS[ability.kind];
+  const patchAbility = (p: Partial<RacialAbilityConfig>) => onChange({ ...ability, ...p });
+
+  return (
+    <SectionCard
+      title="Racial Passive Ability"
+      actions={
+        <div className="flex items-center gap-2">
+          <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill-soft)] px-2.5 py-1 font-display text-[0.6rem] uppercase tracking-[0.18em] text-text-muted">
+            {trigger === "LOW_HEALTH" ? "Low-health trigger" : "Lethal-blow trigger"}
+          </span>
+          <button
+            type="button"
+            onClick={() => onChange(undefined)}
+            className="focus-ring inline-flex items-center gap-1 rounded-lg border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted transition hover:border-status-error/40 hover:text-status-error"
+          >
+            <TrashIcon className="h-3 w-3" />
+            Remove
+          </button>
+        </div>
+      }
+    >
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <FieldLabel label="Mechanic" required>
+          <SelectInput
+            value={ability.kind}
+            onCommit={(v) => patchAbility({ kind: v as RacialAbilityKind })}
+            options={RACIAL_ABILITY_KINDS.map((k) => ({ value: k, label: ABILITY_KIND_LABELS[k] }))}
+            dense
+          />
+        </FieldLabel>
+        <FieldLabel label="Display Name">
+          <TextInput
+            value={ability.displayName ?? ""}
+            onCommit={(v) => patchAbility({ displayName: v || undefined })}
+            placeholder="Immolation"
+            dense
+          />
+        </FieldLabel>
+        <FieldLabel label="Cooldown (ms)">
+          <NumberInput
+            value={ability.cooldownMs}
+            onCommit={(v) => patchAbility({ cooldownMs: v })}
+            min={0}
+            step={1000}
+            placeholder="120000"
+            dense
+          />
+        </FieldLabel>
+
+        {fields.triggerHealthPct && (
+          <FieldLabel label="Trigger HP %">
+            <NumberInput
+              value={ability.triggerHealthPct}
+              onCommit={(v) => patchAbility({ triggerHealthPct: v })}
+              min={1}
+              max={100}
+              placeholder="10"
+              dense
+            />
+          </FieldLabel>
+        )}
+        {fields.aoeDamagePctOfMaxHp && (
+          <FieldLabel label="AoE damage (× max HP)">
+            <NumberInput
+              value={ability.aoeDamagePctOfMaxHp}
+              onCommit={(v) => patchAbility({ aoeDamagePctOfMaxHp: v })}
+              min={0}
+              step={0.05}
+              placeholder="0.6"
+              dense
+            />
+          </FieldLabel>
+        )}
+        {fields.damageMultiplier && (
+          <FieldLabel label="Damage multiplier">
+            <NumberInput
+              value={ability.damageMultiplier}
+              onCommit={(v) => patchAbility({ damageMultiplier: v })}
+              min={0}
+              step={0.1}
+              placeholder="1.5"
+              dense
+            />
+          </FieldLabel>
+        )}
+        {fields.buffDurationMs && (
+          <FieldLabel label="Buff duration (ms)">
+            <NumberInput
+              value={ability.buffDurationMs}
+              onCommit={(v) => patchAbility({ buffDurationMs: v })}
+              min={0}
+              step={500}
+              placeholder="6000"
+              dense
+            />
+          </FieldLabel>
+        )}
+        {fields.stunStatusId && (
+          <FieldLabel label="Stun status effect" required>
+            <SelectInput
+              value={ability.stunStatusId ?? ""}
+              onCommit={(v) => patchAbility({ stunStatusId: v || undefined })}
+              options={stunOptions}
+              placeholder="— pick a stun effect —"
+              allowEmpty
+              dense
+            />
+          </FieldLabel>
+        )}
+        {fields.petTemplateKey && (
+          <FieldLabel label="Pet template" required>
+            <SelectInput
+              value={ability.petTemplateKey ?? ""}
+              onCommit={(v) => patchAbility({ petTemplateKey: v || undefined })}
+              options={petOptions}
+              placeholder="— pick a pet —"
+              allowEmpty
+              dense
+            />
+          </FieldLabel>
+        )}
+        {fields.petCounts && (
+          <>
+            <FieldLabel label="Pet count (min)">
+              <NumberInput
+                value={ability.petCountMin}
+                onCommit={(v) => patchAbility({ petCountMin: v })}
+                min={1}
+                placeholder="1"
+                dense
+              />
+            </FieldLabel>
+            <FieldLabel label="Pet count (max)">
+              <NumberInput
+                value={ability.petCountMax}
+                onCommit={(v) => patchAbility({ petCountMax: v })}
+                min={1}
+                placeholder="3"
+                dense
+              />
+            </FieldLabel>
+          </>
+        )}
+        {fields.petDurationMs && (
+          <FieldLabel label="Pet duration (ms)">
+            <NumberInput
+              value={ability.petDurationMs}
+              onCommit={(v) => patchAbility({ petDurationMs: v })}
+              min={0}
+              step={500}
+              placeholder="12000"
+              dense
+            />
+          </FieldLabel>
+        )}
+        {fields.regenPctOfMaxHp && (
+          <FieldLabel label="Regen (× max HP)">
+            <NumberInput
+              value={ability.regenPctOfMaxHp}
+              onCommit={(v) => patchAbility({ regenPctOfMaxHp: v })}
+              min={0}
+              step={0.05}
+              placeholder="0.2"
+              dense
+            />
+          </FieldLabel>
+        )}
+        {fields.stoneStatusId && (
+          <FieldLabel label="Stone-form root effect">
+            <SelectInput
+              value={ability.stoneStatusId ?? ""}
+              onCommit={(v) => patchAbility({ stoneStatusId: v || undefined })}
+              options={rootOptions}
+              placeholder="— pick a root effect —"
+              allowEmpty
+              dense
+            />
+          </FieldLabel>
+        )}
+        {fields.stoneDurationMs && (
+          <FieldLabel label="Stone-form duration (ms)">
+            <NumberInput
+              value={ability.stoneDurationMs}
+              onCommit={(v) => patchAbility({ stoneDurationMs: v })}
+              min={0}
+              step={500}
+              placeholder="4000"
+              dense
+            />
+          </FieldLabel>
+        )}
+        {fields.phaseTicks && (
+          <FieldLabel label="Phase rounds">
+            <NumberInput
+              value={ability.phaseTicks}
+              onCommit={(v) => patchAbility({ phaseTicks: v })}
+              min={1}
+              placeholder="2"
+              dense
+            />
+          </FieldLabel>
+        )}
+      </div>
+
+      <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <div className="flex flex-col gap-1">
+          <span className="font-display text-2xs uppercase tracking-wider text-text-muted">
+            Self message
+          </span>
+          <CommitTextarea
+            label=""
+            value={ability.selfMessage ?? ""}
+            onCommit={(v) => patchAbility({ selfMessage: v || undefined })}
+            placeholder="Shown to the triggering player, e.g. 'Your blood boils over — you erupt in flame!'"
+            rows={2}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="font-display text-2xs uppercase tracking-wider text-text-muted">
+            Room message
+          </span>
+          <CommitTextarea
+            label=""
+            value={ability.roomMessage ?? ""}
+            onCommit={(v) => patchAbility({ roomMessage: v || undefined })}
+            placeholder="Broadcast to others in the room. Use {player} for the name."
+            rows={2}
+          />
+        </div>
+      </div>
+    </SectionCard>
   );
 }
 

--- a/creator/src/lib/__tests__/exportMud.test.ts
+++ b/creator/src/lib/__tests__/exportMud.test.ts
@@ -557,3 +557,46 @@ ambonmud:
     expect(parseAppConfigYaml(stringify({ ambonmud: runtime })).akathavae.renounceCostGold).toBe(5000);
   });
 });
+
+describe("racial ability round-trip", () => {
+  it("serializes a race's racialAbility and re-parses it intact", () => {
+    const config: AppConfig = {
+      ...BASE_CONFIG,
+      races: {
+        MYCORAE: {
+          displayName: "Mycorae",
+          racialAbility: {
+            kind: "MYCORAE_SPORES",
+            displayName: "Spore Burst",
+            cooldownMs: 120000,
+            triggerHealthPct: 25,
+            petTemplateKey: "spore_mushroom",
+            petCountMin: 1,
+            petCountMax: 3,
+            petDurationMs: 12000,
+            selfMessage: "You burst, scattering spores!",
+            roomMessage: "{player} bursts in a cloud of spores!",
+          },
+        },
+      },
+    };
+
+    const runtime = buildMonolithicConfigObject(config) as any;
+    const ability = runtime.engine.races.definitions.MYCORAE.racialAbility;
+    expect(ability.kind).toBe("MYCORAE_SPORES");
+    expect(ability.petTemplateKey).toBe("spore_mushroom");
+    expect(ability.petCountMax).toBe(3);
+
+    const reparsed = parseAppConfigYaml(stringify({ ambonmud: runtime }));
+    expect(reparsed.races.MYCORAE.racialAbility).toEqual(config.races.MYCORAE.racialAbility);
+  });
+
+  it("omits racialAbility for races without one", () => {
+    const config: AppConfig = {
+      ...BASE_CONFIG,
+      races: { HUMAN: { displayName: "Human" } },
+    };
+    const runtime = buildMonolithicConfigObject(config) as any;
+    expect("racialAbility" in runtime.engine.races.definitions.HUMAN).toBe(false);
+  });
+});

--- a/creator/src/lib/__tests__/validateConfig.test.ts
+++ b/creator/src/lib/__tests__/validateConfig.test.ts
@@ -530,6 +530,77 @@ describe("validateConfig", () => {
     );
   });
 
+  // ─── Racial abilities ──────────────────────────────────────────
+  it("errors on an unknown racial ability kind", () => {
+    const cfg = {
+      ...BASE_CONFIG,
+      races: { elf: { displayName: "Elf", racialAbility: { kind: "NOPE_KIND" as never } } },
+    };
+    const issues = validateConfig(cfg);
+    expect(issues).toContainEqual(
+      expect.objectContaining({ entity: "race:elf", severity: "error" }),
+    );
+  });
+
+  it("errors on a low-health ability with no trigger threshold", () => {
+    const cfg = {
+      ...BASE_CONFIG,
+      races: {
+        pyrae: {
+          displayName: "Pyrae",
+          racialAbility: { kind: "PYRAE_IMMOLATE" as const, triggerHealthPct: 0 },
+        },
+      },
+    };
+    const issues = validateConfig(cfg);
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        entity: "race:pyrae",
+        severity: "error",
+        message: expect.stringContaining("trigger HP"),
+      }),
+    );
+  });
+
+  it("errors when a dazzle ability has no stun status effect", () => {
+    const cfg = {
+      ...BASE_CONFIG,
+      races: {
+        aurelia: {
+          displayName: "Aurelia",
+          racialAbility: { kind: "AURELIA_DAZZLE" as const, triggerHealthPct: 15 },
+        },
+      },
+    };
+    const issues = validateConfig(cfg);
+    expect(issues).toContainEqual(
+      expect.objectContaining({
+        entity: "race:aurelia",
+        severity: "error",
+        message: expect.stringContaining("stun status effect"),
+      }),
+    );
+  });
+
+  it("accepts a fully configured low-health ability", () => {
+    const cfg = {
+      ...BASE_CONFIG,
+      races: {
+        ophirae: {
+          displayName: "Ophirae",
+          racialAbility: {
+            kind: "OPHIRAE_WRATH" as const,
+            triggerHealthPct: 20,
+            damageMultiplier: 1.5,
+            buffDurationMs: 6000,
+          },
+        },
+      },
+    };
+    const issues = validateConfig(cfg);
+    expect(issues.filter((i) => i.entity === "race:ophirae" && i.severity === "error")).toEqual([]);
+  });
+
   // ─── Stat bindings (melee combat formula) ──────────────────────
   it("errors when meleeStatMultiplier is negative", () => {
     const cfg = {

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -905,6 +905,30 @@ export function housingToPlain(h: AppConfig["housing"]): Record<string, unknown>
   };
 }
 
+export function racialAbilityToPlain(
+  ability: NonNullable<AppConfig["races"][string]["racialAbility"]>,
+): Record<string, unknown> {
+  const obj: Record<string, unknown> = { kind: ability.kind };
+  if (ability.displayName) obj.displayName = ability.displayName;
+  if (ability.cooldownMs != null) obj.cooldownMs = ability.cooldownMs;
+  if (ability.triggerHealthPct != null) obj.triggerHealthPct = ability.triggerHealthPct;
+  if (ability.aoeDamagePctOfMaxHp != null) obj.aoeDamagePctOfMaxHp = ability.aoeDamagePctOfMaxHp;
+  if (ability.damageMultiplier != null) obj.damageMultiplier = ability.damageMultiplier;
+  if (ability.buffDurationMs != null) obj.buffDurationMs = ability.buffDurationMs;
+  if (ability.stunStatusId) obj.stunStatusId = ability.stunStatusId;
+  if (ability.petTemplateKey) obj.petTemplateKey = ability.petTemplateKey;
+  if (ability.petCountMin != null) obj.petCountMin = ability.petCountMin;
+  if (ability.petCountMax != null) obj.petCountMax = ability.petCountMax;
+  if (ability.petDurationMs != null) obj.petDurationMs = ability.petDurationMs;
+  if (ability.regenPctOfMaxHp != null) obj.regenPctOfMaxHp = ability.regenPctOfMaxHp;
+  if (ability.stoneStatusId) obj.stoneStatusId = ability.stoneStatusId;
+  if (ability.stoneDurationMs != null) obj.stoneDurationMs = ability.stoneDurationMs;
+  if (ability.phaseTicks != null) obj.phaseTicks = ability.phaseTicks;
+  if (ability.selfMessage) obj.selfMessage = ability.selfMessage;
+  if (ability.roomMessage) obj.roomMessage = ability.roomMessage;
+  return obj;
+}
+
 export function raceToPlain(race: AppConfig["races"][string]): Record<string, unknown> {
   const obj: Record<string, unknown> = { displayName: race.displayName };
   if (race.description) obj.description = race.description;
@@ -916,6 +940,7 @@ export function raceToPlain(race: AppConfig["races"][string]): Record<string, un
   if (race.bodyDescription) obj.bodyDescription = race.bodyDescription;
   if (race.imagePromptDirective) obj.imagePromptDirective = race.imagePromptDirective;
   if (race.staffPrompt) obj.staffPrompt = race.staffPrompt;
+  if (race.racialAbility) obj.racialAbility = racialAbilityToPlain(race.racialAbility);
   return obj;
 }
 

--- a/creator/src/lib/validateConfig.ts
+++ b/creator/src/lib/validateConfig.ts
@@ -1,4 +1,5 @@
-import type { AppConfig } from "@/types/config";
+import type { AppConfig, RacialAbilityKind } from "@/types/config";
+import { RACIAL_ABILITY_KINDS, RACIAL_ABILITY_TRIGGERS } from "@/types/config";
 import { missingRequiredGlobalAssets } from "./requiredGlobalAssets";
 import type { ValidationIssue } from "./validateZone";
 import { flattenEffect, incompatibleChildEffects } from "./abilityEffects";
@@ -448,6 +449,77 @@ export function validateConfig(config: AppConfig): ValidationIssue[] {
             entity: `race:${id}`,
             message: `Stat modifier references unknown stat "${statId}"`,
           });
+        }
+      }
+    }
+
+    // ─── Racial passive ability ─── (mirrors server validateEngineRaces)
+    const ability = race.racialAbility;
+    if (ability) {
+      const entity = `race:${id}`;
+      const push = (message: string, severity: ValidationIssue["severity"] = "error") =>
+        issues.push({ severity, entity, message });
+
+      if (!RACIAL_ABILITY_KINDS.includes(ability.kind)) {
+        push(`Racial ability kind "${ability.kind}" is not a known mechanic`);
+      } else {
+        const trigger = RACIAL_ABILITY_TRIGGERS[ability.kind as RacialAbilityKind];
+        // Server applies defaults for omitted fields; mirror them so blank-but-valid passes.
+        const cooldownMs = ability.cooldownMs ?? 120000;
+        const triggerHealthPct = ability.triggerHealthPct ?? 0;
+        const damageMultiplier = ability.damageMultiplier ?? 1;
+        const aoe = ability.aoeDamagePctOfMaxHp ?? 0;
+        const regen = ability.regenPctOfMaxHp ?? 0;
+        const petCountMin = ability.petCountMin ?? 1;
+        const petCountMax = ability.petCountMax ?? 1;
+        const phaseTicks = ability.phaseTicks ?? 2;
+
+        if (cooldownMs < 0) push("Racial ability cooldown must be >= 0");
+        if (triggerHealthPct < 0 || triggerHealthPct > 100)
+          push("Racial ability trigger HP % must be between 0 and 100");
+        if (damageMultiplier < 0) push("Racial ability damage multiplier must be >= 0");
+        if (aoe < 0) push("Racial ability AoE damage must be >= 0");
+        if (regen < 0) push("Racial ability regen must be >= 0");
+        if (petCountMin < 1) push("Racial ability pet count (min) must be >= 1");
+        if (petCountMax < petCountMin)
+          push("Racial ability pet count (max) must be >= pet count (min)");
+        if (phaseTicks < 1) push("Racial ability phase rounds must be >= 1");
+
+        if (trigger === "LOW_HEALTH" && !(triggerHealthPct >= 1 && triggerHealthPct <= 100)) {
+          push(`Low-health ability "${ability.kind}" needs a trigger HP % between 1 and 100`);
+        }
+
+        if (ability.kind === "AURELIA_DAZZLE" && !ability.stunStatusId?.trim()) {
+          push(`"${ability.kind}" requires a stun status effect`);
+        }
+        if (
+          (ability.kind === "MYCORAE_SPORES" || ability.kind === "ARCHAE_DRENGARIAE") &&
+          !ability.petTemplateKey?.trim()
+        ) {
+          push(`"${ability.kind}" requires a pet template`);
+        }
+
+        // Cross-reference checks (warnings — referenced entities may live in an overlay).
+        if (
+          ability.stunStatusId?.trim() &&
+          statusEffectIds.size > 0 &&
+          !statusEffectIds.has(ability.stunStatusId)
+        ) {
+          push(`Stun status effect "${ability.stunStatusId}" is not defined`, "warning");
+        }
+        if (
+          ability.stoneStatusId?.trim() &&
+          statusEffectIds.size > 0 &&
+          !statusEffectIds.has(ability.stoneStatusId)
+        ) {
+          push(`Stone-form status effect "${ability.stoneStatusId}" is not defined`, "warning");
+        }
+        if (
+          ability.petTemplateKey?.trim() &&
+          petIds.size > 0 &&
+          !petIds.has(ability.petTemplateKey)
+        ) {
+          push(`Pet template "${ability.petTemplateKey}" is not defined`, "warning");
         }
       }
     }

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -1001,6 +1001,86 @@ export interface RaceDefinitionConfig {
   /** Whether this race appears in character creation. Defaults to true when
    *  omitted. Mirrors the same field on `ClassDefinitionConfig`. */
   selectable?: boolean;
+  /** Optional race-specific passive ability (low-health / lethal-blow trigger). */
+  racialAbility?: RacialAbilityConfig;
+}
+
+/**
+ * The distinct race-specific passive ability mechanics. Each `kind` selects one bespoke
+ * behaviour resolved by the server's `RacialAbilitySystem`; the remaining fields on
+ * `RacialAbilityConfig` are read only by the kinds that use them. Mirrors the server's
+ * `RacialAbilityKind` enum — keep in sync.
+ */
+export const RACIAL_ABILITY_KINDS = [
+  "PYRAE_IMMOLATE",
+  "LUSTRIAE_TIMESLIP",
+  "AURELIA_DAZZLE",
+  "LITHAE_STONEFORM",
+  "MYCORAE_SPORES",
+  "KITSARAE_REVERSAL",
+  "ARCHAE_DRENGARIAE",
+  "OPHIRAE_WRATH",
+  "AETHERAE_PHASE",
+] as const;
+
+export type RacialAbilityKind = (typeof RACIAL_ABILITY_KINDS)[number];
+
+/** Which combat hook fires a racial ability. */
+export type RacialTrigger = "LOW_HEALTH" | "LETHAL_BLOW";
+
+/** Maps each ability kind to the combat hook that fires it. Mirrors the server enum. */
+export const RACIAL_ABILITY_TRIGGERS: Record<RacialAbilityKind, RacialTrigger> = {
+  PYRAE_IMMOLATE: "LOW_HEALTH",
+  LUSTRIAE_TIMESLIP: "LETHAL_BLOW",
+  AURELIA_DAZZLE: "LOW_HEALTH",
+  LITHAE_STONEFORM: "LETHAL_BLOW",
+  MYCORAE_SPORES: "LOW_HEALTH",
+  KITSARAE_REVERSAL: "LETHAL_BLOW",
+  ARCHAE_DRENGARIAE: "LOW_HEALTH",
+  OPHIRAE_WRATH: "LOW_HEALTH",
+  AETHERAE_PHASE: "LETHAL_BLOW",
+};
+
+/**
+ * Tunable knobs for a race's passive ability. `kind` selects the mechanic; the remaining
+ * fields are read only by the kinds that use them and keep harmless defaults otherwise.
+ * Mirrors the server's `RacialAbilityConfig`.
+ */
+export interface RacialAbilityConfig {
+  kind: RacialAbilityKind;
+  displayName?: string;
+  /** Cooldown before the ability can fire again, in milliseconds. */
+  cooldownMs?: number;
+  /** LOW_HEALTH only: fires once the player's HP is at or below this percent (1..100) of max. */
+  triggerHealthPct?: number;
+  /** Pyrae: AoE damage dealt to each enemy, as a fraction of the player's max HP. */
+  aoeDamagePctOfMaxHp?: number;
+  /** Ophirae: outgoing-damage multiplier while the wrath buff is active. */
+  damageMultiplier?: number;
+  /** Ophirae: how long the wrath buff lasts, in milliseconds. */
+  buffDurationMs?: number;
+  /** Aurelia: status-effect id (of effectType "stun") applied to enemies. */
+  stunStatusId?: string;
+  /** Mycorae/Archae: pet template key to summon. */
+  petTemplateKey?: string;
+  /** Mycorae: inclusive lower bound on the number of pets spawned. */
+  petCountMin?: number;
+  /** Mycorae: inclusive upper bound on the number of pets spawned. */
+  petCountMax?: number;
+  /** Mycorae/Archae: how long the summoned pets live before despawning, in milliseconds. */
+  petDurationMs?: number;
+  /** Lithae: HP restored on entering stone form, as a fraction of max HP. */
+  regenPctOfMaxHp?: number;
+  /** Lithae: status-effect id (of effectType "root") applied to self so the player can't move. */
+  stoneStatusId?: string;
+  /** Lithae: how long the player stays untargetable in stone form, in milliseconds. */
+  stoneDurationMs?: number;
+  /** Aetherae: number of combat rounds the player stays phased/untargetable after the blow. */
+  phaseTicks?: number;
+  /** Message shown to the triggering player. */
+  selfMessage?: string;
+  /** Message broadcast to others in the room ({player} is substituted). */
+  roomMessage?: string;
 }
 
 // ─── Images ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Arcanum-side support for the new **racial passive ability** subsystem landing in AmbonMUD server [PR #1349](https://github.com/jnoecker/AmbonMUD/pull/1349). Race definitions can now carry an optional `racialAbility` block that the server fires from combat hooks (a low-health threshold or a would-be-lethal blow) on a long, persisted cooldown.

This lets worldbuilders configure all nine abilities (Pyrae immolate, Aurelia dazzle, Mycorae spores, Archae soldier, Ophirae wrath, Kitsarae reversal, Lustriae timeslip, Lithae stoneform, Aetherae phase) directly in the Race designer.

## Changes

- **`types/config.ts`** — `RacialAbilityConfig` interface plus `RacialAbilityKind` / `RacialTrigger` mirrors of the server's enums (and a `RACIAL_ABILITY_TRIGGERS` map), and the optional `racialAbility` field on `RaceDefinitionConfig`.
- **`lib/exportMud.ts`** — `racialAbilityToPlain()` serializer wired into `raceToPlain()`, which is shared by both `saveConfig.ts` and MUD export. Only set fields are emitted, so YAML stays clean and the block is omitted entirely for races without an ability.
- **`components/config/races/RaceEditor.tsx`** — a new **Racial Passive Ability** card: enable/remove toggle, mechanic picker, a trigger badge (low-health vs. lethal-blow), and only the fields relevant to the selected mechanic. Stun/root status effects and pet templates are chosen from dropdowns populated from the live config rather than free-text.
- **`lib/validateConfig.ts`** — mirrors the server's `validateEngineRaces()` rules (valid kind, non-negative knobs, low-health trigger threshold, required stun-status/pet-template per kind) and adds cross-reference warnings when a referenced status effect or pet template isn't defined locally.
- **Tests** — racial-ability YAML round-trip (`exportMud.test.ts`) and validation coverage (`validateConfig.test.ts`).

## Already covered

The PR also bundles two status effects (`dazzle_stun`, `stoneform_root`) and two pet templates (`spore_mushroom`, `drengariae_soldier`). Those entity types are already fully editable through the existing Status Effect and Pet designers — and `threatMultiplier` (used by the spore tank) already exists on the pet schema. No Rust changes are needed: the backend persists config YAML generically; the schema lives in TypeScript.

## Testing

- `bunx tsc --noEmit` — clean
- `bun run test` — 2244 passed (6 new)
