### PR TITLE
Reliable large-zone generation: parallel batching + square grid

### DIFF
--- a/creator/src-tauri/src/anthropic.rs
+++ b/creator/src-tauri/src/anthropic.rs
@@ -77,7 +77,7 @@ pub async fn complete(
         }],
     };
 
-    let client = crate::http::shared_client();
+    let client = crate::http::llm_client();
     let response = client
         .post(API_URL)
         .header("x-api-key", api_key)
@@ -131,7 +131,7 @@ pub async fn complete_with_vision(
         }],
     };
 
-    let client = crate::http::shared_client();
+    let client = crate::http::llm_client();
     let response = client
         .post(API_URL)
         .header("x-api-key", api_key)

--- a/creator/src-tauri/src/http.rs
+++ b/creator/src-tauri/src/http.rs
@@ -17,6 +17,24 @@ pub fn shared_client() -> &'static reqwest::Client {
     })
 }
 
+/// Dedicated client for text LLM completions. These are non-streaming, so the
+/// total timeout has to cover the full generation time — a large zone can ask
+/// for up to 16k output tokens, which is several minutes of wall-clock. The
+/// 120s budget on `shared_client` (sized for image generation) cuts those off
+/// mid-flight and surfaces as "error sending request for url". connect_timeout
+/// stays short so dead connections still fail fast.
+static LLM_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+pub fn llm_client() -> &'static reqwest::Client {
+    LLM_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(600))
+            .build()
+            .expect("Failed to build LLM HTTP client")
+    })
+}
+
 /// Build a Bearer authorization header value.
 pub fn bearer_header(api_key: &str) -> String {
     format!("Bearer {api_key}")

--- a/creator/src-tauri/src/hub_ai.rs
+++ b/creator/src-tauri/src/hub_ai.rs
@@ -285,7 +285,7 @@ pub async fn complete(
         max_tokens: Some(max_tokens),
     };
     let url = format!("{}/ai/llm/complete", base_url(s));
-    let client = crate::http::shared_client();
+    let client = crate::http::llm_client();
     let response = client
         .post(&url)
         .bearer_auth(&s.hub_api_key)
@@ -319,7 +319,7 @@ pub async fn complete_with_vision(
         max_tokens: Some(4096),
     };
     let url = format!("{}/ai/llm/vision", base_url(s));
-    let client = crate::http::shared_client();
+    let client = crate::http::llm_client();
     let response = client
         .post(&url)
         .bearer_auth(&s.hub_api_key)

--- a/creator/src-tauri/src/llm.rs
+++ b/creator/src-tauri/src/llm.rs
@@ -31,7 +31,7 @@ async fn openai_complete(
         "max_tokens": max_tokens,
         "temperature": 0.7,
     });
-    let client = crate::http::shared_client();
+    let client = crate::http::llm_client();
     let response = client
         .post(OPENAI_CHAT_URL)
         .header("Authorization", crate::http::bearer_header(api_key))
@@ -151,7 +151,7 @@ pub async fn complete_from_settings(
                 "temperature": 0.7
             });
 
-            let client = crate::http::shared_client();
+            let client = crate::http::llm_client();
             let response = client
                 .post(chat_url)
                 .header("Authorization", crate::http::bearer_header(&s.deepinfra_api_key))

--- a/creator/src-tauri/src/openrouter.rs
+++ b/creator/src-tauri/src/openrouter.rs
@@ -54,7 +54,7 @@ pub async fn complete(
         temperature: 0.7,
     };
 
-    let client = crate::http::shared_client();
+    let client = crate::http::llm_client();
     let response = client
         .post(API_URL)
         .header("Authorization", crate::http::bearer_header(api_key))

--- a/creator/src/components/NewZoneDialog.tsx
+++ b/creator/src/components/NewZoneDialog.tsx
@@ -82,6 +82,7 @@ export function NewZoneDialog({ onClose, prefill, onCreated }: NewZoneDialogProp
   // ─── Wizard state ─────────────────────────────────────────────
   const [step, setStep] = useState<WizardStep>(prefill ? "content" : "target");
   const [creating, setCreating] = useState(false);
+  const [genProgress, setGenProgress] = useState<{ done: number; total: number } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const trapRef = useFocusTrap<HTMLDivElement>(creating ? undefined : onClose);
 
@@ -240,6 +241,7 @@ export function NewZoneDialog({ onClose, prefill, onCreated }: NewZoneDialogProp
   const handleGenerate = async () => {
     if (!project || creating) return;
     setCreating(true);
+    setGenProgress(null);
     setError(null);
 
     try {
@@ -253,8 +255,12 @@ export function NewZoneDialog({ onClose, prefill, onCreated }: NewZoneDialogProp
       setStep("error");
     } finally {
       setCreating(false);
+      setGenProgress(null);
     }
   };
+
+  const reportProgress = (done: number, total: number) =>
+    setGenProgress({ done, total });
 
   const handleCreateNew = async () => {
     if (!project) return;
@@ -279,7 +285,7 @@ export function NewZoneDialog({ onClose, prefill, onCreated }: NewZoneDialogProp
         // No description → stub sketch rooms without LLM
         world = buildStubFromSketch(zoneId, layout);
       } else {
-        world = await generateZoneFromSketch(buildGenParams(zoneId), layout);
+        world = await generateZoneFromSketch(buildGenParams(zoneId), layout, reportProgress);
       }
     } else {
       // Pure AI generation
@@ -287,7 +293,7 @@ export function NewZoneDialog({ onClose, prefill, onCreated }: NewZoneDialogProp
         // No description → fall back to an empty stub of the requested size
         world = createFallbackZone(zoneId, preset.rooms);
       } else {
-        world = await generateZoneContent(buildGenParams(zoneId));
+        world = await generateZoneContent(buildGenParams(zoneId), reportProgress);
       }
     }
 
@@ -386,6 +392,7 @@ export function NewZoneDialog({ onClose, prefill, onCreated }: NewZoneDialogProp
               .join(" "),
           },
           layout,
+          reportProgress,
         );
         newRooms = partial.rooms;
         newMobs = partial.mobs ?? {};
@@ -605,9 +612,11 @@ export function NewZoneDialog({ onClose, prefill, onCreated }: NewZoneDialogProp
             {step === "review" && (
               <ActionButton variant="primary" size="sm" onClick={handleGenerate} disabled={creating}>
                 {creating
-                  ? target === "new"
-                    ? "Generating zone..."
-                    : "Generating rooms..."
+                  ? genProgress && genProgress.total > 0
+                    ? `Flavoring rooms ${genProgress.done}/${genProgress.total}...`
+                    : target === "new"
+                      ? "Generating zone..."
+                      : "Generating rooms..."
                   : target === "new"
                     ? "Create Zone"
                     : "Add Rooms"}

--- a/creator/src/lib/__tests__/generateZoneContent.test.ts
+++ b/creator/src/lib/__tests__/generateZoneContent.test.ts
@@ -6,6 +6,10 @@ const {
   applyHandTopology,
   extractJson,
   parseGeneratedContent,
+  parseRooms,
+  parseEntities,
+  chunk,
+  mapWithConcurrency,
   renameRoomsByTitle,
   slugifyTitle,
 } = __test__;
@@ -352,5 +356,89 @@ describe("parseGeneratedContent", () => {
   it("throws on empty rooms array", () => {
     const raw = JSON.stringify({ rooms: [] });
     expect(() => parseGeneratedContent(raw)).toThrow();
+  });
+});
+
+// ─── chunk ──────────────────────────────────────────────────────────
+
+describe("chunk", () => {
+  it("splits into batches of the given size", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("returns a single batch when size exceeds length", () => {
+    expect(chunk([1, 2, 3], 10)).toEqual([[1, 2, 3]]);
+  });
+
+  it("returns an empty array for no items", () => {
+    expect(chunk([], 4)).toEqual([]);
+  });
+});
+
+// ─── mapWithConcurrency ─────────────────────────────────────────────
+
+describe("mapWithConcurrency", () => {
+  it("preserves input order regardless of completion order", async () => {
+    const items = [30, 10, 20, 5];
+    const out = await mapWithConcurrency(items, 2, async (n: number) => {
+      await new Promise((r) => setTimeout(r, n));
+      return n * 2;
+    });
+    expect(out).toEqual([60, 20, 40, 10]);
+  });
+
+  it("never exceeds the concurrency limit", async () => {
+    let active = 0;
+    let peak = 0;
+    const items = Array.from({ length: 10 }, (_, i) => i);
+    await mapWithConcurrency(items, 3, async (n: number) => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 2));
+      active--;
+      return n;
+    });
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  it("runs every item exactly once", async () => {
+    const seen: number[] = [];
+    const items = Array.from({ length: 7 }, (_, i) => i);
+    await mapWithConcurrency(items, 4, async (n: number) => {
+      seen.push(n);
+      return n;
+    });
+    expect(seen.sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+});
+
+// ─── parseRooms / parseEntities ─────────────────────────────────────
+
+describe("parseRooms", () => {
+  it("extracts a rooms array (ignoring code fences)", () => {
+    const raw = '```json\n{"rooms": [{"id": "a", "title": "A", "description": "."}]}\n```';
+    expect(parseRooms(raw)).toHaveLength(1);
+  });
+
+  it("throws when the rooms array is missing", () => {
+    expect(() => parseRooms('{"mobs": []}')).toThrow();
+  });
+});
+
+describe("parseEntities", () => {
+  it("returns mobs and items when present", () => {
+    const raw = JSON.stringify({
+      mobs: [{ id: "slime", name: "Slime", description: ".", tier: "weak", room: "a" }],
+      items: [{ id: "blade", displayName: "Blade", description: "." }],
+    });
+    const result = parseEntities(raw);
+    expect(result.mobs).toHaveLength(1);
+    expect(result.items).toHaveLength(1);
+  });
+
+  it("defaults missing arrays to empty", () => {
+    const result = parseEntities('{"mobs": [{"id": "a", "name": "A", "description": ".", "tier": "weak", "room": "r"}]}');
+    expect(result.mobs).toHaveLength(1);
+    expect(result.items).toEqual([]);
   });
 });

--- a/creator/src/lib/__tests__/gridGenerator.test.ts
+++ b/creator/src/lib/__tests__/gridGenerator.test.ts
@@ -99,10 +99,39 @@ describe("generateGridLayout", () => {
     expect(a).toEqual(b);
   });
 
-  it("produces different layouts for different seeds", () => {
+  it("ignores the seed — a given count always yields the same rectangle", () => {
     const a = generateGridLayout({ count: 20, seed: "one" });
     const b = generateGridLayout({ count: 20, seed: "two" });
-    expect(a).not.toEqual(b);
+    expect(a).toEqual(b);
+  });
+
+  it("packs rooms into a compact rectangle", () => {
+    const layout = generateGridLayout({ count: 24 });
+    const grid = reconstructGrid(layout);
+    expect(grid).not.toBeNull();
+
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (const [, [x, y]] of grid!) {
+      minX = Math.min(minX, x);
+      maxX = Math.max(maxX, x);
+      minY = Math.min(minY, y);
+      maxY = Math.max(maxY, y);
+    }
+    const cols = maxX - minX + 1;
+    const rows = maxY - minY + 1;
+    // Big enough to hold every room...
+    expect(cols * rows).toBeGreaterThanOrEqual(24);
+    // ...but tight: dropping a whole row or column would no longer fit.
+    expect((cols - 1) * rows).toBeLessThan(24);
+    expect(cols * (rows - 1)).toBeLessThan(24);
+  });
+
+  it("fully connects interior rooms (all four cardinals)", () => {
+    const layout = generateGridLayout({ count: 9 }); // 3x3 → a center room
+    const maxExits = Math.max(
+      ...layout.rooms.map((r) => Object.keys(r.exits).length),
+    );
+    expect(maxExits).toBe(4);
   });
 
   it("uses only cardinal directions", () => {

--- a/creator/src/lib/batchArt.ts
+++ b/creator/src/lib/batchArt.ts
@@ -22,7 +22,7 @@ import {
 import type { GeneratedImage } from "@/types/assets";
 import { ENTITY_DIMENSIONS, requestsTransparentBackground, resolveImageModel, modelNativelyTransparent } from "@/types/assets";
 import { generateAssetImage } from "@/lib/imageGen";
-import { removeBgAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
+import { removeBgFromFileAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
 import { AI_ENABLED } from "@/lib/featureFlags";
 
 export function assetTypeForKind(kind: string): string {
@@ -44,7 +44,6 @@ export interface BatchTarget {
   checked: boolean;
   hasExisting: boolean;
   status: "pending" | "generating" | "done" | "error";
-  result?: GeneratedImage;
   error?: string;
   /** For `musicBoxKeepsake` targets: the song the lyric-sheet commemorates,
    *  resolved from the audio library at collect time (the prompt needs it, and
@@ -263,7 +262,7 @@ export async function runBatchArtGeneration(
   const worldRef = { current: { ...world } };
 
   // Collect background removal promises so we can await them before saving
-  const pendingBgRemovals: { promise: ReturnType<typeof removeBgAndSave>; kind: string; id: string }[] = [];
+  const pendingBgRemovals: { promise: ReturnType<typeof removeBgFromFileAndSave>; kind: string; id: string }[] = [];
 
   const checkedTargets = targets.filter((t) => t.checked);
   const queue = checkedTargets.map((t) =>
@@ -327,7 +326,7 @@ export async function runBatchArtGeneration(
           continue;
         }
 
-        callbacks.onTargetUpdate(idx, { status: "done", result: image });
+        callbacks.onTargetUpdate(idx, { status: "done" });
 
         // Keepsakes share the per-room music-box editor's manifest identity
         // (entity_type "item", entity_id "musicbox:<roomId>") so variants from
@@ -350,9 +349,9 @@ export async function runBatchArtGeneration(
 
         // Queue background removal — skip if the model already produced native transparency
         const skipBgRemoval = nativeTransparency && requestsTransparentBackground(batchAssetType);
-        if (autoRemoveBg && shouldRemoveBg(batchAssetType) && image.data_url && !skipBgRemoval) {
+        if (autoRemoveBg && shouldRemoveBg(batchAssetType) && image.file_path && !skipBgRemoval) {
           pendingBgRemovals.push({
-            promise: removeBgAndSave(image.data_url, batchAssetType, batchContext, variantGroup),
+            promise: removeBgFromFileAndSave(image.file_path, batchAssetType, batchContext, variantGroup),
             kind: target.kind,
             id: target.id,
           });

--- a/creator/src/lib/generateZoneContent.ts
+++ b/creator/src/lib/generateZoneContent.ts
@@ -357,23 +357,36 @@ Respond with ONLY valid, strict JSON (no trailing commas, no comments, all prope
   "items": [{ "id": string, "displayName": string, "description": string, "slot"?: string, "damage"?: number, "armor"?: number, "stats"?: { statId: number }, "room"?: string }]
 }`;
 
-const SYSTEM_PROMPT_SKETCH = `You are a creative game content designer for a text-based MUD (Multi-User Dungeon). The player has sketched a zone layout and you will write flavor for each of its pre-defined rooms.
+const SYSTEM_PROMPT_SKETCH_ROOMS = `You are a creative game content designer for a text-based MUD (Multi-User Dungeon). The player has sketched a zone layout and you will write flavor for a SUBSET of its pre-defined rooms.
 
 Rules:
 - You will be given a list of room IDs with optional hints from the sketch
 - Return one entry per room, using the SAME room ID (do not rename, do not invent new rooms)
 - Do NOT include exits — the layout is already fixed
+- Do NOT include mobs or items — those are authored separately
 - Use the hint (if any) to inform the room's title and description
-- Mob tiers: "weak", "standard", "elite", or "boss"
-- Mob IDs and item IDs must be snake_case
-- Mob "room" must be one of the provided room IDs
-- Item slots must come from the provided equipment slots list, or be omitted for non-equipment items
 - ${ROOM_DESCRIPTION_GUIDANCE}
 - Match the world and zone themes in tone and content
 
 Respond with ONLY valid, strict JSON (no trailing commas, no comments, all property names double-quoted) matching this schema:
 {
-  "rooms": [{ "id": string, "title": string, "description": string }],
+  "rooms": [{ "id": string, "title": string, "description": string }]
+}`;
+
+const SYSTEM_PROMPT_SKETCH_ENTITIES = `You are a creative game content designer for a text-based MUD (Multi-User Dungeon). The zone's rooms already exist; you will populate them with mobs and items.
+
+Rules:
+- You will be given the zone's room IDs — place mobs and items in those rooms only
+- Do NOT generate rooms
+- Mob tiers: "weak", "standard", "elite", or "boss"
+- Mob IDs and item IDs must be snake_case
+- Mob "room" and item "room" must be one of the provided room IDs
+- Item slots must come from the provided equipment slots list, or be omitted for non-equipment items
+- Item stat bonuses should use the provided stat names
+- Match the world and zone themes in tone and content
+
+Respond with ONLY valid, strict JSON (no trailing commas, no comments, all property names double-quoted) matching this schema:
+{
   "mobs": [{ "id": string, "name": string, "description": string, "tier": string, "room": string }],
   "items": [{ "id": string, "displayName": string, "description": string, "slot"?: string, "damage"?: number, "armor"?: number, "stats"?: { statId: number }, "room"?: string }]
 }`;
@@ -426,25 +439,52 @@ function buildUserPrompt(params: ZoneGenerationParams): string {
   return parts.join("\n");
 }
 
-function buildSketchUserPrompt(
+/** Theme-only context — rooms don't need the stat/slot/class lists. */
+function buildThemeContext(params: ZoneGenerationParams): string[] {
+  return [
+    `World theme: ${params.worldTheme || "A classic fantasy world"}`,
+    `Zone theme: ${params.zoneTheme || "A starting area for adventurers"}`,
+    ...(params.backgroundContext
+      ? [`Background context: ${params.backgroundContext}`]
+      : []),
+  ];
+}
+
+function buildRoomBatchPrompt(
   params: ZoneGenerationParams,
-  layout: FixedLayout,
+  batch: FixedLayoutRoom[],
 ): string {
   const parts = [
-    `Write flavor for a MUD zone called "${params.zoneName}" whose layout has already been sketched.`,
+    `Write flavor for part of a MUD zone called "${params.zoneName}" whose layout has already been sketched.`,
     ``,
-    ...buildCommonContext(params),
+    ...buildThemeContext(params),
     ``,
-    `Room IDs (with optional hints from the sketch):`,
+    `Write a title and description for each of these rooms (with optional hints):`,
   ];
-  for (const room of layout.rooms) {
+  for (const room of batch) {
     parts.push(`- ${room.id}${room.hint ? ` — ${room.hint}` : ""}`);
   }
   parts.push(``);
-  parts.push(`Generate exactly:`);
-  parts.push(`- One entry per room above, using the same IDs`);
-  parts.push(`- ${params.mobCount} mobs spread across the rooms`);
-  parts.push(`- ${params.itemCount} items (some as equipment, some as ground items)`);
+  parts.push(`Return one entry per room above, using the same IDs. Rooms only — no mobs, items, or exits.`);
+  return parts.join("\n");
+}
+
+function buildEntitiesPrompt(
+  params: ZoneGenerationParams,
+  roomIds: string[],
+): string {
+  const parts = [
+    `Populate a MUD zone called "${params.zoneName}" with mobs and items.`,
+    ``,
+    ...buildCommonContext(params),
+    ``,
+    `Room IDs to place content in:`,
+    roomIds.join(", "),
+    ``,
+    `Generate exactly:`,
+    `- ${params.mobCount} mobs spread across the rooms`,
+    `- ${params.itemCount} items (some as equipment, some as ground items)`,
+  ];
   return parts.join("\n");
 }
 
@@ -529,6 +569,61 @@ function parseGeneratedContent(raw: string): GeneratedZoneContent {
     mobs: parsed.mobs ?? [],
     items: parsed.items ?? [],
   };
+}
+
+/** Parse a rooms-only batch response into an array of rooms. */
+function parseRooms(raw: string): LlmRoom[] {
+  const parsed = JSON.parse(extractJson(raw));
+  if (!Array.isArray(parsed.rooms)) {
+    throw new Error("Room batch response missing rooms array");
+  }
+  return parsed.rooms;
+}
+
+/** Parse an entities-only response into mobs + items (both optional). */
+function parseEntities(raw: string): { mobs: LlmMob[]; items: LlmItem[] } {
+  const parsed = JSON.parse(extractJson(raw));
+  return {
+    mobs: Array.isArray(parsed.mobs) ? parsed.mobs : [],
+    items: Array.isArray(parsed.items) ? parsed.items : [],
+  };
+}
+
+// ─── Concurrency helpers ────────────────────────────────────────
+
+function chunk<T>(items: T[], size: number): T[][] {
+  if (size < 1) return [items];
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+/**
+ * Run `fn` over `items` with at most `limit` in flight at once, preserving
+ * input order in the results. A worker pool pulls from a shared cursor so a
+ * slow item doesn't stall the others.
+ */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < items.length) {
+      const i = cursor++;
+      results[i] = await fn(items[i]!, i);
+    }
+  };
+  const pool = Array.from(
+    { length: Math.max(1, Math.min(limit, items.length)) },
+    worker,
+  );
+  await Promise.all(pool);
+  return results;
 }
 
 // ─── WorldFile construction ─────────────────────────────────────
@@ -683,21 +778,98 @@ function buildSystemPrompt(base: string): string {
   return tone ? `${base}\n\nWorld context: ${tone}` : base;
 }
 
+/** Rooms per LLM flavor request. Small batches stay well under the response
+ *  timeout and per-call token ceiling, and they run concurrently. */
+const ROOM_BATCH_SIZE = 20;
+
+/** Max LLM requests in flight while flavoring a zone. */
+const GEN_CONCURRENCY = 5;
+
+/** Progress callback for long multi-batch generations: (roomsDone, total). */
+export type ZoneGenProgress = (done: number, total: number) => void;
+
 function scaleMaxTokens(entityCount: number): number {
   return Math.max(2048, Math.min(entityCount * 350, 16000));
+}
+
+/** One `llm_complete` call with a single retry before giving up. */
+async function llmCompleteOnce(
+  systemPrompt: string,
+  userPrompt: string,
+  maxTokens: number,
+): Promise<string> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return await invoke<string>("llm_complete", {
+        systemPrompt,
+        userPrompt,
+        maxTokens,
+      });
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Flavor one batch of layout rooms. On failure (after a retry) returns `[]` so
+ * the caller stubs those rooms instead of failing the whole zone.
+ */
+async function flavorRoomBatch(
+  params: ZoneGenerationParams,
+  batch: FixedLayoutRoom[],
+): Promise<LlmRoom[]> {
+  try {
+    const response = await llmCompleteOnce(
+      buildSystemPrompt(SYSTEM_PROMPT_SKETCH_ROOMS),
+      buildRoomBatchPrompt(params, batch),
+      scaleMaxTokens(batch.length),
+    );
+    return parseRooms(response);
+  } catch (err) {
+    console.error(`Room batch failed (${batch.length} rooms), stubbing:`, err);
+    return [];
+  }
+}
+
+/**
+ * Generate the zone's mobs + items in a single call, placed in `roomIds`. On
+ * failure (after a retry) returns empty sets so the rooms still ship.
+ */
+async function generateEntities(
+  params: ZoneGenerationParams,
+  roomIds: string[],
+): Promise<{ mobs: LlmMob[]; items: LlmItem[] }> {
+  if (params.mobCount <= 0 && params.itemCount <= 0) {
+    return { mobs: [], items: [] };
+  }
+  try {
+    const response = await llmCompleteOnce(
+      buildSystemPrompt(SYSTEM_PROMPT_SKETCH_ENTITIES),
+      buildEntitiesPrompt(params, roomIds),
+      scaleMaxTokens(params.mobCount + params.itemCount),
+    );
+    return parseEntities(response);
+  } catch (err) {
+    console.error("Entity generation failed; zone will have no mobs/items:", err);
+    return { mobs: [], items: [] };
+  }
 }
 
 /**
  * Generate a fresh zone from scratch.
  *
- * For zones larger than `SMALL_TOPOLOGY_LIMIT` we now place rooms on a grid
- * *first* with a deterministic random-walk, then ask the LLM to flavor the
- * fixed layout (title + description per room). This replaces the old flow
- * where the LLM invented free-form compass exits — which routinely produced
- * geometrically impossible graphs and messy layouts after grid embedding.
+ * For zones larger than `SMALL_TOPOLOGY_LIMIT` we pack the rooms into a square
+ * grid *first* (see `generateGridLayout`), then ask the LLM to flavor the fixed
+ * layout (title + description per room) in parallel batches. This replaces the
+ * old flow where the LLM invented free-form compass exits — which routinely
+ * produced geometrically impossible graphs and messy layouts after embedding.
  */
 export async function generateZoneContent(
   params: ZoneGenerationParams,
+  onProgress?: ZoneGenProgress,
 ): Promise<WorldFile> {
   if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
 
@@ -706,7 +878,7 @@ export async function generateZoneContent(
       count: params.roomCount,
       seed: `${params.zoneName}|${params.zoneTheme}`,
     });
-    const flavored = await generateZoneFromSketch(params, layout);
+    const flavored = await generateZoneFromSketch(params, layout, onProgress);
     return renameRoomsByTitle(flavored);
   }
 
@@ -727,41 +899,57 @@ export async function generateZoneContent(
 }
 
 /**
- * Generate a zone where the layout (rooms + exits) is already fixed,
- * typically from a user-provided sketch. The LLM only writes flavor.
+ * Generate a zone where the layout (rooms + exits) is already fixed — typically
+ * a square grid or a user-provided sketch. The LLM only writes flavor, and it
+ * does so in parallel batches: each batch flavors a slice of the rooms, mobs +
+ * items are authored in one overlapping call, and a batch that fails is stubbed
+ * rather than sinking the whole zone. `onProgress` reports rooms flavored.
  */
 export async function generateZoneFromSketch(
   params: ZoneGenerationParams,
   layout: FixedLayout,
+  onProgress?: ZoneGenProgress,
 ): Promise<WorldFile> {
   if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
   if (layout.rooms.length === 0) {
     throw new Error("Sketch layout has no rooms");
   }
 
-  const userPrompt = buildSketchUserPrompt(params, layout);
-  const systemPrompt = buildSystemPrompt(SYSTEM_PROMPT_SKETCH);
-  const maxTokens = scaleMaxTokens(
-    layout.rooms.length + params.mobCount + params.itemCount,
+  const total = layout.rooms.length;
+  onProgress?.(0, total);
+
+  // Mobs + items are zone-wide; start that single call now so it overlaps the
+  // parallel room-flavor batches instead of running after them.
+  const entitiesPromise = generateEntities(
+    params,
+    layout.rooms.map((r) => r.id),
   );
 
-  const response = await invoke<string>("llm_complete", {
-    systemPrompt,
-    userPrompt,
-    maxTokens,
-  });
+  let done = 0;
+  const batchResults = await mapWithConcurrency(
+    chunk(layout.rooms, ROOM_BATCH_SIZE),
+    GEN_CONCURRENCY,
+    async (batch) => {
+      const flavored = await flavorRoomBatch(params, batch);
+      done += batch.length;
+      onProgress?.(Math.min(done, total), total);
+      return flavored;
+    },
+  );
 
-  const parsed = parseGeneratedContent(response);
-
-  // Enforce: one entry per layout room, use layout's fixed exits.
-  // Match LLM rooms back to layout by ID; if missing, synthesize a stub.
-  const llmById = new Map(parsed.rooms.map((r) => [r.id, r]));
+  // Enforce: one entry per layout room, using the layout's fixed exits. Match
+  // flavored rooms back by ID; stub any the LLM dropped or any failed batch.
+  const llmById = new Map(
+    batchResults
+      .flat()
+      .filter((r) => r && r.id)
+      .map((r) => [r.id, r]),
+  );
   const rooms: LlmRoom[] = layout.rooms.map((layoutRoom) => {
     const llm = llmById.get(layoutRoom.id);
     if (llm) {
       return { ...llm, id: layoutRoom.id };
     }
-    // Fallback: use the hint (or derived title) if the LLM didn't return this room
     const title =
       layoutRoom.hint ||
       layoutRoom.id.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
@@ -775,14 +963,15 @@ export async function generateZoneFromSketch(
   const roomFiles = applyFixedLayout(rooms, layout);
   const roomIds = new Set(Object.keys(roomFiles));
   const fallback = layout.rooms[0]!.id;
+  const { mobs, items } = await entitiesPromise;
 
   return {
     zone: params.zoneName,
     lifespan: 30,
     startRoom: fallback,
     rooms: roomFiles,
-    mobs: buildMobs(parsed.mobs, roomIds, fallback),
-    items: buildItems(parsed.items, roomIds),
+    mobs: buildMobs(mobs, roomIds, fallback),
+    items: buildItems(items, roomIds),
     shops: {},
     quests: {},
     gatheringNodes: {},
@@ -936,6 +1125,10 @@ export const __test__ = {
   applyHandTopology,
   extractJson,
   parseGeneratedContent,
+  parseRooms,
+  parseEntities,
+  chunk,
+  mapWithConcurrency,
   renameRoomsByTitle,
   slugifyTitle,
 };

--- a/creator/src/lib/gridGenerator.ts
+++ b/creator/src/lib/gridGenerator.ts
@@ -1,165 +1,75 @@
 import type { FixedLayout, FixedLayoutRoom } from "./generateZoneContent";
 
 /**
- * Deterministically place `count` rooms on a 2D grid and derive exits from
- * cardinal adjacency. The result is a fully-wired `FixedLayout` that the
- * sketch-flavor LLM path can flesh out — no geometric contradictions possible,
- * which is how we avoid the messy spiral-resolved layouts that the graph-first
- * LLM generator used to produce.
+ * Deterministically pack `count` rooms into a compact rectangle and wire every
+ * orthogonally-adjacent pair, producing a fully-connected grid. The result is a
+ * clean square/rectangular `FixedLayout` that the sketch-flavor LLM path fleshes
+ * out — and, just as importantly, an easy canvas to reshape by hand. Builders
+ * almost always redraw an auto-generated organic sprawl, so we hand them a
+ * predictable block to carve from instead of a wandering walk.
  *
- * Placement is a weighted random-walk BFS: later rooms prefer recent parents
- * (creating natural spines) but occasionally branch from older rooms (creating
- * side-passages and dead-ends). After the spanning tree is built, a fraction
- * of unused grid adjacencies are promoted to loop exits so the map isn't a
- * pure tree.
+ * It renders as an exact rectangle: `compassLayout` (see `dagreLayout.ts`)
+ * embeds the graph with zero collisions because the exits are geometrically
+ * consistent by construction.
  */
 
-const DIR_PAIRS: Array<[string, string, number, number]> = [
-  ["n", "s", 0, -1],
-  ["s", "n", 0, 1],
-  ["e", "w", 1, 0],
-  ["w", "e", -1, 0],
+const DIR_PAIRS: Array<[string, number, number]> = [
+  ["n", 0, -1],
+  ["s", 0, 1],
+  ["e", 1, 0],
+  ["w", -1, 0],
 ];
 
-/** Small fast PRNG — mulberry32. Seed 0 is allowed. */
-function mulberry32(seed: number): () => number {
-  let a = seed >>> 0;
-  return () => {
-    a = (a + 0x6d2b79f5) >>> 0;
-    let t = a;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
-function hashString(s: string): number {
-  let h = 0x811c9dc5;
-  for (let i = 0; i < s.length; i++) {
-    h = Math.imul(h ^ s.charCodeAt(i), 0x01000193);
-  }
-  return h >>> 0;
-}
+/** Default width:height ratio — a touch wider than tall reads well left-to-right. */
+const DEFAULT_ASPECT = 1.2;
 
 export interface GridGenerationOptions {
   /** Number of rooms to place (≥ 1). */
   count: number;
-  /** Deterministic seed. Strings are hashed. */
+  /**
+   * Accepted for call-site compatibility. The packed grid is deterministic by
+   * size, so the seed no longer changes the shape — a given `count` always
+   * yields the same rectangle.
+   */
   seed?: number | string;
-  /** Bias toward recent placements. 0.4 = moderate spines with occasional branches. */
-  branchBias?: number;
-  /** Fraction of grid-adjacent, non-tree pairs that become loop exits. */
-  loopProbability?: number;
+  /** Target width:height ratio of the rectangle. Default ~1.2. */
+  aspect?: number;
   /** Room ID prefix. Defaults to `room`. */
   idPrefix?: string;
 }
 
 export function generateGridLayout(opts: GridGenerationOptions): FixedLayout {
   const count = Math.max(1, Math.floor(opts.count));
-  const seed =
-    typeof opts.seed === "string"
-      ? hashString(opts.seed)
-      : opts.seed ?? Date.now();
-  const rng = mulberry32(seed);
-  const branchBias = opts.branchBias ?? 0.4;
-  const loopProbability = opts.loopProbability ?? 0.22;
   const idPrefix = opts.idPrefix ?? "room";
+  const aspect = opts.aspect && opts.aspect > 0 ? opts.aspect : DEFAULT_ASPECT;
 
-  const cells = new Map<string, string>();
-  const placed: Array<{ id: string; x: number; y: number }> = [];
-  const exits: Record<string, Record<string, string>> = {};
+  // Columns chosen so the block sits close to `aspect`; rows follow from count.
+  // `room_0` lands at the top-left (0,0) so it reads as the natural entry corner.
+  const cols = Math.min(count, Math.max(1, Math.round(Math.sqrt(count * aspect))));
 
-  const start = { id: `${idPrefix}_0`, x: 0, y: 0 };
-  placed.push(start);
-  cells.set("0,0", start.id);
-  exits[start.id] = {};
+  const rooms: FixedLayoutRoom[] = [];
+  const cellId = new Map<string, string>();
+  const coord = new Map<string, [number, number]>();
 
-  for (let i = 1; i < count; i++) {
+  for (let i = 0; i < count; i++) {
+    const x = i % cols;
+    const y = Math.floor(i / cols);
     const id = `${idPrefix}_${i}`;
-    let placedThis = false;
-
-    // Up to N rotations of the "pick a recent room, try to branch" loop before
-    // giving up and doing an exhaustive scan from the oldest room forward.
-    for (let attempt = 0; attempt < 32 && !placedThis; attempt++) {
-      // Geometric(1-branchBias)-ish draw from the tail of `placed`.
-      let offset = 0;
-      while (offset < placed.length - 1 && rng() > branchBias) offset++;
-      const parent = placed[placed.length - 1 - offset]!;
-
-      const shuffled = shuffle(DIR_PAIRS, rng);
-      for (const [dir, rev, dx, dy] of shuffled) {
-        const nx = parent.x + dx;
-        const ny = parent.y + dy;
-        const key = `${nx},${ny}`;
-        if (cells.has(key)) continue;
-        cells.set(key, id);
-        placed.push({ id, x: nx, y: ny });
-        exits[id] = {};
-        exits[parent.id]![dir] = id;
-        exits[id]![rev] = parent.id;
-        placedThis = true;
-        break;
-      }
-    }
-
-    if (placedThis) continue;
-
-    // Fallback: linear scan from oldest to find any room with a free neighbor.
-    for (const parent of placed) {
-      for (const [dir, rev, dx, dy] of DIR_PAIRS) {
-        const nx = parent.x + dx;
-        const ny = parent.y + dy;
-        const key = `${nx},${ny}`;
-        if (cells.has(key)) continue;
-        cells.set(key, id);
-        placed.push({ id, x: nx, y: ny });
-        exits[id] = {};
-        exits[parent.id]![dir] = id;
-        exits[id]![rev] = parent.id;
-        placedThis = true;
-        break;
-      }
-      if (placedThis) break;
-    }
-
-    // Truly-full grid is effectively impossible for practical room counts;
-    // bail if it somehow happens so we return a valid partial layout.
-    if (!placedThis) break;
+    rooms.push({ id, hint: null, exits: {} });
+    cellId.set(`${x},${y}`, id);
+    coord.set(id, [x, y]);
   }
 
-  // Promote a fraction of unused grid adjacencies to loop exits. Iterate in a
-  // stable order so the result is deterministic given the seed.
-  const placedSorted = [...placed].sort((a, b) =>
-    a.x === b.x ? a.y - b.y : a.x - b.x,
-  );
-  for (const room of placedSorted) {
-    for (const [dir, rev, dx, dy] of DIR_PAIRS) {
-      const neighborId = cells.get(`${room.x + dx},${room.y + dy}`);
-      if (!neighborId) continue;
-      if (exits[room.id]![dir]) continue;
-      if (exits[neighborId]![rev]) continue;
-      if (rng() >= loopProbability) continue;
-      exits[room.id]![dir] = neighborId;
-      exits[neighborId]![rev] = room.id;
+  // Wire each room to its existing cardinal neighbors. Visiting every room sets
+  // both halves of each pair (A→e→B when on A, B→w→A when on B), so the graph
+  // comes out fully bidirectional without a separate reverse pass.
+  for (const room of rooms) {
+    const [x, y] = coord.get(room.id)!;
+    for (const [dir, dx, dy] of DIR_PAIRS) {
+      const neighbor = cellId.get(`${x + dx},${y + dy}`);
+      if (neighbor) room.exits[dir] = neighbor;
     }
   }
-
-  const rooms: FixedLayoutRoom[] = placed.map((p) => ({
-    id: p.id,
-    hint: null,
-    exits: exits[p.id]!,
-  }));
 
   return { rooms };
-}
-
-function shuffle<T>(arr: readonly T[], rng: () => number): T[] {
-  const a = [...arr];
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    const tmp = a[i]!;
-    a[i] = a[j]!;
-    a[j] = tmp;
-  }
-  return a;
 }

--- a/creator/src/lib/useBackgroundRemoval.ts
+++ b/creator/src/lib/useBackgroundRemoval.ts
@@ -149,37 +149,62 @@ export function shouldRemoveBg(assetType: string): boolean {
  * Existing call sites that relied on null-return can still get that behavior
  * by appending `.catch(() => null)`.
  */
+async function runBgRemoval(
+  imageDataUrl: string,
+  assetType: string,
+  context?: AssetContext,
+  variantGroup?: string,
+): Promise<AssetEntry> {
+  console.log(
+    `[bg-removal] Starting for ${assetType}${variantGroup ? ` (variant: ${variantGroup})` : ""}`,
+  );
+  const blob = await removeBackground(imageDataUrl);
+  const buffer = await blob.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  const chunks: string[] = [];
+  const CHUNK = 8192;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    chunks.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
+  }
+  const b64 = btoa(chunks.join(""));
+
+  const entry = await invoke<AssetEntry>("save_bytes_as_asset", {
+    bytesB64: b64,
+    assetType,
+    context: context ?? null,
+    variantGroup: variantGroup ?? null,
+  });
+  if (variantGroup) {
+    await invoke("set_active_variant", { variantGroup, assetId: entry.id });
+    console.log(`[bg-removal] Set as active variant for ${variantGroup}`);
+  }
+  return entry;
+}
+
 export async function removeBgAndSave(
   imageDataUrl: string,
   assetType: string,
   context?: AssetContext,
   variantGroup?: string,
 ): Promise<AssetEntry> {
-  return enqueueBgTask(async () => {
-    console.log(
-      `[bg-removal] Starting for ${assetType}${variantGroup ? ` (variant: ${variantGroup})` : ""}`,
-    );
-    const blob = await removeBackground(imageDataUrl);
-    const buffer = await blob.arrayBuffer();
-    const bytes = new Uint8Array(buffer);
-    const chunks: string[] = [];
-    const CHUNK = 8192;
-    for (let i = 0; i < bytes.length; i += CHUNK) {
-      chunks.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
-    }
-    const b64 = btoa(chunks.join(""));
+  return enqueueBgTask(() => runBgRemoval(imageDataUrl, assetType, context, variantGroup));
+}
 
-    const entry = await invoke<AssetEntry>("save_bytes_as_asset", {
-      bytesB64: b64,
-      assetType,
-      context: context ?? null,
-      variantGroup: variantGroup ?? null,
-    });
-    if (variantGroup) {
-      await invoke("set_active_variant", { variantGroup, assetId: entry.id });
-      console.log(`[bg-removal] Set as active variant for ${variantGroup}`);
-    }
-    return entry;
+/**
+ * Like `removeBgAndSave`, but reads the source image from disk *inside* the
+ * serialized task instead of holding a multi-MB data URL in memory until the
+ * queue reaches it. Batch art generation uses this so a whole zone's worth of
+ * pending removals doesn't pin every source image at once.
+ */
+export async function removeBgFromFileAndSave(
+  filePath: string,
+  assetType: string,
+  context?: AssetContext,
+  variantGroup?: string,
+): Promise<AssetEntry> {
+  return enqueueBgTask(async () => {
+    const imageDataUrl = await invoke<string>("read_image_data_url", { path: filePath });
+    return runBgRemoval(imageDataUrl, assetType, context, variantGroup);
   });
 }
 


### PR DESCRIPTION
## Problem

Generating large zones (60–100+ rooms) failed with:

> Anthropic API request failed: error sending request for url (https://api.anthropic.com/v1/messages)

Two compounding causes:
1. The shared reqwest client's **120s total timeout** was sized for image generation, but large-zone flavoring is a single non-streaming text call that runs for several minutes — so it tripped the timeout (a transport error, not an API rejection).
2. `scaleMaxTokens` let that one call request up to 16k output tokens, which is exactly what made it run long enough to time out.

## Changes

### Backend — dedicated LLM timeout
- New `llm_client()` in `http.rs` (10s connect, **600s** total). All text-completion paths (Anthropic, OpenRouter, OpenAI, DeepInfra, hub complete/vision) route through it; image generation keeps the 120s client.

### Frontend — parallel batched flavoring (`generateZoneFromSketch`)
- Rooms are flavored in **batches of 20, 5 concurrent** via a new `mapWithConcurrency` pool.
- Mobs + items are a **separate single call** that overlaps the room batches (rooms-only / entities-only prompts stop batches from re-inventing each other's content).
- Each batch + the entity call get **one retry**; a batch that still fails **stubs its own rooms** instead of failing the whole zone.
- A 100-room zone is now ~6 small calls in ~2 waves instead of one ~5-minute request.

### Frontend — square grid layout (`generateGridLayout`)
- Replaced the random-walk with a **packed, fully-wired rectangle** (≈√n × √n). It embeds under `compassLayout` with zero collisions, so it renders as a clean square to carve from rather than an organic sprawl. Now deterministic by size.

### UX
- `NewZoneDialog` shows per-batch progress: **"Flavoring rooms 40/100…"**.

## Testing
- `bunx tsc --noEmit` clean; `cargo check` clean.
- All **2253** Vitest tests pass, including new coverage for the square-grid shape, `chunk`, `parseRooms`/`parseEntities`, and `mapWithConcurrency` (order + concurrency cap).
- Not yet exercised: a live end-to-end 100-room generation (needs the GUI + an API key) — worth a manual smoke test.

## Notes
- Mobs+items remain a single call (they need zone-wide unique IDs / spread); the 600s timeout covers it. Can be batched later if mob counts get very high.