### PR TITLE
ci: work around bun 1.3.14 frozen-lockfile ENOENT flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,13 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: creator
-        run: bun install --frozen-lockfile
+        # `mkdir -p node_modules` works around an intermittent bun 1.3.14 bug
+        # where `bun install --frozen-lockfile` aborts with
+        # "ENOENT: could not open the node_modules directory" on a fresh
+        # checkout before it has created the directory itself.
+        run: |
+          mkdir -p node_modules
+          bun install --frozen-lockfile
 
       - name: TypeScript check
         working-directory: creator


### PR DESCRIPTION
## Problem

The Creator CI job intermittently fails at `bun install --frozen-lockfile` with:

```
ENOENT: could not open the "node_modules" directory
```

This is a known bun 1.3.14 bug: on a fresh checkout `--frozen-lockfile` can abort *before* creating `node_modules` itself. It's non-deterministic — recent PRs passed on the same bun version, but PR #334 hit it three runs in a row, blocking the merge queue.

## Fix

Pre-create `node_modules` with `mkdir -p` before the frozen install so bun always has a directory to open. No change to dependency resolution.

This PR's own Creator run exercises the fixed step.