### PR TITLE
Add flight master room flag + global asset

### DIFF
--- a/creator/src/assets/ui/index.ts
+++ b/creator/src/assets/ui/index.ts
@@ -14,6 +14,8 @@ import roleStylist from "./role_stylist.png";
 import roleTavern from "./role_tavern.png";
 // Placeholder: reuses the scroll panel icon until a bespoke role_akathavae_shrine.png is generated.
 import roleAkathavaeShrine from "./panel_scroll.png";
+// Placeholder: reuses the cloud panel icon until a bespoke role_flight_master.png is generated.
+import roleFlightMaster from "./panel_cloud.png";
 
 // Feature type icons (16×16) — room feature badges
 import featureContainer from "./feature_container.png";
@@ -147,6 +149,7 @@ export const ROLE_ICONS: Record<string, string> = {
   housingBroker: roleHousingBroker,
   inn: roleInn,
   akathavaeShrine: roleAkathavaeShrine,
+  flightMaster: roleFlightMaster,
 };
 
 /** Feature type (lowercase) → icon URL. */

--- a/creator/src/components/playtest/PlaytestPanel.tsx
+++ b/creator/src/components/playtest/PlaytestPanel.tsx
@@ -1067,6 +1067,7 @@ function RoomBadges({ room }: { room: RoomFile }) {
   if (room.auction) flags.push("Auction");
   if (room.stylist) flags.push("Stylist");
   if (room.housingBroker) flags.push("Housing Broker");
+  if (room.flightMaster) flags.push("Flight Master");
   if (room.station) flags.push(`Station: ${room.station}`);
   if (room.terrain) flags.push(room.terrain);
   if (flags.length === 0) return null;

--- a/creator/src/components/zone/RoomNode.tsx
+++ b/creator/src/components/zone/RoomNode.tsx
@@ -103,7 +103,7 @@ function RoomBackground({ image }: { image?: string }) {
 
 /** Role pill badges (bank, tavern/lottery, inn, dungeon, auction, stylist, housingBroker) */
 function RoleBadges({ d }: { d: RoomNodeData }) {
-  if (!d.bank && !d.tavern && !d.inn && !d.dungeon && !d.auction && !d.stylist && !d.housingBroker && !d.akathavaeShrine) return null;
+  if (!d.bank && !d.tavern && !d.inn && !d.dungeon && !d.auction && !d.stylist && !d.housingBroker && !d.akathavaeShrine && !d.flightMaster) return null;
   return (
     <div className="relative flex flex-wrap gap-1">
       {d.bank && (
@@ -152,6 +152,12 @@ function RoleBadges({ d }: { d: RoomNodeData }) {
         <span className="flex items-center gap-0.5 rounded bg-accent/20 px-1 text-3xs font-semibold text-accent" title="Akathavae shrine (pledge/renounce)">
           <img src={ROLE_ICONS.akathavaeShrine} alt="" className="h-3 w-3" />
           Shrine
+        </span>
+      )}
+      {d.flightMaster && (
+        <span className="flex items-center gap-0.5 rounded bg-accent/20 px-1 text-3xs font-semibold text-accent" title="Flight master (flights/fly)">
+          <img src={ROLE_ICONS.flightMaster} alt="" className="h-3 w-3" />
+          Flight
         </span>
       )}
     </div>

--- a/creator/src/components/zone/RoomPanel.tsx
+++ b/creator/src/components/zone/RoomPanel.tsx
@@ -844,7 +844,7 @@ export function RoomPanel({
       {/* Room roles */}
       <Section
         title="Room Roles"
-        defaultExpanded={!!room.station || !!room.bank || !!room.tavern || !!room.dungeon || !!room.auction || !!room.stylist || !!room.housingBroker || !!room.inn || !!room.akathavaeShrine}
+        defaultExpanded={!!room.station || !!room.bank || !!room.tavern || !!room.dungeon || !!room.auction || !!room.stylist || !!room.housingBroker || !!room.inn || !!room.akathavaeShrine || !!room.flightMaster}
       >
         <div className="flex flex-col gap-2">
           {/* Station — dropdown instead of toggle */}
@@ -879,6 +879,7 @@ export function RoomPanel({
             { key: "stylist" as const, label: "Stylist", icon: ROLE_ICONS.stylist },
             { key: "housingBroker" as const, label: "Housing Broker", icon: ROLE_ICONS.housingBroker },
             { key: "akathavaeShrine" as const, label: "Akathavae Shrine", icon: ROLE_ICONS.akathavaeShrine },
+            { key: "flightMaster" as const, label: "Flight Master", icon: ROLE_ICONS.flightMaster },
           ] as const).map(({ key, label, icon }) => {
             const active = !!(room[key]);
             return (

--- a/creator/src/lib/__tests__/validateConfig.test.ts
+++ b/creator/src/lib/__tests__/validateConfig.test.ts
@@ -168,6 +168,7 @@ const BASE_CONFIG: AppConfig = {
     stylist_mirror: "stylist_mirror.png",
     housing_broker: "housing_broker.png",
     inn_widget: "inn_widget.png",
+    flight_roost: "flight_roost.png",
     character_widget: "character_widget.png",
     inventory_widget: "inventory_widget.png",
     equipment_widget: "equipment_widget.png",

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -397,6 +397,16 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
       "A single cozy curtained bed with a warm glowing lantern beside it, centered, soft outline, transparent background.",
     transparent: true,
   },
+  {
+    key: "flight_roost",
+    defaultFilename: "flight_roost.png",
+    label: "Flight Roost",
+    description: "Badge shown on flight master rooms where players can fast-travel between discovered flight points.",
+    assetType: "ability_icon",
+    defaultPrompt:
+      "A single winged creature perched on an ornate roost post, ready for flight, centered, soft outline, transparent background.",
+    transparent: true,
+  },
   // Persistent player-UI navigation buttons rendered down the left edge of
   // every room canvas (unlike the room-feature badges above, which only
   // appear on rooms that host the corresponding feature).

--- a/creator/src/lib/zoneToGraph.ts
+++ b/creator/src/lib/zoneToGraph.ts
@@ -53,6 +53,7 @@ export interface RoomNodeData extends Record<string, unknown> {
   stylist?: boolean;
   housingBroker?: boolean;
   akathavaeShrine?: boolean;
+  flightMaster?: boolean;
   image?: string;
   entities: EntitySprite[];
 }
@@ -134,7 +135,7 @@ function buildGraphFingerprint(world: WorldFile): string {
   const parts: string[] = [`s:${world.startRoom}`];
 
   for (const [id, room] of Object.entries(world.rooms)) {
-    const flags = `${room.bank ? 1 : 0}${room.tavern ? 1 : 0}${room.inn ? 1 : 0}${room.dungeon ? 1 : 0}${room.auction ? 1 : 0}${room.stylist ? 1 : 0}${room.housingBroker ? 1 : 0}${room.akathavaeShrine ? 1 : 0}`;
+    const flags = `${room.bank ? 1 : 0}${room.tavern ? 1 : 0}${room.inn ? 1 : 0}${room.dungeon ? 1 : 0}${room.auction ? 1 : 0}${room.stylist ? 1 : 0}${room.housingBroker ? 1 : 0}${room.akathavaeShrine ? 1 : 0}${room.flightMaster ? 1 : 0}`;
     let exits = "";
     if (room.exits) {
       const exitParts: string[] = [];
@@ -281,7 +282,7 @@ export function zoneToGraph(
       // Fingerprint of every field RoomNode renders. `description` is
       // intentionally excluded — it's authored frequently but not displayed
       // in the graph node, so editing it shouldn't bust the memo.
-      const flags = `${room.bank ? 1 : 0}${room.tavern ? 1 : 0}${room.inn ? 1 : 0}${room.dungeon ? 1 : 0}${room.auction ? 1 : 0}${room.stylist ? 1 : 0}${room.housingBroker ? 1 : 0}${room.akathavaeShrine ? 1 : 0}`;
+      const flags = `${room.bank ? 1 : 0}${room.tavern ? 1 : 0}${room.inn ? 1 : 0}${room.dungeon ? 1 : 0}${room.auction ? 1 : 0}${room.stylist ? 1 : 0}${room.housingBroker ? 1 : 0}${room.akathavaeShrine ? 1 : 0}${room.flightMaster ? 1 : 0}`;
       const fingerprint = [
         room.title,
         room.image ?? "",
@@ -312,6 +313,7 @@ export function zoneToGraph(
         stylist: room.stylist,
         housingBroker: room.housingBroker,
         akathavaeShrine: room.akathavaeShrine,
+        flightMaster: room.flightMaster,
         image: room.image,
         entities,
         _fingerprint: fingerprint,

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -127,6 +127,9 @@ export interface RoomFile {
   /** True if this room holds an Akathavae shrine. Enables the `pledge`/`renounce`
    *  commands for the pacifist explorer path. */
   akathavaeShrine?: boolean;
+  /** True if this room has a flight master. Enables the `flights`/`fly`
+   *  fast-travel commands and the in-world kiosk badge. */
+  flightMaster?: boolean;
   image?: string;
   video?: string;
   /** Prose vision narrated to text/screen-reader clients in place of the video.


### PR DESCRIPTION
Mirrors AmbonMUD server PR [#1361](https://github.com/jnoecker/AmbonMUD/pull/1361) (flight masters: gold fast-travel kiosks) on the Arcanum side.

## What the server added
- A `flightMaster` boolean room flag (`RoomFile` → `Room` → `WorldLoader`), enabling the `flights`/`fly` fast-travel commands and an in-world kiosk badge.
- The web client loads a `flight_roost` global asset for that badge.

## Changes here
- **`flightMaster` room flag** added to the `RoomFile` type (`types/world.ts`).
- **Room Roles editor** (`RoomPanel.tsx`) — new toggle alongside Inn / Stylist / Akathavae Shrine, with an icon (placeholder `panel_cloud.png` until a bespoke `role_flight_master.png` is generated, mirroring how `akathavaeShrine` reuses a placeholder).
- **Zone map node badge** (`RoomNode.tsx` + `zoneToGraph.ts`) — "Flight" role pill, plus the field threaded through `RoomNodeData`, the change-detection fingerprint, and the data mapping.
- **Playtest room badges** (`PlaytestPanel.tsx`) — "Flight Master" badge.
- **`flight_roost` required global asset** (`requiredGlobalAssets.ts`) — the in-world kiosk badge, matching the web client's asset key.

Room flags round-trip automatically via the CST YAML path (`normalizeRoomOutput` spreads `...room`), so no serializer change was needed.

## Checks
- `bunx tsc --noEmit` clean.
- `bun run test` green (2258 passing; updated the validateConfig fixture to include the new required asset).