### PR TITLE
refactor(rust): extract fs_utils::app_data_dir helper

### DIFF
--- a/creator/node_modules
+++ b/creator/node_modules
@@ -1,1 +1,0 @@
-/Users/jnoecker/Arcanum/creator/node_modules

--- a/creator/node_modules
+++ b/creator/node_modules
@@ -1,0 +1,1 @@
+/Users/jnoecker/Arcanum/creator/node_modules

--- a/creator/src-tauri/src/admin.rs
+++ b/creator/src-tauri/src/admin.rs
@@ -3,7 +3,7 @@ use reqwest::header::{AUTHORIZATION, HeaderValue};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::OnceLock;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 // ─── Config persistence ────────────────────────────────────────────
 
@@ -23,10 +23,7 @@ fn config_key(project_path: &str) -> String {
 }
 
 fn admin_config_path(app: &AppHandle, project_path: &str) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    let dir = crate::fs_utils::app_data_dir(app)?;
     Ok(dir.join("admin").join(format!("{}.json", config_key(project_path))))
 }
 

--- a/creator/src-tauri/src/arcanum_meta.rs
+++ b/creator/src-tauri/src/arcanum_meta.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SlotPosition {
@@ -17,10 +17,7 @@ pub struct ArcanumMeta {
 }
 
 fn meta_dir(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    let dir = crate::fs_utils::app_data_dir(app)?;
     Ok(dir.join("arcanum-meta"))
 }
 

--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::LazyLock;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 use tokio::sync::Mutex;
 
 const MANIFEST_FILE: &str = "manifest.json";
@@ -72,10 +72,7 @@ struct Manifest {
 }
 
 fn assets_dir(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    let dir = crate::fs_utils::app_data_dir(app)?;
     Ok(dir.join("assets"))
 }
 

--- a/creator/src-tauri/src/elevenlabs.rs
+++ b/creator/src-tauri/src/elevenlabs.rs
@@ -16,7 +16,7 @@
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use crate::settings;
 use crate::voices::VoiceSettings;
@@ -185,10 +185,7 @@ pub fn text_sha8(text: &str) -> String {
 }
 
 async fn voices_cache_dir(app: &AppHandle) -> Result<std::path::PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+    let dir = crate::fs_utils::app_data_dir(app)?
         .join("assets")
         .join("voices");
     tokio::fs::create_dir_all(&dir)
@@ -578,10 +575,7 @@ pub async fn elevenlabs_generate_sound_effect(
     hasher.update(&bytes);
     let hash = format!("{:x}", hasher.finalize());
 
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+    let dir = crate::fs_utils::app_data_dir(&app)?
         .join("assets")
         .join("audio");
     tokio::fs::create_dir_all(&dir)

--- a/creator/src-tauri/src/ffmpeg.rs
+++ b/creator/src-tauri/src/ffmpeg.rs
@@ -16,7 +16,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 // ─── Types ───────────────────────────────────────────────────────
 
@@ -65,10 +65,7 @@ fn bin_filename() -> &'static str {
 }
 
 fn bundled_bin_dir(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+    let dir = crate::fs_utils::app_data_dir(app)?
         .join("bin");
     Ok(dir)
 }

--- a/creator/src-tauri/src/fs_utils.rs
+++ b/creator/src-tauri/src/fs_utils.rs
@@ -1,9 +1,19 @@
 use base64::Engine;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
+use tauri::{AppHandle, Manager};
+
+/// Resolve the app's data directory, mapping Tauri's path error to the
+/// standard string used across the backend. Every module needs this before
+/// joining onto `assets/`, `settings.json`, etc.
+pub fn app_data_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    app.path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {e}"))
+}
 
 /// Monotonic counter to guarantee temp-file uniqueness even when two atomic
 /// writes inside the same process race in the same millisecond.

--- a/creator/src-tauri/src/generation.rs
+++ b/creator/src-tauri/src/generation.rs
@@ -11,7 +11,7 @@ use image::{
     Rgba,
 };
 use sha2::{Digest, Sha256};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use crate::{deepinfra::GeneratedImage, llm, settings};
 
@@ -154,10 +154,7 @@ pub async fn persist_generated_image(
     hasher.update(bytes);
     let hash = format!("{:x}", hasher.finalize());
 
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+    let dir = crate::fs_utils::app_data_dir(app)?
         .join("assets")
         .join("images");
     tokio::fs::create_dir_all(&dir)

--- a/creator/src-tauri/src/hub.rs
+++ b/creator/src-tauri/src/hub.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter};
 
 use crate::assets::{self, AssetEntry};
 use crate::settings;
@@ -642,10 +642,7 @@ fn sha256_hex(data: &[u8]) -> String {
 }
 
 fn assets_base_dir(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    let dir = crate::fs_utils::app_data_dir(app)?;
     Ok(dir.join("assets"))
 }
 

--- a/creator/src-tauri/src/openai_tts.rs
+++ b/creator/src-tauri/src/openai_tts.rs
@@ -8,7 +8,7 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use crate::settings;
 
@@ -98,10 +98,7 @@ fn cache_hash(text: &str, voice: &str, model: &str, speed: Option<f32>) -> Strin
 }
 
 async fn narration_dir(app: &AppHandle) -> Result<std::path::PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+    let dir = crate::fs_utils::app_data_dir(app)?
         .join("assets")
         .join("narration");
     tokio::fs::create_dir_all(&dir)

--- a/creator/src-tauri/src/project.rs
+++ b/creator/src-tauri/src/project.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use tauri::Manager;
 use tokio::process::Command;
 
 #[derive(Serialize)]
@@ -143,10 +142,7 @@ pub struct MigrationReport {
 
 /// Build a map from content SHA-256 hash to the R2 filename (hash.ext).
 fn load_hash_map(app: &tauri::AppHandle) -> Result<HashMap<String, String>, String> {
-    let manifest_path = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+    let manifest_path = crate::fs_utils::app_data_dir(app)?
         .join("assets")
         .join("manifest.json");
 

--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -6,7 +6,7 @@ use image::imageops::FilterType as ResizeFilter;
 use image::{ExtendedColorType, ImageEncoder};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use crate::assets::{self, AssetEntry};
 use crate::settings;
@@ -449,10 +449,7 @@ async fn upload_object(
 // ─── Tauri commands ─────────────────────────────────────────────────
 
 fn assets_base_dir(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    let dir = crate::fs_utils::app_data_dir(app)?;
     Ok(dir.join("assets"))
 }
 
@@ -476,10 +473,7 @@ fn find_asset_file(base: &Path, file_name: &str) -> Option<PathBuf> {
 // everything — no correctness hazard, just wasted bandwidth.
 
 fn runtime_sync_state_path(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    let dir = crate::fs_utils::app_data_dir(app)?;
     Ok(dir.join("runtime_sync_state.json"))
 }
 

--- a/creator/src-tauri/src/runware.rs
+++ b/creator/src-tauri/src/runware.rs
@@ -1,7 +1,7 @@
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 use crate::{deepinfra::GeneratedImage, generation, settings};
 
@@ -550,10 +550,7 @@ pub async fn runware_generate_audio(
     hasher.update(&bytes);
     let hash = format!("{:x}", hasher.finalize());
 
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+    let dir = crate::fs_utils::app_data_dir(&app)?
         .join("assets")
         .join("audio");
     tokio::fs::create_dir_all(&dir)
@@ -686,10 +683,7 @@ pub async fn runware_generate_video(
             hasher.update(&bytes);
             let hash = format!("{:x}", hasher.finalize());
 
-            let dir = app
-                .path()
-                .app_data_dir()
-                .map_err(|e| format!("Failed to get app data dir: {e}"))?
+            let dir = crate::fs_utils::app_data_dir(&app)?
                 .join("assets")
                 .join("video");
             tokio::fs::create_dir_all(&dir)

--- a/creator/src-tauri/src/settings.rs
+++ b/creator/src-tauri/src/settings.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::LazyLock;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 use tokio::sync::RwLock;
 
 const SETTINGS_FILE: &str = "settings.json";
@@ -186,10 +186,7 @@ impl Default for Settings {
 }
 
 fn settings_path(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    let dir = crate::fs_utils::app_data_dir(app)?;
     Ok(dir.join(SETTINGS_FILE))
 }
 

--- a/creator/src-tauri/src/vibes.rs
+++ b/creator/src-tauri/src/vibes.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ZoneVibe {
@@ -9,10 +9,7 @@ struct ZoneVibe {
 }
 
 fn vibes_dir(app: &AppHandle) -> Result<PathBuf, String> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?;
+    let dir = crate::fs_utils::app_data_dir(app)?;
     Ok(dir.join("vibes"))
 }
 

--- a/creator/src-tauri/src/video_export.rs
+++ b/creator/src-tauri/src/video_export.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 
 use base64::Engine;
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter};
 
 use crate::audio_mix::{self, AudioMixInput};
 use crate::video_encode::{
@@ -43,10 +43,7 @@ fn session_dir(app: &AppHandle, session_id: &str) -> Result<PathBuf, String> {
     if session_id.chars().any(|c| !c.is_ascii_alphanumeric() && c != '-' && c != '_') {
         return Err(format!("Invalid session_id '{session_id}' — alphanumeric + dash/underscore only"));
     }
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {e}"))?
+    let dir = crate::fs_utils::app_data_dir(app)?
         .join("tmp")
         .join("video_export")
         .join(session_id);


### PR DESCRIPTION
## Refactor review finding (HIGH — 17 occurrences)

The block
```rust
app.path()
   .app_data_dir()
   .map_err(|e| format!("Failed to get app data dir: {e}"))
```
was copy-pasted into **17 call sites across 14 modules** (settings, assets, r2, hub, runware, elevenlabs, generation, project, ffmpeg, openai_tts, vibes, admin, arcanum_meta, video_export).

## Changes
- Add `fs_utils::app_data_dir(app: &AppHandle) -> Result<PathBuf, String>` (same call, same error string).
- Repoint all 17 sites; owned-`AppHandle` callers pass `&app`.
- Drop the now-unused `tauri::Manager` import from the 14 files that only imported it for this call.

Pure structural move — no behavior change, guaranteed by the compiler (the underlying call and error message are identical).

## Verification
`cargo check` clean — no warnings, no errors.