### PR TITLE
fix(a11y): trap focus in Sketch, LoreChat, and ImageLightbox dialogs

### DIFF
--- a/creator/src/components/lore/LoreChatPanel.tsx
+++ b/creator/src/components/lore/LoreChatPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 import { invoke } from "@tauri-apps/api/core";
 import { useLoreStore, selectArticles } from "@/stores/loreStore";
 import { useProjectStore } from "@/stores/projectStore";
@@ -38,22 +39,16 @@ export function LoreChatPanel({ onClose }: LoreChatPanelProps) {
   const [busy, setBusy] = useState(false);
   const [visible, setVisible] = useState(false);
 
-  const panelRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const restoreFocusRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     requestAnimationFrame(() => setVisible(true));
   }, []);
 
   useEffect(() => {
-    restoreFocusRef.current = document.activeElement as HTMLElement | null;
     const t = window.setTimeout(() => inputRef.current?.focus(), 60);
-    return () => {
-      window.clearTimeout(t);
-      restoreFocusRef.current?.focus?.();
-    };
+    return () => window.clearTimeout(t);
   }, []);
 
   const handleClose = useCallback(() => {
@@ -61,18 +56,9 @@ export function LoreChatPanel({ onClose }: LoreChatPanelProps) {
     window.setTimeout(() => onClose(), 180);
   }, [onClose]);
 
-  useEffect(() => {
-    const panel = panelRef.current;
-    if (!panel) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        handleClose();
-      }
-    };
-    panel.addEventListener("keydown", onKey);
-    return () => panel.removeEventListener("keydown", onKey);
-  }, [handleClose]);
+  // Full-screen dialog surface: traps Tab focus, closes on Escape (with the
+  // slide-out animation), and restores focus to the opener on unmount.
+  const panelRef = useFocusTrap<HTMLDivElement>(handleClose);
 
   useEffect(() => {
     const s = scrollRef.current;

--- a/creator/src/components/ui/ImageLightbox.tsx
+++ b/creator/src/components/ui/ImageLightbox.tsx
@@ -1,5 +1,6 @@
 import "./EntityArtGenerator.css";
 import { useEffect, useRef, useState } from "react";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 interface ImageLightboxProps {
   src: string;
@@ -16,15 +17,19 @@ export function ImageLightbox({ src, onClose }: ImageLightboxProps) {
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const stageRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const previouslyFocused = document.activeElement as HTMLElement | null;
-    closeBtnRef.current?.focus();
+  // Full-screen dialog: trap Tab focus, close on Escape, restore focus on unmount.
+  const rootRef = useFocusTrap<HTMLDivElement>(onClose);
 
+  // Prefer the Close button as the initial focus target (runs after the trap's
+  // first-focusable default).
+  useEffect(() => {
+    closeBtnRef.current?.focus();
+  }, []);
+
+  // Keyboard zoom shortcuts (Escape is handled by the focus trap).
+  useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-      } else if (e.key === "0") {
+      if (e.key === "0") {
         setZoom(1);
         setPan({ x: 0, y: 0 });
       } else if (e.key === "+" || e.key === "=") {
@@ -34,11 +39,8 @@ export function ImageLightbox({ src, onClose }: ImageLightboxProps) {
       }
     };
     window.addEventListener("keydown", handleKey);
-    return () => {
-      window.removeEventListener("keydown", handleKey);
-      previouslyFocused?.focus?.();
-    };
-  }, [onClose]);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, []);
 
   useEffect(() => {
     const stage = stageRef.current;
@@ -79,6 +81,7 @@ export function ImageLightbox({ src, onClose }: ImageLightboxProps) {
 
   return (
     <div
+      ref={rootRef}
       className="art-lightbox"
       role="dialog"
       aria-modal="true"

--- a/creator/src/components/ui/SketchDialog.tsx
+++ b/creator/src/components/ui/SketchDialog.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from "react";
 import { SketchCanvas, type SketchSavedEntry } from "./SketchCanvas";
 import type { AssetContext } from "@/types/assets";
+import { useFocusTrap } from "@/lib/useFocusTrap";
 
 interface Props {
   open: boolean;
@@ -27,17 +27,7 @@ export function SketchDialog({
   onClose,
   onSave,
 }: Props) {
-  const surfaceRef = useRef<HTMLDivElement | null>(null);
-  const stashedFocus = useRef<Element | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    stashedFocus.current = document.activeElement;
-    surfaceRef.current?.focus();
-    return () => {
-      (stashedFocus.current as HTMLElement | null)?.focus?.();
-    };
-  }, [open]);
+  const surfaceRef = useFocusTrap<HTMLDivElement>(open ? onClose : undefined);
 
   if (!open) return null;
 


### PR DESCRIPTION
## Correctness / a11y fix (refactor review finding)

Three full-screen `role="dialog"` overlays hand-rolled partial focus management and violated the overlay accessibility contract documented in CLAUDE.md (`role=dialog` + `aria-modal` surfaces must trap Tab focus, close on Escape, and restore focus):

| Component | stash/restore | Escape | **Tab trap** |
|---|---|---|---|
| `ui/SketchDialog` | ✅ | ❌ | ❌ |
| `lore/LoreChatPanel` | ✅ | ✅ | ❌ |
| `ui/ImageLightbox` | ✅ | ✅ | ❌ |

Keyboard-only and screen-reader users could Tab out of these surfaces into the obscured page behind them.

## Changes
Replace the bespoke logic with the existing `lib/useFocusTrap` hook (first-focus, Tab/Shift+Tab cycling, Escape, focus restore). Behavior preserved:
- **SketchDialog** — `useFocusTrap(open ? onClose : undefined)` so the trap (re)activates when the `open` prop toggles.
- **LoreChatPanel** — Escape still triggers the animated close (`handleClose`); the delayed textarea focus is retained.
- **ImageLightbox** — zoom-key shortcuts (`0`/`+`/`-`) stay on the window listener with Escape removed; the Close button remains the initial focus target.

## Verification
`bunx tsc --noEmit` clean (`noUnusedLocals` would have caught the removed refs).