### PR TITLE
perf(atlas): level-of-detail world atlas — zones as cards, expand to rooms

### DIFF
--- a/creator/src/components/zone/ZoneAtlasView.tsx
+++ b/creator/src/components/zone/ZoneAtlasView.tsx
@@ -6,9 +6,10 @@ import {
   BackgroundVariant,
   Controls,
   MiniMap,
+  Handle,
+  Position,
   useNodesState,
   useEdgesState,
-  useReactFlow,
   type Node,
   type Edge,
   type NodeMouseHandler,
@@ -25,13 +26,10 @@ import { RoomNode } from "./RoomNode";
 import { ExitEdge } from "./ExitEdge";
 import { DirectionPicker } from "./DirectionPicker";
 import { Starfield } from "./Starfield";
-import { zoneToGraph, worldGraphFingerprint, GRAPH } from "@/lib/zoneToGraph";
-import { addExit, OPPOSITE } from "@/lib/zoneEdits";
-import {
-  compassLayout,
-  getLayoutBounds,
-  type LayoutMeasurement,
-} from "@/lib/dagreLayout";
+import { zoneToGraph } from "@/lib/zoneToGraph";
+import { addExit, OPPOSITE, exitTarget } from "@/lib/zoneEdits";
+import { compassLayout, getLayoutBounds } from "@/lib/dagreLayout";
+import type { WorldFile } from "@/types/world";
 import {
   loadAtlasClusterPositions,
   saveAtlasClusterPosition,
@@ -46,6 +44,66 @@ const GROUP_PAD = 32;
 const HEADER_OFFSET = 64;
 // Fallback grid layout — used only when there are no cross-zone links at all.
 const FALLBACK_GAP = 160;
+// Collapsed zone-card footprint. The meta-graph layout is run with these
+// boxes; expanded zones overlap their neighbors in place, which is fine since
+// expansion is transient and the user repositions as needed.
+const CARD_W = 248;
+const CARD_H = 132;
+
+// Shared anchor handle id for aggregated zone↔zone corridor edges.
+const AGG_HANDLE = "agg";
+
+const aggHandleStyle: React.CSSProperties = {
+  width: 1,
+  height: 1,
+  minWidth: 0,
+  minHeight: 0,
+  background: "transparent",
+  border: "none",
+  opacity: 0,
+};
+
+// ─── Node components ────────────────────────────────────────────────
+
+interface ZoneCardData extends Record<string, unknown> {
+  zoneId: string;
+  zone: string;
+  roomCount: number;
+  linkCount: number;
+}
+
+function ZoneCardNode({ data }: { data: ZoneCardData }) {
+  return (
+    <div
+      className="group relative flex h-full w-full cursor-pointer flex-col justify-between rounded-2xl border border-accent/30 bg-accent/[0.05] px-5 py-4 backdrop-blur-[2px] transition-colors hover:border-accent/70 hover:bg-accent/[0.1]"
+      title="Click to expand this zone into rooms"
+    >
+      <Handle
+        type="source"
+        id={AGG_HANDLE}
+        position={Position.Top}
+        isConnectable={false}
+        style={{ ...aggHandleStyle, left: "50%" }}
+      />
+      <div>
+        <div className="font-display text-lg uppercase tracking-[0.26em] text-accent">
+          {data.zone}
+        </div>
+        <div className="mt-1 text-2xs uppercase tracking-wider text-text-muted">
+          {data.roomCount} {data.roomCount === 1 ? "room" : "rooms"}
+          {data.linkCount > 0 && (
+            <span className="ml-2 text-text-secondary">
+              · {data.linkCount} {data.linkCount === 1 ? "link" : "links"}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="text-3xs uppercase tracking-[0.2em] text-text-muted opacity-0 transition-opacity group-hover:opacity-100">
+        ▸ Click to open rooms
+      </div>
+    </div>
+  );
+}
 
 interface ZoneGroupData extends Record<string, unknown> {
   zone: string;
@@ -55,8 +113,15 @@ interface ZoneGroupData extends Record<string, unknown> {
 
 function ZoneGroupNode({ data }: { data: ZoneGroupData }) {
   return (
-    <div className="group relative h-full w-full cursor-grab rounded-2xl border border-dashed border-accent/25 bg-accent/[0.035] backdrop-blur-[2px] transition-colors hover:border-accent/55 hover:bg-accent/[0.08] active:cursor-grabbing">
-      <div className="pointer-events-none absolute left-4 top-4 flex select-none items-start gap-3 rounded-xl border border-accent/40 bg-bg-abyss/90 px-4 py-2 shadow-[var(--shadow-drop)]">
+    <div className="group relative h-full w-full cursor-grab rounded-2xl border border-dashed border-accent/40 bg-accent/[0.04] backdrop-blur-[2px] transition-colors hover:border-accent/60 active:cursor-grabbing">
+      <Handle
+        type="source"
+        id={AGG_HANDLE}
+        position={Position.Top}
+        isConnectable={false}
+        style={{ ...aggHandleStyle, left: "50%" }}
+      />
+      <div className="pointer-events-none absolute left-4 top-4 flex select-none items-center gap-3 rounded-xl border border-accent/40 bg-bg-abyss/90 px-4 py-2 shadow-[var(--shadow-drop)]">
         <div>
           <div className="font-display text-base uppercase tracking-[0.28em] text-accent">
             {data.zone}
@@ -65,6 +130,9 @@ function ZoneGroupNode({ data }: { data: ZoneGroupData }) {
             {data.roomCount} {data.roomCount === 1 ? "room" : "rooms"}
           </div>
         </div>
+        <span className="rounded-full border border-border-muted px-2 py-0.5 text-3xs uppercase tracking-[0.2em] text-text-muted">
+          ▾ collapse
+        </span>
       </div>
     </div>
   );
@@ -73,6 +141,7 @@ function ZoneGroupNode({ data }: { data: ZoneGroupData }) {
 const nodeTypes = {
   room: RoomNode,
   zoneGroup: ZoneGroupNode,
+  zoneCard: ZoneCardNode,
 };
 
 const edgeTypes = {
@@ -95,74 +164,96 @@ interface PendingXLink {
   inferredDir: string;
 }
 
-/** Split "xzone:zone:room" into { zone, room }, respecting only the first colon after the prefix. */
-function parseXzoneTarget(xzoneId: string): { zone: string; room: string } | null {
-  if (!xzoneId.startsWith("xzone:")) return null;
-  const rest = xzoneId.slice("xzone:".length);
-  const colon = rest.indexOf(":");
-  if (colon < 0) return null;
-  return { zone: rest.slice(0, colon), room: rest.slice(colon + 1) };
+// ─── Cheap zone summary (no graph build) ─────────────────────────────
+//
+// Building the full room graph + compass layout for every zone is what made
+// the atlas crawl. For the default collapsed view we only need a room count
+// and the cross-zone exits, both of which come from a flat scan of the zone's
+// exit table — no ReactFlow nodes, no image IPC, no layout. The expensive
+// graph build is deferred to whichever 2–3 zones the user actually expands.
+
+interface CrossLink {
+  fromZone: string;
+  fromRoom: string;
+  toZone: string;
+  toRoom: string;
 }
 
-// ─── Atlas build ────────────────────────────────────────────────────
-
-interface ClusterSpec {
+interface ZoneSummary {
   zoneId: string;
   zoneName: string;
-  layoutNodes: Node[];
-  layoutEdges: Edge[];
-  /** Bounding box from compassLayout, in the cluster's own coordinate space. */
-  bounds: { x: number; y: number; width: number; height: number };
-  /** Group-node size (inner bounds + padding + header). */
-  groupWidth: number;
-  groupHeight: number;
+  roomIds: Set<string>;
+  crossLinks: CrossLink[];
 }
 
-interface XzoneLink {
+function summarizeZone(zoneId: string, world: WorldFile): ZoneSummary {
+  const roomIds = new Set(Object.keys(world.rooms ?? {}));
+  const crossLinks: CrossLink[] = [];
+  for (const [roomId, room] of Object.entries(world.rooms ?? {})) {
+    if (!room.exits) continue;
+    for (const val of Object.values(room.exits)) {
+      const raw = exitTarget(val);
+      const colon = raw.indexOf(":");
+      if (colon < 0) continue;
+      crossLinks.push({
+        fromZone: zoneId,
+        fromRoom: roomId,
+        toZone: raw.slice(0, colon),
+        toRoom: raw.slice(colon + 1),
+      });
+    }
+  }
+  return { zoneId, zoneName: world.zone || zoneId, roomIds, crossLinks };
+}
+
+/** A deduped, undirected cross-zone corridor between two specific rooms. */
+interface Corridor {
+  aZone: string;
+  aRoom: string;
+  bZone: string;
+  bRoom: string;
+  resolved: boolean;
+}
+
+// ─── Meta-graph layout ──────────────────────────────────────────────
+
+interface ZoneBox {
+  zoneId: string;
+  width: number;
+  height: number;
+}
+
+interface ZonePair {
   a: string;
   b: string;
 }
 
-interface AtlasStats {
-  zones: number;
-  rooms: number;
-  crossLinks: number;
-  orphans: number;
-}
-
-interface AtlasBuild {
-  nodes: Node[];
-  edges: Edge[];
-  stats: AtlasStats;
-  isEmpty: boolean;
-}
-
-/** Layout the cluster meta-graph using dagre, returning top-left positions. */
-function layoutClusters(
-  specs: ClusterSpec[],
-  links: XzoneLink[],
+/** Layout the zone meta-graph using dagre, returning top-left positions. */
+function layoutZoneBoxes(
+  boxes: ZoneBox[],
+  pairs: ZonePair[],
 ): Map<string, { x: number; y: number }> {
-  if (specs.length === 0) return new Map();
+  if (boxes.length === 0) return new Map();
 
   const positions = new Map<string, { x: number; y: number }>();
 
-  // Dedup undirected links — dagre is directed but we only want one edge per pair.
   const linkSet = new Set<string>();
-  const dedupedLinks: XzoneLink[] = [];
-  for (const link of links) {
-    const key = link.a < link.b ? `${link.a}|${link.b}` : `${link.b}|${link.a}`;
+  const dedupedPairs: ZonePair[] = [];
+  for (const pair of pairs) {
+    if (pair.a === pair.b) continue;
+    const key = pair.a < pair.b ? `${pair.a}|${pair.b}` : `${pair.b}|${pair.a}`;
     if (linkSet.has(key)) continue;
     linkSet.add(key);
-    dedupedLinks.push(link);
+    dedupedPairs.push(pair);
   }
 
-  if (dedupedLinks.length === 0) {
+  if (dedupedPairs.length === 0) {
     // No cross-zone connectivity — fall back to a uniform grid so disconnected
     // worlds still get a reasonable starting layout.
-    const cols = Math.max(1, Math.ceil(Math.sqrt(specs.length)));
-    const cellW = Math.max(...specs.map((c) => c.groupWidth)) + FALLBACK_GAP;
-    const cellH = Math.max(...specs.map((c) => c.groupHeight)) + FALLBACK_GAP;
-    specs.forEach((c, i) => {
+    const cols = Math.max(1, Math.ceil(Math.sqrt(boxes.length)));
+    const cellW = Math.max(...boxes.map((c) => c.width)) + FALLBACK_GAP;
+    const cellH = Math.max(...boxes.map((c) => c.height)) + FALLBACK_GAP;
+    boxes.forEach((c, i) => {
       const row = Math.floor(i / cols);
       const col = i % cols;
       positions.set(c.zoneId, { x: col * cellW, y: row * cellH });
@@ -180,328 +271,315 @@ function layoutClusters(
     marginy: 60,
   });
 
-  for (const spec of specs) {
-    g.setNode(spec.zoneId, { width: spec.groupWidth, height: spec.groupHeight });
+  for (const box of boxes) {
+    g.setNode(box.zoneId, { width: box.width, height: box.height });
   }
-  for (const link of dedupedLinks) {
-    // Sort so the "source" is deterministic — dagre will cycle-break if needed.
-    const [a, b] = link.a < link.b ? [link.a, link.b] : [link.b, link.a];
+  for (const pair of dedupedPairs) {
+    const [a, b] = pair.a < pair.b ? [pair.a, pair.b] : [pair.b, pair.a];
     g.setEdge(a, b);
   }
 
   dagre.layout(g);
 
-  for (const spec of specs) {
-    const n = g.node(spec.zoneId);
+  const boxById = new Map(boxes.map((b) => [b.zoneId, b]));
+  for (const box of boxes) {
+    const n = g.node(box.zoneId);
     if (!n) continue;
-    // dagre returns the center; convert to top-left.
-    positions.set(spec.zoneId, {
-      x: n.x - spec.groupWidth / 2,
-      y: n.y - spec.groupHeight / 2,
+    positions.set(box.zoneId, {
+      x: n.x - box.width / 2,
+      y: n.y - box.height / 2,
     });
   }
 
-  // Handle any clusters dagre didn't place (disconnected + skipped for some reason)
-  // by appending them to the right of the laid-out bounding box.
+  // Append any clusters dagre didn't place to the right of the laid-out box.
   const placed = Array.from(positions.values());
   const maxRight = placed.length
-    ? Math.max(...placed.map((p) => p.x)) + specs[0]!.groupWidth + FALLBACK_GAP
+    ? Math.max(...placed.map((p) => p.x)) + (boxes[0]?.width ?? CARD_W) + FALLBACK_GAP
     : 0;
   let orphanY = 0;
-  for (const spec of specs) {
-    if (positions.has(spec.zoneId)) continue;
-    positions.set(spec.zoneId, { x: maxRight, y: orphanY });
-    orphanY += spec.groupHeight + FALLBACK_GAP;
+  for (const box of boxes) {
+    if (positions.has(box.zoneId)) continue;
+    positions.set(box.zoneId, { x: maxRight, y: orphanY });
+    orphanY += (boxById.get(box.zoneId)?.height ?? CARD_H) + FALLBACK_GAP;
   }
 
   return positions;
 }
 
-interface AtlasBuildCacheEntry {
-  digest: string;
-  build: AtlasBuild;
+// ─── Atlas build ────────────────────────────────────────────────────
+
+interface AtlasStats {
+  zones: number;
+  rooms: number;
+  crossLinks: number;
+  orphans: number;
 }
 
-// One-slot memo of the last assembled atlas. The zones Map gets a fresh
-// reference on every edit (zoneStore allocates a new Map per mutation), so the
-// upstream useMemo re-runs buildAtlas on edits to *any* zone. Returning the
-// previous build verbatim when nothing that affects the atlas changed keeps
-// `initial` referentially stable, which lets the reconcile effect skip the
-// O(rooms) setNodes pass entirely. The single slot self-replaces on the next
-// distinct digest (e.g. a project switch), so it stays bounded without an
-// explicit clear, and the content digest guarantees a stale build is never
-// returned for a different world.
-let atlasBuildCache: AtlasBuildCacheEntry | null = null;
+interface AtlasBuild {
+  nodes: Node[];
+  edges: Edge[];
+  stats: AtlasStats;
+  isEmpty: boolean;
+}
 
-function buildAtlasDigest(
-  zones: ReturnType<typeof useZoneStore.getState>["zones"],
-  savedPositions: Record<string, AtlasPosition>,
-): string {
-  const parts: string[] = [];
-  for (const [zoneId, state] of zones) {
-    // The graph fingerprint covers rooms, exits, start room, and entities —
-    // everything that changes the atlas's nodes, edges, or layout. The zone
-    // name is added because it shows in the group header but isn't part of the
-    // graph fingerprint.
-    parts.push(
-      `${zoneId} ${state.data.zone ?? ""} ${worldGraphFingerprint(state.data)}`,
-    );
-  }
-  parts.push(`__saved__ ${JSON.stringify(savedPositions)}`);
-  return parts.join("\n");
+/** Per-expanded-zone laid-out graph + bounds. */
+interface ExpandedGraph {
+  layoutNodes: Node[];
+  layoutEdges: Edge[];
+  bounds: { x: number; y: number; width: number; height: number };
+  groupWidth: number;
+  groupHeight: number;
+}
+
+function buildExpandedGraph(world: WorldFile): ExpandedGraph {
+  const { nodes: rawNodes, edges: rawEdges } = zoneToGraph(world);
+  const realNodes = rawNodes.filter((n) => !n.id.startsWith("xzone:"));
+  const laid = compassLayout(realNodes, world);
+  const bounds = getLayoutBounds(laid) ?? { x: 0, y: 0, width: 320, height: 240 };
+  return {
+    layoutNodes: laid,
+    layoutEdges: rawEdges,
+    bounds,
+    groupWidth: bounds.width + GROUP_PAD * 2,
+    groupHeight: bounds.height + GROUP_PAD * 2 + HEADER_OFFSET,
+  };
 }
 
 function buildAtlas(
   zones: ReturnType<typeof useZoneStore.getState>["zones"],
   savedPositions: Record<string, AtlasPosition>,
+  expandedZones: Set<string>,
 ): AtlasBuild {
-  const digest = buildAtlasDigest(zones, savedPositions);
-  if (atlasBuildCache && atlasBuildCache.digest === digest) {
-    return atlasBuildCache.build;
-  }
+  const summaries: ZoneSummary[] = Array.from(zones.entries()).map(
+    ([zoneId, state]) => summarizeZone(zoneId, state.data),
+  );
 
-  const specs: ClusterSpec[] = Array.from(zones.entries()).map(([zoneId, state]) => {
-    const world = state.data;
-    const { nodes: rawNodes, edges: rawEdges } = zoneToGraph(world, zoneId);
-    // Drop the synthetic cross-zone ghost nodes — we'll resolve their edges
-    // to real nodes in sibling clusters after all clusters are built.
-    const realNodes = rawNodes.filter((n) => !n.id.startsWith("xzone:"));
-    const laid = compassLayout(realNodes, world, undefined, zoneId);
-    const bounds = getLayoutBounds(laid) ?? { x: 0, y: 0, width: 320, height: 240 };
+  if (summaries.length === 0) {
     return {
-      zoneId,
-      zoneName: world.zone || zoneId,
-      layoutNodes: laid,
-      layoutEdges: rawEdges,
-      bounds,
-      groupWidth: bounds.width + GROUP_PAD * 2,
-      groupHeight: bounds.height + GROUP_PAD * 2 + HEADER_OFFSET,
-    };
-  });
-
-  if (specs.length === 0) {
-    const build: AtlasBuild = {
       nodes: [],
       edges: [],
       stats: { zones: 0, rooms: 0, crossLinks: 0, orphans: 0 },
       isEmpty: true,
     };
-    atlasBuildCache = { digest, build };
-    return build;
   }
 
-  // ── First pass: collect all cross-zone link pairs for meta-graph layout ──
-  const allLinks: XzoneLink[] = [];
-  for (const spec of specs) {
-    for (const edge of spec.layoutEdges) {
-      const tgtStr = String(edge.target);
-      if (!tgtStr.startsWith("xzone:")) continue;
-      const parsed = parseXzoneTarget(tgtStr);
-      if (!parsed) continue;
-      allLinks.push({ a: spec.zoneId, b: parsed.zone });
+  const summaryById = new Map(summaries.map((s) => [s.zoneId, s]));
+
+  // ── Dedup cross-zone exits into undirected corridors ──────────────
+  const corridorMap = new Map<string, Corridor>();
+  for (const summary of summaries) {
+    for (const link of summary.crossLinks) {
+      const a = `${link.fromZone}:${link.fromRoom}`;
+      const b = `${link.toZone}:${link.toRoom}`;
+      const key = a < b ? `${a}|${b}` : `${b}|${a}`;
+      if (corridorMap.has(key)) continue;
+      const target = summaryById.get(link.toZone);
+      const resolved = !!target && target.roomIds.has(link.toRoom);
+      corridorMap.set(key, {
+        aZone: link.fromZone,
+        aRoom: link.fromRoom,
+        bZone: link.toZone,
+        bRoom: link.toRoom,
+        resolved,
+      });
     }
   }
+  const corridors = Array.from(corridorMap.values());
+  const validCorridors = corridors.filter((c) => c.resolved);
+  const orphans = corridors.length - validCorridors.length;
 
-  // Only run the (relatively expensive) dagre meta-graph layout on clusters
-  // that don't already have a saved position. Saved positions always win so
-  // that user drags persist across reloads.
-  const unsaved = specs.filter((s) => !savedPositions[s.zoneId]);
-  const dagrePositions =
-    unsaved.length > 0 ? layoutClusters(unsaved, allLinks) : new Map();
-  const clusterPositions = new Map<string, { x: number; y: number }>();
-  for (const spec of specs) {
-    const saved = savedPositions[spec.zoneId];
+  // ── Build the laid-out graph for each expanded zone ────────────────
+  const expanded = new Map<string, ExpandedGraph>();
+  for (const summary of summaries) {
+    if (!expandedZones.has(summary.zoneId)) continue;
+    const state = zones.get(summary.zoneId);
+    if (!state) continue;
+    expanded.set(summary.zoneId, buildExpandedGraph(state.data));
+  }
+
+  // ── Meta-graph layout for zones without a saved position ───────────
+  const pairs: ZonePair[] = validCorridors.map((c) => ({ a: c.aZone, b: c.bZone }));
+  const boxes: ZoneBox[] = summaries
+    .filter((s) => !savedPositions[s.zoneId])
+    .map((s) => {
+      const exp = expanded.get(s.zoneId);
+      return {
+        zoneId: s.zoneId,
+        width: exp ? exp.groupWidth : CARD_W,
+        height: exp ? exp.groupHeight : CARD_H,
+      };
+    });
+  const dagrePositions = boxes.length > 0 ? layoutZoneBoxes(boxes, pairs) : new Map();
+
+  const positions = new Map<string, { x: number; y: number }>();
+  for (const summary of summaries) {
+    const saved = savedPositions[summary.zoneId];
     if (saved) {
-      clusterPositions.set(spec.zoneId, { x: saved.x, y: saved.y });
+      positions.set(summary.zoneId, { x: saved.x, y: saved.y });
     } else {
-      clusterPositions.set(
-        spec.zoneId,
-        dagrePositions.get(spec.zoneId) ?? { x: 0, y: 0 },
+      positions.set(
+        summary.zoneId,
+        dagrePositions.get(summary.zoneId) ?? { x: 0, y: 0 },
       );
     }
   }
 
-  // ── Build ReactFlow nodes ──────────────────────────────────────────
+  // ── Nodes: one card OR group per zone, plus children for expanded ──
   const allNodes: Node[] = [];
-  const roomIndex = new Map<string, Set<string>>();
   const nodeIdSet = new Set<string>();
+  let totalRooms = 0;
 
-  // Parent nodes first — ReactFlow requires parent nodes to be emitted before
-  // their children so the parentId lookup during render succeeds.
-  for (const spec of specs) {
-    const pos = clusterPositions.get(spec.zoneId) ?? { x: 0, y: 0 };
-    allNodes.push({
-      id: `group:${spec.zoneId}`,
-      type: "zoneGroup",
-      position: pos,
-      data: {
-        zone: spec.zoneName,
-        roomCount: spec.layoutNodes.length,
-        zoneId: spec.zoneId,
-      } satisfies ZoneGroupData,
-      // Explicit dimensions (not just style) so fit-to-view and bounds math
-      // know each cluster's size even while it's culled off-screen by
-      // onlyRenderVisibleElements and has never been DOM-measured.
-      width: spec.groupWidth,
-      height: spec.groupHeight,
-      style: {
-        width: spec.groupWidth,
-        height: spec.groupHeight,
-      },
-      draggable: true,
-      selectable: false,
-      focusable: false,
-    });
+  for (const summary of summaries) {
+    const pos = positions.get(summary.zoneId) ?? { x: 0, y: 0 };
+    const roomCount = summary.roomIds.size;
+    totalRooms += roomCount;
+    const exp = expanded.get(summary.zoneId);
+    const linkCount = validCorridors.filter(
+      (c) => c.aZone === summary.zoneId || c.bZone === summary.zoneId,
+    ).length;
+
+    if (exp) {
+      allNodes.push({
+        id: `group:${summary.zoneId}`,
+        type: "zoneGroup",
+        position: pos,
+        data: {
+          zone: summary.zoneName,
+          roomCount,
+          zoneId: summary.zoneId,
+        } satisfies ZoneGroupData,
+        style: { width: exp.groupWidth, height: exp.groupHeight },
+        draggable: true,
+        selectable: false,
+        focusable: false,
+      });
+    } else {
+      allNodes.push({
+        id: `group:${summary.zoneId}`,
+        type: "zoneCard",
+        position: pos,
+        data: {
+          zone: summary.zoneName,
+          roomCount,
+          linkCount,
+          zoneId: summary.zoneId,
+        } satisfies ZoneCardData,
+        style: { width: CARD_W, height: CARD_H },
+        draggable: true,
+        selectable: false,
+        focusable: false,
+      });
+    }
   }
 
-  // Children — positions are RELATIVE to their parent group.
-  for (const spec of specs) {
-    const clusterRooms = new Set<string>();
-    for (const node of spec.layoutNodes) {
-      // Strip anything that triggers a Tauri IPC image read. RoomNode loads
-      // the room background and each entity sprite via `useImageSrc`, which
-      // invokes `read_image_data_url` per call. Multiply by every room in
-      // every loaded zone and you get hundreds of concurrent base64 reads
-      // when the atlas first opens — enough to freeze the app. Overview
-      // entity counts + role badges still come through from data.
+  // Children — emitted after all parents (ReactFlow requires parent-first).
+  for (const summary of summaries) {
+    const exp = expanded.get(summary.zoneId);
+    if (!exp) continue;
+    for (const node of exp.layoutNodes) {
       const baseData = node.data as Record<string, unknown>;
-      const prefixedId = `${spec.zoneId}::${node.id}`;
+      const prefixedId = `${summary.zoneId}::${node.id}`;
       allNodes.push({
         ...node,
         id: prefixedId,
-        parentId: `group:${spec.zoneId}`,
+        parentId: `group:${summary.zoneId}`,
         extent: "parent",
         position: {
-          x: (node.position?.x ?? 0) - spec.bounds.x + GROUP_PAD,
-          y: (node.position?.y ?? 0) - spec.bounds.y + GROUP_PAD + HEADER_OFFSET,
+          x: (node.position?.x ?? 0) - exp.bounds.x + GROUP_PAD,
+          y: (node.position?.y ?? 0) - exp.bounds.y + GROUP_PAD + HEADER_OFFSET,
         },
         data: {
           ...baseData,
-          image: undefined,
-          entities: [],
-          __zoneId: spec.zoneId,
+          __zoneId: summary.zoneId,
           __roomId: node.id,
         } satisfies Record<string, unknown> & AtlasRoomExtra,
         draggable: false,
       });
       nodeIdSet.add(prefixedId);
-      clusterRooms.add(node.id);
     }
-    roomIndex.set(spec.zoneId, clusterRooms);
   }
 
-  // ── Build ReactFlow edges ──────────────────────────────────────────
+  // ── Edges ──────────────────────────────────────────────────────────
   const allEdges: Edge[] = [];
-  interface PendingXzone {
-    sourceZone: string;
-    sourceRoom: string;
-    targetZone: string;
-    targetRoom: string;
-    baseEdge: Edge;
-  }
-  const pendingXzone: PendingXzone[] = [];
 
-  for (const spec of specs) {
-    for (const edge of spec.layoutEdges) {
+  // Intra-zone edges for expanded zones only.
+  for (const summary of summaries) {
+    const exp = expanded.get(summary.zoneId);
+    if (!exp) continue;
+    for (const edge of exp.layoutEdges) {
       const srcStr = String(edge.source);
       const tgtStr = String(edge.target);
-      if (tgtStr.startsWith("xzone:")) {
-        const parsed = parseXzoneTarget(tgtStr);
-        if (!parsed) continue;
-        pendingXzone.push({
-          sourceZone: spec.zoneId,
-          sourceRoom: srcStr,
-          targetZone: parsed.zone,
-          targetRoom: parsed.room,
-          baseEdge: edge,
-        });
-        continue;
-      }
-      if (srcStr.startsWith("xzone:")) continue; // defensive
+      if (tgtStr.startsWith("xzone:") || srcStr.startsWith("xzone:")) continue;
       allEdges.push({
         ...edge,
-        id: `${spec.zoneId}::${edge.id}`,
-        source: `${spec.zoneId}::${srcStr}`,
-        target: `${spec.zoneId}::${tgtStr}`,
+        id: `${summary.zoneId}::${edge.id}`,
+        source: `${summary.zoneId}::${srcStr}`,
+        target: `${summary.zoneId}::${tgtStr}`,
         selectable: false,
       });
     }
   }
 
-  // ── Resolve cross-zone edges ─────────────────────────────────────
-  // Dedup reciprocal exits (A↔B shows up from both sides) by sorted pair key
-  // and mark merged edges bidirectional so they read as an undirected corridor.
-  const xzoneMap = new Map<string, { first: PendingXzone; second?: PendingXzone }>();
-  let orphans = 0;
-
-  for (const p of pendingXzone) {
-    const targetRooms = roomIndex.get(p.targetZone);
-    if (!targetRooms || !targetRooms.has(p.targetRoom)) {
-      orphans += 1;
-      continue;
-    }
-    const a = `${p.sourceZone}:${p.sourceRoom}`;
-    const b = `${p.targetZone}:${p.targetRoom}`;
-    const key = a < b ? `${a}|${b}` : `${b}|${a}`;
-    const existing = xzoneMap.get(key);
-    if (!existing) {
-      xzoneMap.set(key, { first: p });
-    } else if (!existing.second) {
-      existing.second = p;
+  // Cross-zone corridors. Both zones expanded → room-level edges. Otherwise →
+  // a single aggregated zone↔zone edge per pair, labelled with the count.
+  const aggCounts = new Map<string, { a: string; b: string; count: number }>();
+  for (const c of validCorridors) {
+    const bothExpanded = expanded.has(c.aZone) && expanded.has(c.bZone);
+    if (bothExpanded) {
+      const sourceId = `${c.aZone}::${c.aRoom}`;
+      const targetId = `${c.bZone}::${c.bRoom}`;
+      if (!nodeIdSet.has(sourceId) || !nodeIdSet.has(targetId)) continue;
+      allEdges.push({
+        id: `xroom::${c.aZone}:${c.aRoom}|${c.bZone}:${c.bRoom}`,
+        type: "exitEdge",
+        source: sourceId,
+        target: targetId,
+        selectable: false,
+        style: { stroke: "var(--color-graph-cross)", strokeWidth: 2.5 },
+        zIndex: 5,
+      });
+    } else {
+      const key = c.aZone < c.bZone ? `${c.aZone}|${c.bZone}` : `${c.bZone}|${c.aZone}`;
+      const existing = aggCounts.get(key);
+      if (existing) existing.count += 1;
+      else aggCounts.set(key, { a: c.aZone, b: c.bZone, count: 1 });
     }
   }
 
-  let resolved = 0;
-  for (const [key, entry] of xzoneMap.entries()) {
-    const p = entry.first;
-    const sourceId = `${p.sourceZone}::${p.sourceRoom}`;
-    const targetId = `${p.targetZone}::${p.targetRoom}`;
-    if (!nodeIdSet.has(sourceId) || !nodeIdSet.has(targetId)) {
-      orphans += 1;
-      continue;
-    }
-    resolved += 1;
-    const bidirectional = !!entry.second;
-    const baseEdge = p.baseEdge;
-    const baseStyle = (baseEdge.style ?? {}) as Record<string, unknown>;
+  for (const [key, { a, b, count }] of aggCounts.entries()) {
     allEdges.push({
-      ...baseEdge,
-      id: `xzone::${key}`,
-      source: sourceId,
-      target: targetId,
+      id: `agg::${key}`,
+      source: `group:${a}`,
+      target: `group:${b}`,
+      sourceHandle: AGG_HANDLE,
+      targetHandle: AGG_HANDLE,
       selectable: false,
-      markerEnd: bidirectional ? undefined : baseEdge.markerEnd,
+      label: count > 1 ? `${count}` : undefined,
       style: {
-        ...baseStyle,
-        strokeWidth: 2.5,
-        strokeDasharray: undefined,
+        stroke: "var(--color-graph-cross)",
+        strokeWidth: 2,
+        strokeDasharray: "6 4",
       },
-      label: baseEdge.label,
-      zIndex: 5,
+      zIndex: 4,
     });
   }
 
-  const totalRooms = specs.reduce((sum, c) => sum + c.layoutNodes.length, 0);
-
-  const build: AtlasBuild = {
+  return {
     nodes: allNodes,
     edges: allEdges,
     stats: {
-      zones: specs.length,
+      zones: summaries.length,
       rooms: totalRooms,
-      crossLinks: resolved,
+      crossLinks: validCorridors.length,
       orphans,
     },
     isEmpty: false,
   };
-  atlasBuildCache = { digest, build };
-  return build;
 }
 
 // ─── Component ──────────────────────────────────────────────────────
 
 function ZoneAtlas() {
-  const reactFlow = useReactFlow();
   const zones = useZoneStore((s) => s.zones);
   const updateZone = useZoneStore((s) => s.updateZone);
   const navigateTo = useProjectStore((s) => s.navigateTo);
@@ -510,20 +588,34 @@ function ZoneAtlas() {
   // An in-progress room→room drag awaiting a direction. Cross-zone only.
   const [pendingLink, setPendingLink] = useState<PendingXLink | null>(null);
 
+  // Which zones are expanded into room nodes. Default: all collapsed (cheap).
+  const [expandedZones, setExpandedZones] = useState<Set<string>>(() => new Set());
+
   // Saved cluster positions per project. `resetNonce` bumps when the user
-  // resets the layout, forcing `initial` to re-run with a fresh (empty) map.
+  // resets the layout, forcing the memo to re-read storage.
   const [resetNonce, setResetNonce] = useState(0);
   const savedPositions = useMemo(
     () => (projectPath ? loadAtlasClusterPositions(projectPath) : {}),
-    // resetNonce is in the dep list intentionally — bumping it re-reads storage
-    // after we clear it.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [projectPath, resetNonce],
   );
 
+  // Drop expanded zones that no longer exist (zone deleted / project switched).
+  useEffect(() => {
+    setExpandedZones((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (zones.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [zones]);
+
   const initial = useMemo(
-    () => buildAtlas(zones, savedPositions),
-    [zones, savedPositions],
+    () => buildAtlas(zones, savedPositions, expandedZones),
+    [zones, savedPositions, expandedZones],
   );
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initial.nodes);
@@ -532,13 +624,13 @@ function ZoneAtlas() {
   // Reconcile ReactFlow state with the freshly computed atlas.
   //
   // `savedPositions` only changes identity on a project switch or an explicit
-  // "Reset Layout" (its memo is keyed on [projectPath, resetNonce]). We use
-  // that to decide between two behaviors:
-  //   • savedPositions changed → apply the fresh layout wholesale (first open,
-  //     project switch, or reset).
-  //   • only `zones` changed (e.g. an exit was added) → refresh node data and
-  //     edges but KEEP the positions currently on screen, so creating a link
-  //     doesn't relayout the atlas and shove every cluster around.
+  // "Reset Layout". We use that to decide between two behaviors:
+  //   • savedPositions changed → apply the fresh layout wholesale.
+  //   • otherwise (zone edit OR expand/collapse) → refresh nodes and edges but
+  //     KEEP the on-screen position of any node that survives, so creating a
+  //     link or expanding a zone doesn't shove every cluster around. Zone
+  //     cards and groups share the `group:<id>` node id, so a card's position
+  //     carries straight into its expanded group and back.
   const prevSavedRef = useRef(savedPositions);
   useEffect(() => {
     const savedChanged = prevSavedRef.current !== savedPositions;
@@ -558,60 +650,26 @@ function ZoneAtlas() {
     setEdges(initial.edges);
   }, [initial, savedPositions, setNodes, setEdges]);
 
-  // ─── One-shot fit-to-view ────────────────────────────────────────
-  // We can't use the `fitView` prop: it's unreliable under
-  // `onlyRenderVisibleElements` (off-screen clusters aren't DOM-measured, so
-  // the prop's bounds collapse) and it re-queues a store write on every render
-  // because `fitViewOptions` would be a fresh object. Instead we fit once per
-  // loadout from `getLayoutBounds`, which derives bounds from node positions +
-  // explicit cluster sizes and therefore works without measuring every node.
-  // `savedPositions` only changes identity on project switch or "Reset Layout",
-  // so edits and pans never re-fit.
-  //
-  // We fit over the zone-group nodes only: they're top-level (absolute
-  // positions) and each is sized to fully contain its rooms, so their union is
-  // the whole atlas extent. The room nodes are children whose `position` is
-  // relative to their group — feeding those into `getLayoutBounds`, which
-  // treats position as absolute, would skew the bounds. Group dimensions are
-  // explicit, so this works even while every group is culled off-screen and
-  // unmeasured.
-  const fitDoneRef = useRef<Record<string, AtlasPosition> | null>(null);
-  useEffect(() => {
-    if (nodes.length === 0) return;
-    if (fitDoneRef.current === savedPositions) return;
-
-    let cancelled = false;
-    // Two rAFs: one to let React commit the nodes, one to let ReactFlow adopt
-    // their dimensions before we measure.
-    const raf1 = requestAnimationFrame(() => {
-      if (cancelled) return;
-      requestAnimationFrame(() => {
-        if (cancelled) return;
-        const groups = reactFlow
-          .getNodes()
-          .filter((node) => node.type === "zoneGroup");
-        if (groups.length === 0) return;
-        const measurements = new Map<string, LayoutMeasurement>();
-        for (const node of groups) {
-          const width = node.measured?.width ?? node.width;
-          const height = node.measured?.height ?? node.height;
-          if (width && height) measurements.set(node.id, { width, height });
-        }
-        const bounds = getLayoutBounds(groups, measurements);
-        if (bounds && bounds.width > 0 && bounds.height > 0) {
-          reactFlow.fitBounds(bounds, { padding: 0.15, duration: 0 });
-          fitDoneRef.current = savedPositions;
-        }
-      });
-    });
-    return () => {
-      cancelled = true;
-      cancelAnimationFrame(raf1);
-    };
-  }, [savedPositions, nodes.length, reactFlow]);
-
   const onNodeClick: NodeMouseHandler = useCallback(
     (_event, node) => {
+      if (node.type === "zoneCard") {
+        const zoneId = (node.data as ZoneCardData).zoneId;
+        setExpandedZones((prev) => {
+          const next = new Set(prev);
+          next.add(zoneId);
+          return next;
+        });
+        return;
+      }
+      if (node.type === "zoneGroup") {
+        const zoneId = (node.data as ZoneGroupData).zoneId;
+        setExpandedZones((prev) => {
+          const next = new Set(prev);
+          next.delete(zoneId);
+          return next;
+        });
+        return;
+      }
       const d = node.data as Partial<AtlasRoomExtra> | undefined;
       if (d?.__zoneId && d.__roomId) {
         navigateTo({ zoneId: d.__zoneId, roomId: d.__roomId });
@@ -621,10 +679,8 @@ function ZoneAtlas() {
   );
 
   // ─── Cross-zone linking ──────────────────────────────────────────
-  // Dragging from one room's exit handle to a room in another cluster opens
-  // the direction picker; confirming writes a two-way cross-zone exit into
-  // both zones. Same-cluster drags are ignored — intra-zone exits belong in
-  // the zone editor.
+  // Dragging from one room's exit handle to a room in another expanded zone
+  // opens the direction picker; confirming writes a two-way cross-zone exit.
   const onConnect = useCallback(
     (connection: Connection) => {
       const { source, target, sourceHandle } = connection;
@@ -674,8 +730,6 @@ function ZoneAtlas() {
         return;
       }
 
-      // Don't clobber an existing exit on either end — keep the picker open so
-      // the user can choose a free direction.
       if (sourceData.rooms[sourceRoom]?.exits?.[direction]) {
         useToastStore
           .getState()
@@ -721,10 +775,10 @@ function ZoneAtlas() {
 
   const onNodeDragStop: OnNodeDrag = useCallback(
     (_event, node) => {
-      if (node.type !== "zoneGroup") return;
-      const groupData = node.data as ZoneGroupData | undefined;
-      if (!groupData?.zoneId || !projectPath) return;
-      saveAtlasClusterPosition(projectPath, groupData.zoneId, {
+      if (node.type !== "zoneGroup" && node.type !== "zoneCard") return;
+      const zoneId = (node.data as { zoneId?: string }).zoneId;
+      if (!zoneId || !projectPath) return;
+      saveAtlasClusterPosition(projectPath, zoneId, {
         x: node.position.x,
         y: node.position.y,
       });
@@ -737,6 +791,10 @@ function ZoneAtlas() {
     clearAtlasClusterPositions(projectPath);
     setResetNonce((n) => n + 1);
   }, [projectPath]);
+
+  const handleCollapseAll = useCallback(() => {
+    setExpandedZones(new Set());
+  }, []);
 
   const hasSavedLayout = Object.keys(savedPositions).length > 0;
 
@@ -774,11 +832,10 @@ function ZoneAtlas() {
         // RoomNode ships a single source-type handle per direction; loose
         // mode lets edge targets anchor to them.
         connectionMode={ConnectionMode.Loose}
-        // Mount only the clusters/rooms in the viewport. At ~700 rooms the
-        // atlas otherwise keeps every room node (10 handles each) live at all
-        // times, which is what makes pan/zoom crawl. Initial fit is handled
-        // manually above. See ZoneEditor for the same trade-off.
+        // Cull off-screen room nodes so expanded zones stay cheap to render.
         onlyRenderVisibleElements
+        fitView
+        fitViewOptions={{ padding: 0.15 }}
         nodesDraggable
         // Rooms stay non-draggable (set per-node), but their handles are live
         // so users can drag a room→room cross-zone link.
@@ -794,15 +851,7 @@ function ZoneAtlas() {
           color="var(--color-graph-grid)"
         />
         <Controls showInteractive={false} />
-        <MiniMap
-          pannable
-          zoomable
-          className="!bg-bg-abyss/80"
-          nodeColor={(node) =>
-            node.type === "zoneGroup" ? GRAPH().cross : GRAPH().node
-          }
-          maskColor="var(--graph-minimap-mask)"
-        />
+        <MiniMap pannable zoomable className="!bg-bg-abyss/80" />
       </ReactFlow>
       <div className="pointer-events-none absolute left-4 top-4 z-10 flex flex-wrap items-center gap-2 text-2xs">
         <AtlasStat label="zones" value={initial.stats.zones} />
@@ -810,6 +859,16 @@ function ZoneAtlas() {
         <AtlasStat label="cross-zone links" value={initial.stats.crossLinks} />
         {initial.stats.orphans > 0 && (
           <AtlasStat label="orphan links" value={initial.stats.orphans} tone="warn" />
+        )}
+        {expandedZones.size > 0 && (
+          <button
+            type="button"
+            onClick={handleCollapseAll}
+            className="pointer-events-auto rounded-full border border-border-muted bg-bg-abyss/80 px-2.5 py-1 uppercase tracking-wider text-text-muted backdrop-blur transition-colors hover:border-accent/40 hover:text-accent"
+            title="Collapse every expanded zone back to a card"
+          >
+            Collapse All ({expandedZones.size})
+          </button>
         )}
         {hasSavedLayout && (
           <button
@@ -823,8 +882,9 @@ function ZoneAtlas() {
         )}
       </div>
       <div className="pointer-events-none absolute bottom-20 right-4 z-10 max-w-xs rounded-lg border border-border-muted bg-bg-abyss/85 px-3 py-2 text-2xs italic text-text-muted backdrop-blur">
-        Drag from a room's edge handle to a room in another zone to link them two ways. Drag a
-        cluster to reposition it (saved per project). Click a room to open its zone.
+        Drag zone cards into rough positions (saved per project). Click a card to open its
+        rooms; click an open zone's header to collapse it. With two zones open, drag from a
+        room's edge handle to a room in the other to link them.
       </div>
 
       {/* Cross-zone direction picker */}


### PR DESCRIPTION
## Problem

The World Atlas continues to be a bottleneck and won't survive the projected ~10k-room world:

1. **Dragging big zones is very slow.** Every room in every loaded zone is a ReactFlow child node with ~10 handles each. Dragging a zone group re-renders the absolute position of every child on each pointer frame. The #314/#311 work attacked mount/rebuild cost, but drag cost scales with the children inside the dragged group — unwinnable at scale.
2. **Layout "doesn't save."** When zones pack tightly, room children (which sit on top of the group) intercept the drag; a click on a room *navigates to its editor* instead of moving the zone, so no group drag completes and no position is saved.
3. **Doesn't scale.** Room nodes exist whether or not you care about them.

## Approach (level-of-detail)

Two node states, swapping on the shared `group:<zoneId>` node id so position carries across:

- **Collapsed (default):** each zone is one lightweight `zoneCard`, built from a flat scan of the zone's exit table — no `zoneToGraph`, no `compassLayout`, no image IPC. Dragging it moves a single childless node: fast at any world size, unambiguous drag target.
- **Expanded (click a card):** mounts that zone's room graph + intra-zone edges, positioned relative to the card. Click an open zone's header to collapse.

Cost drops from O(total rooms) to O(zones + rooms-in-expanded-zones).

### Cross-zone connections
- Collapsed (or mixed) pairs render as **aggregated zone↔zone edges** between cards, labelled with the corridor count.
- When **both** zones are expanded, edges resolve to the room level and the existing drag-a-handle-to-link flow works — matching the "2–3 zones open to wire connections" workflow.

## Design decisions (per discussion)
- Expansion is **in-place**, overlapping neighbors temporarily (transient; user repositions).
- Collapsed cards are **fixed-size** with a room-count + link-count badge.
- Aggregated cross-zone edges are **shown** when collapsed.

## Compatibility
- Saved-position storage (`atlasClusterPositions`) is unchanged — cards/groups reuse the same `group:<id>` ids and per-project persistence.
- Cross-zone link creation + direction picker flow unchanged.
- Added a **Collapse All** control alongside Reset Layout.

## Verification
- `bunx tsc --noEmit`: clean.
- `bun run test`: 2271 passing.
- Not yet exercised in the running app — would appreciate a manual pass on drag-to-reposition, expand/collapse, and cross-zone linking between two expanded zones.