### PR TITLE
refactor(admin): share StatRow and Section widgets across admin panels

### DIFF
--- a/creator/src/components/admin/AdminAbilityList.tsx
+++ b/creator/src/components/admin/AdminAbilityList.tsx
@@ -2,24 +2,7 @@ import { memo, useEffect } from "react";
 import { useAdminStore } from "@/stores/adminStore";
 import { ActionButton, Badge, EmptyState } from "@/components/ui/FormWidgets";
 import type { AbilityEntry } from "@/types/admin";
-
-const StatRow = memo(function StatRow({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
-      <span className="text-xs text-text-muted">{label}</span>
-      <span className="text-xs text-text-primary">{value}</span>
-    </div>
-  );
-});
-
-const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
-      <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
-      {children}
-    </div>
-  );
-});
+import { StatRow, Section } from "@/components/admin/AdminWidgets";
 
 const AbilityRow = memo(function AbilityRow({
   ability,

--- a/creator/src/components/admin/AdminAchievementList.tsx
+++ b/creator/src/components/admin/AdminAchievementList.tsx
@@ -2,24 +2,7 @@ import { memo, useEffect } from "react";
 import { useAdminStore } from "@/stores/adminStore";
 import { ActionButton, Badge, EmptyState } from "@/components/ui/FormWidgets";
 import type { AchievementEntry } from "@/types/admin";
-
-const StatRow = memo(function StatRow({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
-      <span className="text-xs text-text-muted">{label}</span>
-      <span className="text-xs text-text-primary">{value}</span>
-    </div>
-  );
-});
-
-const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
-      <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
-      {children}
-    </div>
-  );
-});
+import { StatRow, Section } from "@/components/admin/AdminWidgets";
 
 const AchievementRow = memo(function AchievementRow({
   achievement,

--- a/creator/src/components/admin/AdminEffectList.tsx
+++ b/creator/src/components/admin/AdminEffectList.tsx
@@ -2,24 +2,7 @@ import { memo, useEffect } from "react";
 import { useAdminStore } from "@/stores/adminStore";
 import { ActionButton, Badge, EmptyState } from "@/components/ui/FormWidgets";
 import type { EffectEntry } from "@/types/admin";
-
-const StatRow = memo(function StatRow({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
-      <span className="text-xs text-text-muted">{label}</span>
-      <span className="text-xs text-text-primary">{value}</span>
-    </div>
-  );
-});
-
-const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
-      <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
-      {children}
-    </div>
-  );
-});
+import { StatRow, Section } from "@/components/admin/AdminWidgets";
 
 const EffectRow = memo(function EffectRow({
   effect,

--- a/creator/src/components/admin/AdminMobDetail.tsx
+++ b/creator/src/components/admin/AdminMobDetail.tsx
@@ -1,15 +1,7 @@
 import { memo } from "react";
 import { useAdminStore } from "@/stores/adminStore";
 import { ActionButton, Badge } from "@/components/ui/FormWidgets";
-
-const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
-      <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
-      {children}
-    </div>
-  );
-});
+import { Section } from "@/components/admin/AdminWidgets";
 
 const StatRow = memo(function StatRow({ label, value, valueClass }: { label: string; value: string | number; valueClass?: string }) {
   return (

--- a/creator/src/components/admin/AdminPlayerDetail.tsx
+++ b/creator/src/components/admin/AdminPlayerDetail.tsx
@@ -2,6 +2,7 @@ import { memo, useState, useRef, useEffect } from "react";
 import { useAdminStore } from "@/stores/adminStore";
 import { ActionButton, Badge } from "@/components/ui/FormWidgets";
 import type { PlayerDetail } from "@/types/admin";
+import { Section } from "@/components/admin/AdminWidgets";
 
 const StatRow = memo(function StatRow({ label, value, valueClass }: { label: string; value: string | number; valueClass?: string }) {
   return (
@@ -44,15 +45,6 @@ const VitalBar = memo(function VitalBar({
           {current} / {max}
         </span>
       </div>
-    </div>
-  );
-});
-
-const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
-      <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
-      {children}
     </div>
   );
 });

--- a/creator/src/components/admin/AdminQuestList.tsx
+++ b/creator/src/components/admin/AdminQuestList.tsx
@@ -2,24 +2,7 @@ import { memo, useEffect } from "react";
 import { useAdminStore } from "@/stores/adminStore";
 import { ActionButton, Badge, EmptyState } from "@/components/ui/FormWidgets";
 import type { QuestEntry } from "@/types/admin";
-
-const StatRow = memo(function StatRow({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
-      <span className="text-xs text-text-muted">{label}</span>
-      <span className="text-xs text-text-primary">{value}</span>
-    </div>
-  );
-});
-
-const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
-      <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
-      {children}
-    </div>
-  );
-});
+import { StatRow, Section } from "@/components/admin/AdminWidgets";
 
 const QuestRow = memo(function QuestRow({
   quest,

--- a/creator/src/components/admin/AdminRoomDetail.tsx
+++ b/creator/src/components/admin/AdminRoomDetail.tsx
@@ -1,15 +1,7 @@
 import { memo } from "react";
 import { useAdminStore } from "@/stores/adminStore";
 import { ActionButton } from "@/components/ui/FormWidgets";
-
-const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
-      <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
-      {children}
-    </div>
-  );
-});
+import { Section } from "@/components/admin/AdminWidgets";
 
 const StatRow = memo(function StatRow({ label, value, valueClass }: { label: string; value: string | number; valueClass?: string }) {
   return (

--- a/creator/src/components/admin/AdminWidgets.tsx
+++ b/creator/src/components/admin/AdminWidgets.tsx
@@ -1,0 +1,21 @@
+import { memo } from "react";
+
+/** Label/value row used across the admin list and detail panels. */
+export const StatRow = memo(function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-center justify-between border-b border-[var(--chrome-stroke)] py-2 last:border-b-0">
+      <span className="text-xs text-text-muted">{label}</span>
+      <span className="text-xs text-text-primary">{value}</span>
+    </div>
+  );
+});
+
+/** Titled card wrapper shared by every admin panel. */
+export const Section = memo(function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-3xl border border-[var(--chrome-stroke)] bg-gradient-panel-light p-4 shadow-section">
+      <h4 className="mb-2 text-2xs uppercase tracking-wide-ui text-text-muted">{title}</h4>
+      {children}
+    </div>
+  );
+});


### PR DESCRIPTION
## Refactor review finding (HIGH — 7 files)

The `Section` card wrapper (byte-identical) was copy-pasted into all 7 `Admin*` list/detail components, and the plain `StatRow` (label/value row) into the 4 `Admin*List` panels.

## Changes
- New `admin/AdminWidgets.tsx` exporting shared `StatRow` and `Section`.
- The 4 list panels (Ability/Effect/Quest/Achievement) import both; their local copies are removed.
- The 3 detail panels (Mob/Player/Room) import the shared `Section`.

Scoped for zero visual change: only byte-identical components are merged. The detail panels keep their own `StatRow` variant, which adds `capitalize` on the label and an optional `valueClass` — unifying it would require adding a prop at ~20 call sites with visual-regression risk, so it's left as-is.

## Verification
`tsc --noEmit` clean.

## Note
Pushed a `bun.lock` was **not** modified; only the 8 admin files changed.