### PR TITLE
perf(llm): prompt caching + per-class icon palettes

### DIFF
--- a/creator/src-tauri/src/anthropic.rs
+++ b/creator/src-tauri/src/anthropic.rs
@@ -7,8 +7,44 @@ const API_VERSION: &str = "2023-06-01";
 struct AnthropicRequest {
     model: String,
     max_tokens: u32,
-    system: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    system: Vec<SystemBlock>,
     messages: Vec<AnthropicMessage>,
+}
+
+// System prompt as a content block so we can attach `cache_control`. The
+// enhancement/generation system prompts are deterministic per (world, asset
+// type) and re-sent on every call; caching the prefix bills it at ~10% on
+// repeats within the 5-minute TTL. Prompts below the model's minimum cacheable
+// length (2048 tokens on Sonnet 4.6) silently skip caching with no penalty.
+#[derive(Debug, Serialize)]
+struct SystemBlock {
+    #[serde(rename = "type")]
+    block_type: String,
+    text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<CacheControl>,
+}
+
+#[derive(Debug, Serialize)]
+struct CacheControl {
+    #[serde(rename = "type")]
+    cache_type: String,
+}
+
+impl SystemBlock {
+    fn cached(text: &str) -> Vec<SystemBlock> {
+        if text.is_empty() {
+            return Vec::new();
+        }
+        vec![SystemBlock {
+            block_type: "text".to_string(),
+            text: text.to_string(),
+            cache_control: Some(CacheControl {
+                cache_type: "ephemeral".to_string(),
+            }),
+        }]
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -70,7 +106,7 @@ pub async fn complete(
     let body = AnthropicRequest {
         model: model.to_string(),
         max_tokens,
-        system: system_prompt.to_string(),
+        system: SystemBlock::cached(system_prompt),
         messages: vec![AnthropicMessage {
             role: "user".to_string(),
             content: user_prompt.to_string(),

--- a/creator/src/components/config/abilities/AbilityEditor.tsx
+++ b/creator/src/components/config/abilities/AbilityEditor.tsx
@@ -336,6 +336,7 @@ function CombatVisualsCard({
             currentImage={visual.projectileImage}
             onAccept={(filePath) => patchVisual({ projectileImage: filePath })}
             assetType="ability_sprite"
+            iconClass={ability.requiredClass || ability.classRestriction}
             context={{ zone: "", entity_type: "ability_visual", entity_id: id }}
             surface="worldbuilding"
           />

--- a/creator/src/components/config/panels/AbilitiesPanel.tsx
+++ b/creator/src/components/config/panels/AbilitiesPanel.tsx
@@ -419,6 +419,7 @@ export function AbilityDetail({
             currentImage={ability.image}
             onAccept={(filePath) => patch({ image: filePath })}
             assetType="ability_icon"
+            iconClass={ability.requiredClass || ability.classRestriction}
             context={{ zone: "", entity_type: "ability", entity_id: id }}
             surface="worldbuilding"
           />

--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -43,6 +43,9 @@ interface EntityArtGeneratorProps {
   onAccept: (filePath: string) => void;
   /** Asset type for manifest (e.g. "entity_portrait", "background") */
   assetType?: string;
+  /** For ability/status-effect icons: the entity's class, so prompt enhancement
+   *  includes only that class's color palette rather than all of them. */
+  iconClass?: string;
   /** Context tags for the asset manifest */
   context?: AssetContext;
   /** @deprecated Vibe no longer influences generation; field kept for callers pending cleanup. */
@@ -108,6 +111,7 @@ export function EntityArtGenerator({
   currentImage,
   onAccept,
   assetType,
+  iconClass,
   context,
   vibe: _vibe,
   surface,
@@ -264,7 +268,7 @@ export function EntityArtGenerator({
     ec: string | undefined,
     fh: string | undefined,
   ): Promise<string> => {
-    const systemPrompt = getEnhanceSystemPrompt(artStyle, assetType, surface, nativeTransparency);
+    const systemPrompt = getEnhanceSystemPrompt(artStyle, assetType, surface, nativeTransparency, iconClass);
     const resolver = useReferenceStore.getState().resolver();
     const used: ReferenceSubject[] = [];
     const collect = (subs: ReferenceSubject[]) => {

--- a/creator/src/lib/arcanumPrompts.ts
+++ b/creator/src/lib/arcanumPrompts.ts
@@ -690,27 +690,51 @@ Output ONLY the finished prompt text — no explanation, no labels, no markdown.
 /** System prompt for the prompt enhancement LLM — kept for backward compat */
 export const ENHANCE_SYSTEM_PROMPT = ENHANCE_SYSTEM_PROMPT_ARCANUM;
 
-/** Class color palette reference for ability and status effect icon generation. */
-export const CLASS_COLOR_PALETTES = `
-CLASS COLOR PALETTES (use when generating ability or status effect icons):
-- Bulwark (defensive tank): warm golds, burnished steel, shield shapes, fortress silhouettes, heavy metallic tones
-- Warden (aggressive fighter): warm amber, rust reds, earthy brown, sharp weapon motifs, fur and leather textures
-- Arcanist (scholarly mage): deep purples, electric blues, crystalline whites, arcane sigils, glowing tomes
-- Faeweaver (nature mage): living greens, floral pinks, vine tendrils, petal formations, budding flowers
-- Necromancer (death + clockwork): sickly greens, clockwork brass, bone whites, ghostly teal, gear motifs
-- Veil (shadow assassin): deep indigos, midnight purples, smoky grays, dagger silhouettes, living shadow wisps
-- Binder (anti-magic enforcer): blazing amber, golden chains, rune circles, suppression barriers, dissolving spell fragments
-- Stormblade (lightning warrior): electric blues, white lightning, storm grays, zig-zag energy streaks, crackling arcs
-- Herald (divine cleric): warm whites, soft golds, holy radiance, sacred symbols, gentle divine glow
-- Starweaver (cosmic mage): cosmic purples, nebula pinks, stellar whites, constellation patterns, swirling galaxies
+/** Per-class palette descriptors for ability and status effect icon generation,
+ *  keyed by the built-in Ambon class name (lowercased for matching). */
+const CLASS_PALETTE_LINES: Record<string, string> = {
+  bulwark: "- Bulwark (defensive tank): warm golds, burnished steel, shield shapes, fortress silhouettes, heavy metallic tones",
+  warden: "- Warden (aggressive fighter): warm amber, rust reds, earthy brown, sharp weapon motifs, fur and leather textures",
+  arcanist: "- Arcanist (scholarly mage): deep purples, electric blues, crystalline whites, arcane sigils, glowing tomes",
+  faeweaver: "- Faeweaver (nature mage): living greens, floral pinks, vine tendrils, petal formations, budding flowers",
+  necromancer: "- Necromancer (death + clockwork): sickly greens, clockwork brass, bone whites, ghostly teal, gear motifs",
+  veil: "- Veil (shadow assassin): deep indigos, midnight purples, smoky grays, dagger silhouettes, living shadow wisps",
+  binder: "- Binder (anti-magic enforcer): blazing amber, golden chains, rune circles, suppression barriers, dissolving spell fragments",
+  stormblade: "- Stormblade (lightning warrior): electric blues, white lightning, storm grays, zig-zag energy streaks, crackling arcs",
+  herald: "- Herald (divine cleric): warm whites, soft golds, holy radiance, sacred symbols, gentle divine glow",
+  starweaver: "- Starweaver (cosmic mage): cosmic purples, nebula pinks, stellar whites, constellation patterns, swirling galaxies",
+};
 
-EFFECT COLOR MODIFIERS:
+const EFFECT_COLOR_MODIFIERS = `EFFECT COLOR MODIFIERS:
 - Healing/regeneration: warm golden-white light, green life energy
 - Shields/protection: translucent barriers, dome shapes, soft glowing edges
 - Damage-over-time: smoldering embers, dripping venom, crackling energy
 - Stun/crowd-control: stars, shattered glass, frozen shards
 - Buffs: ascending arrows, radiant auras, empowering glows
 - Debuffs: descending spirals, dark mists, weakening auras`;
+
+/** Full class color palette reference (all classes). Used when the relevant
+ *  class is unknown — e.g. cross-class status effects, or custom-class worlds
+ *  whose class names don't match the built-in palettes. */
+export const CLASS_COLOR_PALETTES = `
+CLASS COLOR PALETTES (use when generating ability or status effect icons):
+${Object.values(CLASS_PALETTE_LINES).join("\n")}
+
+${EFFECT_COLOR_MODIFIERS}`;
+
+/** Palette block for an ability/status icon prompt. When the icon's class is
+ *  known and matches a built-in palette, emit only that class's line plus the
+ *  shared effect modifiers (instead of all ten palettes); otherwise fall back
+ *  to the full reference. */
+export function buildClassPalettes(iconClass?: string): string {
+  const line = CLASS_PALETTE_LINES[iconClass?.trim().toLowerCase() ?? ""];
+  if (!line) return CLASS_COLOR_PALETTES;
+  return `
+CLASS COLOR PALETTE (use for this ability/status effect icon):
+${line}
+
+${EFFECT_COLOR_MODIFIERS}`;
+}
 
 /** Full sprite safety block for BG-removal models (FLUX etc.) */
 const SPRITE_SAFETY_ENHANCER_BLOCK = `
@@ -748,7 +772,7 @@ function isRoomScene(assetType: string | undefined): boolean {
 
 /** Get the system prompt for prompt enhancement — defers to world visual style when defined.
  *  Pass `nativeTransparency` to use lighter framing rules instead of full BG-removal safety. */
-export function getEnhanceSystemPrompt(style: ArtStyle, assetType?: string, surface?: ArtStyleSurface, nativeTransparency?: boolean): string {
+export function getEnhanceSystemPrompt(style: ArtStyle, assetType?: string, surface?: ArtStyleSurface, nativeTransparency?: boolean, iconClass?: string): string {
   const visualStyle = buildVisualStyleDirective(surface);
   const tone = buildToneDirective({ imageContext: true });
   const spriteSafety = assetType && needsBgRemovalSafety(assetType)
@@ -763,7 +787,7 @@ export function getEnhanceSystemPrompt(style: ArtStyle, assetType?: string, surf
       ? `\n\nWorld visual style: ${visualStyle}\nAll enhanced prompts must conform to this visual style.`
       : "";
     const palettes = (assetType === "ability_icon" || assetType === "status_effect_icon" || assetType === "ability_sprite")
-      ? `\n\n${CLASS_COLOR_PALETTES}`
+      ? `\n\n${buildClassPalettes(iconClass)}`
       : "";
 
     return `You are an expert image prompt engineer for AI image generators.${toneBlock}${styleBlock}
@@ -787,7 +811,7 @@ When enhancing a prompt:
     ? ENHANCE_SYSTEM_PROMPT_ARCANUM
     : ENHANCE_SYSTEM_PROMPT_GENTLE_MAGIC;
   const palettes = (assetType === "ability_icon" || assetType === "status_effect_icon" || assetType === "ability_sprite")
-    ? `\n\n${CLASS_COLOR_PALETTES}`
+    ? `\n\n${buildClassPalettes(iconClass)}`
     : "";
   return `${base}${palettes}${spriteSafety}${roomScene}`;
 }

--- a/hub-worker/src/handlers/ai.ts
+++ b/hub-worker/src/handlers/ai.ts
@@ -479,7 +479,7 @@ async function llmComplete(req: Request, env: Env, user: UserRow): Promise<Respo
       model: LLM_MODEL,
       max_tokens: clamp(body.maxTokens ?? 1024, 16, 8192),
       temperature: clamp(body.temperature ?? 0.7, 0, 1),
-      system: body.system?.trim() || undefined,
+      system: cachedSystem(body.system),
       messages: [{ role: "user", content: prompt }],
     }),
   });
@@ -749,6 +749,19 @@ async function embed(req: Request, env: Env, user: UserRow): Promise<Response> {
 function clamp(n: number, lo: number, hi: number): number {
   if (!Number.isFinite(n)) return lo;
   return Math.min(hi, Math.max(lo, Math.round(n)));
+}
+
+// Render the system prompt as a cache-controlled content block. The
+// enhancement/generation system prompts are deterministic per (world, asset
+// type) and re-sent on every call; an ephemeral breakpoint bills the prefix at
+// ~10% on cache reads within the 5-minute TTL (batch art, multi-room zone
+// generation reuse it constantly). Prompts under the model's minimum cacheable
+// length (2048 tokens on Sonnet 4.6) silently skip caching with no penalty.
+// Returns undefined for an empty system so the request omits the field.
+function cachedSystem(system: string | undefined) {
+  const text = system?.trim();
+  if (!text) return undefined;
+  return [{ type: "text", text, cache_control: { type: "ephemeral" } }];
 }
 
 function roundTo16(n: number): number {


### PR DESCRIPTION
Two token-reduction changes to the LLM pipeline, from investigating monthly usage (~11.8M input / 2.46M output).

## 1. Cache deterministic system prompts (Anthropic prompt caching)

Attach an ephemeral `cache_control` breakpoint to the **system prompt** in both LLM completion paths so the deterministic system prefix is no longer re-billed as fresh input on every call:

- `hub-worker/src/handlers/ai.ts` → `llmComplete` (the `api.arcanum-hub.com` proxy; the hub's Anthropic bill)
- `creator/src-tauri/src/anthropic.rs` → `complete` (direct-provider mode)

The enhancement / zone-generation / lore system prompts are deterministic per (world, asset type) and re-sent verbatim every call. With caching, reads bill the cached prefix at **~10%** within the 5-minute TTL. The high-volume, repeated-prefix paths benefit most — **batch art** (same system prompt across N entities) and **multi-room zone generation**.

- No beta header — prompt caching is GA.
- Prompts under the model's minimum cacheable length (**2048 tokens on Sonnet 4.6**) silently skip caching with no penalty, so this is safe to apply unconditionally.

## 2. Send only the relevant class palette for ability/status icons

`CLASS_COLOR_PALETTES` injected **all ten** class palettes (~1650 chars / ~410 tokens) into every ability/status-icon enhancement prompt when only one class is relevant. Split into per-class lines + shared effect modifiers and thread the ability's class through `getEnhanceSystemPrompt`:

- `buildClassPalettes(iconClass)` emits just the matching class line + effect modifiers; **falls back to the full block** when the class is unknown (cross-class status effects, custom-class worlds) — no regression.
- `EntityArtGenerator` gains an optional `iconClass` prop; `AbilitiesPanel` and `AbilityEditor` pass the ability's `requiredClass`/`classRestriction`. Status-effect editors pass nothing and keep the full reference.

Trims ~9 irrelevant palettes (~360 tokens) from each class-bound icon enhancement.

## Scope note — #2 of the original plan (double-enhancement) was a no-op

The investigation also flagged a suspected double-enhancement (frontend LLM enhance → backend `maybe_enhance_prompt`). On inspection the frontend already guards it: every path that enhances frontend-side passes `autoEnhance: false` (or `!promptGeneratedByLlm`), and `imageGen.ts` defaults it to `false`. No systemic double-enhancement exists, so no code change was needed there.

## Verification

- `cargo check` ✅
- hub-worker `tsc --noEmit` ✅
- creator `tsc --noEmit` ✅ (0 errors)
- creator data-layer tests ✅ (2284 passed)

No behavior change in any path — same prompts, same response shapes; only token/billing footprint changes.