### PR TITLE
feat(batch-art): "Changed only" selector for stale entity art

### DIFF
--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -45,6 +45,11 @@ pub struct AssetEntry {
     pub lyrics: String,
     #[serde(default)]
     pub duration_seconds: f64,
+    /// Fingerprint of the entity render context this asset was generated from,
+    /// used to detect description changes since the last render. Empty for art
+    /// rendered before change-detection existed.
+    #[serde(default)]
+    pub source_hash: String,
 }
 
 fn default_sync_status() -> String {
@@ -127,6 +132,7 @@ pub async fn accept_asset(
     variant_group: Option<String>,
     is_active: Option<bool>,
     display_name: Option<String>,
+    source_hash: Option<String>,
 ) -> Result<AssetEntry, String> {
     let vg = variant_group.unwrap_or_default();
     let active = is_active.unwrap_or(!vg.is_empty());
@@ -151,6 +157,7 @@ pub async fn accept_asset(
         artist: String::new(),
         lyrics: String::new(),
         duration_seconds: 0.0,
+        source_hash: source_hash.unwrap_or_default(),
     };
 
     let _lock = MANIFEST_LOCK.lock().await;
@@ -487,6 +494,7 @@ pub async fn import_asset(
         artist: String::new(),
         lyrics: String::new(),
         duration_seconds,
+        source_hash: String::new(),
     };
 
     let _lock = MANIFEST_LOCK.lock().await;
@@ -705,6 +713,7 @@ pub async fn save_bytes_as_asset(
         artist: String::new(),
         lyrics: String::new(),
         duration_seconds: 0.0,
+        source_hash: String::new(),
     };
 
     manifest.assets.retain(|a| a.hash != entry.hash);
@@ -994,6 +1003,7 @@ pub async fn import_player_sprites(
             artist: String::new(),
             lyrics: String::new(),
             duration_seconds: 0.0,
+            source_hash: String::new(),
         };
 
         manifest.assets.push(entry);
@@ -1133,6 +1143,7 @@ pub async fn bulk_import_images(
             artist: String::new(),
             lyrics: String::new(),
             duration_seconds: 0.0,
+            source_hash: String::new(),
         };
 
         manifest.assets.push(asset_entry);
@@ -1234,6 +1245,7 @@ pub async fn flip_image(app: AppHandle, image_ref: String) -> Result<String, Str
             artist: String::new(),
             lyrics: String::new(),
             duration_seconds: 0.0,
+            source_hash: String::new(),
         };
 
         let vg = &entry.variant_group;

--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -15,6 +15,7 @@ import { generateAssetImageWithRetry } from "@/lib/imageGen";
 import { useReferenceStore } from "@/stores/referenceStore";
 import { ReferenceMentionField } from "@/components/ui/ReferenceMentionField";
 import { applyReferences, buildReferenceBlock, buildResolver, expandReferences } from "@/lib/referenceTokens";
+import { contentHash } from "@/lib/contentHash";
 import type { ReferenceSubject } from "@/types/reference";
 import { AssetPickerModal } from "./AssetPickerModal";
 import { removeBgAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
@@ -75,12 +76,13 @@ function autoAcceptImage(
   assetType: string | undefined,
   context: AssetContext | undefined,
   variantGroup: string,
+  sourceHash: string | undefined,
 ) {
   const fileName = img.file_path.split(/[\\/]/).pop() ?? img.hash;
   onAccept(fileName);
   if (assetType) {
     useAssetStore.getState().acceptAsset(
-      img, assetType, prompt ?? undefined, context, variantGroup, true,
+      img, assetType, prompt ?? undefined, context, variantGroup, true, true, sourceHash,
     ).catch(() => {});
   }
 }
@@ -170,6 +172,10 @@ export function EntityArtGenerator({
   // leaving these props stale in the click handler's closure.
   const entityContextRef = useRef(entityContext);
   entityContextRef.current = entityContext;
+  // Fingerprint the render context so batch art can later detect description
+  // changes against this asset's last render. Empty context → no fingerprint.
+  const sourceHashRef = useRef<string | undefined>(undefined);
+  sourceHashRef.current = entityContext ? contentHash(entityContext) : undefined;
   const framingHintRef = useRef(framingHint);
   framingHintRef.current = framingHint;
   const getPromptRef = useRef(getPrompt);
@@ -182,7 +188,7 @@ export function EntityArtGenerator({
       mountedRef.current = false;
       const img = pendingResultRef.current;
       if (!img) return;
-      autoAcceptImage(img, pendingPromptRef.current, onAcceptRef.current, assetTypeRef.current, contextRef.current, variantGroupRef.current);
+      autoAcceptImage(img, pendingPromptRef.current, onAcceptRef.current, assetTypeRef.current, contextRef.current, variantGroupRef.current, sourceHashRef.current);
     };
   }, []);
 
@@ -360,7 +366,7 @@ export function EntityArtGenerator({
         negativePrompt: getNegativePrompt(assetType),
       });
       if (!mountedRef.current) {
-        autoAcceptImage(image, finalPrompt, onAcceptRef.current, assetTypeRef.current, contextRef.current, variantGroupRef.current);
+        autoAcceptImage(image, finalPrompt, onAcceptRef.current, assetTypeRef.current, contextRef.current, variantGroupRef.current, sourceHashRef.current);
         return;
       }
       pendingResultRef.current = image;
@@ -445,7 +451,7 @@ export function EntityArtGenerator({
     const savedDataUrl = result.data_url;
     onAccept(fileName);
     if (assetType) {
-      await acceptAsset(result, assetType, lastEnhancedPrompt ?? undefined, context, variantGroup, true).catch(() => {});
+      await acceptAsset(result, assetType, lastEnhancedPrompt ?? undefined, context, variantGroup, true, true, sourceHashRef.current).catch(() => {});
     }
     setStage("idle");
     setResult(null);

--- a/creator/src/components/zone/BatchArtGenerator.tsx
+++ b/creator/src/components/zone/BatchArtGenerator.tsx
@@ -86,6 +86,7 @@ function BatchArtPanel() {
   const selectAll = useBatchArtStore((s) => s.selectAll);
   const selectNone = useBatchArtStore((s) => s.selectNone);
   const selectMissing = useBatchArtStore((s) => s.selectMissing);
+  const selectChanged = useBatchArtStore((s) => s.selectChanged);
   const setConcurrency = useBatchArtStore((s) => s.setConcurrency);
   const start = useBatchArtStore((s) => s.start);
   const abort = useBatchArtStore((s) => s.abort);
@@ -93,6 +94,7 @@ function BatchArtPanel() {
   const { targets, running, bgRemoval, concurrency, zoneId } = job;
   const checkedTargets = targets.filter((t) => t.checked);
   const missingTargets = targets.filter((t) => !t.hasExisting);
+  const changedTargets = targets.filter((t) => t.descriptionChanged);
   const doneCount = targets.filter((t) => t.status === "done").length;
   const errorCount = targets.filter((t) => t.status === "error").length;
   const imageProvider = settings?.image_provider ?? "deepinfra";
@@ -159,6 +161,17 @@ function BatchArtPanel() {
                 {missingTargets.length < targets.length && (
                   <ActionButton onClick={selectMissing} variant="ghost" size="sm" className="min-h-9 px-3">
                     Missing only
+                  </ActionButton>
+                )}
+                {changedTargets.length > 0 && (
+                  <ActionButton
+                    onClick={selectChanged}
+                    variant="ghost"
+                    size="sm"
+                    className="min-h-9 px-3"
+                    title="Select entities whose description changed since their art was last generated"
+                  >
+                    Changed only ({changedTargets.length})
                   </ActionButton>
                 )}
               </div>
@@ -249,8 +262,14 @@ function BatchArtPanel() {
                 <span className="min-w-0 flex-1 truncate text-text-secondary">
                   {target.label}
                 </span>
-                {target.hasExisting && target.status === "pending" && (
-                  <span className="text-2xs text-status-success">has art</span>
+                {target.descriptionChanged && target.status === "pending" ? (
+                  <span className="text-2xs text-warm" title="Description changed since last render">
+                    description changed
+                  </span>
+                ) : (
+                  target.hasExisting && target.status === "pending" && (
+                    <span className="text-2xs text-status-success">has art</span>
+                  )
                 )}
                 {target.error && (
                   <span className="truncate text-2xs text-status-error" title={target.error}>

--- a/creator/src/lib/__tests__/batchArt.test.ts
+++ b/creator/src/lib/__tests__/batchArt.test.ts
@@ -2,11 +2,44 @@ import { describe, it, expect } from "vitest";
 import type { WorldFile } from "@/types/world";
 import type { AudioTrackMeta } from "@/lib/audioLibrary";
 import type { ReferenceSubject } from "@/types/reference";
-import { collectTargets, getTargetPrompt, getTargetContext, assetTypeForKind, applyImageToWorld, buildBatchUserPrompt } from "@/lib/batchArt";
+import type { AssetEntry } from "@/types/assets";
+import { collectTargets, getTargetPrompt, getTargetContext, getTargetSourceHash, assetTypeForKind, applyImageToWorld, buildBatchUserPrompt } from "@/lib/batchArt";
 import { buildResolver } from "@/lib/referenceTokens";
 
 function makeWorld(rooms: WorldFile["rooms"]): WorldFile {
   return { zone: "parlor_zone", startRoom: "parlor_a", rooms };
+}
+
+function mobAsset(variantGroup: string, sourceHash: string): AssetEntry {
+  return {
+    id: "a1",
+    hash: "h1",
+    prompt: "",
+    enhanced_prompt: "",
+    model: "flux",
+    asset_type: "mob",
+    context: { zone: "parlor_zone", entity_type: "mob", entity_id: "goblin" },
+    created_at: "2026-01-01T00:00:00Z",
+    file_name: "h1.png",
+    width: 1024,
+    height: 1024,
+    sync_status: "local",
+    variant_group: variantGroup,
+    is_active: true,
+    display_name: "",
+    description: "",
+    artist: "",
+    lyrics: "",
+    duration_seconds: 0,
+    source_hash: sourceHash,
+  };
+}
+
+function worldWithGoblin(description: string): WorldFile {
+  return {
+    ...makeWorld({ parlor_a: { title: "Parlor A", description: "" } }),
+    mobs: { goblin: { name: "Goblin", description, image: "mobs/goblin.png" } as WorldFile["mobs"][string] },
+  };
 }
 
 const meta: Map<string, AudioTrackMeta> = new Map([
@@ -143,5 +176,45 @@ describe("buildBatchUserPrompt — reference expansion", () => {
       `Generate an image prompt for this entity:\n${context}\n\nReference style template (adapt but prioritize the entity description above):\n${base}`,
     );
     expect(buildBatchUserPrompt("", base, empty)).toBe(base);
+  });
+});
+
+describe("collectTargets — description change detection", () => {
+  const variantGroup = "mob:parlor_zone:goblin";
+
+  it("flags an entity whose context drifted from its last stamped render", () => {
+    const stale = worldWithGoblin("a small goblin");
+    const staleHash = getTargetSourceHash(collectTargets(stale).find((t) => t.kind === "mob")!, stale);
+    const world = worldWithGoblin("now a towering ogre");
+    const targets = collectTargets(world, undefined, [mobAsset(variantGroup, staleHash)]);
+    const goblin = targets.find((t) => t.kind === "mob")!;
+    expect(goblin.descriptionChanged).toBe(true);
+    // Changed entities are pre-selected so they surface on open.
+    expect(goblin.checked).toBe(true);
+  });
+
+  it("does not flag when the stored fingerprint matches the current context", () => {
+    const world = worldWithGoblin("a small goblin");
+    const currentHash = getTargetSourceHash(collectTargets(world).find((t) => t.kind === "mob")!, world);
+    const targets = collectTargets(world, undefined, [mobAsset(variantGroup, currentHash)]);
+    const goblin = targets.find((t) => t.kind === "mob")!;
+    expect(goblin.descriptionChanged).toBeFalsy();
+    // Existing art with no change stays unselected.
+    expect(goblin.checked).toBe(false);
+  });
+
+  it("treats pre-feature art (no stamped fingerprint) as up to date", () => {
+    const world = worldWithGoblin("a small goblin");
+    const targets = collectTargets(world, undefined, [mobAsset(variantGroup, "")]);
+    const goblin = targets.find((t) => t.kind === "mob")!;
+    expect(goblin.descriptionChanged).toBeFalsy();
+    expect(goblin.checked).toBe(false);
+  });
+
+  it("ignores fingerprints from a different variant group", () => {
+    const world = worldWithGoblin("a small goblin");
+    const targets = collectTargets(world, undefined, [mobAsset("mob:other_zone:goblin", "deadbeef")]);
+    const goblin = targets.find((t) => t.kind === "mob")!;
+    expect(goblin.descriptionChanged).toBeFalsy();
   });
 });

--- a/creator/src/lib/batchArt.ts
+++ b/creator/src/lib/batchArt.ts
@@ -13,17 +13,19 @@ import {
   musicBoxKeepsakeContext,
 } from "@/lib/entityPrompts";
 import type { AudioTrackMeta } from "@/lib/audioLibrary";
+import { splitLyricsLines } from "@/lib/audioLibrary";
 import {
   getNegativePrompt,
   getEnhanceSystemPrompt,
   getStyleSuffix,
   type ArtStyle,
 } from "@/lib/arcanumPrompts";
-import type { GeneratedImage } from "@/types/assets";
+import type { GeneratedImage, AssetEntry, AssetContext } from "@/types/assets";
 import { ENTITY_DIMENSIONS, requestsTransparentBackground, resolveImageModel, modelNativelyTransparent } from "@/types/assets";
 import { generateAssetImage } from "@/lib/imageGen";
 import { removeBgFromFileAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
 import { AI_ENABLED } from "@/lib/featureFlags";
+import { contentHash } from "@/lib/contentHash";
 import { applyReferences, buildReferenceBlock, expandReferences } from "@/lib/referenceTokens";
 import type { ReferenceSubject } from "@/types/reference";
 import { useReferenceStore } from "@/stores/referenceStore";
@@ -48,15 +50,60 @@ export interface BatchTarget {
   hasExisting: boolean;
   status: "pending" | "generating" | "done" | "error";
   error?: string;
+  /** True when the entity's render context changed since its art was last
+   *  generated (only ever set for targets that already have art and whose last
+   *  render stamped a source fingerprint — see {@link collectTargets}). */
+  descriptionChanged?: boolean;
   /** For `musicBoxKeepsake` targets: the song the lyric-sheet commemorates,
    *  resolved from the audio library at collect time (the prompt needs it, and
    *  an in-editor music box is a bare `{ file }` until save-time enrichment). */
-  song?: { title: string; artist?: string };
+  song?: { title: string; artist?: string; lyrics?: string[] };
+}
+
+/** The manifest context an asset is filed under for a given batch target. */
+export function batchAssetContext(kind: string, id: string, zoneId: string): AssetContext {
+  // Keepsakes share the per-room music-box editor's manifest identity so
+  // variants from either authoring path land in the same group.
+  if (kind === "musicBoxKeepsake") {
+    return { zone: zoneId, entity_type: "item", entity_id: `musicbox:${id}` };
+  }
+  return { zone: zoneId, entity_type: kind, entity_id: id };
+}
+
+export function variantGroupForContext(ctx: AssetContext): string {
+  return `${ctx.entity_type}:${ctx.zone}:${ctx.entity_id}`;
+}
+
+/**
+ * Fingerprint of the render context for a target — what the art was generated
+ * from. Stamped on each accepted asset and compared at collect time to detect
+ * description changes. Matches the single-entity path, which hashes the same
+ * `entityContext` string it feeds the LLM.
+ */
+export function getTargetSourceHash(target: BatchTarget, world: WorldFile): string {
+  return contentHash(getTargetContext(target, world));
+}
+
+/**
+ * The source fingerprint of the most recent render in a variant group, or
+ * undefined if none was stamped. Reads across the whole group (not just the
+ * active asset) so background-removed variants — which inherit the group but
+ * carry no fingerprint of their own — don't mask the original render's hash.
+ */
+function latestSourceHash(assets: AssetEntry[], variantGroup: string): string | undefined {
+  let best: AssetEntry | undefined;
+  for (const a of assets) {
+    if (a.variant_group !== variantGroup || !a.source_hash) continue;
+    if (!best || a.created_at > best.created_at) best = a;
+  }
+  return best?.source_hash;
 }
 
 export function collectTargets(
   world: WorldFile,
   audioMeta?: Map<string, AudioTrackMeta>,
+  assets: AssetEntry[] = [],
+  zoneId: string = world.zone,
 ): BatchTarget[] {
   const targets: BatchTarget[] = [];
 
@@ -79,6 +126,9 @@ export function collectTargets(
     const title = meta?.name ?? box.title ?? "";
     const songLabel = title.trim() || box.file;
     const hasImage = !!box.image;
+    // Mirror RoomPanel's keepsake context so the source fingerprint matches
+    // whichever path last rendered it.
+    const lyrics = meta?.lyrics ? splitLyricsLines(meta.lyrics) : box.lyrics;
     targets.push({
       kind: "musicBoxKeepsake",
       id,
@@ -86,7 +136,7 @@ export function collectTargets(
       checked: !hasImage,
       hasExisting: hasImage,
       status: "pending",
-      song: { title, artist: meta?.artist ?? box.artist },
+      song: { title, artist: meta?.artist ?? box.artist, lyrics },
     });
   }
 
@@ -162,6 +212,21 @@ export function collectTargets(
           hasExisting: hasImage,
           status: "pending",
         });
+      }
+    }
+  }
+
+  // Flag targets whose render context drifted from their last stamped render.
+  // Only entities with existing art and a stamped fingerprint can be "changed";
+  // pre-feature art carries no fingerprint and is treated as up to date.
+  if (assets.length > 0) {
+    for (const t of targets) {
+      if (!t.hasExisting) continue;
+      const stored = latestSourceHash(assets, variantGroupForContext(batchAssetContext(t.kind, t.id, zoneId)));
+      if (!stored) continue;
+      if (stored !== getTargetSourceHash(t, world)) {
+        t.descriptionChanged = true;
+        t.checked = true;
       }
     }
   }
@@ -277,7 +342,7 @@ export function getTargetContext(
     return roomContext(id, world.rooms[id]!);
   }
   if (kind === "musicBoxKeepsake") {
-    return musicBoxKeepsakeContext(target.song?.title ?? "", target.song?.artist);
+    return musicBoxKeepsakeContext(target.song?.title ?? "", target.song?.artist, target.song?.lyrics);
   }
   if (kind === "dungeon" && world.dungeon) {
     return dungeonContext(world.dungeon, world.zone);
@@ -347,6 +412,7 @@ export interface ArtGenerationCallbacks {
     context: { zone: string; entity_type: string; entity_id: string },
     variantGroup: string,
     isActive: boolean,
+    sourceHash: string,
   ) => Promise<void>;
 }
 
@@ -433,14 +499,8 @@ export async function runBatchArtGeneration(
 
         callbacks.onTargetUpdate(idx, { status: "done" });
 
-        // Keepsakes share the per-room music-box editor's manifest identity
-        // (entity_type "item", entity_id "musicbox:<roomId>") so variants from
-        // either authoring path land in the same group.
-        const batchContext =
-          target.kind === "musicBoxKeepsake"
-            ? { zone: zoneId, entity_type: "item", entity_id: `musicbox:${target.id}` }
-            : { zone: zoneId, entity_type: target.kind, entity_id: target.id };
-        const variantGroup = `${batchContext.entity_type}:${zoneId}:${batchContext.entity_id}`;
+        const batchContext = batchAssetContext(target.kind, target.id, zoneId);
+        const variantGroup = variantGroupForContext(batchContext);
         await callbacks
           .acceptAsset(
             image,
@@ -449,6 +509,7 @@ export async function runBatchArtGeneration(
             batchContext,
             variantGroup,
             true,
+            getTargetSourceHash(target, world),
           )
           .catch(() => {});
 

--- a/creator/src/lib/contentHash.ts
+++ b/creator/src/lib/contentHash.ts
@@ -1,0 +1,16 @@
+/**
+ * Stable, fast, non-cryptographic hash of a string → 8-char hex.
+ *
+ * Used to fingerprint the entity context an asset was rendered from, so batch
+ * art can flag entities whose description changed since their last render. A
+ * collision merely misses a "changed" flag (never corrupts data), so FNV-1a is
+ * more than sufficient and avoids pulling in async SubtleCrypto.
+ */
+export function contentHash(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}

--- a/creator/src/stores/assetStore.ts
+++ b/creator/src/stores/assetStore.ts
@@ -52,7 +52,7 @@ interface AssetState {
   saveProjectSettings: (projectDir: string, settings: ProjectSettings) => Promise<void>;
 
   loadAssets: () => Promise<void>;
-  acceptAsset: (image: GeneratedImage, assetType: string, enhancedPrompt?: string, context?: AssetContext, variantGroup?: string, isActive?: boolean, reload?: boolean) => Promise<void>;
+  acceptAsset: (image: GeneratedImage, assetType: string, enhancedPrompt?: string, context?: AssetContext, variantGroup?: string, isActive?: boolean, reload?: boolean, sourceHash?: string) => Promise<void>;
   importAsset: (
     sourcePath: string,
     assetType: string,
@@ -138,7 +138,7 @@ export const useAssetStore = create<AssetState>((set, get) => ({
     set({ assets });
   },
 
-  acceptAsset: async (image, assetType, enhancedPrompt, context, variantGroup, isActive, reload = true) => {
+  acceptAsset: async (image, assetType, enhancedPrompt, context, variantGroup, isActive, reload = true, sourceHash) => {
     const fileName = image.file_path.split(/[\\/]/).pop() ?? image.hash;
 
     await invoke<AssetEntry>("accept_asset", {
@@ -154,6 +154,7 @@ export const useAssetStore = create<AssetState>((set, get) => ({
       height: image.height,
       variantGroup: variantGroup ?? null,
       isActive: isActive ?? null,
+      sourceHash: sourceHash ?? null,
     });
     // Reloading the whole manifest after every accept is O(n²) across a batch
     // (each reload marshals the entire AssetEntry[] over IPC into the WebView).

--- a/creator/src/stores/batchArtStore.ts
+++ b/creator/src/stores/batchArtStore.ts
@@ -40,6 +40,8 @@ interface BatchArtStore {
   selectAll: () => void;
   selectNone: () => void;
   selectMissing: () => void;
+  /** Select only targets whose render context changed since their last render. */
+  selectChanged: () => void;
   setConcurrency: (n: number) => void;
 
   /** Kick off generation for the checked targets. Runs in the background. */
@@ -66,8 +68,9 @@ export const useBatchArtStore = create<BatchArtStore>((set, get) => ({
 
     const zone = useZoneStore.getState().zones.get(zoneId);
     if (!zone) return;
-    const audioMeta = buildAudioMetaIndex(useAssetStore.getState().assets);
-    const targets = collectTargets(zone.data, audioMeta);
+    const assets = useAssetStore.getState().assets;
+    const audioMeta = buildAudioMetaIndex(assets);
+    const targets = collectTargets(zone.data, audioMeta, assets, zoneId);
     const concurrency = useAssetStore.getState().settings?.batch_concurrency ?? 5;
 
     set({
@@ -117,6 +120,18 @@ export const useBatchArtStore = create<BatchArtStore>((set, get) => ({
             job: {
               ...s.job,
               targets: s.job.targets.map((t) => ({ ...t, checked: !t.hasExisting })),
+            },
+          }
+        : s,
+    ),
+
+  selectChanged: () =>
+    set((s) =>
+      s.job && !s.job.running
+        ? {
+            job: {
+              ...s.job,
+              targets: s.job.targets.map((t) => ({ ...t, checked: !!t.descriptionChanged })),
             },
           }
         : s,
@@ -177,7 +192,7 @@ export const useBatchArtStore = create<BatchArtStore>((set, get) => ({
           set((s) => (s.job ? { job: { ...s.job, bgRemoval: { done, total } } } : s)),
         // reload=false: skip the per-image manifest reload (O(n²) on big zones —
         // it OOMs the WebView). The whole batch refreshes once on completion.
-        acceptAsset: (image, assetType, enhancedPrompt, context, variantGroup, isActive) =>
+        acceptAsset: (image, assetType, enhancedPrompt, context, variantGroup, isActive, sourceHash) =>
           asset.acceptAsset(
             image,
             assetType,
@@ -186,6 +201,7 @@ export const useBatchArtStore = create<BatchArtStore>((set, get) => ({
             variantGroup,
             isActive,
             false,
+            sourceHash,
           ),
       },
       settings?.auto_remove_bg,

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -31,6 +31,9 @@ export interface AssetEntry {
   artist: string;
   lyrics: string;
   duration_seconds: number;
+  /** Fingerprint of the entity render context this asset was generated from.
+   *  Empty/absent for art rendered before change-detection was introduced. */
+  source_hash?: string;
 }
 
 export interface AssetContext {


### PR DESCRIPTION
## What

Adds a new "Select All" mode in **Batch Art** — **Changed only** — that selects every entity whose description changed since its art was last rendered. One click to re-render everything that's gone stale, instead of hunting entity by entity.

Per the request, this assumes preexisting art has not changed: only renders that happen *after this lands* are fingerprinted, and only fingerprinted art can be flagged as changed.

## How it works

- Each accepted asset now stores a **source fingerprint** — an FNV-1a hash of the entity *context string* (the exact text fed to the art LLM, e.g. `mobContext`/`itemContext`/`roomContext`). This is stamped on **both** render paths:
  - Batch generation (`runBatchArtGeneration`)
  - Single-entity generation (`EntityArtGenerator`, used by the mob/item/room/keepsake editors and everything else)
- `collectTargets` computes the current context hash for each entity and compares it to the **latest stamped hash in the asset's variant group**. Reading across the whole group (not just the active asset) means a background-removed variant — which inherits the group but carries no fingerprint of its own — doesn't mask the original render's hash.
- Changed targets are flagged (`descriptionChanged`), **pre-selected** when the panel opens, and badged **"description changed"** in the list. A new **Changed only (N)** button appears when any target is stale.

Because both render paths build context with the same `entityContext` functions, editing a mob's description in the editor (without re-rendering) and then opening Batch Art correctly surfaces it as changed.

## Storage

New `source_hash` field on `AssetEntry` (Rust + TS), `#[serde(default)]` so old manifests load unchanged. Threaded through `accept_asset` and `assetStore.acceptAsset` as a trailing optional param — existing callers are unaffected.

## Tests

- New `contentHash` util.
- 4 new `collectTargets` change-detection tests (drift flagged + pre-selected, matching hash not flagged, pre-feature empty fingerprint treated as up to date, cross-variant-group fingerprints ignored).
- `bunx tsc --noEmit` clean · `bun run test` 2304 passing · `cargo check` clean.

## Notes / caveats

- The fingerprint covers the full entity context (description plus prompt-driving metadata like tier/level/slot), so a change to those also marks art stale — i.e. "the inputs to the art changed," which is the intent.
- If a future code change edits the constant prompt directives in the context builders, fingerprints shift and entities may show as changed once. Non-destructive — the user reviews the pre-selected list before generating.