### PR TITLE
feat: racial passive ability descriptions + spellbook icon generation

### DIFF
--- a/creator/src/components/config/races/RaceEditor.tsx
+++ b/creator/src/components/config/races/RaceEditor.tsx
@@ -33,6 +33,16 @@ Rules:
 - Do NOT include clothing, armor, or weapons — the class system handles those
 - Output ONLY the description text — no quotes, no explanation`;
 
+const RACIAL_ABILITY_DESC_SYSTEM_PROMPT = `You are writing player-facing spellbook copy for a fantasy MUD's racial passive ability.
+
+Given a race, the ability's name, and its mechanics (trigger condition, cooldown, and effect values), write a concise description a player reads in their spellbook.
+
+Rules:
+- 1-2 sentences, present tense, addressed to the player ("you" / "your").
+- State plainly WHEN it triggers (e.g. when you drop to low health, or when a blow would kill you) and WHAT it does, weaving in the concrete numbers you are given (percentages, counts, durations).
+- Evocative but clear — this is a tooltip, not lore. No title, no quotes, no markdown.
+- Output ONLY the description text.`;
+
 
 interface RaceEditorProps {
   id: string;
@@ -106,6 +116,8 @@ export function RaceEditor({
       </div>
 
       <RacialAbilityCard
+        raceId={id}
+        raceName={race.displayName}
         ability={race.racialAbility}
         onChange={(racialAbility) => patch({ racialAbility })}
       />
@@ -159,13 +171,18 @@ const KIND_FIELDS: Record<RacialAbilityKind, KindFields> = {
 };
 
 function RacialAbilityCard({
+  raceId,
+  raceName,
   ability,
   onChange,
 }: {
+  raceId: string;
+  raceName: string;
   ability: RacialAbilityConfig | undefined;
   onChange: (ability: RacialAbilityConfig | undefined) => void;
 }) {
   const config = useConfigStore((s) => s.config);
+  const assetsDir = useAssetStore((s) => s.assetsDir);
   const statusEffects = config?.statusEffects ?? {};
   const pets = config?.pets ?? {};
 
@@ -206,6 +223,30 @@ function RacialAbilityCard({
   const fields = KIND_FIELDS[ability.kind] ?? {};
   const trigger = RACIAL_ABILITY_TRIGGERS[ability.kind];
   const patchAbility = (p: Partial<RacialAbilityConfig>) => onChange({ ...ability, ...p });
+
+  const abilityName = ability.displayName || ABILITY_KIND_LABELS[ability.kind];
+  const iconImagePath =
+    ability.image && assetsDir ? `${assetsDir}\\images\\${ability.image}` : undefined;
+
+  const buildAbilityContext = () => {
+    const parts = [
+      `Race: ${raceName}`,
+      `Racial passive ability: ${abilityName}`,
+      `Trigger: ${trigger === "LOW_HEALTH" ? "when the player drops to low health" : "when a blow would be lethal"}`,
+    ];
+    if (ability.cooldownMs != null) parts.push(`Cooldown: ${Math.round(ability.cooldownMs / 1000)}s`);
+    if (ability.triggerHealthPct != null) parts.push(`Triggers at ${ability.triggerHealthPct}% max HP`);
+    if (ability.aoeDamagePctOfMaxHp != null) parts.push(`AoE damage: ${Math.round(ability.aoeDamagePctOfMaxHp * 100)}% of max HP to each enemy`);
+    if (ability.damageMultiplier != null) parts.push(`Damage multiplier: ${ability.damageMultiplier}x`);
+    if (ability.buffDurationMs != null) parts.push(`Buff lasts ${Math.round(ability.buffDurationMs / 1000)}s`);
+    if (ability.petTemplateKey) parts.push(`Summons: ${ability.petTemplateKey}`);
+    if (ability.petCountMin != null || ability.petCountMax != null) parts.push(`Pets spawned: ${ability.petCountMin ?? 1}-${ability.petCountMax ?? ability.petCountMin ?? 1}`);
+    if (ability.petDurationMs != null) parts.push(`Pets last ${Math.round(ability.petDurationMs / 1000)}s`);
+    if (ability.regenPctOfMaxHp != null) parts.push(`Heals ${Math.round(ability.regenPctOfMaxHp * 100)}% of max HP`);
+    if (ability.stoneDurationMs != null) parts.push(`Untargetable for ${Math.round(ability.stoneDurationMs / 1000)}s`);
+    if (ability.phaseTicks != null) parts.push(`Phases out for ${ability.phaseTicks} combat rounds`);
+    return parts.join("\n");
+  };
 
   return (
     <SectionCard
@@ -407,6 +448,50 @@ function RacialAbilityCard({
             />
           </FieldLabel>
         )}
+      </div>
+
+      <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[1fr_auto]">
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="font-display text-2xs uppercase tracking-wider text-text-muted">
+            Spellbook Description
+          </span>
+          <CommitTextarea
+            label=""
+            value={ability.description ?? ""}
+            onCommit={(v) => patchAbility({ description: v || undefined })}
+            placeholder="Player-facing explanation shown in the spellbook — when it fires and what it does."
+            rows={4}
+          />
+          <div className="mt-1.5 flex justify-end">
+            <EnhanceDescriptionButton
+              entitySummary={buildAbilityContext()}
+              currentDescription={ability.description}
+              onAccept={(v) => patchAbility({ description: v })}
+              systemPrompt={RACIAL_ABILITY_DESC_SYSTEM_PROMPT}
+              label="AI generate"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <span className="font-display text-2xs uppercase tracking-wider text-text-muted">
+            Spellbook Icon
+          </span>
+          <EntityArtGenerator
+            getPrompt={(style: ArtStyle) =>
+              composePrompt("racial_ability_icon", style, `Racial ability: ${abilityName} (${raceName})`)
+            }
+            entityContext={buildAbilityContext()}
+            currentImage={iconImagePath}
+            onAccept={(filePath) => {
+              const fileName = filePath.split(/[\\/]/).pop() ?? "";
+              patchAbility({ image: fileName });
+            }}
+            assetType="racial_ability_icon"
+            context={{ zone: "", entity_type: "racial_ability", entity_id: raceId }}
+            surface="worldbuilding"
+          />
+        </div>
       </div>
 
       <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-2">

--- a/creator/src/lib/__tests__/exportMud.test.ts
+++ b/creator/src/lib/__tests__/exportMud.test.ts
@@ -568,6 +568,8 @@ describe("racial ability round-trip", () => {
           racialAbility: {
             kind: "MYCORAE_SPORES",
             displayName: "Spore Burst",
+            description: "When you drop to 25% health, you erupt in spores that congeal into tank mushrooms to guard you.",
+            image: "abc123.png",
             cooldownMs: 120000,
             triggerHealthPct: 25,
             petTemplateKey: "spore_mushroom",
@@ -586,6 +588,8 @@ describe("racial ability round-trip", () => {
     expect(ability.kind).toBe("MYCORAE_SPORES");
     expect(ability.petTemplateKey).toBe("spore_mushroom");
     expect(ability.petCountMax).toBe(3);
+    expect(ability.description).toContain("25% health");
+    expect(ability.image).toBe("abc123.png");
 
     const reparsed = parseAppConfigYaml(stringify({ ambonmud: runtime }));
     expect(reparsed.races.MYCORAE.racialAbility).toEqual(config.races.MYCORAE.racialAbility);

--- a/creator/src/lib/arcanumPrompts.ts
+++ b/creator/src/lib/arcanumPrompts.ts
@@ -143,6 +143,7 @@ export const FORMAT_BY_ASSET_TYPE: Partial<Record<AssetType, string>> = {
   ability_sprite: FORMAT_BY_TYPE.ability_icon,
   ability_icon: FORMAT_BY_TYPE.ability_icon,
   status_effect_icon: FORMAT_BY_TYPE.status_effect_icon,
+  racial_ability_icon: FORMAT_BY_TYPE.ability_icon,
   zone_map: "16:9 illustrated fantasy map or cartographic overview, top-down or elevated perspective, no readable labels",
   showcase_banner: "21:9 ultra-wide cinematic hero banner, sweeping establishing vista, strong negative space in upper and lower thirds for title text overlay, no readable text",
   showcase_favicon: "1:1 square world logo icon, bold centered emblem filling most of the frame, high-contrast silhouette that reads at tiny sizes, no text, no fine detail",
@@ -497,6 +498,13 @@ export const ASSET_TEMPLATES: Record<AssetType, { label: string; templates: Reco
     templates: {
       arcanum: `A single iconic status effect symbol rendered as flowing energy against deep cosmic indigo void, baroque scrollwork frame dissolving at edges, the central icon glows with concentrated light — shields in steel-blue, buffs in warm gold, debuffs in sickly green, DoTs in smoldering ember-red — soft bloom, centered square composition like a game status icon, painterly, luminous, extremely detailed, no text, no figures`,
       gentle_magic: `A single iconic status effect symbol as a softly glowing natural form against deep mist-blue background, the icon rendered as living magic — shields as crystalline domes, buffs as gentle auras, debuffs as wilting tendrils, DoTs as slow-burning embers — radiating pale lavender and contextual color light with diffused bloom, framed by a subtle circle of floating light motes, centered square composition like a game status icon, organic shapes, no harsh edges, painterly, luminous, dreamlike, no text, no figures`,
+    },
+  },
+  racial_ability_icon: {
+    label: "Racial Ability Icon",
+    templates: {
+      arcanum: `A single iconic emblem for an innate racial passive power rendered as flowing ancestral energy against deep cosmic indigo void, baroque scrollwork frame dissolving at edges, the central symbol glows with concentrated aurum-gold light and soft bloom evoking the bloodline's signature force — flame, time, light, stone, spore, reversal, beast-call, draconic wrath, or aetheric phase — blue-violet atmospheric fill behind, centered square composition like a game ability icon, painterly, luminous, extremely detailed, no text, no figures`,
+      gentle_magic: `A single iconic emblem for an innate racial passive power as a softly glowing natural form against deep mist-blue background, the icon rendered as living ancestral magic that captures the bloodline's signature force — a gentle flame, a swirl of luminous time, drifting motes of light, weathered stone, blooming spores, or a curling phase-shimmer — radiating pale lavender and warm gold light with diffused bloom, framed by a subtle circle of floating light motes, centered square composition like a game ability icon, organic shapes, no harsh edges, painterly, luminous, dreamlike, no text, no figures`,
     },
   },
   music: {

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -910,6 +910,8 @@ export function racialAbilityToPlain(
 ): Record<string, unknown> {
   const obj: Record<string, unknown> = { kind: ability.kind };
   if (ability.displayName) obj.displayName = ability.displayName;
+  if (ability.description) obj.description = ability.description;
+  if (ability.image) obj.image = normalizeAssetRef(ability.image);
   if (ability.cooldownMs != null) obj.cooldownMs = ability.cooldownMs;
   if (ability.triggerHealthPct != null) obj.triggerHealthPct = ability.triggerHealthPct;
   if (ability.aoeDamagePctOfMaxHp != null) obj.aoeDamagePctOfMaxHp = ability.aoeDamagePctOfMaxHp;

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -48,6 +48,7 @@ export type AssetType =
   | "ability_sprite"
   | "ability_icon"
   | "status_effect_icon"
+  | "racial_ability_icon"
   | "zone_map"
   | "splash_hero"
   | "loading_vignette"
@@ -309,6 +310,7 @@ export const ENTITY_DIMENSIONS: Record<string, { width: number; height: number; 
   lever_bg: { width: 1024, height: 1536, label: "1024×1536 (Portrait)" },
   puzzle_bg: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },
   ability: { width: 1024, height: 1024, label: "1024×1024 (Icon)" },
+  racial_ability: { width: 1024, height: 1024, label: "1024×1024 (Icon)" },
   shop: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },
   dungeon: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },
   dungeonRoom: { width: 1536, height: 1024, label: "1536×1024 (Landscape)" },

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -1049,6 +1049,10 @@ export const RACIAL_ABILITY_TRIGGERS: Record<RacialAbilityKind, RacialTrigger> =
 export interface RacialAbilityConfig {
   kind: RacialAbilityKind;
   displayName?: string;
+  /** Player-facing explanation of what the ability does, surfaced in the spellbook. */
+  description?: string;
+  /** Spellbook icon: a raw image filename resolved against the images base URL when emitted. */
+  image?: string;
   /** Cooldown before the ability can fire again, in milliseconds. */
   cooldownMs?: number;
   /** LOW_HEALTH only: fires once the player's HP is at or below this percent (1..100) of max. */


### PR DESCRIPTION
## What

Surfaces racial passive abilities in the in-game spellbook by giving Arcanum's racial-ability editor the two new fields from server [PR #1353](https://github.com/jnoecker/AmbonMUD/pull/1353):

- **`description`** — player-facing spellbook copy explaining when the passive fires and what it does.
- **`image`** — a spellbook icon for the passive.

The mechanical racial-ability editor already shipped; this fills the gap so authored worlds can actually populate the fields the server now reads.

## Changes

- **Type** (`types/config.ts`) — `RacialAbilityConfig` gains `description?` and `image?`, mirroring the server's `RacialAbility`.
- **Round-trip** (`exportMud.ts`) — `racialAbilityToPlain` serializes both; `image` is run through `normalizeAssetRef` like every other asset ref. Loading already preserved them (the race loader casts raw YAML).
- **Art pipeline** — new `racial_ability_icon` `AssetType` with arcanum + gentle_magic prompt templates, `FORMAT_BY_ASSET_TYPE` entry (square icon), and 1024×1024 dimensions for the `racial_ability` entity type.
- **Editor** (`RaceEditor.tsx`) — `RacialAbilityCard` now has:
  - a **Spellbook Description** textarea with an **AI generate** button that drafts a tooltip from the ability's actual mechanics (trigger, cooldown, effect values), and
  - a **Spellbook Icon** generator (`EntityArtGenerator`, `racial_ability_icon`) wired to `racialAbility.image`.

## Testing

- `bunx tsc --noEmit` — clean
- `bun run test` — 2244 passing; extended the racial-ability round-trip test in `exportMud.test.ts` to assert `description` + `image` survive serialize → re-parse.

Manual generation/UI not exercised in this environment.
