### PR TITLE
feat(progression): under-level XP bonus config

### DIFF
--- a/creator/src/components/config/panels/WorldPanel.tsx
+++ b/creator/src/components/config/panels/WorldPanel.tsx
@@ -1,5 +1,5 @@
 import type { ConfigPanelProps, AppConfig } from "./types";
-import type { DiminishingXpConfig, DiminishingXpThreshold } from "@/types/config";
+import type { DiminishingXpConfig, DiminishingXpThreshold, UnderLevelBonusConfig } from "@/types/config";
 import { NumberInput, TextInput, IconButton, ActionButton } from "@/components/ui/FormWidgets";
 
 import { OrnateCard } from "@/components/ui/OrnateCard";
@@ -199,9 +199,21 @@ export function WorldPanel({ config, onChange }: ConfigPanelProps) {
           />
         </OrnateCard>
 
-        {/* 6 — Level-Up Rewards */}
+        {/* 6 — Under-Level Bonus */}
         <OrnateCard
           number={6}
+          title="Under-Level Bonus"
+          description="Award extra XP when a player kills a mob above their own level, scaling with the level gap up to a cap."
+        >
+          <UnderLevelBonusEditor
+            value={p.xp.underLevelBonus}
+            onChange={(next) => patchXp({ underLevelBonus: next })}
+          />
+        </OrnateCard>
+
+        {/* 7 — Level-Up Rewards */}
+        <OrnateCard
+          number={7}
           title="Level-Up Rewards"
           description="Stat growth and rewards players receive on level up."
         >
@@ -255,9 +267,9 @@ export function WorldPanel({ config, onChange }: ConfigPanelProps) {
           </div>
         </OrnateCard>
 
-        {/* 7 — Combat */}
+        {/* 8 — Combat */}
         <OrnateCard
-          number={7}
+          number={8}
           title="Combat"
           description="Combat pacing and on-screen feedback. Each tick processes one round of attacks for all active fights."
         >
@@ -301,9 +313,9 @@ export function WorldPanel({ config, onChange }: ConfigPanelProps) {
           </div>
         </OrnateCard>
 
-        {/* 8 — Recall */}
+        {/* 9 — Recall */}
         <OrnateCard
-          number={8}
+          number={9}
           title="Recall"
           description="Controls the recall ability cooldown."
         >
@@ -320,9 +332,9 @@ export function WorldPanel({ config, onChange }: ConfigPanelProps) {
           </IconField>
         </OrnateCard>
 
-        {/* 9 — Recall Messages */}
+        {/* 10 — Recall Messages */}
         <OrnateCard
-          number={9}
+          number={10}
           title="Recall Messages"
           description="Customize the messages players see during recall. Use {seconds} for the cooldown placeholder."
         >
@@ -380,9 +392,9 @@ export function WorldPanel({ config, onChange }: ConfigPanelProps) {
           </div>
         </OrnateCard>
 
-        {/* 10 — Sanctum & Death */}
+        {/* 11 — Sanctum & Death */}
         <OrnateCard
-          number={10}
+          number={11}
           title="Sanctum & Death"
           description="Where players return after death. HP/Mana values are fractions of max (0–1.0). XP penalty is a fraction of total XP lost (0–0.5)."
         >
@@ -434,9 +446,9 @@ export function WorldPanel({ config, onChange }: ConfigPanelProps) {
           </div>
         </OrnateCard>
 
-        {/* 11 — Sanctum Messages */}
+        {/* 12 — Sanctum Messages */}
         <OrnateCard
-          number={11}
+          number={12}
           title="Sanctum Messages"
           description="Customize messages related to the sanctum, departure, and edge cases."
         >
@@ -605,6 +617,67 @@ function DiminishingReturnsEditor({
           <ActionButton variant="ghost" size="sm" onClick={addThreshold}>
             Add Threshold
           </ActionButton>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UnderLevelBonusEditor({
+  value,
+  onChange,
+}: {
+  value: UnderLevelBonusConfig | undefined;
+  onChange: (next: UnderLevelBonusConfig | undefined) => void;
+}) {
+  const enabled = !!value?.enabled;
+  const bonusPerLevel = value?.bonusPerLevel ?? 0.15;
+  const maxBonus = value?.maxBonus ?? 0.5;
+
+  const setEnabled = (on: boolean) => {
+    if (!on && !value) return;
+    onChange({ enabled: on, bonusPerLevel, maxBonus });
+  };
+
+  const patch = (next: Partial<UnderLevelBonusConfig>) => {
+    onChange({ enabled, bonusPerLevel, maxBonus, ...next });
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Toggle
+        checked={enabled}
+        onChange={setEnabled}
+        label="Enable under-level bonus"
+      />
+      {enabled && (
+        <div className="grid grid-cols-2 gap-2">
+          <IconField
+            label="Bonus / Level"
+            layout="column"
+            hint="0.15 = +15% per level above you"
+          >
+            <NumberInput
+              value={bonusPerLevel}
+              onCommit={(v) => patch({ bonusPerLevel: v ?? 0.15 })}
+              min={0}
+              step={0.05}
+              dense
+            />
+          </IconField>
+          <IconField
+            label="Max Bonus"
+            layout="column"
+            hint="0.5 = capped at +50%"
+          >
+            <NumberInput
+              value={maxBonus}
+              onCommit={(v) => patch({ maxBonus: v ?? 0.5 })}
+              min={0}
+              step={0.05}
+              dense
+            />
+          </IconField>
         </div>
       )}
     </div>

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -574,6 +574,16 @@ function parseDiminishingXp(raw: unknown): AppConfig["progression"]["xp"]["dimin
   };
 }
 
+function parseUnderLevelBonus(raw: unknown): AppConfig["progression"]["xp"]["underLevelBonus"] {
+  if (raw == null) return undefined;
+  const s = (raw ?? {}) as Record<string, unknown>;
+  return {
+    enabled: asBool(s.enabled, false),
+    bonusPerLevel: asNumber(s.bonusPerLevel, 0.15),
+    maxBonus: asNumber(s.maxBonus, 0.5),
+  };
+}
+
 function parseProgressionConfig(raw: unknown): AppConfig["progression"] {
   const s = (raw ?? {}) as Record<string, unknown>;
   const xp = (s.xp ?? {}) as Record<string, unknown>;
@@ -587,6 +597,7 @@ function parseProgressionConfig(raw: unknown): AppConfig["progression"] {
       multiplier: asNumber(xp.multiplier, 1.0),
       defaultKillXp: asNumber(xp.defaultKillXp, 50),
       diminishing: parseDiminishingXp(xp.diminishing),
+      underLevelBonus: parseUnderLevelBonus(xp.underLevelBonus),
     },
     rewards: {
       hpScalingRate: asNumber(rewards.hpScalingRate, 1.1),

--- a/creator/src/lib/tuning/presets.ts
+++ b/creator/src/lib/tuning/presets.ts
@@ -203,6 +203,11 @@ export const CASUAL_PRESET: TuningPreset = {
             { levelsBelow: 10, multiplier: 0.1 },
           ],
         },
+        underLevelBonus: {
+          enabled: true,
+          bonusPerLevel: 0.1,
+          maxBonus: 0.4,
+        },
       },
       rewards: {
         hpScalingRate: 1.3,
@@ -548,6 +553,11 @@ export const BALANCED_PRESET: TuningPreset = {
             { levelsBelow: 10, multiplier: 0.05 },
           ],
         },
+        underLevelBonus: {
+          enabled: true,
+          bonusPerLevel: 0.15,
+          maxBonus: 0.5,
+        },
       },
       rewards: {
         hpScalingRate: 1.3,
@@ -892,6 +902,11 @@ export const HARDCORE_PRESET: TuningPreset = {
             { levelsBelow: 10, multiplier: 0.0 },
           ],
         },
+        underLevelBonus: {
+          enabled: true,
+          bonusPerLevel: 0.25,
+          maxBonus: 1.0,
+        },
       },
       rewards: {
         hpScalingRate: 1.3,
@@ -1101,6 +1116,11 @@ export const SOLO_STORY_PRESET: TuningPreset = {
             { levelsBelow: 12, multiplier: 0.0 },
           ],
         },
+        underLevelBonus: {
+          enabled: true,
+          bonusPerLevel: 0.2,
+          maxBonus: 0.75,
+        },
       },
       rewards: { hpScalingRate: 1.097, manaScalingRate: 1.094, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 160, baseMana: 150 },
       quests: {
@@ -1183,6 +1203,11 @@ export const PVP_ARENA_PRESET: TuningPreset = {
             { levelsBelow: 8, multiplier: 0.0 },
           ],
         },
+        underLevelBonus: {
+          enabled: true,
+          bonusPerLevel: 0.15,
+          maxBonus: 0.5,
+        },
       },
       rewards: { hpScalingRate: 1.098, manaScalingRate: 1.095, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 135, baseMana: 125 },
       quests: {
@@ -1264,6 +1289,11 @@ export const LORE_EXPLORER_PRESET: TuningPreset = {
             { levelsBelow: 5, multiplier: 0.5 },
             { levelsBelow: 10, multiplier: 0.0 },
           ],
+        },
+        underLevelBonus: {
+          enabled: true,
+          bonusPerLevel: 0.15,
+          maxBonus: 0.5,
         },
       },
       rewards: { hpScalingRate: 1.097, manaScalingRate: 1.091, fullHealOnLevelUp: true, fullManaOnLevelUp: true, baseHp: 200, baseMana: 200 },

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -393,6 +393,14 @@ export interface DiminishingXpConfig {
   thresholds: DiminishingXpThreshold[];
 }
 
+export interface UnderLevelBonusConfig {
+  enabled: boolean;
+  /** Extra fraction of kill XP per level the mob is above the player (0.15 = +15%/level). */
+  bonusPerLevel: number;
+  /** Maximum total bonus fraction, regardless of how far above the player the mob is (0.5 = +50%). */
+  maxBonus: number;
+}
+
 export interface XpCurveConfig {
   baseXp: number;
   exponent: number;
@@ -401,6 +409,8 @@ export interface XpCurveConfig {
   defaultKillXp: number;
   /** Optional diminishing-returns curve when a player over-levels a mob. */
   diminishing?: DiminishingXpConfig;
+  /** Optional bonus XP when a player kills a mob above their own level. */
+  underLevelBonus?: UnderLevelBonusConfig;
 }
 
 export interface LevelRewardsConfig {


### PR DESCRIPTION
## Summary

The AmbonMUD server added extra XP for defeating mobs **above** the player's level. This adds the Arcanum-side config to author it, alongside the existing diminishing-returns penalty for killing under-leveled mobs.

New config under `progression.xp.underLevelBonus`:

```yaml
ambonMUD.progression.xp.underLevelBonus:
  enabled: true
  bonusPerLevel: 0.15   # +15% per level the mob is above you
  maxBonus: 0.5         # capped at +50%
```

## Changes

- **`types/config.ts`** — `UnderLevelBonusConfig` interface + optional `underLevelBonus` on `XpCurveConfig`, mirroring `diminishing`.
- **`lib/loader.ts`** — `parseUnderLevelBonus()` wired into `parseProgressionConfig` (defaults: enabled false, 0.15/0.5). Save path needs no change — `saveConfig` writes `config.progression` directly and `yaml.stringify` omits the field when unset, so it round-trips exactly like `diminishing`.
- **`components/config/panels/WorldPanel.tsx`** — new 'Under-Level Bonus' OrnateCard (card 6) with an `UnderLevelBonusEditor` (enable toggle + Bonus/Level + Max Bonus). Subsequent cards renumbered 7–12.
- **`lib/tuning/presets.ts`** — `underLevelBonus` added to all six presets, tuned to each (hardcore +25%/level cap +100%, casual +10%/+40%, rest default +15%/+50%).

## Verification

- `bunx tsc --noEmit` — clean
- `bun run test` — 2296 passed