### PR TITLE
fix: repair broken racial ability spellbook icon layout

### DIFF
--- a/creator/src/components/config/races/RaceEditor.tsx
+++ b/creator/src/components/config/races/RaceEditor.tsx
@@ -450,33 +450,33 @@ function RacialAbilityCard({
         )}
       </div>
 
-      <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[1fr_auto]">
-        <div className="flex min-w-0 flex-col gap-1">
-          <span className="font-display text-2xs uppercase tracking-wider text-text-muted">
-            Spellbook Description
-          </span>
-          <CommitTextarea
-            label=""
-            value={ability.description ?? ""}
-            onCommit={(v) => patchAbility({ description: v || undefined })}
-            placeholder="Player-facing explanation shown in the spellbook — when it fires and what it does."
-            rows={4}
+      <div className="mt-4 flex flex-col gap-1">
+        <span className="font-display text-2xs uppercase tracking-wider text-text-muted">
+          Spellbook Description
+        </span>
+        <CommitTextarea
+          label=""
+          value={ability.description ?? ""}
+          onCommit={(v) => patchAbility({ description: v || undefined })}
+          placeholder="Player-facing explanation shown in the spellbook — when it fires and what it does."
+          rows={4}
+        />
+        <div className="mt-1.5 flex justify-end">
+          <EnhanceDescriptionButton
+            entitySummary={buildAbilityContext()}
+            currentDescription={ability.description}
+            onAccept={(v) => patchAbility({ description: v })}
+            systemPrompt={RACIAL_ABILITY_DESC_SYSTEM_PROMPT}
+            label="AI generate"
           />
-          <div className="mt-1.5 flex justify-end">
-            <EnhanceDescriptionButton
-              entitySummary={buildAbilityContext()}
-              currentDescription={ability.description}
-              onAccept={(v) => patchAbility({ description: v })}
-              systemPrompt={RACIAL_ABILITY_DESC_SYSTEM_PROMPT}
-              label="AI generate"
-            />
-          </div>
         </div>
+      </div>
 
-        <div className="flex flex-col gap-1">
-          <span className="font-display text-2xs uppercase tracking-wider text-text-muted">
-            Spellbook Icon
-          </span>
+      <div className="mt-3 flex flex-col gap-1">
+        <span className="font-display text-2xs uppercase tracking-wider text-text-muted">
+          Spellbook Icon
+        </span>
+        <div className="rounded-2xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-3">
           <EntityArtGenerator
             getPrompt={(style: ArtStyle) =>
               composePrompt("racial_ability_icon", style, `Racial ability: ${abilityName} (${raceName})`)


### PR DESCRIPTION
## Problem

The "Spellbook Icon" image generator in the Racial Passive Ability editor renders badly broken: the art panel is crammed into a narrow column with an overflowing prompt box, and a large empty void sits under the short Spellbook Description.

## Root cause

The icon was placed in an `auto`-sized grid track:

```
lg:grid-cols-[1fr_auto]  // description | icon
```

`EntityArtGenerator` is a `container-type: inline-size` layout that only switches to its two-column hero+studio view at `>=640px`. An `auto` track sizes to min-content, collapsing the panel well below that threshold — so it stayed cramped single-column, and the `1fr` description (only 4 rows tall) left a tall empty gap beside it.

## Fix

Stack the Spellbook Description and Spellbook Icon vertically and give the art panel a full-width bordered block — the same `rounded-2xl border bg-gradient-panel-light p-3` chrome `AbilityEditor` already uses for its art generator. At full card width the panel reaches its two-column threshold and lays out correctly.

Typecheck clean (`bunx tsc --noEmit`).