### PR TITLE
fix(batch-art): expand @ references in batch image generation

### DIFF
--- a/creator/src/lib/__tests__/batchArt.test.ts
+++ b/creator/src/lib/__tests__/batchArt.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type { WorldFile } from "@/types/world";
 import type { AudioTrackMeta } from "@/lib/audioLibrary";
-import { collectTargets, getTargetPrompt, getTargetContext, assetTypeForKind, applyImageToWorld } from "@/lib/batchArt";
+import type { ReferenceSubject } from "@/types/reference";
+import { collectTargets, getTargetPrompt, getTargetContext, assetTypeForKind, applyImageToWorld, buildBatchUserPrompt } from "@/lib/batchArt";
+import { buildResolver } from "@/lib/referenceTokens";
 
 function makeWorld(rooms: WorldFile["rooms"]): WorldFile {
   return { zone: "parlor_zone", startRoom: "parlor_a", rooms };
@@ -93,5 +95,53 @@ describe("applyImageToWorld", () => {
     const world = makeWorld({ parlor_a: { title: "Parlor A", description: "" } });
     expect(applyImageToWorld(world, "room", "ghost", "x.png")).toBe(world);
     expect(applyImageToWorld(world, "mob", "absent", "x.png")).toBe(world);
+  });
+});
+
+describe("buildBatchUserPrompt — reference expansion", () => {
+  const subject: ReferenceSubject = {
+    id: "s1",
+    token: "aineroia",
+    name: "Aineroia",
+    category: "character",
+    appearance: "a silver-haired sentinel in obsidian plate",
+  };
+  const resolver = buildResolver([subject]);
+
+  it("expands @tokens and appends the canonical appearance block", () => {
+    const prompt = buildBatchUserPrompt(
+      'Mob "Guard" (id: guard)\nDescription: a loyal servant of @aineroia',
+      "A loyal servant of @aineroia, painterly.",
+      resolver,
+    );
+    // Sigils stripped to the display name in both context and base prompt.
+    expect(prompt).toContain("a loyal servant of Aineroia");
+    expect(prompt).not.toContain("@aineroia");
+    // Canonical appearance injected once, deduped across context + base.
+    expect(prompt).toContain("Canonical appearance references");
+    expect(prompt).toContain("Aineroia: a silver-haired sentinel in obsidian plate");
+    expect(prompt.match(/silver-haired sentinel/g)).toHaveLength(1);
+  });
+
+  it("matches the @[Display Name] bracket form", () => {
+    const prompt = buildBatchUserPrompt("", "A portrait of @[Aineroia].", resolver);
+    expect(prompt).toContain("A portrait of Aineroia.");
+    expect(prompt).toContain("a silver-haired sentinel in obsidian plate");
+  });
+
+  it("leaves unregistered tokens' sigils out and adds no block", () => {
+    const prompt = buildBatchUserPrompt("Description: near @nowhere", "A scene near @nowhere.", resolver);
+    expect(prompt).toContain("near nowhere");
+    expect(prompt).not.toContain("Canonical appearance references");
+  });
+
+  it("reproduces the prior raw prompt when the resolver is empty", () => {
+    const empty = buildResolver([]);
+    const context = 'Mob "Guard" (id: guard)\nDescription: a loyal servant';
+    const base = "A loyal servant, painterly.";
+    expect(buildBatchUserPrompt(context, base, empty)).toBe(
+      `Generate an image prompt for this entity:\n${context}\n\nReference style template (adapt but prioritize the entity description above):\n${base}`,
+    );
+    expect(buildBatchUserPrompt("", base, empty)).toBe(base);
   });
 });

--- a/creator/src/lib/batchArt.ts
+++ b/creator/src/lib/batchArt.ts
@@ -24,6 +24,9 @@ import { ENTITY_DIMENSIONS, requestsTransparentBackground, resolveImageModel, mo
 import { generateAssetImage } from "@/lib/imageGen";
 import { removeBgFromFileAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
 import { AI_ENABLED } from "@/lib/featureFlags";
+import { applyReferences, buildReferenceBlock, expandReferences } from "@/lib/referenceTokens";
+import type { ReferenceSubject } from "@/types/reference";
+import { useReferenceStore } from "@/stores/referenceStore";
 
 export function assetTypeForKind(kind: string): string {
   if (kind === "room") return "background";
@@ -291,6 +294,42 @@ export function getTargetContext(
   return entityContext(kind, id, entity);
 }
 
+/**
+ * Assemble the LLM enhancement user-prompt for one batch target. Expands any
+ * `@token` references in the entity context and base prompt to their canonical
+ * subject, and appends a canonical-appearance block so referenced subjects
+ * render consistently — parity with the single-entity path (`EntityArtGenerator`).
+ * With an empty resolver this reproduces the prior raw-context prompt verbatim.
+ */
+export function buildBatchUserPrompt(
+  context: string,
+  basePrompt: string,
+  resolver: Map<string, ReferenceSubject>,
+): string {
+  const used: ReferenceSubject[] = [];
+  const collect = (subs: ReferenceSubject[]) => {
+    for (const s of subs) if (!used.some((u) => u.id === s.id)) used.push(s);
+  };
+
+  const parts: string[] = [];
+  if (context) {
+    const ctx = expandReferences(context, resolver);
+    collect(ctx.used);
+    const base = expandReferences(basePrompt, resolver);
+    collect(base.used);
+    parts.push(`Generate an image prompt for this entity:\n${ctx.text}`);
+    parts.push(`\nReference style template (adapt but prioritize the entity description above):\n${base.text}`);
+  } else {
+    const base = expandReferences(basePrompt, resolver);
+    collect(base.used);
+    parts.push(base.text);
+  }
+
+  const block = buildReferenceBlock(used);
+  if (block) parts.push(`\n${block}`);
+  return parts.join("\n");
+}
+
 export interface ArtGenerationCallbacks {
   onTargetUpdate: (idx: number, update: Partial<BatchTarget>) => void;
   /**
@@ -337,6 +376,7 @@ export async function runBatchArtGeneration(
   const model = resolveImageModel(imageProvider, configuredModel);
   const nativeTransparency = modelNativelyTransparent(imageProvider, model?.id);
   const styleSuffix = getStyleSuffix("worldbuilding");
+  const resolver = useReferenceStore.getState().resolver();
 
   const worker = async () => {
     while (queue.length > 0 && !abortRef.current) {
@@ -352,18 +392,18 @@ export async function runBatchArtGeneration(
         const context = getTargetContext(target, world);
         const batchAssetType = assetTypeForKind(target.kind);
 
-        let finalPrompt = basePrompt;
+        // Reference-expanded base prompt is the fallback when LLM enhancement
+        // is unavailable or fails — raw `@tokens` must never reach the model.
+        let finalPrompt = applyReferences(basePrompt, resolver).prompt;
         try {
           const systemPrompt = getEnhanceSystemPrompt(artStyle, batchAssetType, "worldbuilding", nativeTransparency);
-          const userPrompt = context
-            ? `Generate an image prompt for this entity:\n${context}\n\nReference style template (adapt but prioritize the entity description above):\n${basePrompt}`
-            : basePrompt;
+          const userPrompt = buildBatchUserPrompt(context, basePrompt, resolver);
           finalPrompt = await invoke<string>("llm_complete", {
             systemPrompt,
             userPrompt,
           });
         } catch {
-          // Fall back to base prompt
+          // Fall back to the reference-expanded base prompt
         }
 
         // Append style suffix to ensure consistent aesthetic (matches individual path)


### PR DESCRIPTION
## Problem

Batch ("Batch Art" / zone-wide) image generation was **not** honoring `@token` references from the Reference Canon feature. Mob images in particular looked inaccurate because the referenced subject's canonical appearance was never injected.

## Root cause

Reference Canon (#302) wired `@token` expansion into the **single-entity** art path only (`EntityArtGenerator.enhancePromptWith`). The zone batch pipeline (`lib/batchArt.ts`) never imported the reference system at all — it built the LLM enhancement prompt inline from `mobContext()` / `mobPrompt()`, passing raw `@token` text straight through. This was a gap from day one of the feature, not a recent regression (#321's background-batch refactor touched no reference lines).

So: generating a mob from its editor expanded references correctly; regenerating the same mob via Batch Art silently dropped them.

## Fix

- New `buildBatchUserPrompt(context, basePrompt, resolver)` in `lib/batchArt.ts`, mirroring `EntityArtGenerator`: expands `@tokens` in both the entity context and the base prompt, dedupes referenced subjects, and appends the `buildReferenceBlock()` canonical-appearance block.
- The worker reads `useReferenceStore.getState().resolver()` once per batch run and uses the helper.
- The LLM-failure fallback now uses a **reference-expanded** base prompt (`applyReferences`) so raw sigils never reach the image model even when enhancement fails.
- With an empty resolver, the assembled prompt is byte-identical to the previous output (verified by test), so non-reference projects are unaffected.

This brings batch art for **every** entity type (mobs, items, rooms, …) to parity with single-generate.

## Testing

- `bunx tsc --noEmit` clean
- Full suite: 73 files / 2300 tests pass, including 4 new `buildBatchUserPrompt` cases (bare token, `@[Display Name]` bracket form, unregistered-token no-op, and empty-resolver byte-parity).