### PR TITLE
fix(editors): call hooks unconditionally in entity editors

### DIFF
--- a/creator/src/components/editors/DialogueEditor.tsx
+++ b/creator/src/components/editors/DialogueEditor.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useState } from "react";
 import type {
   WorldFile,
+  MobFile,
   DialogueNodeFile,
   DialogueChoiceFile,
 } from "@/types/world";
@@ -20,14 +21,22 @@ interface DialogueEditorProps {
   onWorldChange: (world: WorldFile) => void;
 }
 
-export function DialogueEditor({
+export function DialogueEditor(props: DialogueEditorProps) {
+  const mob = props.world.mobs?.[props.mobId];
+  if (!mob) return null;
+  return <DialogueEditorContent {...props} mob={mob} />;
+}
+
+interface DialogueEditorContentProps extends DialogueEditorProps {
+  mob: MobFile;
+}
+
+function DialogueEditorContent({
   mobId,
   world,
   onWorldChange,
-}: DialogueEditorProps) {
-  const mob = world.mobs?.[mobId];
-  if (!mob) return null;
-
+  mob,
+}: DialogueEditorContentProps) {
   const dialogue = mob.dialogue ?? {};
   const nodeIds = Object.keys(dialogue);
 

--- a/creator/src/components/editors/GatheringNodeEditor.tsx
+++ b/creator/src/components/editors/GatheringNodeEditor.tsx
@@ -35,24 +35,44 @@ const FALLBACK_GATHERING_SKILLS = [
   { value: "herbalism", label: "Herbalism" },
 ];
 
-export function GatheringNodeEditor({
-  nodeId,
-  world,
-  onWorldChange,
-  onDelete,
-  zoneId,
-}: GatheringNodeEditorProps) {
-  const { entity: node, patch, handleDelete, rooms } =
+export function GatheringNodeEditor(props: GatheringNodeEditorProps) {
+  const { entity, patch, handleDelete, rooms } =
     useEntityEditor<GatheringNodeFile>(
-      world,
-      nodeId,
-      (w) => w.gatheringNodes?.[nodeId],
+      props.world,
+      props.nodeId,
+      (w) => w.gatheringNodes?.[props.nodeId],
       updateGatheringNode,
       deleteGatheringNode,
-      onWorldChange,
-      onDelete,
+      props.onWorldChange,
+      props.onDelete,
     );
+  if (!entity) return null;
+  return (
+    <GatheringNodeEditorContent
+      {...props}
+      node={entity}
+      patch={patch}
+      handleDelete={handleDelete}
+      rooms={rooms}
+    />
+  );
+}
 
+interface GatheringNodeEditorContentProps extends GatheringNodeEditorProps {
+  node: GatheringNodeFile;
+  patch: (p: Partial<GatheringNodeFile>) => void;
+  handleDelete: () => void;
+  rooms: { value: string; label: string }[];
+}
+
+function GatheringNodeEditorContent({
+  nodeId,
+  zoneId,
+  node,
+  patch,
+  handleDelete,
+  rooms,
+}: GatheringNodeEditorContentProps) {
   const craftingSkills = useConfigStore((s) => s.config?.craftingSkills);
   const gatheringSkills = useMemo(() => {
     if (!craftingSkills) return undefined;
@@ -63,8 +83,6 @@ export function GatheringNodeEditor({
     return Object.keys(filtered).length > 0 ? filtered : undefined;
   }, [craftingSkills]);
   const gatheringSkillOptions = useConfigOptions(gatheringSkills, FALLBACK_GATHERING_SKILLS);
-
-  if (!node) return null;
 
   // ─── Yield helpers ────────────────────────────────────────────
   const {

--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -46,24 +46,45 @@ const ITEM_TABS: readonly { value: ItemTab; label: string }[] = [
   { value: "media", label: "Media" },
 ] as const;
 
-export function ItemEditor({
-  itemId,
-  zoneId,
-  world,
-  onWorldChange,
-  onDelete,
-  onDuplicate,
-}: ItemEditorProps) {
-  const [activeTab, setActiveTab] = useState<ItemTab>("item");
-  const { entity: item, patch, handleDelete, rooms } = useEntityEditor<ItemFile>(
-    world,
-    itemId,
-    (w) => w.items?.[itemId],
+export function ItemEditor(props: ItemEditorProps) {
+  const { entity, patch, handleDelete, rooms } = useEntityEditor<ItemFile>(
+    props.world,
+    props.itemId,
+    (w) => w.items?.[props.itemId],
     updateItem,
     deleteItem,
-    onWorldChange,
-    onDelete,
+    props.onWorldChange,
+    props.onDelete,
   );
+  if (!entity) return null;
+  return (
+    <ItemEditorContent
+      {...props}
+      item={entity}
+      patch={patch}
+      handleDelete={handleDelete}
+      rooms={rooms}
+    />
+  );
+}
+
+interface ItemEditorContentProps extends ItemEditorProps {
+  item: ItemFile;
+  patch: (p: Partial<ItemFile>) => void;
+  handleDelete: () => void;
+  rooms: { value: string; label: string }[];
+}
+
+function ItemEditorContent({
+  itemId,
+  zoneId,
+  onDuplicate,
+  item,
+  patch,
+  handleDelete,
+  rooms,
+}: ItemEditorContentProps) {
+  const [activeTab, setActiveTab] = useState<ItemTab>("item");
   const equipmentSlots = useConfigStore((s) => s.config?.equipmentSlots);
   const slotOptions = useConfigOptions(equipmentSlots, [
     { value: "head", label: "Head" },
@@ -132,8 +153,6 @@ export function ItemEditor({
       disableTertiary: item.disableTertiary,
     });
   }, [item, isAccessory]);
-
-  if (!item) return null;
 
   const stats = item.stats ?? {};
 

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -144,25 +144,47 @@ const MOB_TABS: readonly { value: MobTab; label: string }[] = [
   { value: "media", label: "Media" },
 ] as const;
 
-export function MobEditor({
+export function MobEditor(props: MobEditorProps) {
+  const { entity, patch, handleDelete, rooms } = useEntityEditor<MobFile>(
+    props.world,
+    props.mobId,
+    (w) => w.mobs?.[props.mobId],
+    updateMob,
+    deleteMob,
+    props.onWorldChange,
+    props.onDelete,
+  );
+  if (!entity) return null;
+  return (
+    <MobEditorContent
+      {...props}
+      mob={entity}
+      patch={patch}
+      handleDelete={handleDelete}
+      rooms={rooms}
+    />
+  );
+}
+
+interface MobEditorContentProps extends MobEditorProps {
+  mob: MobFile;
+  patch: (p: Partial<MobFile>) => void;
+  handleDelete: () => void;
+  rooms: { value: string; label: string }[];
+}
+
+function MobEditorContent({
   mobId,
   world,
   onWorldChange,
-  onDelete,
   onDuplicate,
   zoneId,
-}: MobEditorProps) {
+  mob,
+  patch,
+  handleDelete,
+  rooms,
+}: MobEditorContentProps) {
   const [activeTab, setActiveTab] = useState<MobTab>("mob");
-  const { entity: mob, patch, handleDelete, rooms } = useEntityEditor<MobFile>(
-    world,
-    mobId,
-    (w) => w.mobs?.[mobId],
-    updateMob,
-    deleteMob,
-    onWorldChange,
-    onDelete,
-  );
-  if (!mob) return null;
 
   const role: MobRole = mob.role ?? "combat";
   const isCombatant = role === "combat";

--- a/creator/src/components/editors/QuestEditor.tsx
+++ b/creator/src/components/editors/QuestEditor.tsx
@@ -63,28 +63,44 @@ const DIFFICULTY_OPTIONS = [
   ...QUEST_DIFFICULTIES.map((d) => ({ value: d, label: QUEST_DIFFICULTY_LABELS[d] })),
 ];
 
-export function QuestEditor({
-  questId,
-  world,
-  onWorldChange,
-  onDelete,
-}: QuestEditorProps) {
-  const { entity: quest, patch, handleDelete } = useEntityEditor<QuestFile>(
-    world,
-    questId,
-    (w) => w.quests?.[questId],
+export function QuestEditor(props: QuestEditorProps) {
+  const { entity, patch, handleDelete } = useEntityEditor<QuestFile>(
+    props.world,
+    props.questId,
+    (w) => w.quests?.[props.questId],
     updateQuest,
     deleteQuest,
-    onWorldChange,
-    onDelete,
+    props.onWorldChange,
+    props.onDelete,
   );
+  if (!entity) return null;
+  return (
+    <QuestEditorContent
+      {...props}
+      quest={entity}
+      patch={patch}
+      handleDelete={handleDelete}
+    />
+  );
+}
+
+interface QuestEditorContentProps extends QuestEditorProps {
+  quest: QuestFile;
+  patch: (p: Partial<QuestFile>) => void;
+  handleDelete: () => void;
+}
+
+function QuestEditorContent({
+  world,
+  quest,
+  patch,
+  handleDelete,
+}: QuestEditorContentProps) {
   const completionTypes = useConfigStore((s) => s.config?.questCompletionTypes);
   const completionOptions = useConfigOptions(completionTypes, FALLBACK_COMPLETION_OPTIONS);
 
   const objectiveTypes = useConfigStore((s) => s.config?.questObjectiveTypes);
   const objectiveTypeOptions = useConfigOptions(objectiveTypes, FALLBACK_OBJECTIVE_TYPES);
-
-  if (!quest) return null;
 
   const zoneMobs = Object.entries(world.mobs ?? {}).map(([id, m]) => ({
     value: id,

--- a/creator/src/components/editors/RecipeEditor.tsx
+++ b/creator/src/components/editors/RecipeEditor.tsx
@@ -37,29 +37,45 @@ const FALLBACK_STATION_OPTIONS = [
   { value: "workbench", label: "Workbench" },
 ];
 
-export function RecipeEditor({
-  recipeId,
-  world,
-  onWorldChange,
-  onDelete,
-  zoneId,
-}: RecipeEditorProps) {
-  const { entity: recipe, patch, handleDelete } = useEntityEditor<RecipeFile>(
-    world,
-    recipeId,
-    (w) => w.recipes?.[recipeId],
+export function RecipeEditor(props: RecipeEditorProps) {
+  const { entity, patch, handleDelete } = useEntityEditor<RecipeFile>(
+    props.world,
+    props.recipeId,
+    (w) => w.recipes?.[props.recipeId],
     updateRecipe,
     deleteRecipe,
-    onWorldChange,
-    onDelete,
+    props.onWorldChange,
+    props.onDelete,
   );
+  if (!entity) return null;
+  return (
+    <RecipeEditorContent
+      {...props}
+      recipe={entity}
+      patch={patch}
+      handleDelete={handleDelete}
+    />
+  );
+}
+
+interface RecipeEditorContentProps extends RecipeEditorProps {
+  recipe: RecipeFile;
+  patch: (p: Partial<RecipeFile>) => void;
+  handleDelete: () => void;
+}
+
+function RecipeEditorContent({
+  recipeId,
+  zoneId,
+  recipe,
+  patch,
+  handleDelete,
+}: RecipeEditorContentProps) {
   const craftingSkills = useConfigStore((s) => s.config?.craftingSkills);
   const craftingSkillOptions = useConfigOptions(craftingSkills, FALLBACK_CRAFTING_SKILLS);
 
   const stationTypes = useConfigStore((s) => s.config?.craftingStationTypes);
   const stationOptions = useConfigOptions(stationTypes, FALLBACK_STATION_OPTIONS);
-
-  if (!recipe) return null;
 
   // ─── Material helpers ─────────────────────────────────────────
   const {

--- a/creator/src/components/editors/ShopEditor.tsx
+++ b/creator/src/components/editors/ShopEditor.tsx
@@ -22,24 +22,44 @@ interface ShopEditorProps {
   zoneId?: string;
 }
 
-export function ShopEditor({
-  shopId,
-  world,
-  onWorldChange,
-  onDelete,
-  zoneId,
-}: ShopEditorProps) {
-  const { entity: shop, patch, handleDelete, rooms } = useEntityEditor<ShopFile>(
-    world,
-    shopId,
-    (w) => w.shops?.[shopId],
+export function ShopEditor(props: ShopEditorProps) {
+  const { entity, patch, handleDelete, rooms } = useEntityEditor<ShopFile>(
+    props.world,
+    props.shopId,
+    (w) => w.shops?.[props.shopId],
     updateShop,
     deleteShop,
-    onWorldChange,
-    onDelete,
+    props.onWorldChange,
+    props.onDelete,
   );
-  if (!shop) return null;
+  if (!entity) return null;
+  return (
+    <ShopEditorContent
+      {...props}
+      shop={entity}
+      patch={patch}
+      handleDelete={handleDelete}
+      rooms={rooms}
+    />
+  );
+}
 
+interface ShopEditorContentProps extends ShopEditorProps {
+  shop: ShopFile;
+  patch: (p: Partial<ShopFile>) => void;
+  handleDelete: () => void;
+  rooms: { value: string; label: string }[];
+}
+
+function ShopEditorContent({
+  shopId,
+  world,
+  zoneId,
+  shop,
+  patch,
+  handleDelete,
+  rooms,
+}: ShopEditorContentProps) {
   const zoneItems = Object.entries(world.items ?? {}).map(([id, item]) => ({
     value: id,
     label: `${item.displayName} (${id})`,


### PR DESCRIPTION
## Problem

Adding a new mob crashed the app with:

> Rendered fewer hooks than expected. This may be caused by an accidental early return statement.

## Root cause

`MobEditor` (and several sibling editors) called ~30 React hooks **after** an early `if (!entity) return null` guard. When the resolved entity flipped between present and absent while the editor stayed mounted, the number of hooks called changed between renders, violating the Rules of Hooks and throwing.

This was a shared latent bug across every editor built on `useEntityEditor`.

## Fix

Each affected editor is split into:
- a thin **wrapper** that runs `useEntityEditor`, does the `if (!entity) return null` check, and renders…
- an inner **content** component that holds all the remaining hooks.

Hooks now always run in a stable order; the conditional return happens in the wrapper before any of the content hooks exist.

## Affected files
- `MobEditor.tsx` — the reported crash
- `ItemEditor.tsx`
- `QuestEditor.tsx`
- `ShopEditor.tsx`
- `GatheringNodeEditor.tsx`
- `RecipeEditor.tsx`
- `DialogueEditor.tsx`

`PuzzleEditor` and `DungeonEditor` were checked and already place their early return after all hooks — left unchanged.

## Verification
- `bunx tsc --noEmit` — clean
- `bun run test` — 2304 tests pass