### PR TITLE
perf(atlas): make the world atlas usable at ~700 rooms

### DIFF
--- a/creator/src/components/zone/Starfield.tsx
+++ b/creator/src/components/zone/Starfield.tsx
@@ -75,21 +75,18 @@ export function Starfield() {
     const resizeObs = new ResizeObserver(resize);
     resizeObs.observe(canvas.parentElement!);
 
-    // Visibility — pause when off-screen
+    // Visibility — fully stop the rAF loop when off-screen rather than
+    // rescheduling empty frames forever; the observer restarts it on return.
     let visible = true;
-    const visObs = new IntersectionObserver(
-      ([entry]) => {
-        visible = !!entry?.isIntersecting;
-      },
-      { threshold: 0 },
-    );
-    visObs.observe(canvas);
-
+    let running = false;
     let lastTime = performance.now();
 
     const draw = (now: number) => {
+      if (!visible) {
+        running = false;
+        return;
+      }
       rafRef.current = requestAnimationFrame(draw);
-      if (!visible) return;
 
       const dt = (now - lastTime) / 1000;
       lastTime = now;
@@ -127,10 +124,29 @@ export function Starfield() {
       }
     };
 
-    rafRef.current = requestAnimationFrame(draw);
+    const start = () => {
+      if (running) return;
+      running = true;
+      lastTime = performance.now();
+      rafRef.current = requestAnimationFrame(draw);
+    };
+
+    const visObs = new IntersectionObserver(
+      ([entry]) => {
+        const nowVisible = !!entry?.isIntersecting;
+        if (nowVisible === visible) return;
+        visible = nowVisible;
+        if (visible) start();
+      },
+      { threshold: 0 },
+    );
+    visObs.observe(canvas);
+
+    start();
 
     return () => {
       cancelAnimationFrame(rafRef.current);
+      running = false;
       resizeObs.disconnect();
       visObs.disconnect();
     };

--- a/creator/src/components/zone/ZoneAtlasView.tsx
+++ b/creator/src/components/zone/ZoneAtlasView.tsx
@@ -8,6 +8,7 @@ import {
   MiniMap,
   useNodesState,
   useEdgesState,
+  useReactFlow,
   type Node,
   type Edge,
   type NodeMouseHandler,
@@ -24,9 +25,13 @@ import { RoomNode } from "./RoomNode";
 import { ExitEdge } from "./ExitEdge";
 import { DirectionPicker } from "./DirectionPicker";
 import { Starfield } from "./Starfield";
-import { zoneToGraph } from "@/lib/zoneToGraph";
+import { zoneToGraph, worldGraphFingerprint, GRAPH } from "@/lib/zoneToGraph";
 import { addExit, OPPOSITE } from "@/lib/zoneEdits";
-import { compassLayout, getLayoutBounds } from "@/lib/dagreLayout";
+import {
+  compassLayout,
+  getLayoutBounds,
+  type LayoutMeasurement,
+} from "@/lib/dagreLayout";
 import {
   loadAtlasClusterPositions,
   saveAtlasClusterPosition,
@@ -212,17 +217,56 @@ function layoutClusters(
   return positions;
 }
 
+interface AtlasBuildCacheEntry {
+  digest: string;
+  build: AtlasBuild;
+}
+
+// One-slot memo of the last assembled atlas. The zones Map gets a fresh
+// reference on every edit (zoneStore allocates a new Map per mutation), so the
+// upstream useMemo re-runs buildAtlas on edits to *any* zone. Returning the
+// previous build verbatim when nothing that affects the atlas changed keeps
+// `initial` referentially stable, which lets the reconcile effect skip the
+// O(rooms) setNodes pass entirely. The single slot self-replaces on the next
+// distinct digest (e.g. a project switch), so it stays bounded without an
+// explicit clear, and the content digest guarantees a stale build is never
+// returned for a different world.
+let atlasBuildCache: AtlasBuildCacheEntry | null = null;
+
+function buildAtlasDigest(
+  zones: ReturnType<typeof useZoneStore.getState>["zones"],
+  savedPositions: Record<string, AtlasPosition>,
+): string {
+  const parts: string[] = [];
+  for (const [zoneId, state] of zones) {
+    // The graph fingerprint covers rooms, exits, start room, and entities —
+    // everything that changes the atlas's nodes, edges, or layout. The zone
+    // name is added because it shows in the group header but isn't part of the
+    // graph fingerprint.
+    parts.push(
+      `${zoneId} ${state.data.zone ?? ""} ${worldGraphFingerprint(state.data)}`,
+    );
+  }
+  parts.push(`__saved__ ${JSON.stringify(savedPositions)}`);
+  return parts.join("\n");
+}
+
 function buildAtlas(
   zones: ReturnType<typeof useZoneStore.getState>["zones"],
   savedPositions: Record<string, AtlasPosition>,
 ): AtlasBuild {
+  const digest = buildAtlasDigest(zones, savedPositions);
+  if (atlasBuildCache && atlasBuildCache.digest === digest) {
+    return atlasBuildCache.build;
+  }
+
   const specs: ClusterSpec[] = Array.from(zones.entries()).map(([zoneId, state]) => {
     const world = state.data;
-    const { nodes: rawNodes, edges: rawEdges } = zoneToGraph(world);
+    const { nodes: rawNodes, edges: rawEdges } = zoneToGraph(world, zoneId);
     // Drop the synthetic cross-zone ghost nodes — we'll resolve their edges
     // to real nodes in sibling clusters after all clusters are built.
     const realNodes = rawNodes.filter((n) => !n.id.startsWith("xzone:"));
-    const laid = compassLayout(realNodes, world);
+    const laid = compassLayout(realNodes, world, undefined, zoneId);
     const bounds = getLayoutBounds(laid) ?? { x: 0, y: 0, width: 320, height: 240 };
     return {
       zoneId,
@@ -236,12 +280,14 @@ function buildAtlas(
   });
 
   if (specs.length === 0) {
-    return {
+    const build: AtlasBuild = {
       nodes: [],
       edges: [],
       stats: { zones: 0, rooms: 0, crossLinks: 0, orphans: 0 },
       isEmpty: true,
     };
+    atlasBuildCache = { digest, build };
+    return build;
   }
 
   // ── First pass: collect all cross-zone link pairs for meta-graph layout ──
@@ -293,6 +339,11 @@ function buildAtlas(
         roomCount: spec.layoutNodes.length,
         zoneId: spec.zoneId,
       } satisfies ZoneGroupData,
+      // Explicit dimensions (not just style) so fit-to-view and bounds math
+      // know each cluster's size even while it's culled off-screen by
+      // onlyRenderVisibleElements and has never been DOM-measured.
+      width: spec.groupWidth,
+      height: spec.groupHeight,
       style: {
         width: spec.groupWidth,
         height: spec.groupHeight,
@@ -432,7 +483,7 @@ function buildAtlas(
 
   const totalRooms = specs.reduce((sum, c) => sum + c.layoutNodes.length, 0);
 
-  return {
+  const build: AtlasBuild = {
     nodes: allNodes,
     edges: allEdges,
     stats: {
@@ -443,11 +494,14 @@ function buildAtlas(
     },
     isEmpty: false,
   };
+  atlasBuildCache = { digest, build };
+  return build;
 }
 
 // ─── Component ──────────────────────────────────────────────────────
 
 function ZoneAtlas() {
+  const reactFlow = useReactFlow();
   const zones = useZoneStore((s) => s.zones);
   const updateZone = useZoneStore((s) => s.updateZone);
   const navigateTo = useProjectStore((s) => s.navigateTo);
@@ -503,6 +557,58 @@ function ZoneAtlas() {
     });
     setEdges(initial.edges);
   }, [initial, savedPositions, setNodes, setEdges]);
+
+  // ─── One-shot fit-to-view ────────────────────────────────────────
+  // We can't use the `fitView` prop: it's unreliable under
+  // `onlyRenderVisibleElements` (off-screen clusters aren't DOM-measured, so
+  // the prop's bounds collapse) and it re-queues a store write on every render
+  // because `fitViewOptions` would be a fresh object. Instead we fit once per
+  // loadout from `getLayoutBounds`, which derives bounds from node positions +
+  // explicit cluster sizes and therefore works without measuring every node.
+  // `savedPositions` only changes identity on project switch or "Reset Layout",
+  // so edits and pans never re-fit.
+  //
+  // We fit over the zone-group nodes only: they're top-level (absolute
+  // positions) and each is sized to fully contain its rooms, so their union is
+  // the whole atlas extent. The room nodes are children whose `position` is
+  // relative to their group — feeding those into `getLayoutBounds`, which
+  // treats position as absolute, would skew the bounds. Group dimensions are
+  // explicit, so this works even while every group is culled off-screen and
+  // unmeasured.
+  const fitDoneRef = useRef<Record<string, AtlasPosition> | null>(null);
+  useEffect(() => {
+    if (nodes.length === 0) return;
+    if (fitDoneRef.current === savedPositions) return;
+
+    let cancelled = false;
+    // Two rAFs: one to let React commit the nodes, one to let ReactFlow adopt
+    // their dimensions before we measure.
+    const raf1 = requestAnimationFrame(() => {
+      if (cancelled) return;
+      requestAnimationFrame(() => {
+        if (cancelled) return;
+        const groups = reactFlow
+          .getNodes()
+          .filter((node) => node.type === "zoneGroup");
+        if (groups.length === 0) return;
+        const measurements = new Map<string, LayoutMeasurement>();
+        for (const node of groups) {
+          const width = node.measured?.width ?? node.width;
+          const height = node.measured?.height ?? node.height;
+          if (width && height) measurements.set(node.id, { width, height });
+        }
+        const bounds = getLayoutBounds(groups, measurements);
+        if (bounds && bounds.width > 0 && bounds.height > 0) {
+          reactFlow.fitBounds(bounds, { padding: 0.15, duration: 0 });
+          fitDoneRef.current = savedPositions;
+        }
+      });
+    });
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf1);
+    };
+  }, [savedPositions, nodes.length, reactFlow]);
 
   const onNodeClick: NodeMouseHandler = useCallback(
     (_event, node) => {
@@ -668,8 +774,11 @@ function ZoneAtlas() {
         // RoomNode ships a single source-type handle per direction; loose
         // mode lets edge targets anchor to them.
         connectionMode={ConnectionMode.Loose}
-        fitView
-        fitViewOptions={{ padding: 0.15 }}
+        // Mount only the clusters/rooms in the viewport. At ~700 rooms the
+        // atlas otherwise keeps every room node (10 handles each) live at all
+        // times, which is what makes pan/zoom crawl. Initial fit is handled
+        // manually above. See ZoneEditor for the same trade-off.
+        onlyRenderVisibleElements
         nodesDraggable
         // Rooms stay non-draggable (set per-node), but their handles are live
         // so users can drag a room→room cross-zone link.
@@ -685,7 +794,15 @@ function ZoneAtlas() {
           color="var(--color-graph-grid)"
         />
         <Controls showInteractive={false} />
-        <MiniMap pannable zoomable className="!bg-bg-abyss/80" />
+        <MiniMap
+          pannable
+          zoomable
+          className="!bg-bg-abyss/80"
+          nodeColor={(node) =>
+            node.type === "zoneGroup" ? GRAPH().cross : GRAPH().node
+          }
+          maskColor="var(--graph-minimap-mask)"
+        />
       </ReactFlow>
       <div className="pointer-events-none absolute left-4 top-4 z-10 flex flex-wrap items-center gap-2 text-2xs">
         <AtlasStat label="zones" value={initial.stats.zones} />

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -301,8 +301,8 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
   // Rebuild graph when WorldFile changes
   const { layoutNodes, layoutEdges } = useMemo(() => {
     if (!zoneState) return { layoutNodes: [], layoutEdges: [] };
-    const { nodes: rawNodes, edges } = zoneToGraph(zoneState.data);
-    const nodes = compassLayout(rawNodes, zoneState.data);
+    const { nodes: rawNodes, edges } = zoneToGraph(zoneState.data, zoneId);
+    const nodes = compassLayout(rawNodes, zoneState.data, undefined, zoneId);
     return { layoutNodes: nodes, layoutEdges: edges };
   }, [zoneState]);
 
@@ -397,8 +397,8 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
         measurements.set(node.id, { width, height });
       }
     }
-    const { nodes: rawNodes } = zoneToGraph(zoneState.data);
-    const fresh = compassLayout(rawNodes, zoneState.data, measurements);
+    const { nodes: rawNodes } = zoneToGraph(zoneState.data, zoneId);
+    const fresh = compassLayout(rawNodes, zoneState.data, measurements, zoneId);
     setNodes(fresh);
     const bounds = getLayoutBounds(fresh, measurements);
     if (bounds && bounds.width > 0 && bounds.height > 0) {

--- a/creator/src/lib/dagreLayout.ts
+++ b/creator/src/lib/dagreLayout.ts
@@ -76,12 +76,17 @@ interface LayoutCacheEntry {
   result: Node[];
 }
 
-let layoutCache: LayoutCacheEntry | null = null;
+// Keyed by a stable per-zone cache key (the zone id). A single shared slot
+// thrashes the moment the atlas lays out more than one zone in a loop, so each
+// zone gets its own entry. Bounded by the number of distinct zones, cleared on
+// project switch. Callers that don't pass a key share one default slot.
+const DEFAULT_LAYOUT_CACHE_KEY = "__default__";
+const layoutCache = new Map<string, LayoutCacheEntry>();
 
 /** Free the layout cache. Call when switching projects so the cache doesn't
  *  pin memory for rooms that no longer exist. */
 export function clearLayoutCache(): void {
-  layoutCache = null;
+  layoutCache.clear();
 }
 
 function buildLayoutFingerprint(world: WorldFile): string {
@@ -128,30 +133,32 @@ export function compassLayout(
   nodes: Node[],
   world: WorldFile,
   measurements?: Map<string, LayoutMeasurement>,
+  cacheKey: string = DEFAULT_LAYOUT_CACHE_KEY,
 ): Node[] {
   if (nodes.length === 0) return nodes;
 
   // Cache hits only when not measuring (the measurement path is for the
   // user-triggered relayout and must always recompute).
-  if (!measurements && layoutCache) {
-    if (layoutCache.rawNodesRef === nodes) {
-      return layoutCache.result;
+  const cached = measurements ? undefined : layoutCache.get(cacheKey);
+  if (cached) {
+    if (cached.rawNodesRef === nodes) {
+      return cached.result;
     }
     const fp = buildLayoutFingerprint(world);
-    if (layoutCache.fingerprint === fp) {
+    if (cached.fingerprint === fp) {
       // Layout structure unchanged, but rawNodes refs differ (zoneToGraph
       // had to rebuild for a non-layout-affecting reason). Apply cached
       // positions to the new rawNodes so downstream consumers still see
       // a stable visual layout.
       const posById = new Map<string, { x: number; y: number }>();
-      for (const n of layoutCache.result) {
+      for (const n of cached.result) {
         posById.set(n.id, n.position);
       }
       const result = nodes.map((n) => {
         const pos = posById.get(n.id);
         return pos ? { ...n, position: pos } : n;
       });
-      layoutCache = { fingerprint: fp, rawNodesRef: nodes, result };
+      layoutCache.set(cacheKey, { fingerprint: fp, rawNodesRef: nodes, result });
       return result;
     }
   }
@@ -289,11 +296,11 @@ export function compassLayout(
   }
 
   if (!measurements) {
-    layoutCache = {
+    layoutCache.set(cacheKey, {
       fingerprint: buildLayoutFingerprint(world),
       rawNodesRef: nodes,
       result,
-    };
+    });
   }
   return result;
 }
@@ -430,8 +437,9 @@ export function layoutZone(
   nodes: Node[],
   world: WorldFile,
   measurements?: Map<string, LayoutMeasurement>,
+  cacheKey?: string,
 ): Node[] {
-  return compassLayout(nodes, world, measurements);
+  return compassLayout(nodes, world, measurements, cacheKey);
 }
 
 /**

--- a/creator/src/lib/zoneToGraph.ts
+++ b/creator/src/lib/zoneToGraph.ts
@@ -86,19 +86,19 @@ function buildEntityFingerprint(entities: EntitySprite[]): string {
 }
 
 function cachedRoomData(
-  roomId: string,
+  cacheKey: string,
   build: () => RoomNodeData & { _fingerprint: string },
 ): RoomNodeData {
   const next = build();
   const fingerprint = next._fingerprint;
-  const cached = roomDataCache.get(roomId);
+  const cached = roomDataCache.get(cacheKey);
   if (cached && cached.fingerprint === fingerprint) {
     return cached.data;
   }
   // Strip the internal fingerprint field — RoomNodeData doesn't carry it.
   const { _fingerprint: _ignore, ...data } = next;
   void _ignore;
-  roomDataCache.set(roomId, { fingerprint, data });
+  roomDataCache.set(cacheKey, { fingerprint, data });
   return data;
 }
 
@@ -106,7 +106,7 @@ function cachedRoomData(
  *  doesn't pin memory for rooms that no longer exist. */
 export function clearRoomDataCache(): void {
   roomDataCache.clear();
-  graphCache = null;
+  graphCache.clear();
 }
 
 // ─── Whole-graph memoization ─────────────────────────────────────────
@@ -128,7 +128,15 @@ interface GraphCacheEntry {
   edges: Edge[];
 }
 
-let graphCache: GraphCacheEntry | null = null;
+// Keyed by a stable per-zone cache key (the zone id) rather than by the
+// fingerprint itself. Each zone keeps exactly one entry holding its latest
+// fingerprint + result, so the cache is bounded by the number of distinct
+// zones — not by the number of edits — while still letting the multi-zone
+// atlas reuse unchanged zones across rebuilds. A single shared slot (the old
+// behavior) would thrash the moment buildAtlas iterates more than one zone.
+// Callers that don't pass a key share one default slot.
+const DEFAULT_GRAPH_CACHE_KEY = "__default__";
+const graphCache = new Map<string, GraphCacheEntry>();
 
 function buildGraphFingerprint(world: WorldFile): string {
   const parts: string[] = [`s:${world.startRoom}`];
@@ -205,15 +213,24 @@ interface RawExit {
 
 // ─── Main conversion ────────────────────────────────────────────────
 
+/** Stable content fingerprint of a zone's displayed graph. Exposed so a
+ *  multi-zone consumer (the atlas) can detect whether a zone's graph would
+ *  change — and skip reassembling the whole world — without rebuilding it. */
+export function worldGraphFingerprint(world: WorldFile): string {
+  return buildGraphFingerprint(world);
+}
+
 export function zoneToGraph(
   world: WorldFile,
+  cacheKey: string = DEFAULT_GRAPH_CACHE_KEY,
 ): {
   nodes: Node[];
   edges: Edge[];
 } {
   const fingerprint = buildGraphFingerprint(world);
-  if (graphCache && graphCache.fingerprint === fingerprint) {
-    return { nodes: graphCache.nodes, edges: graphCache.edges };
+  const cached = graphCache.get(cacheKey);
+  if (cached && cached.fingerprint === fingerprint) {
+    return { nodes: cached.nodes, edges: cached.edges };
   }
 
   // Count entities per room
@@ -277,7 +294,7 @@ export function zoneToGraph(
     const gatheringNodeCount = gatheringNodesPerRoom.get(roomId) ?? 0;
     const entities = entitiesPerRoom.get(roomId) ?? [];
 
-    const data = cachedRoomData(roomId, () => {
+    const data = cachedRoomData(`${cacheKey}::${roomId}`, () => {
       // Fingerprint of every field RoomNode renders. `description` is
       // intentionally excluded — it's authored frequently but not displayed
       // in the graph node, so editing it shouldn't bust the memo.
@@ -369,6 +386,16 @@ export function zoneToGraph(
     }
   }
 
+  // Index exits by "source|target" so the bidirectional-pair lookup below is
+  // O(1) instead of a linear scan per edge (O(exits²) in dense zones). First
+  // writer wins, matching the previous Array.find which returned the first
+  // matching reverse exit.
+  const exitByEndpoints = new Map<string, RawExit>();
+  for (const exit of sameZoneExits) {
+    const key = `${exit.source}|${exit.target}`;
+    if (!exitByEndpoints.has(key)) exitByEndpoints.set(key, exit);
+  }
+
   // Deduplicate bidirectional exits: show one edge per room pair
   const edges: Edge[] = [];
   const seen = new Set<string>();
@@ -379,9 +406,7 @@ export function zoneToGraph(
     seen.add(pairKey);
 
     // Look for the reverse exit
-    const reverse = sameZoneExits.find(
-      (e) => e.source === exit.target && e.target === exit.source,
-    );
+    const reverse = exitByEndpoints.get(`${exit.target}|${exit.source}`);
 
     const isBidirectional = !!reverse;
     const isCrossZone = exit.target.startsWith("xzone:");
@@ -415,6 +440,6 @@ export function zoneToGraph(
     });
   }
 
-  graphCache = { fingerprint, nodes, edges };
+  graphCache.set(cacheKey, { fingerprint, nodes, edges });
   return { nodes, edges };
 }


### PR DESCRIPTION
## Why

The world atlas became "almost unusable" at ~700 rooms. A multi-agent audit + manual verification traced the lag to two dominant causes that compound each other, plus a few smaller drains. This PR fixes all of them.

## Root causes & fixes

**1. No viewport virtualization (the big one).** The atlas mounted every room node at once — each `RoomNode` renders 10 `<Handle>` components, so ~7,000 handles stayed live at all zoom levels and every pan/zoom reconciled the whole graph. The single-zone editor already used `onlyRenderVisibleElements`; the atlas didn't. **Fix:** add `onlyRenderVisibleElements` so only the clusters/rooms in view mount.

**2. Caches that never hit + rebuild-on-every-edit.** `zoneToGraph`'s `graphCache` and `dagreLayout`'s `layoutCache` were single nullable slots, but `buildAtlas` calls them once per zone in a loop — so each zone evicted the previous and the caches effectively never hit. On top of that, `buildAtlas` (a `useMemo` keyed on the `zones` Map) re-ran on every edit because `zoneStore` allocates a fresh Map per mutation, recomputing all zones. **Fix:**
- Key `graphCache`/`layoutCache`/the per-room data cache by a stable **per-zone key** (the zone id) — bounded by zone count, reused across rebuilds. (Also fixes a latent cross-zone collision in the room cache, which was keyed by bare room id.)
- Memoize `buildAtlas` on a **content digest** (per-zone graph fingerprints + zone names + saved positions) so it returns the previous build verbatim when nothing relevant changed, keeping `initial` referentially stable and letting the reconcile effect skip the O(rooms) `setNodes` pass.

**3. `fitView` prop → one-shot manual fit.** The `fitView` prop is unreliable under `onlyRenderVisibleElements` (off-screen clusters aren't measured) and re-queued a store write every render via its inline `fitViewOptions` object. **Fix:** fit once per loadout over the **zone-group nodes only** (top-level absolute positions + explicit sizes that contain their rooms), mirroring the editor's `getLayoutBounds` pattern. Note: the "re-fits every render" claim from the audit didn't hold up — verified in the `@xyflow/react` v12 source that the prop only queues a fit once — but the manual fit is still needed for reliability under virtualization.

**4. Smaller drains.**
- `Starfield` rescheduled `requestAnimationFrame` *before* its visibility guard, queuing an empty frame every tick while off-screen. Now the loop fully stops off-screen and restarts from the IntersectionObserver.
- MiniMap got a `nodeColor`/`maskColor` (matching the editor) instead of default per-node rendering.
- Replaced an `O(exits²)` reverse-exit `Array.find` in `zoneToGraph` with an O(1) endpoint-indexed map.

## Expected impact

`onlyRenderVisibleElements` is the largest single win (pan/zoom). The per-zone caches + build memo remove most edit-time stutter (an edit to one zone no longer recomputes or re-reconciles all zones). The rest are polish.

## Risk / behavior preserved

- **Cross-zone linking, cluster drag-to-reposition, saved layouts, reset-layout** all use node ids / state arrays and are unaffected. One acceptable UX nuance from virtualization: dragging a cross-zone link *to* a room that's scrolled off-screen now requires panning to it first.
- All new cache params are optional with defaults, so the editor / map panel / pin placement / tests keep their existing behavior.

## Verification

- `bunx tsc --noEmit` — clean
- `bun run test` — 2258 passed (incl. `zoneToGraph` + `dagreLayout` suites)
- Not yet exercised in a live 700-room project; worth a manual smoke test of open-fit, pan/zoom, cross-zone linking, cluster drag, and reset-layout.

## Not included (deliberately deferred)

Lazy-mounting the 6 non-cardinal room handles (diagonals + up/down) would further cut handle count but risks the cross-zone drag UX, and virtualization already removes the bulk of the handle cost. Left as a follow-up.
