### PR TITLE
perf(zone): cap concurrent thumbnail decodes on zone load

### DIFF
--- a/creator/src-tauri/Cargo.toml
+++ b/creator/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ hmac = "0.12"
 hex = "0.4"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1", features = ["fs", "process"] }
+tokio = { version = "1", features = ["fs", "process", "sync"] }
 tauri-plugin-window-state = "2.4.1"
 imagesize = "0.13"
 regex = "1"

--- a/creator/src-tauri/src/fs_utils.rs
+++ b/creator/src-tauri/src/fs_utils.rs
@@ -109,6 +109,24 @@ fn thumbnail_cache() -> &'static Mutex<HashMap<String, String>> {
     THUMBNAIL_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Bounds how many thumbnail decodes run concurrently. A zone load fires one
+/// IPC per visible room background + entity sprite all at once; without a cap
+/// every one of those spawns a CPU-heavy `image::load_from_memory` + resize +
+/// WebP encode on the blocking pool simultaneously, saturating every core and
+/// spiking memory (each decode transiently holds a full-resolution bitmap).
+/// Capping to roughly half the cores keeps the UI responsive while the queue
+/// drains.
+static DECODE_SEMAPHORE: OnceLock<tokio::sync::Semaphore> = OnceLock::new();
+
+fn decode_semaphore() -> &'static tokio::sync::Semaphore {
+    DECODE_SEMAPHORE.get_or_init(|| {
+        let cores = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4);
+        tokio::sync::Semaphore::new((cores / 2).max(2))
+    })
+}
+
 /// Generous upper bound; thumbnails are ~10–40 KB each, so a full cache is a
 /// few tens of MB. Cleared wholesale rather than LRU-evicted — re-encoding on
 /// the rare overflow is cheaper than tracking recency on every hit.
@@ -158,6 +176,14 @@ pub async fn read_image_thumbnail_data_url(path: String, max_dim: u32) -> Result
     {
         return Ok(hit.clone());
     }
+
+    // Gate the expensive decode behind the semaphore so a zone-load burst of
+    // requests drains a few at a time instead of all at once. Cache hits above
+    // return before reaching here, so warm images never wait on the queue.
+    let _permit = decode_semaphore()
+        .acquire()
+        .await
+        .map_err(|e| format!("Decode semaphore closed: {e}"))?;
 
     let bytes = tokio::fs::read(&path)
         .await

--- a/creator/src/lib/useImageSrc.ts
+++ b/creator/src/lib/useImageSrc.ts
@@ -27,13 +27,47 @@ function cacheKey(path: string, maxDim?: number): string {
   return maxDim ? `${path}${KEY_SEP}${maxDim}` : path;
 }
 
+/**
+ * Bound how many image IPCs are in flight at once. A zone load mounts dozens of
+ * ReactFlow nodes that each request a background + entity sprites in the same
+ * tick; firing them all together floods the IPC channel and forces the backend
+ * to hold many full-resolution decodes (and their base64 blobs) in memory
+ * simultaneously. Draining a handful at a time keeps the app responsive without
+ * changing total work. The backend has its own decode semaphore as the
+ * authoritative guard; this just stops us from queuing a huge burst across IPC.
+ */
+const MAX_INFLIGHT_IMAGE_IPCS = 6;
+let inflightImageIpcs = 0;
+const imageIpcQueue: (() => void)[] = [];
+
+function runNextImageIpc(): void {
+  if (inflightImageIpcs >= MAX_INFLIGHT_IMAGE_IPCS) return;
+  const next = imageIpcQueue.shift();
+  if (!next) return;
+  inflightImageIpcs++;
+  next();
+}
+
+function invokeImageIpc(path: string, maxDim?: number): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    imageIpcQueue.push(() => {
+      const call = maxDim
+        ? invoke<string>("read_image_thumbnail_data_url", { path, maxDim })
+        : invoke<string>("read_image_data_url", { path });
+      call.then(resolve, reject).finally(() => {
+        inflightImageIpcs--;
+        runNextImageIpc();
+      });
+    });
+    runNextImageIpc();
+  });
+}
+
 function fetchImageDataUrl(path: string, maxDim?: number): Promise<string> {
   const key = cacheKey(path, maxDim);
   const cached = imageDataUrlCache.get(key);
   if (cached) return cached;
-  const promise = maxDim
-    ? invoke<string>("read_image_thumbnail_data_url", { path, maxDim })
-    : invoke<string>("read_image_data_url", { path });
+  const promise = invokeImageIpc(path, maxDim);
   imageDataUrlCache.set(key, promise);
   promise.then(
     (dataUrl) => resolvedImageCache.set(key, dataUrl),


### PR DESCRIPTION
## Problem

Loading a new zone in the editor thrashes the whole system for ~30s, consuming all CPU/memory.

## Root cause

On zone load, every visible `RoomNode` fires a `read_image_thumbnail_data_url` IPC for its background plus one per entity sprite — all in the same render tick, with **no concurrency cap**. Each cold call does a full multi-MB PNG decode + resize + WebP encode via `spawn_blocking` (`fs_utils.rs`). Tokio's blocking pool happily runs dozens at once, saturating every core and spiking memory (each decode transiently holds a full-resolution bitmap + base64 blob).

Existing caches (JS module cache + Rust mtime-keyed thumbnail cache) only help *repeat* loads — a cold zone pays the full storm.

## Fix

Two-sided concurrency cap. Total work is unchanged; it just drains a few at a time instead of all at once.

- **Backend** (`fs_utils.rs`): a global `tokio::sync::Semaphore` sized to ~half the cores (min 2) gates the decode. Cache hits return *before* acquiring, so warm images never queue. Adds the tokio `sync` feature.
- **Frontend** (`useImageSrc.ts`): a small queue bounds image IPCs to 6 in flight, so we stop firing a huge burst across the IPC channel at once. The backend semaphore is the authoritative guard; this reduces channel/memory pressure.

## Verification

- `cargo check` ✅
- `bunx tsc --noEmit` ✅
- `bun run test` — 2300 passed ✅

Manual: open a cold zone with many rooms/sprites and confirm CPU stays bounded and the UI stays responsive while thumbnails fill in progressively.

## Tuning notes

If `6` (frontend) or `cores/2` (backend) feels too conservative/aggressive on your hardware, both are single constants (`MAX_INFLIGHT_IMAGE_IPCS`, `decode_semaphore`).