### PR TITLE
fix: adding a cross-zone exit no longer relayouts the world atlas

### DIFF
--- a/creator/src/components/zone/ZoneAtlasView.tsx
+++ b/creator/src/components/zone/ZoneAtlasView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -475,13 +475,34 @@ function ZoneAtlas() {
   const [nodes, setNodes, onNodesChange] = useNodesState(initial.nodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initial.edges);
 
-  // When the zone set (or saved positions) changes, snap back to the freshly
-  // computed atlas. Saved positions are already baked into `initial.nodes`,
-  // so this also restores on first open.
+  // Reconcile ReactFlow state with the freshly computed atlas.
+  //
+  // `savedPositions` only changes identity on a project switch or an explicit
+  // "Reset Layout" (its memo is keyed on [projectPath, resetNonce]). We use
+  // that to decide between two behaviors:
+  //   • savedPositions changed → apply the fresh layout wholesale (first open,
+  //     project switch, or reset).
+  //   • only `zones` changed (e.g. an exit was added) → refresh node data and
+  //     edges but KEEP the positions currently on screen, so creating a link
+  //     doesn't relayout the atlas and shove every cluster around.
+  const prevSavedRef = useRef(savedPositions);
   useEffect(() => {
-    setNodes(initial.nodes);
+    const savedChanged = prevSavedRef.current !== savedPositions;
+    prevSavedRef.current = savedPositions;
+    if (savedChanged) {
+      setNodes(initial.nodes);
+      setEdges(initial.edges);
+      return;
+    }
+    setNodes((current) => {
+      const positions = new Map(current.map((n) => [n.id, n.position]));
+      return initial.nodes.map((n) => {
+        const existing = positions.get(n.id);
+        return existing ? { ...n, position: existing } : n;
+      });
+    });
     setEdges(initial.edges);
-  }, [initial, setNodes, setEdges]);
+  }, [initial, savedPositions, setNodes, setEdges]);
 
   const onNodeClick: NodeMouseHandler = useCallback(
     (_event, node) => {


### PR DESCRIPTION
## Problem

In the world atlas, **adding an exit moves the blocks around and resets the layout** — manual arrangement (and even un-dragged clusters) jump to new positions the moment a cross-zone link is created.

## Root cause

`ZoneAtlasView` derives its layout from:

```ts
const initial = useMemo(() => buildAtlas(zones, savedPositions), [zones, savedPositions]);
useEffect(() => {
  setNodes(initial.nodes);   // <-- unconditional reset
  setEdges(initial.edges);
}, [initial, setNodes, setEdges]);
```

Confirming a link calls `updateZone(...)` for both ends, which replaces each zone's `data` and the `zones` Map. That recomputes `initial`, and the effect then **unconditionally** overwrites every node's position with a freshly computed layout. For clusters without a saved position it's doubly bad: the new cross-zone exit adds an edge to the dagre meta-graph, so `layoutClusters` re-runs and physically relocates the clusters.

## Fix

`buildAtlas` already bakes saved cluster positions into `initial.nodes`, and `savedPositions` is a `useMemo` keyed on `[projectPath, resetNonce]` — so its **identity only changes on a project switch or an explicit "Reset Layout"**, never on a plain zone edit. The reconcile effect now branches on that signal:

- **`savedPositions` identity changed** → apply the fresh layout wholesale (first open, project switch, and the Reset Layout button all still work).
- **only `zones` changed** (exit added, room edited) → refresh node `data` + edges but **keep the positions currently on screen**.

This mirrors the position-preserving merge `ZoneEditor` already uses, so graph-neutral edits don't disturb manual arrangement. Dragging a cluster (saved on `onNodeDragStop`) is preserved too — the merge keeps the live on-screen position even before the next reload.

## Testing

- `bunx tsc --noEmit` clean
- `bun run test` — 2258 passing (UI/ReactFlow reconciliation; no data-layer test applies, behavior verified against the established `ZoneEditor` pattern)

Manual scenarios reasoned through: first open, add cross-zone link (no movement ✓), drag cluster then add link (drag preserved ✓), Reset Layout (full re-layout ✓), project switch (fresh layout ✓).