### PR TITLE
perf(creator): cap stored images to the runtime serving profile at ingest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,8 @@ All public functions exposed to the frontend are `#[tauri::command]` and return 
 - `fs_utils.rs` — shared filesystem helpers
 - `http.rs` — shared HTTP client utilities
 - `assets.rs` — asset manifest (JSON) with content-addressed SHA-256 storage
-- `generation.rs` — image generation utilities (dimension capping to 1024px, format inference, resize pipeline, per-asset-type runtime image profiles shared with the R2 optimizer and ingest paths)
+- `generation.rs` — image generation utilities (dimension capping to 1024px, format inference, resize pipeline)
+- `image_profiles.rs` — per-asset-type runtime image profiles + downscale helpers, shared by the ingest paths and the R2 optimizer. Always compiled (not behind the `ai` feature) because `assets.rs` and `r2.rs` use it in the Community Edition build
 - `deepinfra.rs` — DeepInfra API client (FLUX image generation)
 - `runware.rs` — Runware API client (alternative image provider)
 - `openai_images.rs` — OpenAI GPT Image provider
@@ -290,7 +291,7 @@ Images are served to the frontend as base64 data URLs via the `read_image_data_u
 - **Showcase data flow** — "Publish Lore" in Toolbar → `exportShowcaseData()` → `deploy_showcase_to_r2` (self-hosted) or `publish_to_hub` (hub mode). The showcase SPA fetches this at runtime. No rebuild required for content updates.
 - **Showcase images** — Article/map images reference R2 URLs via `imageBaseUrl` from creator settings (`r2_custom_domain`). Images must be synced to R2 before they appear on the showcase.
 - **Lore undo/redo** — All lore mutations must call `snapshotLore(s)` inside their `set()` callback. Missing it means the operation can't be undone. The zone store uses a different pattern (zundo middleware).
-- **Generation dimensions** — Image generation APIs receive dimensions capped at 1024px via `generation::cap_generation_dims`. The backend resizes to the final target after generation. Don't request >1024px from FLUX models. Stored images are additionally capped to the per-asset-type runtime profile (`generation::runtime_image_profile`, the same table the R2 upload optimizer uses) at generation and import time — the asset store keeps what the runtime serves (e.g. 256px icons, 512×768 portraits), not the raw generation resolution. Types without a profile store at full requested size.
+- **Generation dimensions** — Image generation APIs receive dimensions capped at 1024px via `generation::cap_generation_dims`. The backend resizes to the final target after generation. Don't request >1024px from FLUX models. Stored images are additionally capped to the per-asset-type runtime profile (`image_profiles::runtime_image_profile`, the same table the R2 upload optimizer uses) at generation and import time — the asset store keeps what the runtime serves (e.g. 256px icons, 512×768 portraits), not the raw generation resolution. Types without a profile store at full requested size.
 - **Command palette** — Ctrl+K opens the global command palette, not a sidebar search. The old sidebar search focus handler was removed.
 - **Article gallery** — Articles have both `image?: string` (primary) and `gallery?: string[]` (additional). Export resolves both to `imageUrl` and `galleryUrls` in `ShowcaseData`.
 - **Vision API** — `llm_complete_with_vision` requires an Anthropic API key (or hub mode with credit on the hub's Anthropic account). Used for map analysis. The data URL must be a valid `data:image/...;base64,...` format.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ All public functions exposed to the frontend are `#[tauri::command]` and return 
 - `fs_utils.rs` — shared filesystem helpers
 - `http.rs` — shared HTTP client utilities
 - `assets.rs` — asset manifest (JSON) with content-addressed SHA-256 storage
-- `generation.rs` — image generation utilities (dimension capping to 1024px, format inference, resize pipeline)
+- `generation.rs` — image generation utilities (dimension capping to 1024px, format inference, resize pipeline, per-asset-type runtime image profiles shared with the R2 optimizer and ingest paths)
 - `deepinfra.rs` — DeepInfra API client (FLUX image generation)
 - `runware.rs` — Runware API client (alternative image provider)
 - `openai_images.rs` — OpenAI GPT Image provider
@@ -290,7 +290,7 @@ Images are served to the frontend as base64 data URLs via the `read_image_data_u
 - **Showcase data flow** — "Publish Lore" in Toolbar → `exportShowcaseData()` → `deploy_showcase_to_r2` (self-hosted) or `publish_to_hub` (hub mode). The showcase SPA fetches this at runtime. No rebuild required for content updates.
 - **Showcase images** — Article/map images reference R2 URLs via `imageBaseUrl` from creator settings (`r2_custom_domain`). Images must be synced to R2 before they appear on the showcase.
 - **Lore undo/redo** — All lore mutations must call `snapshotLore(s)` inside their `set()` callback. Missing it means the operation can't be undone. The zone store uses a different pattern (zundo middleware).
-- **Generation dimensions** — Image generation APIs receive dimensions capped at 1024px via `generation::cap_generation_dims`. The backend resizes to the final target after generation. Don't request >1024px from FLUX models.
+- **Generation dimensions** — Image generation APIs receive dimensions capped at 1024px via `generation::cap_generation_dims`. The backend resizes to the final target after generation. Don't request >1024px from FLUX models. Stored images are additionally capped to the per-asset-type runtime profile (`generation::runtime_image_profile`, the same table the R2 upload optimizer uses) at generation and import time — the asset store keeps what the runtime serves (e.g. 256px icons, 512×768 portraits), not the raw generation resolution. Types without a profile store at full requested size.
 - **Command palette** — Ctrl+K opens the global command palette, not a sidebar search. The old sidebar search focus handler was removed.
 - **Article gallery** — Articles have both `image?: string` (primary) and `gallery?: string[]` (additional). Export resolves both to `imageUrl` and `galleryUrls` in `ShowcaseData`.
 - **Vision API** — `llm_complete_with_vision` requires an Anthropic API key (or hub mode with credit on the hub's Anthropic account). Used for map analysis. The data URL must be a valid `data:image/...;base64,...` format.

--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -437,11 +437,6 @@ pub async fn import_asset(
         .await
         .map_err(|e| format!("Failed to read source file: {e}"))?;
 
-    // Content-addressed hash
-    let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    let hash = format!("{:x}", hasher.finalize());
-
     // Determine extension — prefer magic bytes, fall back to source extension
     let detected = detect_extension(&bytes);
     let ext = if detected == "bin" {
@@ -449,6 +444,14 @@ pub async fn import_asset(
     } else {
         detected
     };
+
+    // Cap oversized images to the runtime profile before hashing so the
+    // content-addressed name reflects the bytes actually stored.
+    let bytes = crate::generation::cap_image_bytes(&asset_type, ext, &bytes);
+
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let hash = format!("{:x}", hasher.finalize());
     let file_name = format!("{hash}.{ext}");
 
     // Read dimensions from image header (0x0 for non-image files)
@@ -457,7 +460,7 @@ pub async fn import_asset(
         Err(_) => (0, 0),
     };
 
-    // Copy to assets/<subdir>
+    // Write to assets/<subdir>
     let subdir = media_subdir(ext);
     let dest_dir = assets_dir(&app)?.join(subdir);
     tokio::fs::create_dir_all(&dest_dir)
@@ -466,9 +469,9 @@ pub async fn import_asset(
 
     let dest = dest_dir.join(&file_name);
     if !dest.exists() {
-        tokio::fs::copy(&source_path, &dest)
+        tokio::fs::write(&dest, &bytes)
             .await
-            .map_err(|e| format!("Failed to copy file: {e}"))?;
+            .map_err(|e| format!("Failed to write file: {e}"))?;
     }
 
     // Extract original filename for the prompt field
@@ -661,12 +664,16 @@ pub async fn save_bytes_as_asset(
         .decode(&bytes_b64)
         .map_err(|e| format!("Failed to decode base64: {e}"))?;
 
+    let detected = detect_extension(&bytes);
+    let ext = if detected == "bin" { "png" } else { detected };
+
+    // Cap oversized images to the runtime profile before hashing so the
+    // content-addressed name reflects the bytes actually stored.
+    let bytes = crate::generation::cap_image_bytes(&asset_type, ext, &bytes);
+
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
     let hash = format!("{:x}", hasher.finalize());
-
-    let detected = detect_extension(&bytes);
-    let ext = if detected == "bin" { "png" } else { detected };
     let file_name = format!("{hash}.{ext}");
 
     let (width, height) = match imagesize::blob_size(&bytes) {
@@ -1097,6 +1104,17 @@ pub async fn bulk_import_images(
             }
         };
 
+        let detected = detect_extension(&bytes);
+        let file_ext = if detected == "bin" {
+            extension_from_path(&fname).unwrap_or("png")
+        } else {
+            detected
+        };
+
+        // Cap oversized images to the runtime profile before hashing so the
+        // content-addressed name reflects the bytes actually stored.
+        let bytes = crate::generation::cap_image_bytes(&asset_type, file_ext, &bytes);
+
         let mut hasher = Sha256::new();
         hasher.update(&bytes);
         let hash = format!("{:x}", hasher.finalize());
@@ -1111,12 +1129,6 @@ pub async fn bulk_import_images(
             continue;
         }
 
-        let detected = detect_extension(&bytes);
-        let file_ext = if detected == "bin" {
-            extension_from_path(&fname).unwrap_or("png")
-        } else {
-            detected
-        };
         let file_name = format!("{hash}.{file_ext}");
 
         let (width, height) = match imagesize::blob_size(&bytes) {
@@ -1126,8 +1138,8 @@ pub async fn bulk_import_images(
 
         let dest = images_dir.join(&file_name);
         if !dest.exists() {
-            if let Err(e) = std::fs::copy(&path, &dest) {
-                result.errors.push(format!("Failed to copy {fname}: {e}"));
+            if let Err(e) = std::fs::write(&dest, &bytes) {
+                result.errors.push(format!("Failed to write {fname}: {e}"));
                 continue;
             }
         }

--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -447,7 +447,7 @@ pub async fn import_asset(
 
     // Cap oversized images to the runtime profile before hashing so the
     // content-addressed name reflects the bytes actually stored.
-    let bytes = crate::generation::cap_image_bytes(&asset_type, ext, &bytes);
+    let bytes = crate::image_profiles::cap_image_bytes(&asset_type, ext, &bytes);
 
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
@@ -669,7 +669,7 @@ pub async fn save_bytes_as_asset(
 
     // Cap oversized images to the runtime profile before hashing so the
     // content-addressed name reflects the bytes actually stored.
-    let bytes = crate::generation::cap_image_bytes(&asset_type, ext, &bytes);
+    let bytes = crate::image_profiles::cap_image_bytes(&asset_type, ext, &bytes);
 
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
@@ -1113,7 +1113,7 @@ pub async fn bulk_import_images(
 
         // Cap oversized images to the runtime profile before hashing so the
         // content-addressed name reflects the bytes actually stored.
-        let bytes = crate::generation::cap_image_bytes(&asset_type, file_ext, &bytes);
+        let bytes = crate::image_profiles::cap_image_bytes(&asset_type, file_ext, &bytes);
 
         let mut hasher = Sha256::new();
         hasher.update(&bytes);

--- a/creator/src-tauri/src/generation.rs
+++ b/creator/src-tauri/src/generation.rs
@@ -3,13 +3,10 @@ use std::io::Cursor;
 use base64::Engine;
 use image::{
     codecs::jpeg::JpegEncoder,
-    codecs::png::{CompressionType as PngCompressionType, FilterType as PngFilterType, PngEncoder},
     imageops::FilterType,
     DynamicImage,
-    ExtendedColorType,
     GenericImageView,
     ImageBuffer,
-    ImageEncoder,
     ImageFormat,
     Rgba,
 };
@@ -33,119 +30,6 @@ pub struct ImageBehavior {
     pub target_height: u32,
     pub output_format: OutputFormat,
     pub transparent_background: bool,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct RuntimeImageProfile {
-    pub max_width: u32,
-    pub max_height: u32,
-    pub jpeg_quality: u8,
-}
-
-/// Maximum resolution the runtime ever serves per asset type. Single source
-/// of truth shared by the ingest paths (generation targets, imports) and the
-/// R2 upload optimizer, so what lands on disk matches what actually ships.
-pub fn runtime_image_profile(asset_type: &str) -> Option<RuntimeImageProfile> {
-    let profile = match asset_type {
-        "player_sprite" | "ability_icon" | "status_effect_icon" | "ability_sprite" | "item" | "lore_item" | "status_art" => {
-            RuntimeImageProfile { max_width: 256, max_height: 256, jpeg_quality: 82 }
-        }
-        "mob" | "pet" | "entity_portrait" | "race_portrait" | "class_portrait" | "lore_character" | "lore_species" => {
-            RuntimeImageProfile { max_width: 512, max_height: 768, jpeg_quality: 84 }
-        }
-        "room" | "background" | "zone_map" | "splash_hero" | "panel_header" | "loading_vignette" | "empty_state" | "ornament" | "lore_location" => {
-            RuntimeImageProfile { max_width: 1280, max_height: 1280, jpeg_quality: 82 }
-        }
-        "lore_map" => {
-            RuntimeImageProfile { max_width: 2048, max_height: 2048, jpeg_quality: 85 }
-        }
-        "showcase_banner" => {
-            RuntimeImageProfile { max_width: 1920, max_height: 820, jpeg_quality: 85 }
-        }
-        "showcase_favicon" => {
-            RuntimeImageProfile { max_width: 512, max_height: 512, jpeg_quality: 88 }
-        }
-        _ => return None,
-    };
-    Some(profile)
-}
-
-/// Fit dimensions within the asset type's runtime profile, preserving aspect
-/// ratio. Types with no profile pass through unchanged.
-pub fn cap_stored_dims(asset_type: &str, width: u32, height: u32) -> (u32, u32) {
-    let Some(profile) = runtime_image_profile(asset_type) else {
-        return (width, height);
-    };
-    if width <= profile.max_width && height <= profile.max_height {
-        return (width, height);
-    }
-    let scale = (profile.max_width as f64 / width as f64)
-        .min(profile.max_height as f64 / height as f64);
-    (
-        ((width as f64 * scale).round() as u32).max(1),
-        ((height as f64 * scale).round() as u32).max(1),
-    )
-}
-
-/// Downscale and re-encode image bytes to the asset type's runtime profile.
-/// Returns the original bytes when no profile applies, the extension isn't a
-/// re-encodable format (WebP passes through), decoding fails, or the
-/// re-encode isn't smaller at unchanged dimensions.
-pub fn cap_image_bytes(asset_type: &str, ext: &str, bytes: &[u8]) -> Vec<u8> {
-    let Some(profile) = runtime_image_profile(asset_type) else {
-        return bytes.to_vec();
-    };
-    if !matches!(ext, "png" | "jpg" | "jpeg") {
-        return bytes.to_vec();
-    }
-
-    let decoded = match image::load_from_memory(bytes) {
-        Ok(img) => img,
-        Err(_) => return bytes.to_vec(),
-    };
-    let original_width = decoded.width();
-    let original_height = decoded.height();
-
-    let resized = if original_width > profile.max_width || original_height > profile.max_height {
-        decoded.resize(profile.max_width, profile.max_height, FilterType::Lanczos3)
-    } else {
-        decoded
-    };
-
-    let mut out = Vec::new();
-    let encode_result = if ext == "png" {
-        let rgba = resized.to_rgba8();
-        let encoder = PngEncoder::new_with_quality(
-            &mut out,
-            PngCompressionType::Best,
-            PngFilterType::Adaptive,
-        );
-        encoder.write_image(
-            rgba.as_raw(),
-            rgba.width(),
-            rgba.height(),
-            ExtendedColorType::Rgba8,
-        )
-    } else {
-        let rgb = resized.to_rgb8();
-        let encoder = JpegEncoder::new_with_quality(&mut out, profile.jpeg_quality);
-        encoder.write_image(
-            rgb.as_raw(),
-            rgb.width(),
-            rgb.height(),
-            ExtendedColorType::Rgb8,
-        )
-    };
-
-    if encode_result.is_err() || out.is_empty() {
-        return bytes.to_vec();
-    }
-
-    if out.len() < bytes.len() || resized.width() != original_width || resized.height() != original_height {
-        out
-    } else {
-        bytes.to_vec()
-    }
 }
 
 /// Cap generation dimensions to 1024px on the long edge while preserving aspect ratio.
@@ -206,7 +90,8 @@ pub fn infer_behavior(
     // Store at the resolution the runtime actually serves — R2/hub uploads
     // downscale to the profile anyway, so anything larger is wasted disk,
     // IPC payload, and decode time.
-    let (target_width, target_height) = cap_stored_dims(asset_type, width.max(1), height.max(1));
+    let (target_width, target_height) =
+        crate::image_profiles::cap_stored_dims(asset_type, width.max(1), height.max(1));
 
     ImageBehavior {
         target_width,
@@ -338,46 +223,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn cap_stored_dims_fits_profile_preserving_aspect() {
-        assert_eq!(cap_stored_dims("item", 1024, 1024), (256, 256));
-        assert_eq!(cap_stored_dims("mob", 1024, 1536), (512, 768));
-        assert_eq!(cap_stored_dims("room", 1536, 1024), (1280, 853));
-    }
-
-    #[test]
-    fn cap_stored_dims_passes_through_unprofiled_and_fitting() {
-        assert_eq!(cap_stored_dims("story_scene", 4096, 4096), (4096, 4096));
-        assert_eq!(cap_stored_dims("item", 128, 128), (128, 128));
-    }
-
-    #[test]
     fn infer_behavior_caps_generation_targets() {
         let b = infer_behavior(Some("ability_icon"), 1024, 1024, None);
         assert_eq!((b.target_width, b.target_height), (256, 256));
         assert_eq!(b.output_format, OutputFormat::Png);
-    }
-
-    #[test]
-    fn cap_image_bytes_downscales_oversized_png() {
-        let img = DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
-            512,
-            512,
-            Rgba([120, 40, 200, 255]),
-        ));
-        let mut cursor = Cursor::new(Vec::new());
-        img.write_to(&mut cursor, ImageFormat::Png).unwrap();
-        let bytes = cursor.into_inner();
-
-        let capped = cap_image_bytes("item", "png", &bytes);
-        let decoded = image::load_from_memory(&capped).unwrap();
-        assert_eq!((decoded.width(), decoded.height()), (256, 256));
-    }
-
-    #[test]
-    fn cap_image_bytes_passes_through_unprofiled_types_and_webp() {
-        let bytes = vec![1, 2, 3];
-        assert_eq!(cap_image_bytes("story_scene", "png", &bytes), bytes);
-        assert_eq!(cap_image_bytes("item", "webp", &bytes), bytes);
     }
 }
 

--- a/creator/src-tauri/src/generation.rs
+++ b/creator/src-tauri/src/generation.rs
@@ -3,10 +3,13 @@ use std::io::Cursor;
 use base64::Engine;
 use image::{
     codecs::jpeg::JpegEncoder,
+    codecs::png::{CompressionType as PngCompressionType, FilterType as PngFilterType, PngEncoder},
     imageops::FilterType,
     DynamicImage,
+    ExtendedColorType,
     GenericImageView,
     ImageBuffer,
+    ImageEncoder,
     ImageFormat,
     Rgba,
 };
@@ -30,6 +33,119 @@ pub struct ImageBehavior {
     pub target_height: u32,
     pub output_format: OutputFormat,
     pub transparent_background: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeImageProfile {
+    pub max_width: u32,
+    pub max_height: u32,
+    pub jpeg_quality: u8,
+}
+
+/// Maximum resolution the runtime ever serves per asset type. Single source
+/// of truth shared by the ingest paths (generation targets, imports) and the
+/// R2 upload optimizer, so what lands on disk matches what actually ships.
+pub fn runtime_image_profile(asset_type: &str) -> Option<RuntimeImageProfile> {
+    let profile = match asset_type {
+        "player_sprite" | "ability_icon" | "status_effect_icon" | "ability_sprite" | "item" | "lore_item" | "status_art" => {
+            RuntimeImageProfile { max_width: 256, max_height: 256, jpeg_quality: 82 }
+        }
+        "mob" | "pet" | "entity_portrait" | "race_portrait" | "class_portrait" | "lore_character" | "lore_species" => {
+            RuntimeImageProfile { max_width: 512, max_height: 768, jpeg_quality: 84 }
+        }
+        "room" | "background" | "zone_map" | "splash_hero" | "panel_header" | "loading_vignette" | "empty_state" | "ornament" | "lore_location" => {
+            RuntimeImageProfile { max_width: 1280, max_height: 1280, jpeg_quality: 82 }
+        }
+        "lore_map" => {
+            RuntimeImageProfile { max_width: 2048, max_height: 2048, jpeg_quality: 85 }
+        }
+        "showcase_banner" => {
+            RuntimeImageProfile { max_width: 1920, max_height: 820, jpeg_quality: 85 }
+        }
+        "showcase_favicon" => {
+            RuntimeImageProfile { max_width: 512, max_height: 512, jpeg_quality: 88 }
+        }
+        _ => return None,
+    };
+    Some(profile)
+}
+
+/// Fit dimensions within the asset type's runtime profile, preserving aspect
+/// ratio. Types with no profile pass through unchanged.
+pub fn cap_stored_dims(asset_type: &str, width: u32, height: u32) -> (u32, u32) {
+    let Some(profile) = runtime_image_profile(asset_type) else {
+        return (width, height);
+    };
+    if width <= profile.max_width && height <= profile.max_height {
+        return (width, height);
+    }
+    let scale = (profile.max_width as f64 / width as f64)
+        .min(profile.max_height as f64 / height as f64);
+    (
+        ((width as f64 * scale).round() as u32).max(1),
+        ((height as f64 * scale).round() as u32).max(1),
+    )
+}
+
+/// Downscale and re-encode image bytes to the asset type's runtime profile.
+/// Returns the original bytes when no profile applies, the extension isn't a
+/// re-encodable format (WebP passes through), decoding fails, or the
+/// re-encode isn't smaller at unchanged dimensions.
+pub fn cap_image_bytes(asset_type: &str, ext: &str, bytes: &[u8]) -> Vec<u8> {
+    let Some(profile) = runtime_image_profile(asset_type) else {
+        return bytes.to_vec();
+    };
+    if !matches!(ext, "png" | "jpg" | "jpeg") {
+        return bytes.to_vec();
+    }
+
+    let decoded = match image::load_from_memory(bytes) {
+        Ok(img) => img,
+        Err(_) => return bytes.to_vec(),
+    };
+    let original_width = decoded.width();
+    let original_height = decoded.height();
+
+    let resized = if original_width > profile.max_width || original_height > profile.max_height {
+        decoded.resize(profile.max_width, profile.max_height, FilterType::Lanczos3)
+    } else {
+        decoded
+    };
+
+    let mut out = Vec::new();
+    let encode_result = if ext == "png" {
+        let rgba = resized.to_rgba8();
+        let encoder = PngEncoder::new_with_quality(
+            &mut out,
+            PngCompressionType::Best,
+            PngFilterType::Adaptive,
+        );
+        encoder.write_image(
+            rgba.as_raw(),
+            rgba.width(),
+            rgba.height(),
+            ExtendedColorType::Rgba8,
+        )
+    } else {
+        let rgb = resized.to_rgb8();
+        let encoder = JpegEncoder::new_with_quality(&mut out, profile.jpeg_quality);
+        encoder.write_image(
+            rgb.as_raw(),
+            rgb.width(),
+            rgb.height(),
+            ExtendedColorType::Rgb8,
+        )
+    };
+
+    if encode_result.is_err() || out.is_empty() {
+        return bytes.to_vec();
+    }
+
+    if out.len() < bytes.len() || resized.width() != original_width || resized.height() != original_height {
+        out
+    } else {
+        bytes.to_vec()
+    }
 }
 
 /// Cap generation dimensions to 1024px on the long edge while preserving aspect ratio.
@@ -87,9 +203,14 @@ pub fn infer_behavior(
 
     let transparent_background = transparent_background.unwrap_or(false);
 
+    // Store at the resolution the runtime actually serves — R2/hub uploads
+    // downscale to the profile anyway, so anything larger is wasted disk,
+    // IPC payload, and decode time.
+    let (target_width, target_height) = cap_stored_dims(asset_type, width.max(1), height.max(1));
+
     ImageBehavior {
-        target_width: width.max(1),
-        target_height: height.max(1),
+        target_width,
+        target_height,
         output_format,
         transparent_background,
     }
@@ -210,6 +331,54 @@ fn encode_jpeg(image: &DynamicImage) -> Result<Vec<u8>, String> {
         .encode_image(&DynamicImage::ImageRgb8(flattened))
         .map_err(|e| format!("Failed to encode JPEG: {e}"))?;
     Ok(cursor.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cap_stored_dims_fits_profile_preserving_aspect() {
+        assert_eq!(cap_stored_dims("item", 1024, 1024), (256, 256));
+        assert_eq!(cap_stored_dims("mob", 1024, 1536), (512, 768));
+        assert_eq!(cap_stored_dims("room", 1536, 1024), (1280, 853));
+    }
+
+    #[test]
+    fn cap_stored_dims_passes_through_unprofiled_and_fitting() {
+        assert_eq!(cap_stored_dims("story_scene", 4096, 4096), (4096, 4096));
+        assert_eq!(cap_stored_dims("item", 128, 128), (128, 128));
+    }
+
+    #[test]
+    fn infer_behavior_caps_generation_targets() {
+        let b = infer_behavior(Some("ability_icon"), 1024, 1024, None);
+        assert_eq!((b.target_width, b.target_height), (256, 256));
+        assert_eq!(b.output_format, OutputFormat::Png);
+    }
+
+    #[test]
+    fn cap_image_bytes_downscales_oversized_png() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            512,
+            512,
+            Rgba([120, 40, 200, 255]),
+        ));
+        let mut cursor = Cursor::new(Vec::new());
+        img.write_to(&mut cursor, ImageFormat::Png).unwrap();
+        let bytes = cursor.into_inner();
+
+        let capped = cap_image_bytes("item", "png", &bytes);
+        let decoded = image::load_from_memory(&capped).unwrap();
+        assert_eq!((decoded.width(), decoded.height()), (256, 256));
+    }
+
+    #[test]
+    fn cap_image_bytes_passes_through_unprofiled_types_and_webp() {
+        let bytes = vec![1, 2, 3];
+        assert_eq!(cap_image_bytes("story_scene", "png", &bytes), bytes);
+        assert_eq!(cap_image_bytes("item", "webp", &bytes), bytes);
+    }
 }
 
 fn flatten_alpha(image: &ImageBuffer<Rgba<u8>, Vec<u8>>) -> image::RgbImage {

--- a/creator/src-tauri/src/image_profiles.rs
+++ b/creator/src-tauri/src/image_profiles.rs
@@ -1,0 +1,164 @@
+use image::{
+    codecs::jpeg::JpegEncoder,
+    codecs::png::{CompressionType as PngCompressionType, FilterType as PngFilterType, PngEncoder},
+    imageops::FilterType,
+    ExtendedColorType,
+    ImageEncoder,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct RuntimeImageProfile {
+    pub max_width: u32,
+    pub max_height: u32,
+    pub jpeg_quality: u8,
+}
+
+/// Maximum resolution the runtime ever serves per asset type. Single source
+/// of truth shared by the ingest paths (generation targets, imports) and the
+/// R2 upload optimizer, so what lands on disk matches what actually ships.
+pub fn runtime_image_profile(asset_type: &str) -> Option<RuntimeImageProfile> {
+    let profile = match asset_type {
+        "player_sprite" | "ability_icon" | "status_effect_icon" | "ability_sprite" | "item" | "lore_item" | "status_art" => {
+            RuntimeImageProfile { max_width: 256, max_height: 256, jpeg_quality: 82 }
+        }
+        "mob" | "pet" | "entity_portrait" | "race_portrait" | "class_portrait" | "lore_character" | "lore_species" => {
+            RuntimeImageProfile { max_width: 512, max_height: 768, jpeg_quality: 84 }
+        }
+        "room" | "background" | "zone_map" | "splash_hero" | "panel_header" | "loading_vignette" | "empty_state" | "ornament" | "lore_location" => {
+            RuntimeImageProfile { max_width: 1280, max_height: 1280, jpeg_quality: 82 }
+        }
+        "lore_map" => {
+            RuntimeImageProfile { max_width: 2048, max_height: 2048, jpeg_quality: 85 }
+        }
+        "showcase_banner" => {
+            RuntimeImageProfile { max_width: 1920, max_height: 820, jpeg_quality: 85 }
+        }
+        "showcase_favicon" => {
+            RuntimeImageProfile { max_width: 512, max_height: 512, jpeg_quality: 88 }
+        }
+        _ => return None,
+    };
+    Some(profile)
+}
+
+/// Fit dimensions within the asset type's runtime profile, preserving aspect
+/// ratio. Types with no profile pass through unchanged.
+#[cfg_attr(not(feature = "ai"), allow(dead_code))]
+pub fn cap_stored_dims(asset_type: &str, width: u32, height: u32) -> (u32, u32) {
+    let Some(profile) = runtime_image_profile(asset_type) else {
+        return (width, height);
+    };
+    if width <= profile.max_width && height <= profile.max_height {
+        return (width, height);
+    }
+    let scale = (profile.max_width as f64 / width as f64)
+        .min(profile.max_height as f64 / height as f64);
+    (
+        ((width as f64 * scale).round() as u32).max(1),
+        ((height as f64 * scale).round() as u32).max(1),
+    )
+}
+
+/// Downscale and re-encode image bytes to the asset type's runtime profile.
+/// Returns the original bytes when no profile applies, the extension isn't a
+/// re-encodable format (WebP passes through), decoding fails, or the
+/// re-encode isn't smaller at unchanged dimensions.
+pub fn cap_image_bytes(asset_type: &str, ext: &str, bytes: &[u8]) -> Vec<u8> {
+    let Some(profile) = runtime_image_profile(asset_type) else {
+        return bytes.to_vec();
+    };
+    if !matches!(ext, "png" | "jpg" | "jpeg") {
+        return bytes.to_vec();
+    }
+
+    let decoded = match image::load_from_memory(bytes) {
+        Ok(img) => img,
+        Err(_) => return bytes.to_vec(),
+    };
+    let original_width = decoded.width();
+    let original_height = decoded.height();
+
+    let resized = if original_width > profile.max_width || original_height > profile.max_height {
+        decoded.resize(profile.max_width, profile.max_height, FilterType::Lanczos3)
+    } else {
+        decoded
+    };
+
+    let mut out = Vec::new();
+    let encode_result = if ext == "png" {
+        let rgba = resized.to_rgba8();
+        let encoder = PngEncoder::new_with_quality(
+            &mut out,
+            PngCompressionType::Best,
+            PngFilterType::Adaptive,
+        );
+        encoder.write_image(
+            rgba.as_raw(),
+            rgba.width(),
+            rgba.height(),
+            ExtendedColorType::Rgba8,
+        )
+    } else {
+        let rgb = resized.to_rgb8();
+        let encoder = JpegEncoder::new_with_quality(&mut out, profile.jpeg_quality);
+        encoder.write_image(
+            rgb.as_raw(),
+            rgb.width(),
+            rgb.height(),
+            ExtendedColorType::Rgb8,
+        )
+    };
+
+    if encode_result.is_err() || out.is_empty() {
+        return bytes.to_vec();
+    }
+
+    if out.len() < bytes.len() || resized.width() != original_width || resized.height() != original_height {
+        out
+    } else {
+        bytes.to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{DynamicImage, ImageFormat, Rgba};
+    use std::io::Cursor;
+
+    #[test]
+    fn cap_stored_dims_fits_profile_preserving_aspect() {
+        assert_eq!(cap_stored_dims("item", 1024, 1024), (256, 256));
+        assert_eq!(cap_stored_dims("mob", 1024, 1536), (512, 768));
+        assert_eq!(cap_stored_dims("room", 1536, 1024), (1280, 853));
+    }
+
+    #[test]
+    fn cap_stored_dims_passes_through_unprofiled_and_fitting() {
+        assert_eq!(cap_stored_dims("story_scene", 4096, 4096), (4096, 4096));
+        assert_eq!(cap_stored_dims("item", 128, 128), (128, 128));
+    }
+
+    #[test]
+    fn cap_image_bytes_downscales_oversized_png() {
+        let img = DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            512,
+            512,
+            Rgba([120, 40, 200, 255]),
+        ));
+        let mut cursor = Cursor::new(Vec::new());
+        img.write_to(&mut cursor, ImageFormat::Png).unwrap();
+        let bytes = cursor.into_inner();
+
+        let capped = cap_image_bytes("item", "png", &bytes);
+        let decoded = image::load_from_memory(&capped).unwrap();
+        assert_eq!((decoded.width(), decoded.height()), (256, 256));
+    }
+
+    #[test]
+    fn cap_image_bytes_passes_through_unprofiled_types_and_webp() {
+        let bytes = vec![1, 2, 3];
+        assert_eq!(cap_image_bytes("story_scene", "png", &bytes), bytes);
+        assert_eq!(cap_image_bytes("item", "webp", &bytes), bytes);
+    }
+}

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod git;
 mod generation;
 mod http;
 mod hub;
+mod image_profiles;
 #[cfg(feature = "ai")]
 mod hub_ai;
 #[cfg(feature = "ai")]

--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -1,9 +1,5 @@
 use chrono::Utc;
 use hmac::{Hmac, Mac};
-use image::codecs::jpeg::JpegEncoder;
-use image::codecs::png::{CompressionType as PngCompressionType, FilterType as PngFilterType, PngEncoder};
-use image::imageops::FilterType as ResizeFilter;
-use image::{ExtendedColorType, ImageEncoder};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use tauri::AppHandle;
@@ -52,13 +48,6 @@ pub struct VoiceUploadJob {
     pub text_sha8: String,
     /// Cache filename stem of the local clip to upload.
     pub cache_hash: String,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct RuntimeImageProfile {
-    max_width: u32,
-    max_height: u32,
-    jpeg_quality: u8,
 }
 
 // ─── AWS Signature V4 (minimal, for S3-compatible R2) ───────────────
@@ -272,102 +261,17 @@ fn image_extension(path: &str) -> Option<String> {
     }
 }
 
-fn runtime_image_profile(asset_type: &str) -> Option<RuntimeImageProfile> {
-    let profile = match asset_type {
-        "player_sprite" | "ability_icon" | "status_effect_icon" | "ability_sprite" | "item" | "lore_item" | "status_art" => {
-            RuntimeImageProfile { max_width: 256, max_height: 256, jpeg_quality: 82 }
-        }
-        "mob" | "pet" | "entity_portrait" | "race_portrait" | "class_portrait" | "lore_character" | "lore_species" => {
-            RuntimeImageProfile { max_width: 512, max_height: 768, jpeg_quality: 84 }
-        }
-        "room" | "background" | "zone_map" | "splash_hero" | "panel_header" | "loading_vignette" | "empty_state" | "ornament" | "lore_location" => {
-            RuntimeImageProfile { max_width: 1280, max_height: 1280, jpeg_quality: 82 }
-        }
-        "lore_map" => {
-            RuntimeImageProfile { max_width: 2048, max_height: 2048, jpeg_quality: 85 }
-        }
-        "showcase_banner" => {
-            RuntimeImageProfile { max_width: 1920, max_height: 820, jpeg_quality: 85 }
-        }
-        "showcase_favicon" => {
-            RuntimeImageProfile { max_width: 512, max_height: 512, jpeg_quality: 88 }
-        }
-        _ => return None,
-    };
-    Some(profile)
-}
-
 fn optimized_runtime_image_bytes(
     asset_type: &str,
     source_name: &str,
     object_key: &str,
     bytes: &[u8],
 ) -> Vec<u8> {
-    let Some(profile) = runtime_image_profile(asset_type) else {
-        return bytes.to_vec();
-    };
-
     let target_ext = image_extension(object_key).or_else(|| image_extension(source_name));
     let Some(target_ext) = target_ext else {
         return bytes.to_vec();
     };
-
-    // Keep WEBP pass-through for now; current runtime optimization only re-encodes PNG/JPEG.
-    if target_ext == "webp" {
-        return bytes.to_vec();
-    }
-
-    let decoded = match image::load_from_memory(bytes) {
-        Ok(img) => img,
-        Err(_) => return bytes.to_vec(),
-    };
-    let original_width = decoded.width();
-    let original_height = decoded.height();
-
-    let resized = if original_width > profile.max_width || original_height > profile.max_height {
-        decoded.resize(profile.max_width, profile.max_height, ResizeFilter::Lanczos3)
-    } else {
-        decoded
-    };
-
-    let mut out = Vec::new();
-    let encode_result = match target_ext.as_str() {
-        "jpg" | "jpeg" => {
-            let rgb = resized.to_rgb8();
-            let mut encoder = JpegEncoder::new_with_quality(&mut out, profile.jpeg_quality);
-            encoder.encode(
-                rgb.as_raw(),
-                rgb.width(),
-                rgb.height(),
-                ExtendedColorType::Rgb8,
-            )
-        }
-        "png" => {
-            let rgba = resized.to_rgba8();
-            let encoder = PngEncoder::new_with_quality(
-                &mut out,
-                PngCompressionType::Best,
-                PngFilterType::Adaptive,
-            );
-            encoder.write_image(
-                rgba.as_raw(),
-                rgba.width(),
-                rgba.height(),
-                ExtendedColorType::Rgba8,
-            )
-        }
-        _ => return bytes.to_vec(),
-    };
-
-    if encode_result.is_err() || out.is_empty() {
-        return bytes.to_vec();
-    }
-
-    if out.len() < bytes.len() || resized.width() != original_width || resized.height() != original_height {
-        out
-    } else {
-        bytes.to_vec()
-    }
+    crate::generation::cap_image_bytes(asset_type, &target_ext, bytes)
 }
 
 /// Check if an object already exists in R2.

--- a/creator/src-tauri/src/r2.rs
+++ b/creator/src-tauri/src/r2.rs
@@ -271,7 +271,7 @@ fn optimized_runtime_image_bytes(
     let Some(target_ext) = target_ext else {
         return bytes.to_vec();
     };
-    crate::generation::cap_image_bytes(asset_type, &target_ext, bytes)
+    crate::image_profiles::cap_image_bytes(asset_type, &target_ext, bytes)
 }
 
 /// Check if an object already exists in R2.


### PR DESCRIPTION
## Why

Audit finding: no consumer of a stored asset ever uses the full generation resolution. R2 sync and hub publish both re-encode to per-asset-type caps before upload, the story/cinematic pipeline composites at target video resolution, and the creator UI renders thumbnails. Yet generation output was stored at the requested 1024–1536px — icons at **4× the linear size** anything ever serves (1024² stored, 256² shipped), portraits at 2×. That inflates disk usage, base64 IPC payloads, and decode time everywhere images are touched.

## What

**Single source of truth:** the per-asset-type profile table moves from `r2.rs` to `generation.rs` as `runtime_image_profile` (256² icons/items/sprites, 512×768 portraits, 1280² rooms/backgrounds, 2048² lore maps, …). The R2 upload optimizer now delegates to the shared `cap_image_bytes` helper — no behavior change on the upload path.

**Applied at ingest:**
- `infer_behavior` caps generation target dimensions, so all four providers (Runware, DeepInfra, OpenAI Images, hub proxy) store at profile size. Generation still runs at ~1024px for model quality — the downscale is effectively supersampling.
- `import_asset`, `save_bytes_as_asset` (bg-removal output), and `bulk_import_images` downscale oversized images before hashing, so the content-addressed filename reflects the bytes actually stored. Writes switched from `copy` to `write` accordingly.

**Deliberately untouched:**
- Types without a profile (e.g. story scenes) store at full requested size.
- `import_player_sprites` / `import_zone_assets` keep raw-byte hashing — their retag/dedup flows must match hashes already in the manifest.
- **No migration of existing assets.** Filenames are content hashes, so re-encoding in place would orphan every zone/lore reference. A migration command with reference rewriting is a separate follow-up.

**Trade-off accepted:** the in-app lightbox/detail preview now tops out at the serving resolution (a 256px icon can't be zoomed to 1024 anymore). Preview shows exactly what ships.

## Testing

- `cargo check` clean, `cargo test` passes (5 new unit tests covering dim capping, aspect preservation, PNG downscale round-trip, and passthrough cases; existing r2 voice-contract tests still green)
- CLAUDE.md updated (generation.rs module note + Generation dimensions pitfall)
- Not yet exercised against a live generation run