### PR TITLE
fix: stop batch art OOM-crashing the WebView on very large zones

### DIFF
--- a/creator/src/components/zone/BatchArtGenerator.tsx
+++ b/creator/src/components/zone/BatchArtGenerator.tsx
@@ -44,6 +44,7 @@ export function BatchArtGenerator({
   const imageProvider = settings?.image_provider ?? "deepinfra";
 
   const acceptAsset = useAssetStore((s) => s.acceptAsset);
+  const loadAssets = useAssetStore((s) => s.loadAssets);
 
   const toggleTarget = (idx: number) => {
     setTargets((prev) => prev.map((t, i) => (i === idx ? { ...t, checked: !t.checked } : t)));
@@ -58,32 +59,38 @@ export function BatchArtGenerator({
     abortRef.current = false;
 
     setBgRemoval(null);
-    await runBatchArtGeneration(
-      targets,
-      world,
-      zoneId,
-      artStyle,
-      vibe,
-      imageProvider,
-      settings?.image_model,
-      concurrency,
-      abortRef,
-      {
-        onTargetUpdate: (idx, update) => {
-          setTargets((prev) =>
-            prev.map((t, i) => (i === idx ? { ...t, ...update } : t)),
-          );
+    try {
+      await runBatchArtGeneration(
+        targets,
+        world,
+        zoneId,
+        artStyle,
+        vibe,
+        imageProvider,
+        settings?.image_model,
+        concurrency,
+        abortRef,
+        {
+          onTargetUpdate: (idx, update) => {
+            setTargets((prev) =>
+              prev.map((t, i) => (i === idx ? { ...t, ...update } : t)),
+            );
+          },
+          onWorldUpdate: onWorldChange,
+          onBgRemovalProgress: (done, total) => setBgRemoval({ done, total }),
+          // reload=false: skip the per-image manifest reload (O(n²) on big
+          // zones — it OOMs the WebView). The whole batch refreshes once below.
+          acceptAsset: (image, assetType, enhancedPrompt, context, variantGroup, isActive) =>
+            acceptAsset(image, assetType, enhancedPrompt, context, variantGroup, isActive, false),
         },
-        onWorldUpdate: onWorldChange,
-        onBgRemovalProgress: (done, total) => setBgRemoval({ done, total }),
-        acceptAsset,
-      },
-      settings?.auto_remove_bg,
-    );
-
-    setBgRemoval(null);
-    setRunning(false);
-  }, [targets, world, onWorldChange, artStyle, vibe, imageProvider, concurrency, zoneId, acceptAsset, settings]);
+        settings?.auto_remove_bg,
+      );
+    } finally {
+      await loadAssets();
+      setBgRemoval(null);
+      setRunning(false);
+    }
+  }, [targets, world, onWorldChange, artStyle, vibe, imageProvider, concurrency, zoneId, acceptAsset, loadAssets, settings]);
 
   if (!AI_ENABLED) return null;
 

--- a/creator/src/stores/__tests__/assetStore.acceptAsset.test.ts
+++ b/creator/src/stores/__tests__/assetStore.acceptAsset.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { GeneratedImage } from "@/types/assets";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+// Import AFTER the mock is registered.
+import { useAssetStore } from "@/stores/assetStore";
+
+function image(): GeneratedImage {
+  return {
+    id: "img1",
+    hash: "abc123",
+    file_path: "/assets/images/abc123.png",
+    data_url: "",
+    width: 1024,
+    height: 1024,
+    prompt: "a cozy parlor",
+    model: "flux",
+  };
+}
+
+function commandsCalled(): string[] {
+  return invokeMock.mock.calls.map((c) => c[0] as string);
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue([]);
+});
+
+describe("acceptAsset — manifest reload control", () => {
+  it("reloads the manifest by default (single-image paths stay live)", async () => {
+    await useAssetStore.getState().acceptAsset(image(), "background");
+    expect(commandsCalled()).toEqual(["accept_asset", "list_assets"]);
+  });
+
+  it("skips the per-image reload when reload=false (batch path)", async () => {
+    // Batch art generation accepts every image with reload=false so a big zone
+    // doesn't trigger an O(n²) full-manifest reload that OOMs the WebView.
+    await useAssetStore
+      .getState()
+      .acceptAsset(image(), "background", undefined, undefined, undefined, true, false);
+    const calls = commandsCalled();
+    expect(calls).toContain("accept_asset");
+    expect(calls).not.toContain("list_assets");
+  });
+});

--- a/creator/src/stores/assetStore.ts
+++ b/creator/src/stores/assetStore.ts
@@ -52,7 +52,7 @@ interface AssetState {
   saveProjectSettings: (projectDir: string, settings: ProjectSettings) => Promise<void>;
 
   loadAssets: () => Promise<void>;
-  acceptAsset: (image: GeneratedImage, assetType: string, enhancedPrompt?: string, context?: AssetContext, variantGroup?: string, isActive?: boolean) => Promise<void>;
+  acceptAsset: (image: GeneratedImage, assetType: string, enhancedPrompt?: string, context?: AssetContext, variantGroup?: string, isActive?: boolean, reload?: boolean) => Promise<void>;
   importAsset: (
     sourcePath: string,
     assetType: string,
@@ -138,7 +138,7 @@ export const useAssetStore = create<AssetState>((set, get) => ({
     set({ assets });
   },
 
-  acceptAsset: async (image, assetType, enhancedPrompt, context, variantGroup, isActive) => {
+  acceptAsset: async (image, assetType, enhancedPrompt, context, variantGroup, isActive, reload = true) => {
     const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
 
     await invoke<AssetEntry>("accept_asset", {
@@ -155,7 +155,10 @@ export const useAssetStore = create<AssetState>((set, get) => ({
       variantGroup: variantGroup ?? null,
       isActive: isActive ?? null,
     });
-    await get().loadAssets();
+    // Reloading the whole manifest after every accept is O(n²) across a batch
+    // (each reload marshals the entire AssetEntry[] over IPC into the WebView).
+    // Batch art passes reload=false and refreshes once when the run finishes.
+    if (reload) await get().loadAssets();
   },
 
   importAsset: async (sourcePath, assetType, context, variantGroup, isActive, displayName) => {


### PR DESCRIPTION
## Problem

Generating batch art for a very large zone still crashes the app — Chromium shows its **"Error code: Out of Memory"** renderer page partway through. PR #308 fixed one OOM cause (retained base64 data URLs) but explicitly left this one documented and unfixed.

## Root cause

Every generated image is accepted through `assetStore.acceptAsset`, which reloaded the **entire** asset manifest after **each** image:

```
accept_asset   -> Rust reads + rewrites the whole manifest.json
loadAssets()   -> list_assets reads + parses the whole manifest AGAIN,
                  marshals the full AssetEntry[] over IPC into the WebView,
                  and replaces the Zustand store array (re-rendering subscribers)
```

The manifest is project-wide and grows toward N as the batch runs, so this is **O(n²) full-manifest reloads** funneled into the renderer in a tight loop. For a large zone (hundreds of images) on top of an already-large project manifest, the transient JSON allocations outrun GC and the renderer heap dies.

The per-image reload is pure waste mid-batch: generation writes the world from `image.file_path` directly and never reads the store's `assets` array during the run.

## Fix

- `assetStore.acceptAsset` gains an optional `reload` flag (**default `true`**) — every single-image caller (`AssetGenerator`, `PortraitStudio`, `SpriteScaffold`, `EntityArtGenerator`, etc.) is byte-for-byte unchanged.
- `BatchArtGenerator` accepts each image with `reload=false` and refreshes the manifest **once** when the whole run finishes, in a `finally` so an abort or early error still resolves the dialog and reloads the store. Background removal already wrote variants directly (bypassing the store), so the single final reload picks those up too.

## Scope note

The Rust-side `accept_asset` still does a read-modify-write of the whole manifest per image (O(n²) disk I/O), but that runs off the renderer thread and does not OOM the WebView — it's a perf follow-up, not the crash. This PR removes the renderer-side O(n²) marshaling, which is the actual crash.

## Testing

- `bunx tsc --noEmit` clean
- `bun run test` — 2258 passing (incl. new `assetStore.acceptAsset.test.ts` regression test asserting the default path reloads and the batch path does not)