### PR TITLE
feat(atlas): map-anchored world overlay

### DIFF
--- a/creator/src/components/MainArea.tsx
+++ b/creator/src/components/MainArea.tsx
@@ -31,6 +31,7 @@ class PanelErrorBoundary extends Component<{ children: ReactNode }, { error: Err
 
 const ZoneEditor = lazy(() => import("./zone/ZoneEditor").then(m => ({ default: m.ZoneEditor })));
 const ZoneAtlasView = lazy(() => import("./zone/ZoneAtlasView").then(m => ({ default: m.ZoneAtlasView })));
+const WorldOverlayView = lazy(() => import("./zone/WorldOverlayView").then(m => ({ default: m.WorldOverlayView })));
 const ConfigPanelHost = lazy(() => import("./config/ConfigPanelHost").then(m => ({ default: m.ConfigPanelHost })));
 const LorePanelHost = lazy(() => import("./lore/LorePanelHost").then(m => ({ default: m.LorePanelHost })));
 const PlayerSpriteManager = lazy(() => import("./PlayerSpriteManager").then(m => ({ default: m.PlayerSpriteManager })));
@@ -147,6 +148,12 @@ export function MainArea() {
       panelIsland = "forge";
       bgPanelKey = WORLD_ATLAS_BG_KEY;
       content = <ZoneAtlasView />;
+      break;
+    }
+    case "worldOverlay": {
+      panelIsland = "forge";
+      bgPanelKey = WORLD_ATLAS_BG_KEY;
+      content = <WorldOverlayView />;
       break;
     }
     // Legacy tab kinds — kept for backward compatibility with persisted tabs

--- a/creator/src/components/map/IslandView.tsx
+++ b/creator/src/components/map/IslandView.tsx
@@ -297,6 +297,10 @@ export function IslandView({ island }: IslandViewProps) {
             setShowZonePicker(false);
             openTab({ id: "zoneAtlas", kind: "zoneAtlas", label: "World Atlas" });
           }}
+          onOpenOverlay={() => {
+            setShowZonePicker(false);
+            openTab({ id: "worldOverlay", kind: "worldOverlay", label: "Map Overlay" });
+          }}
           onCreateNew={() => {
             setShowZonePicker(false);
             setShowNewZone(true);
@@ -313,11 +317,13 @@ function ZonePickerDialog({
   onClose,
   onSelect,
   onOpenAtlas,
+  onOpenOverlay,
   onCreateNew,
 }: {
   onClose: () => void;
   onSelect: (zoneId: string) => void;
   onOpenAtlas: () => void;
+  onOpenOverlay: () => void;
   onCreateNew: () => void;
 }) {
   const trapRef = useFocusTrap<HTMLDivElement>(onClose);
@@ -381,6 +387,34 @@ function ZonePickerDialog({
           </div>
           <div className="mt-0.5 text-2xs text-text-muted">
             All zones at once — click any room to jump in.
+          </div>
+        </div>
+        <span className="text-text-muted">→</span>
+      </button>
+      <button
+        type="button"
+        onClick={onOpenOverlay}
+        className="mb-3 flex w-full items-center gap-3 rounded border border-accent/40 bg-gradient-active-strong px-3 py-2 text-left transition-colors hover:bg-accent/15"
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="h-5 w-5 text-accent"
+        >
+          <path d="M9 4 3 6.5v13L9 17l6 2.5 6-2.5v-13L15 6.5 9 4Z" />
+          <path d="M9 4v13" />
+          <path d="M15 6.5v13" />
+        </svg>
+        <div className="min-w-0 flex-1">
+          <div className="font-display text-sm uppercase tracking-widest text-accent">
+            Map Overlay
+          </div>
+          <div className="mt-0.5 text-2xs text-text-muted">
+            Drape zones over a world map to line up the geography.
           </div>
         </div>
         <span className="text-text-muted">→</span>

--- a/creator/src/components/zone/WorldOverlayView.tsx
+++ b/creator/src/components/zone/WorldOverlayView.tsx
@@ -250,7 +250,7 @@ function MapBackdrop({
   vp: Viewport;
 }) {
   return (
-    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+    <div className="pointer-events-none absolute inset-0 overflow-hidden" style={{ zIndex: 0 }}>
       {src && (
         <img
           src={src}
@@ -432,7 +432,16 @@ function WorldOverlay() {
 
   // Reconcile: add/remove nodes by id, but keep live position/size/selection
   // of survivors so dragging and resizing aren't interrupted mid-gesture.
+  // On a map switch, apply the new map's placements wholesale instead — a zone
+  // placed on both maps must not inherit the previous map's geometry.
+  const prevMapRef = useRef(selectedMapId);
   useEffect(() => {
+    const mapChanged = prevMapRef.current !== selectedMapId;
+    prevMapRef.current = selectedMapId;
+    if (mapChanged) {
+      setNodes(desiredNodes);
+      return;
+    }
     setNodes((cur) => {
       const byId = new Map(cur.map((n) => [n.id, n]));
       return desiredNodes.map((n) => {
@@ -448,7 +457,7 @@ function WorldOverlay() {
         };
       });
     });
-  }, [desiredNodes, setNodes]);
+  }, [desiredNodes, selectedMapId, setNodes]);
 
   useEffect(() => {
     setEdges(desiredEdges);
@@ -600,7 +609,7 @@ function WorldOverlay() {
           elementsSelectable
           panOnDrag
           proOptions={{ hideAttribution: true }}
-          style={{ background: "transparent" }}
+          style={{ background: "transparent", position: "relative", zIndex: 1, height: "100%", width: "100%" }}
         >
           <Controls showInteractive={false} />
         </ReactFlow>

--- a/creator/src/components/zone/WorldOverlayView.tsx
+++ b/creator/src/components/zone/WorldOverlayView.tsx
@@ -1,0 +1,757 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Controls,
+  Handle,
+  Position,
+  ConnectionMode,
+  NodeResizer,
+  useNodesState,
+  useEdgesState,
+  type Node,
+  type Edge,
+  type NodeProps,
+  type NodeMouseHandler,
+  type OnNodeDrag,
+  type Viewport,
+  type ReactFlowInstance,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { useZoneStore } from "@/stores/zoneStore";
+import { useProjectStore } from "@/stores/projectStore";
+import { useLoreStore, selectMaps } from "@/stores/loreStore";
+import { useImageSrc } from "@/lib/useImageSrc";
+import {
+  computeZoneFootprint,
+  roomNormalizedPos,
+  zoneConnectionPoints,
+  DIR_OFFSET,
+  type ZoneFootprint,
+} from "@/lib/zoneFootprint";
+import {
+  loadWorldOverlay,
+  saveOverlaySelectedMap,
+  saveOverlayPlacement,
+  removeOverlayPlacement,
+  clearOverlayPlacements,
+  type OverlayPlacement,
+} from "@/lib/uiPersistence";
+import type { WorldFile } from "@/types/world";
+
+// ─── Geometry helpers ───────────────────────────────────────────────
+
+interface ConnAnchor {
+  id: string;
+  /** Normalized [0..1] position within the zone box. */
+  nx: number;
+  ny: number;
+  position: Position;
+  toZone: string;
+  toRoom: string;
+  roomId: string;
+  dir: string;
+}
+
+interface ZoneMeta {
+  zoneId: string;
+  name: string;
+  footprint: ZoneFootprint;
+  anchors: ConnAnchor[];
+}
+
+function sideFor(dx: number, dy: number): Position {
+  if (dx !== 0 && Math.abs(dx) >= Math.abs(dy)) {
+    return dx > 0 ? Position.Right : Position.Left;
+  }
+  if (dy !== 0) return dy > 0 ? Position.Bottom : Position.Top;
+  return Position.Top;
+}
+
+function buildAnchors(world: WorldFile, fp: ZoneFootprint): ConnAnchor[] {
+  return zoneConnectionPoints(world).map((cp) => {
+    const off = DIR_OFFSET[cp.dir];
+    const dx = off?.[0] ?? 0;
+    const dy = off?.[1] ?? 0;
+    const norm = fp.chaotic ? null : roomNormalizedPos(fp, cp.roomId);
+    const baseNx = norm?.nx ?? 0.5;
+    const baseNy = norm?.ny ?? 0.5;
+    return {
+      id: `cp:${cp.roomId}:${cp.dir}`,
+      nx: dx > 0 ? 1 : dx < 0 ? 0 : baseNx,
+      ny: dy > 0 ? 1 : dy < 0 ? 0 : baseNy,
+      position: sideFor(dx, dy),
+      toZone: cp.toZone,
+      toRoom: cp.toRoom,
+      roomId: cp.roomId,
+      dir: cp.dir,
+    };
+  });
+}
+
+/** SVG path tracing the outer boundary of the occupied footprint cells. */
+function buildOutline(fp: ZoneFootprint): string {
+  const occ = new Set(fp.cells.map((c) => `${c.gx},${c.gy}`));
+  const segs: string[] = [];
+  for (const c of fp.cells) {
+    const x = c.gx - fp.minGx;
+    const y = c.gy - fp.minGy;
+    if (!occ.has(`${c.gx},${c.gy - 1}`)) segs.push(`M${x} ${y}L${x + 1} ${y}`);
+    if (!occ.has(`${c.gx},${c.gy + 1}`)) segs.push(`M${x} ${y + 1}L${x + 1} ${y + 1}`);
+    if (!occ.has(`${c.gx - 1},${c.gy}`)) segs.push(`M${x} ${y}L${x} ${y + 1}`);
+    if (!occ.has(`${c.gx + 1},${c.gy}`)) segs.push(`M${x + 1} ${y}L${x + 1} ${y + 1}`);
+  }
+  return segs.join("");
+}
+
+function defaultRect(
+  fp: ZoneFootprint,
+  mapW: number,
+  mapH: number,
+  cx: number,
+  cy: number,
+): OverlayPlacement {
+  const aspect = Math.max(0.25, Math.min(4, fp.cols / fp.rows));
+  let w = Math.min(mapW * 0.45, Math.max(mapW * 0.14, 140));
+  let h = w / aspect;
+  if (h > mapH * 0.45) {
+    h = mapH * 0.45;
+    w = h * aspect;
+  }
+  return { x: cx - w / 2, y: cy - h / 2, w, h };
+}
+
+// ─── Zone node ──────────────────────────────────────────────────────
+
+interface ZonePlacementData extends Record<string, unknown> {
+  zoneId: string;
+  name: string;
+  footprint: ZoneFootprint;
+  anchors: ConnAnchor[];
+  onRemove: (zoneId: string) => void;
+  onResizeEnd: (zoneId: string, rect: OverlayPlacement) => void;
+}
+
+type ZonePlacementNodeType = Node<ZonePlacementData, "zonePlacement">;
+
+function ZonePlacementNode({ data, selected }: NodeProps<ZonePlacementNodeType>) {
+  const { footprint: fp, anchors } = data;
+  const showSilhouette = !fp.chaotic && fp.cells.length > 0;
+  const outline = useMemo(() => (showSilhouette ? buildOutline(fp) : ""), [fp, showSilhouette]);
+
+  return (
+    <div
+      className={`relative h-full w-full text-accent transition-colors ${
+        selected ? "ring-1 ring-accent/60" : ""
+      }`}
+    >
+      <NodeResizer
+        isVisible={!!selected}
+        minWidth={56}
+        minHeight={40}
+        keepAspectRatio={false}
+        lineClassName="!border-accent/70"
+        handleClassName="!h-2 !w-2 !rounded-sm !border-accent !bg-bg-abyss"
+        onResizeEnd={(_, p) =>
+          data.onResizeEnd(data.zoneId, { x: p.x, y: p.y, w: p.width, h: p.height })
+        }
+      />
+
+      {showSilhouette ? (
+        <svg
+          className="pointer-events-none absolute inset-0 h-full w-full overflow-visible"
+          viewBox={`0 0 ${fp.cols} ${fp.rows}`}
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          {fp.cells.map((c) => (
+            <rect
+              key={c.roomId}
+              x={c.gx - fp.minGx}
+              y={c.gy - fp.minGy}
+              width={1}
+              height={1}
+              fill="currentColor"
+              fillOpacity={0.16}
+            />
+          ))}
+          <path
+            d={outline}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            strokeOpacity={0.85}
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+      ) : (
+        <div className="pointer-events-none absolute inset-0 rounded-lg border-2 border-dashed border-accent/55 bg-accent/[0.08]" />
+      )}
+
+      {/* Cross-zone connection anchors — invisible, just edge endpoints. */}
+      {anchors.map((a) => (
+        <Handle
+          key={a.id}
+          id={a.id}
+          type="source"
+          position={a.position}
+          isConnectable={false}
+          style={{
+            left: `${a.nx * 100}%`,
+            top: `${a.ny * 100}%`,
+            right: "auto",
+            bottom: "auto",
+            transform: "translate(-50%, -50%)",
+            width: 1,
+            height: 1,
+            minWidth: 0,
+            minHeight: 0,
+            border: "none",
+            background: "transparent",
+            opacity: 0,
+          }}
+        />
+      ))}
+
+      <div className="pointer-events-none absolute left-1/2 top-1 -translate-x-1/2 select-none whitespace-nowrap rounded bg-bg-abyss/80 px-1.5 py-0.5 font-display text-[10px] uppercase tracking-wider text-accent backdrop-blur-[1px]">
+        {data.name}
+      </div>
+
+      {selected && (
+        <button
+          type="button"
+          className="nodrag nopan absolute -right-2 -top-2 flex h-5 w-5 items-center justify-center rounded-full border border-status-error/60 bg-bg-abyss text-[11px] leading-none text-status-error transition-colors hover:bg-status-error/20"
+          title="Remove from map"
+          onClick={(e) => {
+            e.stopPropagation();
+            data.onRemove(data.zoneId);
+          }}
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}
+
+const nodeTypes = { zonePlacement: ZonePlacementNode };
+
+// ─── Backdrop synced to the ReactFlow viewport ──────────────────────
+
+function MapBackdrop({
+  src,
+  width,
+  height,
+  vp,
+}: {
+  src: string | null;
+  width: number;
+  height: number;
+  vp: Viewport;
+}) {
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+      {src && (
+        <img
+          src={src}
+          alt=""
+          draggable={false}
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            width,
+            height,
+            transformOrigin: "0 0",
+            transform: `translate(${vp.x}px, ${vp.y}px) scale(${vp.zoom})`,
+            maxWidth: "none",
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Main view ──────────────────────────────────────────────────────
+
+function WorldOverlay() {
+  const zones = useZoneStore((s) => s.zones);
+  const maps = useLoreStore(selectMaps);
+  const openTab = useProjectStore((s) => s.openTab);
+  const projectPath = useProjectStore((s) => s.project?.mudDir ?? "");
+
+  const saved = useMemo(() => loadWorldOverlay(projectPath), [projectPath]);
+
+  const [selectedMapId, setSelectedMapId] = useState<string>(
+    () => saved.selectedMapId ?? maps[0]?.id ?? "",
+  );
+  const [placementsByMap, setPlacementsByMap] = useState<
+    Record<string, Record<string, OverlayPlacement>>
+  >(() => saved.placements);
+
+  // Keep a valid selected map as the lore map list changes.
+  useEffect(() => {
+    if (maps.length === 0) return;
+    if (!maps.some((m) => m.id === selectedMapId)) {
+      setSelectedMapId(maps[0]!.id);
+    }
+  }, [maps, selectedMapId]);
+
+  const selectedMap = maps.find((m) => m.id === selectedMapId) ?? null;
+  const mapW = Math.max(1, selectedMap?.width || 1024);
+  const mapH = Math.max(1, selectedMap?.height || 1024);
+  const mapSrc = useImageSrc(selectedMap?.imageAsset);
+
+  const placements = useMemo(
+    () => placementsByMap[selectedMapId] ?? {},
+    [placementsByMap, selectedMapId],
+  );
+
+  // Stable persistence callbacks — read the live map id via ref.
+  const mapIdRef = useRef(selectedMapId);
+  mapIdRef.current = selectedMapId;
+
+  const place = useCallback(
+    (zoneId: string, rect: OverlayPlacement) => {
+      const mid = mapIdRef.current;
+      setPlacementsByMap((prev) => ({
+        ...prev,
+        [mid]: { ...(prev[mid] ?? {}), [zoneId]: rect },
+      }));
+      saveOverlayPlacement(projectPath, mid, zoneId, rect);
+    },
+    [projectPath],
+  );
+
+  const unplace = useCallback(
+    (zoneId: string) => {
+      const mid = mapIdRef.current;
+      setPlacementsByMap((prev) => {
+        const forMap = { ...(prev[mid] ?? {}) };
+        delete forMap[zoneId];
+        return { ...prev, [mid]: forMap };
+      });
+      removeOverlayPlacement(projectPath, mid, zoneId);
+    },
+    [projectPath],
+  );
+
+  const resetMap = useCallback(() => {
+    const mid = mapIdRef.current;
+    setPlacementsByMap((prev) => {
+      const next = { ...prev };
+      delete next[mid];
+      return next;
+    });
+    clearOverlayPlacements(projectPath, mid);
+  }, [projectPath]);
+
+  const openZone = useCallback(
+    (zoneId: string) => {
+      openTab({ id: `zone:${zoneId}`, kind: "zone", label: zoneId });
+    },
+    [openTab],
+  );
+
+  // ── Per-zone geometry (footprint + connector anchors) ─────────────
+  const zoneMeta = useMemo(() => {
+    const out = new Map<string, ZoneMeta>();
+    for (const [zoneId, state] of zones.entries()) {
+      const world = state.data;
+      const footprint = computeZoneFootprint(world);
+      out.set(zoneId, {
+        zoneId,
+        name: world.zone || zoneId,
+        footprint,
+        anchors: buildAnchors(world, footprint),
+      });
+    }
+    return out;
+  }, [zones]);
+
+  // ── Desired nodes / edges ─────────────────────────────────────────
+  const desiredNodes = useMemo<Node[]>(() => {
+    const list: Node[] = [];
+    for (const meta of zoneMeta.values()) {
+      const pl = placements[meta.zoneId];
+      if (!pl) continue;
+      list.push({
+        id: `z:${meta.zoneId}`,
+        type: "zonePlacement",
+        position: { x: pl.x, y: pl.y },
+        width: pl.w,
+        height: pl.h,
+        style: { width: pl.w, height: pl.h },
+        zIndex: 3,
+        data: {
+          zoneId: meta.zoneId,
+          name: meta.name,
+          footprint: meta.footprint,
+          anchors: meta.anchors,
+          onRemove: unplace,
+          onResizeEnd: place,
+        } satisfies ZonePlacementData,
+      });
+    }
+    return list;
+  }, [zoneMeta, placements, unplace, place]);
+
+  const desiredEdges = useMemo<Edge[]>(() => {
+    const list: Edge[] = [];
+    const seen = new Set<string>();
+    for (const meta of zoneMeta.values()) {
+      if (!placements[meta.zoneId]) continue;
+      for (const a of meta.anchors) {
+        if (!placements[a.toZone]) continue;
+        const left = `${meta.zoneId}:${a.roomId}`;
+        const right = `${a.toZone}:${a.toRoom}`;
+        const key = left < right ? `${left}|${right}` : `${right}|${left}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const back = zoneMeta
+          .get(a.toZone)
+          ?.anchors.find((t) => t.toZone === meta.zoneId && t.toRoom === a.roomId);
+        list.push({
+          id: `xz:${key}`,
+          source: `z:${meta.zoneId}`,
+          sourceHandle: a.id,
+          target: `z:${a.toZone}`,
+          targetHandle: back?.id,
+          type: "default",
+          zIndex: 1,
+          selectable: false,
+          style: { stroke: "var(--color-graph-cross)", strokeWidth: 2 },
+        });
+      }
+    }
+    return list;
+  }, [zoneMeta, placements]);
+
+  const [nodes, setNodes, onNodesChange] = useNodesState(desiredNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(desiredEdges);
+
+  // Reconcile: add/remove nodes by id, but keep live position/size/selection
+  // of survivors so dragging and resizing aren't interrupted mid-gesture.
+  useEffect(() => {
+    setNodes((cur) => {
+      const byId = new Map(cur.map((n) => [n.id, n]));
+      return desiredNodes.map((n) => {
+        const ex = byId.get(n.id);
+        if (!ex) return n;
+        return {
+          ...n,
+          position: ex.position,
+          width: ex.width ?? n.width,
+          height: ex.height ?? n.height,
+          style: ex.style ?? n.style,
+          selected: ex.selected,
+        };
+      });
+    });
+  }, [desiredNodes, setNodes]);
+
+  useEffect(() => {
+    setEdges(desiredEdges);
+  }, [desiredEdges, setEdges]);
+
+  // ── Viewport / backdrop sync ──────────────────────────────────────
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const rfRef = useRef<ReactFlowInstance | null>(null);
+  const [vp, setVp] = useState<Viewport>({ x: 0, y: 0, zoom: 0.5 });
+
+  const fitMap = useCallback(() => {
+    const el = wrapperRef.current;
+    const rf = rfRef.current;
+    if (!el || !rf) return;
+    const { width, height } = el.getBoundingClientRect();
+    if (width === 0 || height === 0) return;
+    const zoom = Math.max(0.05, Math.min(width / mapW, height / mapH) * 0.92);
+    const next = {
+      x: (width - mapW * zoom) / 2,
+      y: (height - mapH * zoom) / 2,
+      zoom,
+    };
+    rf.setViewport(next);
+    setVp(next);
+  }, [mapW, mapH]);
+
+  // Refit whenever the selected map changes.
+  useEffect(() => {
+    fitMap();
+  }, [selectedMapId, fitMap]);
+
+  const handleSelectMap = useCallback(
+    (id: string) => {
+      setSelectedMapId(id);
+      saveOverlaySelectedMap(projectPath, id);
+    },
+    [projectPath],
+  );
+
+  const onNodeDragStop: OnNodeDrag = useCallback(
+    (_e, node) => {
+      if (node.type !== "zonePlacement") return;
+      const zoneId = (node.data as ZonePlacementData).zoneId;
+      const w = node.width ?? node.measured?.width ?? placements[zoneId]?.w ?? 160;
+      const h = node.height ?? node.measured?.height ?? placements[zoneId]?.h ?? 120;
+      place(zoneId, { x: node.position.x, y: node.position.y, w, h });
+    },
+    [place, placements],
+  );
+
+  const onNodeDoubleClick: NodeMouseHandler = useCallback(
+    (_e, node) => {
+      if (node.type === "zonePlacement") openZone((node.data as ZonePlacementData).zoneId);
+    },
+    [openZone],
+  );
+
+  // ── Drag a zone from the tray onto the map ────────────────────────
+  const placeAtFlowPoint = useCallback(
+    (zoneId: string, clientX: number, clientY: number) => {
+      const rf = rfRef.current;
+      const meta = zoneMeta.get(zoneId);
+      if (!rf || !meta) return;
+      const pt = rf.screenToFlowPosition({ x: clientX, y: clientY });
+      place(zoneId, defaultRect(meta.footprint, mapW, mapH, pt.x, pt.y));
+    },
+    [zoneMeta, place, mapW, mapH],
+  );
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const zoneId = e.dataTransfer.getData("application/arcanum-zone");
+      if (zoneId) placeAtFlowPoint(zoneId, e.clientX, e.clientY);
+    },
+    [placeAtFlowPoint],
+  );
+
+  const placeAtCenter = useCallback(
+    (zoneId: string) => {
+      const el = wrapperRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      placeAtFlowPoint(zoneId, r.left + r.width / 2, r.top + r.height / 2);
+    },
+    [placeAtFlowPoint],
+  );
+
+  // ── Tray contents ─────────────────────────────────────────────────
+  const trayZones = useMemo(
+    () =>
+      Array.from(zoneMeta.values())
+        .filter((m) => !placements[m.zoneId])
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [zoneMeta, placements],
+  );
+
+  const placedCount = Object.keys(placements).length;
+
+  if (maps.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center text-text-muted">
+        <div className="max-w-sm text-center">
+          <h2 className="font-display text-lg uppercase tracking-widest text-accent">
+            No World Map
+          </h2>
+          <p className="mt-2 text-xs leading-relaxed text-text-secondary">
+            The map overlay needs a base map. Upload or generate one under{" "}
+            <span className="text-accent">Lore → Maps</span>, then come back to drape your
+            zones over it.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex min-h-0 min-w-0 flex-1">
+      <div
+        ref={wrapperRef}
+        className="relative min-h-0 min-w-0 flex-1"
+        onDrop={onDrop}
+        onDragOver={(e) => {
+          e.preventDefault();
+          e.dataTransfer.dropEffect = "copy";
+        }}
+      >
+        <MapBackdrop src={mapSrc} width={mapW} height={mapH} vp={vp} />
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onNodeDragStop={onNodeDragStop}
+          onNodeDoubleClick={onNodeDoubleClick}
+          onInit={(inst) => {
+            rfRef.current = inst;
+            fitMap();
+          }}
+          onMove={(_, viewport) => setVp(viewport)}
+          minZoom={0.05}
+          maxZoom={4}
+          // Connectors anchor an edge target onto a source-type handle on the
+          // neighbouring zone; loose mode lets that resolve.
+          connectionMode={ConnectionMode.Loose}
+          nodesDraggable
+          nodesConnectable={false}
+          elementsSelectable
+          panOnDrag
+          proOptions={{ hideAttribution: true }}
+          style={{ background: "transparent" }}
+        >
+          <Controls showInteractive={false} />
+        </ReactFlow>
+
+        {/* Toolbar */}
+        <div className="pointer-events-none absolute left-4 top-4 z-10 flex flex-wrap items-center gap-2 text-2xs">
+          <select
+            value={selectedMapId}
+            onChange={(e) => handleSelectMap(e.target.value)}
+            className="ornate-input pointer-events-auto rounded-full px-3 py-1 font-display text-2xs uppercase tracking-wider text-accent"
+            title="Base map"
+          >
+            {maps.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.title || m.id}
+              </option>
+            ))}
+          </select>
+          <OverlayStat label="placed" value={`${placedCount}/${zoneMeta.size}`} />
+          <OverlayStat label="links" value={edges.length} />
+          <button
+            type="button"
+            onClick={fitMap}
+            className="pointer-events-auto rounded-full border border-border-muted bg-bg-abyss/80 px-2.5 py-1 uppercase tracking-wider text-text-muted backdrop-blur transition-colors hover:border-accent/40 hover:text-accent"
+            title="Re-center the map in view"
+          >
+            Fit Map
+          </button>
+          {placedCount > 0 && (
+            <button
+              type="button"
+              onClick={resetMap}
+              className="pointer-events-auto rounded-full border border-border-muted bg-bg-abyss/80 px-2.5 py-1 uppercase tracking-wider text-text-muted backdrop-blur transition-colors hover:border-accent/40 hover:text-accent"
+              title="Return every zone on this map to the tray"
+            >
+              Clear Placements
+            </button>
+          )}
+        </div>
+
+        <div className="pointer-events-none absolute bottom-4 left-4 z-10 max-w-md rounded-lg border border-border-muted bg-bg-abyss/85 px-3 py-2 text-2xs italic text-text-muted backdrop-blur">
+          Drag a zone from the tray onto the map, then drag to move and pull the handles to
+          stretch it into place. Lines mark cross-zone connections — line up the endpoints
+          where zones meet. Double-click a zone to open it.
+        </div>
+      </div>
+
+      {/* Tray of unplaced zones */}
+      <aside className="flex w-60 flex-none flex-col border-l border-border-muted bg-bg-abyss/40 backdrop-blur">
+        <div className="border-b border-border-muted px-3 py-2">
+          <div className="font-display text-2xs uppercase tracking-[0.24em] text-accent">
+            Unplaced Zones
+          </div>
+          <div className="mt-0.5 text-3xs uppercase tracking-wider text-text-muted">
+            {trayZones.length} {trayZones.length === 1 ? "zone" : "zones"} · drag onto map
+          </div>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-2">
+          {trayZones.length === 0 ? (
+            <p className="rounded border border-dashed border-border-muted px-3 py-6 text-center text-3xs italic text-text-muted">
+              Every loaded zone is on the map.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-1.5">
+              {trayZones.map((m) => (
+                <li key={m.zoneId}>
+                  <div
+                    draggable
+                    onDragStart={(e) => {
+                      e.dataTransfer.setData("application/arcanum-zone", m.zoneId);
+                      e.dataTransfer.effectAllowed = "copy";
+                    }}
+                    onDoubleClick={() => placeAtCenter(m.zoneId)}
+                    className="group flex cursor-grab items-center gap-2 rounded border border-border-muted bg-[var(--chrome-fill-soft)] px-2.5 py-2 transition-colors hover:border-accent/40 hover:bg-[var(--chrome-highlight)] active:cursor-grabbing"
+                    title="Drag onto the map (or double-click to drop at center)"
+                  >
+                    <TrayThumb footprint={m.footprint} />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate font-display text-2xs uppercase tracking-wider text-accent">
+                        {m.name}
+                      </div>
+                      <div className="mt-0.5 text-3xs text-text-muted">
+                        {m.footprint.cells.length}{" "}
+                        {m.footprint.cells.length === 1 ? "room" : "rooms"}
+                        {m.anchors.length > 0 && (
+                          <span className="ml-1.5 text-text-secondary">
+                            · {m.anchors.length} link{m.anchors.length === 1 ? "" : "s"}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function TrayThumb({ footprint: fp }: { footprint: ZoneFootprint }) {
+  if (fp.chaotic || fp.cells.length === 0) {
+    return (
+      <div className="h-7 w-7 flex-none rounded border border-dashed border-accent/45 bg-accent/[0.08]" />
+    );
+  }
+  const outline = buildOutline(fp);
+  return (
+    <svg
+      className="h-7 w-7 flex-none text-accent"
+      viewBox={`-0.5 -0.5 ${fp.cols + 1} ${fp.rows + 1}`}
+      preserveAspectRatio="xMidYMid meet"
+      aria-hidden="true"
+    >
+      {fp.cells.map((c) => (
+        <rect
+          key={c.roomId}
+          x={c.gx - fp.minGx}
+          y={c.gy - fp.minGy}
+          width={1}
+          height={1}
+          fill="currentColor"
+          fillOpacity={0.18}
+        />
+      ))}
+      <path
+        d={outline}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={0.16}
+        strokeOpacity={0.85}
+      />
+    </svg>
+  );
+}
+
+function OverlayStat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-full border border-border-muted bg-bg-abyss/80 px-2.5 py-1 text-text-secondary backdrop-blur">
+      <span className="uppercase tracking-wider text-text-muted">{label}</span>
+      <span className="ml-1.5 font-mono text-text-primary">{value}</span>
+    </div>
+  );
+}
+
+export function WorldOverlayView() {
+  return (
+    <ReactFlowProvider>
+      <WorldOverlay />
+    </ReactFlowProvider>
+  );
+}

--- a/creator/src/lib/__tests__/zoneFootprint.test.ts
+++ b/creator/src/lib/__tests__/zoneFootprint.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeZoneFootprint,
+  roomNormalizedPos,
+  zoneConnectionPoints,
+} from "../zoneFootprint";
+import type { WorldFile } from "@/types/world";
+
+function makeWorld(rooms: WorldFile["rooms"], overrides?: Partial<WorldFile>): WorldFile {
+  return {
+    zone: "test_zone",
+    startRoom: Object.keys(rooms)[0] ?? "room1",
+    rooms,
+    ...overrides,
+  };
+}
+
+describe("computeZoneFootprint", () => {
+  it("places a single room at a 1x1 footprint", () => {
+    const fp = computeZoneFootprint(makeWorld({ solo: { title: "S", description: "" } }));
+    expect(fp.cells).toHaveLength(1);
+    expect(fp.cols).toBe(1);
+    expect(fp.rows).toBe(1);
+    expect(fp.chaotic).toBe(false);
+  });
+
+  it("packs a 2x2 loop into a 2-wide, 2-tall grid", () => {
+    const fp = computeZoneFootprint(
+      makeWorld({
+        a: { title: "A", description: "", exits: { e: "b", s: "c" } },
+        b: { title: "B", description: "", exits: { w: "a", s: "d" } },
+        c: { title: "C", description: "", exits: { n: "a", e: "d" } },
+        d: { title: "D", description: "", exits: { w: "c", n: "b" } },
+      }),
+    );
+    expect(fp.cells).toHaveLength(4);
+    expect(fp.cols).toBe(2);
+    expect(fp.rows).toBe(2);
+    expect(fp.chaotic).toBe(false);
+  });
+
+  it("puts a north neighbor above the start room (smaller normalized y)", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { n: "b" } },
+      b: { title: "B", description: "" },
+    });
+    const fp = computeZoneFootprint(world);
+    const a = roomNormalizedPos(fp, "a")!;
+    const b = roomNormalizedPos(fp, "b")!;
+    expect(b.ny).toBeLessThan(a.ny);
+    expect(b.nx).toBeCloseTo(a.nx, 5);
+  });
+
+  it("puts an east neighbor to the right of the start room", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { e: "b" } },
+      b: { title: "B", description: "" },
+    });
+    const fp = computeZoneFootprint(world);
+    const a = roomNormalizedPos(fp, "a")!;
+    const b = roomNormalizedPos(fp, "b")!;
+    expect(b.nx).toBeGreaterThan(a.nx);
+    expect(b.ny).toBeCloseTo(a.ny, 5);
+  });
+
+  it("ignores cross-zone exit targets when building the footprint", () => {
+    const fp = computeZoneFootprint(
+      makeWorld({
+        a: { title: "A", description: "", exits: { e: "other:gate" } },
+      }),
+    );
+    expect(fp.cells).toHaveLength(1);
+  });
+
+  it("places every room even for a geometrically impossible graph", () => {
+    const fp = computeZoneFootprint(
+      makeWorld({
+        a: { title: "A", description: "", exits: { n: "b", e: "c" } },
+        b: { title: "B", description: "", exits: { s: "a", e: "c" } },
+        c: { title: "C", description: "", exits: { w: "a", sw: "b" } },
+      }),
+    );
+    expect(fp.cells).toHaveLength(3);
+    for (const c of fp.cells) {
+      expect(Number.isFinite(c.gx)).toBe(true);
+      expect(Number.isFinite(c.gy)).toBe(true);
+    }
+  });
+});
+
+describe("zoneConnectionPoints", () => {
+  it("extracts cross-zone exits with direction and target", () => {
+    const cps = zoneConnectionPoints(
+      makeWorld({
+        a: { title: "A", description: "", exits: { e: "b", n: "harbor:dock1" } },
+        b: { title: "B", description: "", exits: { w: "a", s: "caves:mouth" } },
+      }),
+    );
+    expect(cps).toHaveLength(2);
+    expect(cps).toContainEqual({ roomId: "a", dir: "n", toZone: "harbor", toRoom: "dock1" });
+    expect(cps).toContainEqual({ roomId: "b", dir: "s", toZone: "caves", toRoom: "mouth" });
+  });
+
+  it("returns nothing when there are no cross-zone exits", () => {
+    const cps = zoneConnectionPoints(
+      makeWorld({
+        a: { title: "A", description: "", exits: { e: "b" } },
+        b: { title: "B", description: "", exits: { w: "a" } },
+      }),
+    );
+    expect(cps).toHaveLength(0);
+  });
+});

--- a/creator/src/lib/uiPersistence.ts
+++ b/creator/src/lib/uiPersistence.ts
@@ -14,6 +14,21 @@ export interface AtlasPosition {
   y: number;
 }
 
+/** A zone's placed rectangle on the world-overlay map, in map pixel space. */
+export interface OverlayPlacement {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface WorldOverlayState {
+  /** Last lore map the user overlaid zones onto. */
+  selectedMapId?: string;
+  /** Placements keyed by map id, then zone id. */
+  placements: Record<string, Record<string, OverlayPlacement>>;
+}
+
 export interface PersistedUI {
   lastProjectPath: string;
   tabs: Tab[];
@@ -28,6 +43,11 @@ export interface PersistedUI {
    * Populated when the user drags a cluster in the World Atlas view.
    */
   atlasClusterPositions?: Record<string, Record<string, AtlasPosition>>;
+  /**
+   * World-overlay atlas state, keyed by project path: which lore map is
+   * selected and where each zone is placed on it.
+   */
+  worldOverlay?: Record<string, WorldOverlayState>;
 }
 
 export function saveUIState(state: PersistedUI): void {
@@ -55,7 +75,9 @@ export function loadUIState(): PersistedUI | null {
       ];
     }
     // Migration: drop tabs with removed kinds (studio, config)
-    const VALID_KINDS = new Set(["panel", "zone", "console", "sprites", "admin"]);
+    const VALID_KINDS = new Set([
+      "panel", "zone", "zoneAtlas", "worldOverlay", "console", "sprites", "admin",
+    ]);
     if (Array.isArray(parsed.tabs)) {
       parsed.tabs = parsed.tabs.filter((t: any) => VALID_KINDS.has(t.kind));
       // Migration: convert old command-kind tabs to panel-kind tabs
@@ -199,4 +221,65 @@ export function clearAtlasClusterPositions(projectPath: string): void {
   if (!(projectPath in state.atlasClusterPositions)) return;
   const { [projectPath]: _removed, ...rest } = state.atlasClusterPositions;
   saveUIState({ ...state, atlasClusterPositions: rest });
+}
+
+// ─── World-overlay atlas state ──────────────────────────────────────
+
+const EMPTY_OVERLAY: WorldOverlayState = { placements: {} };
+
+export function loadWorldOverlay(projectPath: string): WorldOverlayState {
+  if (!projectPath) return EMPTY_OVERLAY;
+  return loadUIState()?.worldOverlay?.[projectPath] ?? EMPTY_OVERLAY;
+}
+
+function mutateWorldOverlay(
+  projectPath: string,
+  fn: (current: WorldOverlayState) => WorldOverlayState,
+): void {
+  if (!projectPath) return;
+  const state = loadUIState();
+  if (!state) return;
+  const all = state.worldOverlay ?? {};
+  const current = all[projectPath] ?? { placements: {} };
+  saveUIState({
+    ...state,
+    worldOverlay: { ...all, [projectPath]: fn(current) },
+  });
+}
+
+export function saveOverlaySelectedMap(projectPath: string, mapId: string): void {
+  mutateWorldOverlay(projectPath, (c) => ({ ...c, selectedMapId: mapId }));
+}
+
+export function saveOverlayPlacement(
+  projectPath: string,
+  mapId: string,
+  zoneId: string,
+  placement: OverlayPlacement,
+): void {
+  if (!mapId || !zoneId) return;
+  mutateWorldOverlay(projectPath, (c) => {
+    const forMap = { ...(c.placements[mapId] ?? {}), [zoneId]: placement };
+    return { ...c, placements: { ...c.placements, [mapId]: forMap } };
+  });
+}
+
+export function removeOverlayPlacement(
+  projectPath: string,
+  mapId: string,
+  zoneId: string,
+): void {
+  mutateWorldOverlay(projectPath, (c) => {
+    const forMap = { ...(c.placements[mapId] ?? {}) };
+    delete forMap[zoneId];
+    return { ...c, placements: { ...c.placements, [mapId]: forMap } };
+  });
+}
+
+export function clearOverlayPlacements(projectPath: string, mapId: string): void {
+  mutateWorldOverlay(projectPath, (c) => {
+    const next = { ...c.placements };
+    delete next[mapId];
+    return { ...c, placements: next };
+  });
 }

--- a/creator/src/lib/zoneFootprint.ts
+++ b/creator/src/lib/zoneFootprint.ts
@@ -1,0 +1,241 @@
+import type { WorldFile } from "@/types/world";
+import { exitTarget } from "@/lib/zoneEdits";
+
+/**
+ * Footprint of a zone derived from a compass-BFS of its room exits — the same
+ * grid the zone-map compass layout uses, reduced to integer cells. This drives
+ * the silhouette drawn on the world-overlay atlas.
+ *
+ * The full pixel layout in `dagreLayout.ts` is overkill here: the overlay only
+ * needs the *shape* (which grid cells are occupied) and each room's position
+ * within it (to anchor cross-zone connectors to the correct edge). When a zone
+ * isn't grid-embeddable (its exits describe an impossible geometry), `chaotic`
+ * is set and callers should fall back to a plain rectangle.
+ */
+
+export const DIR_OFFSET: Record<string, [number, number]> = {
+  n: [0, -1],
+  s: [0, 1],
+  e: [1, 0],
+  w: [-1, 0],
+  ne: [1, -1],
+  nw: [-1, -1],
+  se: [1, 1],
+  sw: [-1, 1],
+};
+
+const DIR_PRIORITY: Record<string, number> = {
+  n: 0, s: 0, e: 0, w: 0,
+  ne: 1, nw: 1, se: 1, sw: 1,
+  u: 2, d: 2,
+};
+
+/** Rows of empty space stacked between separate floors (u/d-linked islands). */
+const ISLAND_GAP = 2;
+
+/** Match dagreLayout's grid-embeddability heuristic. */
+const COLLISION_FALLBACK_RATIO = 0.25;
+
+export interface FootprintCell {
+  roomId: string;
+  gx: number;
+  gy: number;
+}
+
+export interface ZoneFootprint {
+  /** True when the exit graph isn't grid-embeddable — render a rectangle. */
+  chaotic: boolean;
+  cells: FootprintCell[];
+  cellOf: Map<string, { gx: number; gy: number }>;
+  cols: number;
+  rows: number;
+  minGx: number;
+  minGy: number;
+}
+
+function isLocalRoom(world: WorldFile, raw: string): boolean {
+  return !raw.includes(":") && !!world.rooms[raw];
+}
+
+function findEmpty(x: number, y: number, grid: Set<string>): [number, number] {
+  for (let r = 1; r <= 20; r++) {
+    for (let dx = -r; dx <= r; dx++) {
+      for (let dy = -r; dy <= r; dy++) {
+        if (Math.abs(dx) < r && Math.abs(dy) < r) continue;
+        if (!grid.has(`${x + dx},${y + dy}`)) return [x + dx, y + dy];
+      }
+    }
+  }
+  return [x + 1, y];
+}
+
+export function computeZoneFootprint(world: WorldFile): ZoneFootprint {
+  const rooms = world.rooms ?? {};
+  const roomIds = Object.keys(rooms);
+  const cellOf = new Map<string, { gx: number; gy: number }>();
+  const grid = new Set<string>();
+  let collisions = 0;
+
+  function place(id: string, gx: number, gy: number) {
+    if (grid.has(`${gx},${gy}`)) {
+      collisions++;
+      [gx, gy] = findEmpty(gx, gy, grid);
+    }
+    cellOf.set(id, { gx, gy });
+    grid.add(`${gx},${gy}`);
+  }
+
+  function sortedExits(exits: Record<string, unknown>): string[] {
+    return Object.keys(exits).sort(
+      (a, b) => (DIR_PRIORITY[a] ?? 99) - (DIR_PRIORITY[b] ?? 99),
+    );
+  }
+
+  /** BFS one compass-connected floor; collect u/d targets as next-floor seeds. */
+  function placeFloor(startId: string, oy: number): { placed: number; seeds: string[] } {
+    const seeds: string[] = [];
+    if (cellOf.has(startId)) return { placed: 0, seeds };
+
+    place(startId, 0, oy);
+    let placed = 1;
+    const queue = [startId];
+
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      const cell = cellOf.get(cur)!;
+      const room = rooms[cur];
+      if (!room?.exits) continue;
+
+      for (const dir of sortedExits(room.exits)) {
+        const raw = exitTarget(room.exits[dir]!);
+        if (!isLocalRoom(world, raw)) continue;
+        if (cellOf.has(raw)) continue;
+
+        const offset = DIR_OFFSET[dir];
+        if (!offset) {
+          seeds.push(raw); // u/d → its own floor
+          continue;
+        }
+        place(raw, cell.gx + offset[0], cell.gy + offset[1]);
+        placed++;
+        queue.push(raw);
+      }
+    }
+    return { placed, seeds };
+  }
+
+  let maxY = 0;
+  let mainPlaced = 0;
+  let mainCollisions = 0;
+  const floorQueue: string[] = [];
+  if (world.startRoom && rooms[world.startRoom]) floorQueue.push(world.startRoom);
+
+  function advance(seed: string) {
+    if (cellOf.has(seed)) return;
+    const oy = cellOf.size === 0 ? 0 : maxY + ISLAND_GAP;
+    const before = collisions;
+    const { placed } = placeFloor(seed, oy);
+    if (placed === 0) return;
+    for (const { gy } of cellOf.values()) if (gy > maxY) maxY = gy;
+    if (mainPlaced === 0) {
+      mainPlaced = placed;
+      mainCollisions = collisions - before;
+    }
+    // u/d seeds discovered during this floor are queued by placeFloor's caller.
+  }
+
+  // Walk start floor + its u/d-linked floors, stacking each below the last.
+  const seen = new Set<string>();
+  while (floorQueue.length > 0) {
+    const seed = floorQueue.shift()!;
+    if (cellOf.has(seed) || seen.has(seed)) continue;
+    seen.add(seed);
+    const oy = cellOf.size === 0 ? 0 : maxY + ISLAND_GAP;
+    const before = collisions;
+    const { placed, seeds } = placeFloor(seed, oy);
+    if (placed > 0) {
+      for (const { gy } of cellOf.values()) if (gy > maxY) maxY = gy;
+      if (mainPlaced === 0) {
+        mainPlaced = placed;
+        mainCollisions = collisions - before;
+      }
+    }
+    for (const s of seeds) if (!cellOf.has(s)) floorQueue.push(s);
+  }
+
+  // Disconnected pockets become their own stacked islands.
+  for (const id of roomIds) {
+    if (!cellOf.has(id)) advance(id);
+  }
+
+  const cells: FootprintCell[] = [];
+  let minGx = Infinity, minGy = Infinity, maxGx = -Infinity, maxGy = -Infinity;
+  for (const [roomId, { gx, gy }] of cellOf) {
+    cells.push({ roomId, gx, gy });
+    if (gx < minGx) minGx = gx;
+    if (gy < minGy) minGy = gy;
+    if (gx > maxGx) maxGx = gx;
+    if (gy > maxGy) maxGy = gy;
+  }
+
+  if (cells.length === 0) {
+    return { chaotic: false, cells, cellOf, cols: 1, rows: 1, minGx: 0, minGy: 0 };
+  }
+
+  const chaotic =
+    mainPlaced >= 8 && mainCollisions / Math.max(1, mainPlaced) > COLLISION_FALLBACK_RATIO;
+
+  return {
+    chaotic,
+    cells,
+    cellOf,
+    cols: maxGx - minGx + 1,
+    rows: maxGy - minGy + 1,
+    minGx,
+    minGy,
+  };
+}
+
+/**
+ * Normalized [0..1] position of a room's cell center within the footprint
+ * bounding box. `nx` runs left→right, `ny` runs top→bottom (north is up).
+ * Returns null when the room isn't in the grid.
+ */
+export function roomNormalizedPos(
+  fp: ZoneFootprint,
+  roomId: string,
+): { nx: number; ny: number } | null {
+  const cell = fp.cellOf.get(roomId);
+  if (!cell) return null;
+  return {
+    nx: (cell.gx - fp.minGx + 0.5) / fp.cols,
+    ny: (cell.gy - fp.minGy + 0.5) / fp.rows,
+  };
+}
+
+export interface ZoneConnectionPoint {
+  roomId: string;
+  dir: string;
+  toZone: string;
+  toRoom: string;
+}
+
+/** Every cross-zone exit leaving this zone's rooms (one per direction). */
+export function zoneConnectionPoints(world: WorldFile): ZoneConnectionPoint[] {
+  const out: ZoneConnectionPoint[] = [];
+  for (const [roomId, room] of Object.entries(world.rooms ?? {})) {
+    if (!room.exits) continue;
+    for (const [dir, val] of Object.entries(room.exits)) {
+      const raw = exitTarget(val);
+      const colon = raw.indexOf(":");
+      if (colon < 0) continue;
+      out.push({
+        roomId,
+        dir,
+        toZone: raw.slice(0, colon),
+        toRoom: raw.slice(colon + 1),
+      });
+    }
+  }
+  return out;
+}

--- a/creator/src/types/project.ts
+++ b/creator/src/types/project.ts
@@ -22,7 +22,7 @@ export interface ServerState {
   lastError?: string;
 }
 
-export type TabKind = "panel" | "zone" | "zoneAtlas" | "console" | "sprites" | "admin";
+export type TabKind = "panel" | "zone" | "zoneAtlas" | "worldOverlay" | "console" | "sprites" | "admin";
 
 export type AdminSubView =
   | "overview"


### PR DESCRIPTION
## What

A new **Map Overlay** atlas that overlays your real zones onto a Lore map so you can line up the geography of the parts of the world that are done. It's an alternative to the existing graph-based **World Atlas** (which lays zones out abstractly with no background map).

Each loaded zone is drawn as its **true BFS footprint silhouette** (derived from the same compass layout the zone map uses), which you **drag to move** and **stretch via corner/edge handles** to fit it over the right place on the map. **Cross-zone connections** render as lines anchored to the *connecting room's* spot on the footprint edge, leaving in the exit's compass direction — so endpoints line up where two zones meet.

Read-only by design: it doesn't create or edit connections. Double-click a placed zone to open it in the editor; ✕ returns it to the tray; placements are saved per project and per map.

## How it works
- **`lib/zoneFootprint.ts`** — a focused compass BFS that returns occupied grid cells + per-room normalized positions and cross-zone connection points. Flags non-grid-embeddable zones as `chaotic` so they fall back to a rectangle.
- **`components/zone/WorldOverlayView.tsx`** — ReactFlow view. The Lore map is a backdrop layer synced to the viewport transform (guaranteed under nodes/edges); zones are `NodeResizer` silhouette nodes; connectors are edges anchored to invisible side handles (`ConnectionMode.Loose`). Unplaced zones sit in a side tray you drag onto the map.
- **`uiPersistence.ts`** — per-project, per-map `{x,y,w,h}` placement storage + selected map.
- Wired up a `worldOverlay` tab kind, routed in `MainArea`, opened from the Forge **Open Zone → Map Overlay** entry.

## Notes / decisions
- Base map source: **Lore → Maps** (per the build discussion). If no maps exist, the view explains how to add one.
- Footprint silhouettes stretch non-uniformly with the box (`preserveAspectRatio="none"`), so a zone that's "roughly the right shape" can be nudged to fit.
- Diagonal exits anchor to the nearer side; rectangle-fallback zones anchor connectors to side-centers.

## Tests
- `lib/__tests__/zoneFootprint.test.ts` covers footprint packing, north/east placement, cross-zone exclusion, impossible-graph survival, and connection-point extraction.
- Full suite green (2292 tests); `tsc --noEmit` clean.

## Try it
Open a project with at least one Lore map → Forge island → **Open Zone** → **Map Overlay** → drag zones from the tray onto the map.