### PR TITLE
Run batch art generation in the background

### DIFF
--- a/creator/src/components/AppShell.tsx
+++ b/creator/src/components/AppShell.tsx
@@ -14,6 +14,7 @@ import { Toast } from "./ui/Toast";
 import { FloatingSaveButton } from "./ui/FloatingSaveButton";
 import { CosmicBackdrop } from "./ui/CosmicBackdrop";
 import { ValidationPanel } from "./ValidationPanel";
+import { BatchArtOverlay } from "./zone/BatchArtGenerator";
 import { loadGettingStarted, reopenGettingStarted } from "@/lib/gettingStartedPersistence";
 
 const ShortcutsHelp = lazy(() => import("./ui/ShortcutsHelp").then((m) => ({ default: m.ShortcutsHelp })));
@@ -130,6 +131,7 @@ export function AppShell({ onNewProject }: AppShellProps) {
       <Toast />
       <FloatingSaveButton />
       <ValidationPanel />
+      <BatchArtOverlay />
     </div>
   );
 }

--- a/creator/src/components/StudioWorkspace.tsx
+++ b/creator/src/components/StudioWorkspace.tsx
@@ -3,7 +3,7 @@ import { useAssetStore } from "@/stores/assetStore";
 import { useProjectStore } from "@/stores/projectStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useVibeStore } from "@/stores/vibeStore";
-import { BatchArtGenerator } from "@/components/zone/BatchArtGenerator";
+import { useBatchArtStore } from "@/stores/batchArtStore";
 import { ZoneVibePanel } from "@/components/zone/ZoneVibePanel";
 import { ZoneAssetWorkbench } from "@/components/zone/ZoneAssetWorkbench";
 import { CustomAssetStudio } from "@/components/CustomAssetStudio";
@@ -141,7 +141,7 @@ export function StudioWorkspace({ panelId }: { panelId: string }) {
   const loadVibe = useVibeStore((s) => s.loadVibe);
   const vibeMap = useVibeStore((s) => s.vibes);
   const [selectedZoneId, setSelectedZoneId] = useState<string | null>(null);
-  const [showBatchArt, setShowBatchArt] = useState(false);
+  const openBatchArt = useBatchArtStore((s) => s.openSetup);
   const [artSubTab, setArtSubTab] = useState<ArtSubTab>(() => loadArtSubTab());
 
   useEffect(() => {
@@ -217,7 +217,7 @@ export function StudioWorkspace({ panelId }: { panelId: string }) {
                           Open editor
                         </button>
                         <button
-                          onClick={() => setShowBatchArt(true)}
+                          onClick={() => openBatchArt(selectedZoneId!)}
                           className="focus-ring shell-pill-primary rounded-full px-4 py-2 text-xs font-medium"
                         >
                           Batch generate
@@ -271,14 +271,6 @@ export function StudioWorkspace({ panelId }: { panelId: string }) {
         {panelId === "studioAbilities" && <AbilityStudio />}
       </div>
 
-      {showBatchArt && selectedZone && (
-        <BatchArtGenerator
-          zoneId={selectedZoneId!}
-          world={selectedZone.data}
-          onWorldChange={(world) => updateZone(selectedZoneId!, world)}
-          onClose={() => setShowBatchArt(false)}
-        />
-      )}
     </div>
   );
 }

--- a/creator/src/components/zone/BatchArtGenerator.tsx
+++ b/creator/src/components/zone/BatchArtGenerator.tsx
@@ -1,103 +1,110 @@
-import { useState, useCallback, useRef, useMemo } from "react";
 import { AI_ENABLED } from "@/lib/featureFlags";
-import type { WorldFile } from "@/types/world";
 import { ART_STYLE_LABELS } from "@/lib/arcanumPrompts";
 import { useAssetStore } from "@/stores/assetStore";
 import { useVibeStore } from "@/stores/vibeStore";
-import { buildAudioMetaIndex } from "@/lib/audioLibrary";
+import { useBatchArtStore } from "@/stores/batchArtStore";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 import { ActionButton } from "@/components/ui/FormWidgets";
-import {
-  collectTargets,
-  runBatchArtGeneration,
-} from "@/lib/batchArt";
 
-interface BatchArtGeneratorProps {
-  zoneId: string;
-  world: WorldFile;
-  onWorldChange: (world: WorldFile) => void;
-  onClose: () => void;
+/**
+ * Global host for the batch art generator. Renders the full dialog when the
+ * panel is open, or a compact progress pill when a job runs in the background.
+ * Mounted once at the app shell so the job survives closing the dialog and
+ * navigating between zones.
+ */
+export function BatchArtOverlay() {
+  const job = useBatchArtStore((s) => s.job);
+  const panelOpen = useBatchArtStore((s) => s.panelOpen);
+
+  if (!AI_ENABLED || !job) return null;
+  if (panelOpen) return <BatchArtPanel />;
+  if (job.running) return <BatchArtPill />;
+  return null;
 }
 
-export function BatchArtGenerator({
-  zoneId,
-  world,
-  onWorldChange,
-  onClose,
-}: BatchArtGeneratorProps) {
+function BatchArtPill() {
+  const job = useBatchArtStore((s) => s.job);
+  const showPanel = useBatchArtStore((s) => s.showPanel);
+  const abort = useBatchArtStore((s) => s.abort);
+  if (!job) return null;
+
+  const checked = job.targets.filter((t) => t.checked).length;
+  const done = job.targets.filter((t) => t.status === "done").length;
+  const errors = job.targets.filter((t) => t.status === "error").length;
+  const pct = job.bgRemoval
+    ? job.bgRemoval.total > 0
+      ? (job.bgRemoval.done / job.bgRemoval.total) * 100
+      : 0
+    : checked > 0
+      ? ((done + errors) / checked) * 100
+      : 0;
+
+  return (
+    <div className="pointer-events-none fixed bottom-6 left-6 z-40 flex justify-start">
+      <div className="pointer-events-auto w-72 rounded-2xl border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] p-3 shadow-lg backdrop-blur">
+        <div className="flex items-center gap-2">
+          <span className="inline-block h-3 w-3 shrink-0 rounded-full border border-accent border-t-transparent animate-spin" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-2xs uppercase tracking-wide text-text-muted">
+              Batch Art &middot; {job.zoneId}
+            </p>
+            <p className="truncate text-xs text-text-secondary">
+              {job.bgRemoval
+                ? `Removing backgrounds: ${job.bgRemoval.done} of ${job.bgRemoval.total}`
+                : `${done + errors} of ${checked} generated`}
+            </p>
+          </div>
+        </div>
+        <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-bg-primary">
+          <div
+            className="h-full rounded-full bg-accent transition-[width]"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <div className="mt-2 flex justify-end gap-2">
+          <ActionButton onClick={showPanel} variant="ghost" size="sm" className="min-h-8 px-3">
+            View
+          </ActionButton>
+          <ActionButton onClick={abort} variant="danger" size="sm" className="min-h-8 px-3">
+            Abort
+          </ActionButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BatchArtPanel() {
+  const job = useBatchArtStore((s) => s.job)!;
   const artStyle = useAssetStore((s) => s.artStyle);
   const settings = useAssetStore((s) => s.settings);
-  const assets = useAssetStore((s) => s.assets);
-  const vibe = useVibeStore((s) => s.vibes.get(zoneId) ?? "");
-  const audioMeta = useMemo(() => buildAudioMetaIndex(assets), [assets]);
-  const [targets, setTargets] = useState(() => collectTargets(world, audioMeta));
-  const [running, setRunning] = useState(false);
-  const [bgRemoval, setBgRemoval] = useState<{ done: number; total: number } | null>(null);
-  const [concurrency, setConcurrency] = useState(settings?.batch_concurrency ?? 5);
-  const abortRef = useRef(false);
-  const trapRef = useFocusTrap<HTMLDivElement>(running ? undefined : onClose);
+  const vibe = useVibeStore((s) => s.vibes.get(job.zoneId) ?? "");
 
+  const closePanel = useBatchArtStore((s) => s.closePanel);
+  const dismiss = useBatchArtStore((s) => s.dismiss);
+  const toggleTarget = useBatchArtStore((s) => s.toggleTarget);
+  const selectAll = useBatchArtStore((s) => s.selectAll);
+  const selectNone = useBatchArtStore((s) => s.selectNone);
+  const selectMissing = useBatchArtStore((s) => s.selectMissing);
+  const setConcurrency = useBatchArtStore((s) => s.setConcurrency);
+  const start = useBatchArtStore((s) => s.start);
+  const abort = useBatchArtStore((s) => s.abort);
+
+  const { targets, running, bgRemoval, concurrency, zoneId } = job;
   const checkedTargets = targets.filter((t) => t.checked);
   const missingTargets = targets.filter((t) => !t.hasExisting);
   const doneCount = targets.filter((t) => t.status === "done").length;
   const errorCount = targets.filter((t) => t.status === "error").length;
   const imageProvider = settings?.image_provider ?? "deepinfra";
 
-  const acceptAsset = useAssetStore((s) => s.acceptAsset);
-  const loadAssets = useAssetStore((s) => s.loadAssets);
-
-  const toggleTarget = (idx: number) => {
-    setTargets((prev) => prev.map((t, i) => (i === idx ? { ...t, checked: !t.checked } : t)));
-  };
-
-  const selectAll = () => setTargets((prev) => prev.map((t) => ({ ...t, checked: true })));
-  const selectNone = () => setTargets((prev) => prev.map((t) => ({ ...t, checked: false })));
-  const selectMissing = () => setTargets((prev) => prev.map((t) => ({ ...t, checked: !t.hasExisting })));
-
-  const handleRun = useCallback(async () => {
-    setRunning(true);
-    abortRef.current = false;
-
-    setBgRemoval(null);
-    try {
-      await runBatchArtGeneration(
-        targets,
-        world,
-        zoneId,
-        artStyle,
-        vibe,
-        imageProvider,
-        settings?.image_model,
-        concurrency,
-        abortRef,
-        {
-          onTargetUpdate: (idx, update) => {
-            setTargets((prev) =>
-              prev.map((t, i) => (i === idx ? { ...t, ...update } : t)),
-            );
-          },
-          onWorldUpdate: onWorldChange,
-          onBgRemovalProgress: (done, total) => setBgRemoval({ done, total }),
-          // reload=false: skip the per-image manifest reload (O(n²) on big
-          // zones — it OOMs the WebView). The whole batch refreshes once below.
-          acceptAsset: (image, assetType, enhancedPrompt, context, variantGroup, isActive) =>
-            acceptAsset(image, assetType, enhancedPrompt, context, variantGroup, isActive, false),
-        },
-        settings?.auto_remove_bg,
-      );
-    } finally {
-      await loadAssets();
-      setBgRemoval(null);
-      setRunning(false);
-    }
-  }, [targets, world, onWorldChange, artStyle, vibe, imageProvider, concurrency, zoneId, acceptAsset, loadAssets, settings]);
-
-  if (!AI_ENABLED) return null;
+  // Escape backgrounds a running job; otherwise it discards setup / closes results.
+  const trapRef = useFocusTrap<HTMLDivElement>(running ? closePanel : dismiss);
+  const onOverlayClick = running ? closePanel : dismiss;
 
   if (targets.length === 0) {
     return (
-      <div className="dialog-overlay">
-        <div className="dialog-shell w-full max-w-md">
+      <div className="dialog-overlay" onClick={dismiss}>
+        <div className="dialog-shell w-full max-w-md" onClick={(e) => e.stopPropagation()}>
           <div className="dialog-header">
             <h2 className="dialog-title">Batch Art Generation</h2>
           </div>
@@ -107,7 +114,7 @@ export function BatchArtGenerator({
             </p>
           </div>
           <div className="dialog-footer">
-            <ActionButton onClick={onClose} variant="ghost" size="sm">
+            <ActionButton onClick={dismiss} variant="ghost" size="sm">
               Close
             </ActionButton>
           </div>
@@ -116,8 +123,10 @@ export function BatchArtGenerator({
     );
   }
 
+  const showSetup = !running && doneCount === 0;
+
   return (
-    <div className="dialog-overlay" onClick={running ? undefined : onClose}>
+    <div className="dialog-overlay" onClick={onOverlayClick}>
       <div
         ref={trapRef}
         role="dialog"
@@ -139,7 +148,7 @@ export function BatchArtGenerator({
             <span className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1 text-2xs text-text-secondary">
               {checkedTargets.length} of {targets.length} selected
             </span>
-            {!running && doneCount === 0 && (
+            {showSetup && (
               <div className="flex flex-wrap justify-end gap-2">
                 <ActionButton onClick={selectAll} variant="ghost" size="sm" className="min-h-9 px-3">
                   All
@@ -157,7 +166,7 @@ export function BatchArtGenerator({
           </div>
         </div>
 
-        {!running && doneCount === 0 && (
+        {showSetup && (
           <div className="border-b border-border-default px-5 py-3">
             <div className="rounded-2xl border border-border-default/60 bg-bg-primary/60 px-3 py-2 text-xs text-text-secondary">
               Style system: {ART_STYLE_LABELS[artStyle]}
@@ -202,7 +211,7 @@ export function BatchArtGenerator({
                 className="h-full rounded-full bg-accent transition-[width]"
                 style={{ width: `${bgRemoval
                   ? (bgRemoval.total > 0 ? (bgRemoval.done / bgRemoval.total) * 100 : 0)
-                  : ((doneCount + errorCount) / checkedTargets.length) * 100}%` }}
+                  : checkedTargets.length > 0 ? ((doneCount + errorCount) / checkedTargets.length) * 100 : 0}%` }}
               />
             </div>
           </div>
@@ -215,7 +224,7 @@ export function BatchArtGenerator({
                 key={`${target.kind}:${target.id}`}
                 className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-xs hover:bg-bg-elevated"
               >
-                {!running && doneCount === 0 && (
+                {showSetup && (
                   <input
                     type="checkbox"
                     checked={target.checked}
@@ -255,21 +264,22 @@ export function BatchArtGenerator({
 
         <div className="flex justify-end gap-2 border-t border-border-default px-5 py-3">
           {running ? (
-            <ActionButton
-              onClick={() => { abortRef.current = true; }}
-              variant="danger"
-              size="sm"
-            >
-              Abort
-            </ActionButton>
+            <>
+              <ActionButton onClick={closePanel} variant="ghost" size="sm">
+                Run in background
+              </ActionButton>
+              <ActionButton onClick={abort} variant="danger" size="sm">
+                Abort
+              </ActionButton>
+            </>
           ) : (
             <>
-              <ActionButton onClick={onClose} variant="ghost" size="sm">
+              <ActionButton onClick={dismiss} variant="ghost" size="sm">
                 {doneCount > 0 ? "Done" : "Cancel"}
               </ActionButton>
               {doneCount === 0 && (
                 <ActionButton
-                  onClick={handleRun}
+                  onClick={start}
                   disabled={checkedTargets.length === 0}
                   variant="primary"
                   size="sm"

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -33,7 +33,7 @@ import { ExitEdge, ExitDeleteContext } from "./ExitEdge";
 import { RoomPanel, type EntitySelection } from "./RoomPanel";
 import { EntityPanel } from "./EntityPanel";
 import { DirectionPicker } from "./DirectionPicker";
-import { BatchArtGenerator } from "./BatchArtGenerator";
+import { useBatchArtStore } from "@/stores/batchArtStore";
 import { RethemeDialog } from "./RethemeDialog";
 import { DuplicateZoneDialog } from "@/components/DuplicateZoneDialog";
 import { RebalanceZoneDialog } from "@/components/zone/RebalanceZoneDialog";
@@ -185,7 +185,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
     useState<PendingConnection | null>(null);
   const [saving, setSaving] = useState(false);
   const [justSaved, setJustSaved] = useState(false);
-  const [showBatchArt, setShowBatchArt] = useState(false);
+  const openBatchArt = useBatchArtStore((s) => s.openSetup);
   const [showBulkBgRemoval, setShowBulkBgRemoval] = useState(false);
   const [showDuplicate, setShowDuplicate] = useState(false);
   const [showRebalance, setShowRebalance] = useState(false);
@@ -710,7 +710,7 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
 
           <div className="flex flex-wrap items-center gap-2 border-l border-[var(--chrome-stroke)] pl-3">
             <button
-              onClick={() => setShowBatchArt(true)}
+              onClick={() => openBatchArt(zoneId)}
               className="h-6 rounded px-2 text-xs text-stellar-blue transition-colors hover:bg-stellar-blue/10 max-[1100px]:h-9"
               title="Generate art for all entities"
               aria-label="Generate art for all entities"
@@ -1139,15 +1139,8 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
               </div>
             )}
 
-            {/* Batch art generator */}
-            {showBatchArt && zoneState && (
-              <BatchArtGenerator
-                zoneId={zoneId}
-                world={zoneState.data}
-                onWorldChange={applyWorldChange}
-                onClose={() => setShowBatchArt(false)}
-              />
-            )}
+            {/* Batch art generator is hosted globally (BatchArtOverlay in AppShell)
+                so the job survives closing the dialog and navigating zones. */}
 
             {/* Duplicate zone */}
             {showDuplicate && (

--- a/creator/src/lib/__tests__/batchArt.test.ts
+++ b/creator/src/lib/__tests__/batchArt.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { WorldFile } from "@/types/world";
 import type { AudioTrackMeta } from "@/lib/audioLibrary";
-import { collectTargets, getTargetPrompt, getTargetContext, assetTypeForKind } from "@/lib/batchArt";
+import { collectTargets, getTargetPrompt, getTargetContext, assetTypeForKind, applyImageToWorld } from "@/lib/batchArt";
 
 function makeWorld(rooms: WorldFile["rooms"]): WorldFile {
   return { zone: "parlor_zone", startRoom: "parlor_a", rooms };
@@ -59,5 +59,39 @@ describe("collectTargets — music box keepsakes", () => {
     expect(getTargetPrompt(target, world, "gentle_magic")).toContain("Scuttlefish's Lullaby");
     expect(getTargetContext(target, world)).toContain("Scuttlefish's Lullaby");
     expect(assetTypeForKind("musicBoxKeepsake")).toBe("item");
+  });
+});
+
+describe("applyImageToWorld", () => {
+  it("assigns a room image without mutating the input", () => {
+    const world = makeWorld({ parlor_a: { title: "Parlor A", description: "" } });
+    const next = applyImageToWorld(world, "room", "parlor_a", "rooms/parlor.png");
+    expect(next.rooms.parlor_a!.image).toBe("rooms/parlor.png");
+    expect(world.rooms.parlor_a!.image).toBeUndefined();
+    expect(next).not.toBe(world);
+  });
+
+  it("assigns a music box keepsake image under the room's musicBox", () => {
+    const world = makeWorld({
+      parlor_a: { title: "Parlor A", description: "", musicBox: { file: "lullaby.mp3" } },
+    });
+    const next = applyImageToWorld(world, "musicBoxKeepsake", "parlor_a", "items/sheet.png");
+    expect(next.rooms.parlor_a!.musicBox!.image).toBe("items/sheet.png");
+    expect(next.rooms.parlor_a!.musicBox!.file).toBe("lullaby.mp3");
+  });
+
+  it("assigns a collection entity image (mob)", () => {
+    const world: WorldFile = {
+      ...makeWorld({}),
+      mobs: { goblin: { name: "Goblin" } as WorldFile["mobs"][string] },
+    };
+    const next = applyImageToWorld(world, "mob", "goblin", "mobs/goblin.png");
+    expect(next.mobs!.goblin!.image).toBe("mobs/goblin.png");
+  });
+
+  it("is a no-op when the target entity is missing", () => {
+    const world = makeWorld({ parlor_a: { title: "Parlor A", description: "" } });
+    expect(applyImageToWorld(world, "room", "ghost", "x.png")).toBe(world);
+    expect(applyImageToWorld(world, "mob", "absent", "x.png")).toBe(world);
   });
 });

--- a/creator/src/lib/batchArt.ts
+++ b/creator/src/lib/batchArt.ts
@@ -176,6 +176,67 @@ function collectionForKind(kind: string): string {
   }
 }
 
+/**
+ * Return a new WorldFile with the generated image filename assigned to the
+ * entity addressed by `kind`/`id`. Pure — no mutation. Applied incrementally
+ * against the live zone data so a backgrounded batch never clobbers concurrent
+ * edits to other fields. A no-op (returns the same world) if the target is gone.
+ */
+export function applyImageToWorld(
+  world: WorldFile,
+  kind: string,
+  id: string,
+  fileName: string,
+): WorldFile {
+  if (kind === "room") {
+    const room = world.rooms[id];
+    if (!room) return world;
+    return { ...world, rooms: { ...world.rooms, [id]: { ...room, image: fileName } } };
+  }
+  if (kind === "musicBoxKeepsake") {
+    const room = world.rooms[id];
+    if (!room?.musicBox) return world;
+    return {
+      ...world,
+      rooms: {
+        ...world.rooms,
+        [id]: { ...room, musicBox: { ...room.musicBox, image: fileName } },
+      },
+    };
+  }
+  if (kind === "dungeon" && world.dungeon) {
+    return { ...world, dungeon: { ...world.dungeon, image: fileName } };
+  }
+  if (kind === "dungeonRoom" && world.dungeon) {
+    const [category, idxStr] = id.split(":");
+    const idx = parseInt(idxStr!, 10);
+    const templates = world.dungeon.roomTemplates?.[category!];
+    if (!templates?.[idx]) return world;
+    const updatedTemplates = [...templates];
+    updatedTemplates[idx] = { ...templates[idx]!, image: fileName };
+    return {
+      ...world,
+      dungeon: {
+        ...world.dungeon,
+        roomTemplates: { ...world.dungeon.roomTemplates, [category!]: updatedTemplates },
+      },
+    };
+  }
+  const collection = collectionForKind(kind);
+  const entities = (world as unknown as Record<string, unknown>)[collection] as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!entities?.[id]) return world;
+  return {
+    ...world,
+    [collection]: { ...entities, [id]: { ...entities[id], image: fileName } },
+  };
+}
+
+function fileNameFromPath(filePath: string, fallback: string): string {
+  return filePath.split(/[\\/]/).pop() ?? fallback;
+}
+
 export function getTargetPrompt(
   target: BatchTarget,
   world: WorldFile,
@@ -232,7 +293,13 @@ export function getTargetContext(
 
 export interface ArtGenerationCallbacks {
   onTargetUpdate: (idx: number, update: Partial<BatchTarget>) => void;
-  onWorldUpdate: (world: WorldFile) => void;
+  /**
+   * Assign a freshly generated image filename to one entity. Called once per
+   * image (and again after background removal swaps in the bg-free variant).
+   * Implementations apply it against the *current* zone data so the write is
+   * safe even while the batch runs in the background and the user edits on.
+   */
+  applyImage: (kind: string, id: string, fileName: string) => void;
   onBgRemovalProgress?: (done: number, total: number) => void;
   acceptAsset: (
     image: GeneratedImage,
@@ -256,10 +323,8 @@ export async function runBatchArtGeneration(
   abortRef: { current: boolean },
   callbacks: ArtGenerationCallbacks,
   autoRemoveBg?: boolean,
-): Promise<WorldFile> {
+): Promise<void> {
   if (!AI_ENABLED) throw new Error("AI features are not available in Community Edition");
-  // Use a ref-like container so all workers always read/write the latest world
-  const worldRef = { current: { ...world } };
 
   // Collect background removal promises so we can await them before saving
   const pendingBgRemovals: { promise: ReturnType<typeof removeBgFromFileAndSave>; kind: string; id: string }[] = [];
@@ -283,8 +348,8 @@ export async function runBatchArtGeneration(
       callbacks.onTargetUpdate(idx, { status: "generating" });
 
       try {
-        const basePrompt = getTargetPrompt(target, worldRef.current, artStyle, vibe);
-        const context = getTargetContext(target, worldRef.current);
+        const basePrompt = getTargetPrompt(target, world, artStyle, vibe);
+        const context = getTargetContext(target, world);
         const batchAssetType = assetTypeForKind(target.kind);
 
         let finalPrompt = basePrompt;
@@ -357,71 +422,11 @@ export async function runBatchArtGeneration(
           });
         }
 
-        // Update worldRef atomically — always read current value to avoid lost updates
-        const { kind, id } = target;
-        const cur = worldRef.current;
-        if (kind === "room") {
-          const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
-          worldRef.current = {
-            ...cur,
-            rooms: {
-              ...cur.rooms,
-              [id]: { ...cur.rooms[id]!, image: fileName },
-            },
-          };
-        } else if (kind === "musicBoxKeepsake") {
-          const room = cur.rooms[id];
-          if (room?.musicBox) {
-            const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
-            worldRef.current = {
-              ...cur,
-              rooms: {
-                ...cur.rooms,
-                [id]: { ...room, musicBox: { ...room.musicBox, image: fileName } },
-              },
-            };
-          }
-        } else if (kind === "dungeon" && cur.dungeon) {
-          const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
-          worldRef.current = {
-            ...cur,
-            dungeon: { ...cur.dungeon, image: fileName },
-          };
-        } else if (kind === "dungeonRoom" && cur.dungeon) {
-          const [category, idxStr] = id.split(":");
-          const idx = parseInt(idxStr!, 10);
-          const templates = cur.dungeon.roomTemplates?.[category!];
-          if (templates?.[idx]) {
-            const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
-            const updatedTemplates = [...templates];
-            updatedTemplates[idx] = { ...templates[idx]!, image: fileName };
-            worldRef.current = {
-              ...cur,
-              dungeon: {
-                ...cur.dungeon,
-                roomTemplates: {
-                  ...cur.dungeon.roomTemplates,
-                  [category!]: updatedTemplates,
-                },
-              },
-            };
-          }
-        } else {
-          const collection = collectionForKind(kind);
-          const entities = (cur as Record<string, unknown>)[
-            collection
-          ] as Record<string, Record<string, unknown>> | undefined;
-          if (entities?.[id]) {
-            const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
-            worldRef.current = {
-              ...cur,
-              [collection]: {
-                ...entities,
-                [id]: { ...entities[id], image: fileName },
-              },
-            };
-          }
-        }
+        callbacks.applyImage(
+          target.kind,
+          target.id,
+          fileNameFromPath(image.file_path, image.hash),
+        );
       } catch (e) {
         callbacks.onTargetUpdate(idx, {
           status: "error",
@@ -447,35 +452,7 @@ export async function runBatchArtGeneration(
     try {
       const entry = await promise;
       if (entry) {
-        const cur = worldRef.current;
-        if (kind === "musicBoxKeepsake") {
-          const room = cur.rooms[id];
-          if (room?.musicBox) {
-            worldRef.current = {
-              ...cur,
-              rooms: {
-                ...cur.rooms,
-                [id]: { ...room, musicBox: { ...room.musicBox, image: entry.file_name } },
-              },
-            };
-          }
-        } else {
-          const collection =
-            kind === "mob" ? "mobs" : kind === "item" ? "items" : kind === "shop" ? "shops" : null;
-          if (collection) {
-            const entities = (cur as Record<string, unknown>)[collection] as
-              Record<string, Record<string, unknown>> | undefined;
-            if (entities?.[id]) {
-              worldRef.current = {
-                ...cur,
-                [collection]: {
-                  ...entities,
-                  [id]: { ...entities[id], image: entry.file_name },
-                },
-              };
-            }
-          }
-        }
+        callbacks.applyImage(kind, id, entry.file_name);
       }
     } catch {
       // bg removal failed; keep original image
@@ -483,7 +460,4 @@ export async function runBatchArtGeneration(
     removalsComplete++;
     callbacks.onBgRemovalProgress?.(removalsComplete, totalRemovals);
   }
-
-  callbacks.onWorldUpdate(worldRef.current);
-  return worldRef.current;
 }

--- a/creator/src/stores/batchArtStore.ts
+++ b/creator/src/stores/batchArtStore.ts
@@ -1,0 +1,222 @@
+import { create } from "zustand";
+import type { BatchTarget } from "@/lib/batchArt";
+import {
+  collectTargets,
+  runBatchArtGeneration,
+  applyImageToWorld,
+} from "@/lib/batchArt";
+import { buildAudioMetaIndex } from "@/lib/audioLibrary";
+import { useAssetStore } from "./assetStore";
+import { useVibeStore } from "./vibeStore";
+import { useZoneStore } from "./zoneStore";
+import { useToastStore } from "./toastStore";
+
+export interface BatchArtJob {
+  zoneId: string;
+  targets: BatchTarget[];
+  concurrency: number;
+  running: boolean;
+  bgRemoval: { done: number; total: number } | null;
+}
+
+interface BatchArtStore {
+  /** The active or just-finished job. Persists across panel close + navigation. */
+  job: BatchArtJob | null;
+  /** Whether the full setup/progress dialog is on screen (vs. the compact pill). */
+  panelOpen: boolean;
+
+  /**
+   * Open the batch art dialog for a zone. Seeds the target list from the zone's
+   * live data unless a job is already running, in which case it just re-surfaces
+   * the running job (only one batch runs at a time).
+   */
+  openSetup: (zoneId: string) => void;
+  showPanel: () => void;
+  closePanel: () => void;
+  /** Discard a finished job and close. No-op while a job is still running. */
+  dismiss: () => void;
+
+  toggleTarget: (idx: number) => void;
+  selectAll: () => void;
+  selectNone: () => void;
+  selectMissing: () => void;
+  setConcurrency: (n: number) => void;
+
+  /** Kick off generation for the checked targets. Runs in the background. */
+  start: () => void;
+  /** Signal the running job to stop after in-flight work settles. */
+  abort: () => void;
+}
+
+// Module-scoped so the abort signal survives store updates and is shared by
+// every concurrent worker, mirroring the original component ref.
+const abortRef = { current: false };
+
+export const useBatchArtStore = create<BatchArtStore>((set, get) => ({
+  job: null,
+  panelOpen: false,
+
+  openSetup: (zoneId) => {
+    const current = get().job;
+    if (current?.running) {
+      // A batch is already in flight — surface it rather than starting another.
+      set({ panelOpen: true });
+      return;
+    }
+
+    const zone = useZoneStore.getState().zones.get(zoneId);
+    if (!zone) return;
+    const audioMeta = buildAudioMetaIndex(useAssetStore.getState().assets);
+    const targets = collectTargets(zone.data, audioMeta);
+    const concurrency = useAssetStore.getState().settings?.batch_concurrency ?? 5;
+
+    set({
+      job: { zoneId, targets, concurrency, running: false, bgRemoval: null },
+      panelOpen: true,
+    });
+  },
+
+  showPanel: () => set({ panelOpen: true }),
+  closePanel: () => set({ panelOpen: false }),
+
+  dismiss: () =>
+    set((s) => (s.job?.running ? s : { job: null, panelOpen: false })),
+
+  toggleTarget: (idx) =>
+    set((s) =>
+      s.job && !s.job.running
+        ? {
+            job: {
+              ...s.job,
+              targets: s.job.targets.map((t, i) =>
+                i === idx ? { ...t, checked: !t.checked } : t,
+              ),
+            },
+          }
+        : s,
+    ),
+
+  selectAll: () =>
+    set((s) =>
+      s.job && !s.job.running
+        ? { job: { ...s.job, targets: s.job.targets.map((t) => ({ ...t, checked: true })) } }
+        : s,
+    ),
+
+  selectNone: () =>
+    set((s) =>
+      s.job && !s.job.running
+        ? { job: { ...s.job, targets: s.job.targets.map((t) => ({ ...t, checked: false })) } }
+        : s,
+    ),
+
+  selectMissing: () =>
+    set((s) =>
+      s.job && !s.job.running
+        ? {
+            job: {
+              ...s.job,
+              targets: s.job.targets.map((t) => ({ ...t, checked: !t.hasExisting })),
+            },
+          }
+        : s,
+    ),
+
+  setConcurrency: (n) =>
+    set((s) => (s.job && !s.job.running ? { job: { ...s.job, concurrency: n } } : s)),
+
+  start: () => {
+    const job = get().job;
+    if (!job || job.running) return;
+
+    const { zoneId, targets, concurrency } = job;
+    const zone = useZoneStore.getState().zones.get(zoneId);
+    if (!zone) return;
+
+    const asset = useAssetStore.getState();
+    const settings = asset.settings;
+    const vibe = useVibeStore.getState().vibes.get(zoneId) ?? "";
+    const imageProvider = settings?.image_provider ?? "deepinfra";
+
+    abortRef.current = false;
+    set({ job: { ...job, running: true, bgRemoval: null }, panelOpen: true });
+
+    runBatchArtGeneration(
+      targets,
+      zone.data,
+      zoneId,
+      asset.artStyle,
+      vibe,
+      imageProvider,
+      settings?.image_model,
+      concurrency,
+      abortRef,
+      {
+        onTargetUpdate: (idx, update) =>
+          set((s) =>
+            s.job
+              ? {
+                  job: {
+                    ...s.job,
+                    targets: s.job.targets.map((t, i) =>
+                      i === idx ? { ...t, ...update } : t,
+                    ),
+                  },
+                }
+              : s,
+          ),
+        // Write each image into the zone's *live* data so a backgrounded batch
+        // never clobbers concurrent edits, and avoid undo-stack flooding.
+        applyImage: (kind, id, fileName) => {
+          const zs = useZoneStore.getState();
+          const cur = zs.zones.get(zoneId)?.data;
+          if (!cur) return;
+          zs.setZoneDataSilent(zoneId, applyImageToWorld(cur, kind, id, fileName));
+        },
+        onBgRemovalProgress: (done, total) =>
+          set((s) => (s.job ? { job: { ...s.job, bgRemoval: { done, total } } } : s)),
+        // reload=false: skip the per-image manifest reload (O(n²) on big zones —
+        // it OOMs the WebView). The whole batch refreshes once on completion.
+        acceptAsset: (image, assetType, enhancedPrompt, context, variantGroup, isActive) =>
+          asset.acceptAsset(
+            image,
+            assetType,
+            enhancedPrompt,
+            context,
+            variantGroup,
+            isActive,
+            false,
+          ),
+      },
+      settings?.auto_remove_bg,
+    )
+      .catch(() => {})
+      .finally(() => {
+        useAssetStore.getState().loadAssets().catch(() => {});
+        set((s) => (s.job ? { job: { ...s.job, running: false, bgRemoval: null } } : s));
+
+        const finished = get().job;
+        if (finished) {
+          const done = finished.targets.filter((t) => t.status === "done").length;
+          const errors = finished.targets.filter((t) => t.status === "error").length;
+          useToastStore.getState().show(
+            {
+              kicker: "Batch Art",
+              message: `${done} image${done === 1 ? "" : "s"} generated${
+                errors ? `, ${errors} failed` : ""
+              }`,
+              variant: "ember",
+            },
+            4000,
+          );
+          // Auto-clear the job once the user has moved on, but keep it if the
+          // panel is still open so they can review per-target results.
+          if (!get().panelOpen) set({ job: null });
+        }
+      });
+  },
+
+  abort: () => {
+    abortRef.current = true;
+  },
+}));

--- a/creator/src/stores/zoneStore.ts
+++ b/creator/src/stores/zoneStore.ts
@@ -17,6 +17,13 @@ interface ZoneStore {
 
   loadZone: (zoneId: string, filePath: string, data: WorldFile) => void;
   updateZone: (zoneId: string, data: WorldFile) => void;
+  /**
+   * Replace a zone's data and flag it dirty WITHOUT pushing onto the undo
+   * stack. For programmatic side-effects (e.g. backgrounded batch art writing
+   * image filenames) that shouldn't flood the 100-entry history or be reverted
+   * one image at a time by Ctrl+Z. No-op if the zone isn't loaded.
+   */
+  setZoneDataSilent: (zoneId: string, data: WorldFile) => void;
   markClean: (zoneId: string) => void;
   /** Flag a zone as needing a save without touching its data or undo history. */
   markDirty: (zoneId: string) => void;
@@ -68,6 +75,15 @@ export const useZoneStore = create<ZoneStore>((set, get) => ({
           future: [], // new edit clears redo stack
         });
       }
+      return { zones };
+    }),
+
+  setZoneDataSilent: (zoneId, data) =>
+    set((state) => {
+      const existing = state.zones.get(zoneId);
+      if (!existing) return state;
+      const zones = new Map(state.zones);
+      zones.set(zoneId, { ...existing, data, dirty: true });
       return { zones };
     }),
 


### PR DESCRIPTION
## Problem

Batch art generation runs inside a modal owned by the zone editor. While it's running — especially the background-removal pass, which is slow — the only options are **wait** or **abort**. Closing the dialog or leaving the zone kills the run.

## What changed

The batch job now lives in a global store and is hosted at the app shell, so it keeps running while you close the dialog and work elsewhere.

- **`stores/batchArtStore.ts` (new)** — owns the job lifecycle: target selection, the running generation loop, progress, and abort. Drives `runBatchArtGeneration`, writes image filenames straight into the zone store by `zoneId`, and shows a completion toast. Only one batch runs at a time.
- **`BatchArtOverlay` (rewritten `BatchArtGenerator.tsx`)** — mounted once in `AppShell`. Renders the full dialog when open, or a compact **progress pill** (bottom-left, with **View** / **Abort**) when a run is backgrounded. Closing the dialog mid-run now **backgrounds** it instead of aborting; a new **Run in background** button makes that explicit.
- **`lib/batchArt.ts`** — replaced the `worldRef` accumulator + single final `onWorldUpdate` with an incremental `applyImage` callback, plus a pure exported `applyImageToWorld` helper. Images are applied against the zone's **live** data, so a backgrounded batch never clobbers concurrent edits to other fields.
- **`zoneStore.setZoneDataSilent`** — sets data + dirty **without** pushing undo history, so a 100-image batch doesn't flood the 100-entry undo stack (and a stray Ctrl+Z doesn't revert art one image at a time).
- **`ZoneEditor` / `StudioWorkspace`** — the "Batch Art" / "Batch generate" buttons now call `openSetup(zoneId)` on the store; the locally-mounted modals are gone.

## Behavior notes

- Batch art assignment is no longer a single undoable step — it's a programmatic side-effect that just marks the zone dirty. The generated images remain in the asset manifest/gallery regardless.
- Single-job-at-a-time: opening the dialog for another zone while a run is active re-surfaces the running job rather than starting a second.

## Testing

- `bunx tsc --noEmit` clean
- `bun run test` — 2296 passed (added `applyImageToWorld` unit tests covering rooms, music-box keepsakes, collection entities, and missing-target no-ops)
- Manual in-app QA of the background/pill/abort flow still pending.