### PR TITLE
feat(creator): support @references in mob, item, and room name fields

### DIFF
--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -226,9 +226,11 @@ function ItemEditorContent({
     <>
       <EntityHeader type="Item">
         <FieldRow label="Display Name">
-          <TextInput
+          <ReferenceMentionField
             value={item.displayName}
             onCommit={(v) => patch({ displayName: v })}
+            ariaLabel="item display name"
+            placeholder="Display name — type @ to reference a canonical subject"
           />
         </FieldRow>
         <FieldRow label="Description">

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -445,7 +445,12 @@ function MobEditorContent({
   return (
     <>
       <EntityHeader type="Mob">
-        <TextInput value={mob.name} onCommit={(v) => patch({ name: v })} />
+        <ReferenceMentionField
+          value={mob.name}
+          onCommit={(v) => patch({ name: v })}
+          ariaLabel="mob name"
+          placeholder="Mob name — type @ to reference a canonical subject"
+        />
         <div className="flex items-center gap-1">
           <div className="min-w-0 flex-1">
             <ReferenceMentionField

--- a/creator/src/lib/__tests__/referenceTokens.test.ts
+++ b/creator/src/lib/__tests__/referenceTokens.test.ts
@@ -3,12 +3,12 @@ import {
   applyReferences,
   buildReferenceBlock,
   buildResolver,
-  collectDescriptions,
+  collectTokenSlots,
   detectMention,
   expandReferences,
   extractTokens,
   hasTokens,
-  mapDescriptions,
+  mapTokenSlots,
   slugifyToken,
   stripSigils,
 } from "@/lib/referenceTokens";
@@ -159,7 +159,7 @@ describe("detectMention (autocomplete)", () => {
   });
 });
 
-describe("world description traversal", () => {
+describe("world token-slot traversal", () => {
   const world = {
     zone: "test",
     rooms: {
@@ -174,18 +174,43 @@ describe("world description traversal", () => {
     },
   } as unknown as WorldFile;
 
-  it("collects every art-bearing description", () => {
-    const keys = collectDescriptions(world).map((s) => s.key).sort();
-    expect(keys).toEqual(["item/i1", "mob/m1", "room/r1", "room/r2"]);
+  it("collects every art-bearing description and name", () => {
+    const keys = collectTokenSlots(world).map((s) => s.key).sort();
+    expect(keys).toEqual([
+      "item/i1",
+      "item/i1/name",
+      "mob/m1",
+      "mob/m1/name",
+      "room/r1",
+      "room/r1/name",
+      "room/r2",
+      "room/r2/name",
+    ]);
   });
 
   it("maps descriptions and only reallocates changed entities", () => {
     const known = new Set(["aineroia", "archae", "crimson court"]);
-    const stripped = mapDescriptions(world, (_k, text) => stripSigils(text, known));
+    const stripped = mapTokenSlots(world, (_k, text) => stripSigils(text, known));
     expect(stripped.rooms.r1.description).toBe("A beautiful Aineroia stands here");
     expect(stripped.items!.i1.description).toBe("bears the Crimson Court crest");
     // Unchanged room keeps its identity.
     expect(stripped.rooms.r2).toBe(world.rooms.r2);
+  });
+
+  it("maps name fields under their own slot keys", () => {
+    const tokenWorld = {
+      zone: "test",
+      rooms: { r1: { title: "Throne of @Aineroia", description: "grand" } },
+      mobs: { m1: { name: "Herald of the @[Crimson Court]", description: "regal", spawns: [] } },
+      items: { i1: { displayName: "Banner of @archae", description: "woven" } },
+    } as unknown as WorldFile;
+    const known = new Set(["aineroia", "archae", "crimson court"]);
+    const stripped = mapTokenSlots(tokenWorld, (_k, text) => stripSigils(text, known));
+    expect(stripped.rooms.r1.title).toBe("Throne of Aineroia");
+    expect(stripped.mobs!.m1.name).toBe("Herald of the Crimson Court");
+    expect(stripped.items!.i1.displayName).toBe("Banner of archae");
+    // Descriptions without tokens keep their text.
+    expect(stripped.rooms.r1.description).toBe("grand");
   });
 
   it("round-trips: strip then re-detect matches", () => {

--- a/creator/src/lib/referenceTokens.ts
+++ b/creator/src/lib/referenceTokens.ts
@@ -171,36 +171,65 @@ export function applyReferences(
   return { prompt, used, unknown };
 }
 
-// ─── WorldFile description traversal ─────────────────────────────────
-// Token persistence is scoped to the entity descriptions that drive art
-// generation: rooms, mobs, and items.
+// ─── WorldFile token-slot traversal ──────────────────────────────────
+// Token persistence is scoped to the entity fields that drive art
+// generation: the descriptions and names/titles of rooms, mobs, and items.
+// Description slots keep the bare `<kind>/<entityId>` key so annotation
+// files written before name support round-trip unchanged.
 
-export interface DescriptionSlot {
-  /** Stable per-entity key: `<kind>/<entityId>`. */
+export interface TokenSlot {
+  /** Stable key: `<kind>/<entityId>` (description) or `<kind>/<entityId>/name`. */
   key: string;
   text: string;
 }
 
-/** Collect the description of every art-bearing entity in a world. */
-export function collectDescriptions(world: WorldFile): DescriptionSlot[] {
-  const slots: DescriptionSlot[] = [];
+/** Collect every token-bearing field of every art-bearing entity in a world. */
+export function collectTokenSlots(world: WorldFile): TokenSlot[] {
+  const slots: TokenSlot[] = [];
   for (const [id, room] of Object.entries(world.rooms ?? {})) {
     if (typeof room.description === "string") slots.push({ key: `room/${id}`, text: room.description });
+    if (typeof room.title === "string") slots.push({ key: `room/${id}/name`, text: room.title });
   }
   for (const [id, mob] of Object.entries(world.mobs ?? {})) {
     if (typeof mob.description === "string") slots.push({ key: `mob/${id}`, text: mob.description });
+    if (typeof mob.name === "string") slots.push({ key: `mob/${id}/name`, text: mob.name });
   }
   for (const [id, item] of Object.entries(world.items ?? {})) {
     if (typeof item.description === "string") slots.push({ key: `item/${id}`, text: item.description });
+    if (typeof item.displayName === "string") slots.push({ key: `item/${id}/name`, text: item.displayName });
   }
   return slots;
 }
 
+function mapEntitySlots<T>(
+  kind: string,
+  id: string,
+  entity: T,
+  descField: keyof T & string,
+  nameField: keyof T & string,
+  fn: (key: string, text: string) => string,
+  descFallback: string | undefined,
+): T {
+  let next = entity;
+  const desc = entity[descField] as unknown;
+  const descText = typeof desc === "string" ? desc : descFallback;
+  if (typeof descText === "string") {
+    const updated = fn(`${kind}/${id}`, descText);
+    if (updated !== desc) next = { ...next, [descField]: updated } as T;
+  }
+  const name = entity[nameField] as unknown;
+  if (typeof name === "string") {
+    const updated = fn(`${kind}/${id}/name`, name);
+    if (updated !== name) next = { ...next, [nameField]: updated } as T;
+  }
+  return next;
+}
+
 /**
- * Return a shallow-cloned world with every art-bearing description rewritten
- * by `fn`. Only the entities whose description changes are reallocated.
+ * Return a shallow-cloned world with every art-bearing description and
+ * name/title rewritten by `fn`. Only the entities that change are reallocated.
  */
-export function mapDescriptions(
+export function mapTokenSlots(
   world: WorldFile,
   fn: (key: string, text: string) => string,
 ): WorldFile {
@@ -210,13 +239,9 @@ export function mapDescriptions(
   let roomsChanged = false;
   const nextRooms: Record<string, RoomFile> = {};
   for (const [id, room] of Object.entries(rooms)) {
-    const updated = fn(`room/${id}`, room.description ?? "");
-    if (updated !== room.description) {
-      nextRooms[id] = { ...room, description: updated };
-      roomsChanged = true;
-    } else {
-      nextRooms[id] = room;
-    }
+    const updated = mapEntitySlots("room", id, room, "description", "title", fn, "");
+    nextRooms[id] = updated;
+    if (updated !== room) roomsChanged = true;
   }
   if (roomsChanged) next.rooms = nextRooms;
 
@@ -224,17 +249,9 @@ export function mapDescriptions(
     let changed = false;
     const nextMobs: Record<string, MobFile> = {};
     for (const [id, mob] of Object.entries(world.mobs)) {
-      if (typeof mob.description !== "string") {
-        nextMobs[id] = mob;
-        continue;
-      }
-      const updated = fn(`mob/${id}`, mob.description);
-      if (updated !== mob.description) {
-        nextMobs[id] = { ...mob, description: updated };
-        changed = true;
-      } else {
-        nextMobs[id] = mob;
-      }
+      const updated = mapEntitySlots("mob", id, mob, "description", "name", fn, undefined);
+      nextMobs[id] = updated;
+      if (updated !== mob) changed = true;
     }
     if (changed) next.mobs = nextMobs;
   }
@@ -243,17 +260,9 @@ export function mapDescriptions(
     let changed = false;
     const nextItems: Record<string, ItemFile> = {};
     for (const [id, item] of Object.entries(world.items)) {
-      if (typeof item.description !== "string") {
-        nextItems[id] = item;
-        continue;
-      }
-      const updated = fn(`item/${id}`, item.description);
-      if (updated !== item.description) {
-        nextItems[id] = { ...item, description: updated };
-        changed = true;
-      } else {
-        nextItems[id] = item;
-      }
+      const updated = mapEntitySlots("item", id, item, "description", "displayName", fn, undefined);
+      nextItems[id] = updated;
+      if (updated !== item) changed = true;
     }
     if (changed) next.items = nextItems;
   }

--- a/creator/src/stores/referenceStore.ts
+++ b/creator/src/stores/referenceStore.ts
@@ -10,9 +10,9 @@ import type { Project } from "@/types/project";
 import type { WorldFile } from "@/types/world";
 import {
   buildResolver,
-  collectDescriptions,
+  collectTokenSlots,
   hasTokens,
-  mapDescriptions,
+  mapTokenSlots,
   refKey,
   slugifyToken,
   stripSigils,
@@ -42,7 +42,7 @@ async function writeJson(dir: string, file: string, value: unknown): Promise<voi
 interface ReferenceStore {
   projectDir: string | null;
   subjects: ReferenceSubject[];
-  /** `<zoneId>/<kind>/<entityId>` → tokenized description. */
+  /** `<zoneId>/<kind>/<entityId>[/name]` → tokenized description or name. */
   annotations: Record<string, string>;
   loaded: boolean;
 
@@ -60,9 +60,9 @@ interface ReferenceStore {
 
   /** Re-apply stored `@token` annotations onto a freshly-loaded world. */
   applyAnnotations: (zoneId: string, world: WorldFile) => WorldFile;
-  /** Strip reference sigils from a world's descriptions for the game YAML. */
+  /** Strip reference sigils from a world's descriptions and names for the game YAML. */
   stripWorld: (world: WorldFile) => WorldFile;
-  /** Record token-bearing descriptions for a zone and persist. */
+  /** Record token-bearing descriptions and names for a zone and persist. */
   captureAnnotations: (zoneId: string, world: WorldFile) => Promise<void>;
 }
 
@@ -131,10 +131,10 @@ export const useReferenceStore = create<ReferenceStore>((set, get) => ({
   applyAnnotations: (zoneId, world) => {
     const { annotations } = get();
     const known = get().knownKeys();
-    return mapDescriptions(world, (key, text) => {
+    return mapTokenSlots(world, (key, text) => {
       const annotated = annotations[`${zoneId}/${key}`];
       // Only re-apply when the clean form still matches the YAML — otherwise
-      // the description was edited out of band and the YAML wins.
+      // the field was edited out of band and the YAML wins.
       if (annotated && stripSigils(annotated, known) === text) return annotated;
       return text;
     });
@@ -142,7 +142,7 @@ export const useReferenceStore = create<ReferenceStore>((set, get) => ({
 
   stripWorld: (world) => {
     const known = get().knownKeys();
-    return mapDescriptions(world, (_key, text) => stripSigils(text, known));
+    return mapTokenSlots(world, (_key, text) => stripSigils(text, known));
   },
 
   captureAnnotations: async (zoneId, world) => {
@@ -152,7 +152,7 @@ export const useReferenceStore = create<ReferenceStore>((set, get) => ({
     for (const [k, v] of Object.entries(get().annotations)) {
       if (!k.startsWith(prefix)) next[k] = v;
     }
-    for (const slot of collectDescriptions(world)) {
+    for (const slot of collectTokenSlots(world)) {
       if (hasTokens(slot.text)) next[`${zoneId}/${slot.key}`] = slot.text;
     }
     set({ annotations: next });


### PR DESCRIPTION
## Summary

@reference support (autocomplete + sigil round-trip + art-prompt expansion) previously worked only in **description** fields. Name fields were plain `TextInput`s: no autocomplete, and — more importantly — a hand-typed `@token` in a name would have leaked raw into the game YAML, since the strip/re-apply traversal only walked descriptions.

This PR makes names first-class:

- **Editor UI** — `MobEditor` Name and `ItemEditor` Display Name now use `ReferenceMentionField` (single-line mode), so `@` pops the same canon-subject autocomplete as the description fields beside them. Styling is identical (`ornate-input`), so no visual change.
- **Persistence** — the token traversal in `referenceTokens.ts` (renamed `collectDescriptions`/`mapDescriptions` → `collectTokenSlots`/`mapTokenSlots`) also walks `room.title`, `mob.name`, and `item.displayName`. Tokens in names are stripped from the game YAML on save and re-applied from `.arcanum/reference-annotations.json` on load, exactly like descriptions. Name slots use new `<kind>/<id>/name` annotation keys; existing description annotations keep their bare `<kind>/<id>` keys, so **old annotation files round-trip unchanged**.
- **Art prompts** — no changes needed: names reach prompts via `entityContext`/`entityPrompt` strings that already pass through `expandReferences`, so a mob named `Herald of the @[Crimson Court]` now gets the canonical appearance block appended at generation time.

## Notes

- Room titles get the persistence round-trip but not autocomplete UI — the title is edited through the click-to-edit `EditableField` header in `RoomPanel`, which is shared by other call sites. Typing a token by hand there works; adding the dropdown to `EditableField` is a possible follow-up.
- `stripSigils` semantics are unchanged: a bare `@token` saves as the token text (`crimson-court`), the bracket form `@[Crimson Court]` saves as the pretty name. For player-visible names the bracket form is usually what you want — same trade-off descriptions have today.
- The LLM *Enhance* button still sends raw `@` text without expansion — that's pre-existing behavior for descriptions too, left out of scope.

## Testing

- `bunx tsc --noEmit` clean
- `bun run test` — 2305 tests pass, including new coverage for name-slot collection and mapping