### PR TITLE
fix: honor GPT image quality setting on the Runware path

### DIFF
--- a/creator/src-tauri/src/openai_images.rs
+++ b/creator/src-tauri/src/openai_images.rs
@@ -111,7 +111,7 @@ pub async fn openai_generate_image(
     let size = snap_to_openai_size(w, h);
 
     let resolved_quality = quality
-        .or_else(|| resolve_quality_from_settings(&settings, asset_type.as_deref()))
+        .or_else(|| settings::resolve_openai_image_quality(&settings, asset_type.as_deref()))
         .unwrap_or_else(|| "low".to_string());
 
     let body = OpenAIImageRequest {
@@ -178,29 +178,6 @@ pub async fn openai_generate_image(
         behavior.output_format,
     )
     .await
-}
-
-/// Resolve the OpenAI image quality from project settings, honoring an
-/// optional per-AssetType override before falling back to the project default.
-/// Returns None when neither is set, so the caller can apply its own fallback.
-fn resolve_quality_from_settings(
-    s: &settings::Settings,
-    asset_type: Option<&str>,
-) -> Option<String> {
-    if let Some(at) = asset_type {
-        if let Some(q) = s.openai_image_quality_overrides.get(at) {
-            let trimmed = q.trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
-            }
-        }
-    }
-    let trimmed = s.openai_image_quality.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
 }
 
 /// Snap arbitrary dimensions to the nearest supported OpenAI image size.

--- a/creator/src-tauri/src/runware.rs
+++ b/creator/src-tauri/src/runware.rs
@@ -197,11 +197,13 @@ pub async fn runware_generate_image(
 
     // Build provider settings for GPT Image models. v2 dropped the
     // `background` field; only `quality` remains on providerSettings.openai.
+    // Resolution order: per-asset-type override → project default → "low"
+    // fallback. (Hub mode forces "low" and short-circuits above.)
     let provider_settings = if is_gpt_image_model(&mdl) {
+        let quality = settings::resolve_openai_image_quality(&s, asset_type.as_deref())
+            .unwrap_or_else(|| "low".to_string());
         Some(ImageProviderSettings {
-            openai: OpenAIImageSettings {
-                quality: "low".to_string(),
-            },
+            openai: OpenAIImageSettings { quality },
         })
     } else {
         None

--- a/creator/src-tauri/src/settings.rs
+++ b/creator/src-tauri/src/settings.rs
@@ -130,6 +130,27 @@ fn default_openai_image_quality() -> String {
     "low".to_string()
 }
 
+/// Resolve the OpenAI image quality tier ("low" | "medium" | "high" | "auto")
+/// from settings, honoring an optional per-AssetType override before falling
+/// back to the global default. Returns None when neither is set, so the caller
+/// applies its own fallback. Shared by the direct OpenAI and Runware GPT paths.
+pub fn resolve_openai_image_quality(s: &Settings, asset_type: Option<&str>) -> Option<String> {
+    if let Some(at) = asset_type {
+        if let Some(q) = s.openai_image_quality_overrides.get(at) {
+            let trimmed = q.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    let trimmed = s.openai_image_quality.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {

--- a/creator/src/components/config/panels/ApiSettingsPanel.tsx
+++ b/creator/src/components/config/panels/ApiSettingsPanel.tsx
@@ -437,7 +437,8 @@ export function ApiSettingsPanel() {
                   })}
                 </div>
 
-                {projectDraft.image_provider === "openai" && (
+                {(projectDraft.image_provider === "openai" ||
+                  projectDraft.image_model?.startsWith("openai:")) && (
                   <OpenAiQualitySection
                     projectDraft={projectDraft}
                     setProjectDraft={setProjectDraft}
@@ -586,7 +587,8 @@ export function ApiSettingsPanel() {
 }
 
 // ─── OpenAI quality controls ───────────────────────────────────────
-// Surfaced only when image_provider === "openai". The hub proxy forces
+// Surfaced whenever a GPT Image model is selected — direct OpenAI or
+// routed through Runware (model id `openai:…`). The hub proxy forces
 // "low" regardless, so this UI is meaningless in hub mode (covered by
 // the hub-mode banner at the top of the panel).
 
@@ -629,9 +631,9 @@ function OpenAiQualitySection({
         Image quality
       </h4>
       <p className="mb-3 text-3xs text-text-muted/70">
-        Higher quality means more output tokens — and OpenAI bills per token. Use the per-asset
-        overrides to keep bulk types (icons, ornaments) cheap while heroes (sprites, portraits)
-        render at full quality.
+        Higher quality means more output tokens — and GPT Image is billed per token (by OpenAI
+        directly, or by Runware when routed through it). Use the per-asset overrides to keep bulk
+        types (icons, ornaments) cheap while heroes (sprites, portraits) render at full quality.
       </p>
 
       <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

The per-asset image quality setting (`openai_image_quality` + `openai_image_quality_overrides`) was added in `aaa73a82` but only wired into the **direct OpenAI** provider. The **Runware-routed GPT** path (`runware.rs`) hardcoded `quality: "low"`, so the setting silently did nothing for GPT Image 2 generated via Runware — which is the default image path for many setups.

This wires the Runware path into the existing resolution chain and makes the existing UI control visible to the users it affects.

## Changes

- **`settings.rs`** — extract the quality-resolution logic into a shared `resolve_openai_image_quality(s, asset_type)` (natural home; operates on `Settings`).
- **`openai_images.rs`** — drop its private copy of the helper, call the shared one. No behavior change.
- **`runware.rs`** — the GPT-image branch resolves quality via the chain (**per-asset override → project default → `"low"` fallback**) instead of hardcoding `"low"`.
- **`ApiSettingsPanel.tsx`** — the quality UI was gated to `image_provider === "openai"`, so Runware users who selected "GPT Image 2 (Runware)" never saw it. Now shows whenever a GPT model is selected (`image_model` starts with `openai:`). Updated the stale comment + "OpenAI bills per token" copy to cover the Runware-routed case.

## Notes

- Reuses the existing **project-level** setting (API Settings → Image quality) rather than adding a duplicate user-level one.
- **Hub mode unchanged** — the hub proxy still forces `"low"` server-side and short-circuits before this code, by design for quota control. Only direct-provider (BYOK) generation is affected.

## Testing

- `cargo check` ✅
- `bunx tsc --noEmit` ✅
- `bun run test` — 2258 tests ✅