### PR TITLE
fix(hub): reject reserved subdomains in creator-side slug validation

### DIFF
--- a/creator/src-tauri/src/hub.rs
+++ b/creator/src-tauri/src/hub.rs
@@ -618,6 +618,13 @@ fn emit_progress(app: &AppHandle, phase: &str, current: usize, total: usize, lab
 }
 
 fn is_valid_slug(slug: &str) -> bool {
+    // Reserved subdomains belong to the hub itself; the worker rejects them
+    // (hub-worker/src/util.ts::RESERVED_SUBDOMAINS). Mirror that here so a
+    // reserved slug fails before we attempt a publish.
+    const RESERVED: [&str; 8] = ["api", "admin", "www", "hub", "mail", "ftp", "ns1", "ns2"];
+    if RESERVED.contains(&slug) {
+        return false;
+    }
     let len = slug.len();
     if !(3..=32).contains(&len) {
         return false;

--- a/creator/src/components/PublishHubDialog.tsx
+++ b/creator/src/components/PublishHubDialog.tsx
@@ -16,8 +16,12 @@ interface PublishHubDialogProps {
   onClose: () => void;
 }
 
-// Slug validation mirrors the Rust side (hub.rs::is_valid_slug).
+// Slug validation mirrors the Rust side (hub.rs::is_valid_slug) and the
+// hub worker (hub-worker/src/util.ts::RESERVED_SUBDOMAINS). Reserved
+// subdomains belong to the hub itself and the worker rejects them at
+// publish time — check here too so the user gets immediate feedback.
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{1,30}[a-z0-9]$/;
+const RESERVED_SLUGS = new Set(["api", "admin", "www", "hub", "mail", "ftp", "ns1", "ns2"]);
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -75,7 +79,8 @@ export function PublishHubDialog({ onClose }: PublishHubDialogProps) {
   }, []);
 
   const hubConfigured = !!(settings?.hub_api_url && settings?.hub_api_key);
-  const slugValid = SLUG_RE.test(slug);
+  const slugReserved = RESERVED_SLUGS.has(slug);
+  const slugValid = SLUG_RE.test(slug) && !slugReserved;
   const hasLore = articleCount > 0;
   const canPublish =
     !!project && hubConfigured && slugValid && hasLore && !running && !result;
@@ -195,7 +200,10 @@ export function PublishHubDialog({ onClose }: PublishHubDialogProps) {
           <p className="mt-1 text-2xs text-text-muted">
             Your world will live at{" "}
             <code className="font-mono text-accent/70">{slug || "<slug>"}.arcanum-hub.com</code>
-            {slug && !slugValid && (
+            {slug && slugReserved && (
+              <span className="ml-2 text-status-error">(reserved — pick a different name)</span>
+            )}
+            {slug && !slugReserved && !slugValid && (
               <span className="ml-2 text-status-error">(invalid — 3-32 chars, a-z0-9-)</span>
             )}
           </p>


### PR DESCRIPTION
## Correctness fix (refactor review finding)

The hub worker refuses reserved subdomains as world slugs (`hub-worker/src/util.ts::RESERVED_SUBDOMAINS` = `api, admin, www, hub, mail, ftp, ns1, ns2`), but the creator's local validation only mirrored the shape regex `SLUG_RE`, not the reserved list:
- `PublishHubDialog.tsx` accepted `admin`/`www` in the UI.
- `hub.rs::is_valid_slug` accepted them too.

So a user could type a reserved name, see it accepted, and only discover the rejection when the publish call round-tripped to the worker.

## Changes
- `PublishHubDialog.tsx`: add `RESERVED_SLUGS` and fold it into `slugValid`, with a distinct "(reserved — pick a different name)" inline hint separate from the shape error.
- `hub.rs::is_valid_slug`: reject the reserved set before the shape check.

Both sites carry a comment pointing at the worker as the source of truth (cross-language, so kept in sync by convention).

## Verification
`bunx tsc --noEmit` clean; `cargo check` clean.