### PR TITLE
fix(creator): relax enhancer output cap from 100 to 150 words

### DIFF
--- a/creator/src/lib/arcanumPrompts.ts
+++ b/creator/src/lib/arcanumPrompts.ts
@@ -562,7 +562,7 @@ export const ASSET_TEMPLATES: Record<AssetType, { label: string; templates: Reco
 /** Shared output-length rule for all enhancer system prompts. Enhanced
  *  prompts are billed as image-model input tokens on every generation, so
  *  the cap is a direct per-image cost control. */
-const ENHANCE_LENGTH_RULE = `Keep the finished prompt under 100 words — every phrase must add concrete visual information; no filler, no repeated style language.`;
+const ENHANCE_LENGTH_RULE = `Keep the finished prompt under 150 words — every phrase must add concrete visual information; no filler, no repeated style language.`;
 
 const ENHANCE_SYSTEM_PROMPT_ARCANUM = `You are a prompt engineer for AI image generation models. Enhance user prompts for the Arcanum art style (arcanum_v1) — vast, baroque, luminous, like looking into the architecture of creation.
 


### PR DESCRIPTION
## Why

The enhancement-pipeline trim (#338) capped enhancer output at 100 words via the shared `ENHANCE_LENGTH_RULE`. In practice that's squeezing concrete subject detail out of enhanced prompts — race portraits noticeably lost specificity (races render less detailed than before the trim).

Race portraits hit this cap through the standard path: `RaceEditor` → `EntityArtGenerator` (`assetType="race_portrait"`) → `getEnhanceSystemPrompt`, where every enhancer system prompt embeds the rule.

## What

One constant: the shared `ENHANCE_LENGTH_RULE` goes from **under 100 words → under 150 words**. All enhancer system prompts (Arcanum, Gentle Magic, custom-asset, world-visual-style) relax together since they share the constant.

This keeps most of #338's cost win — pre-trim enhancer output ran 250–450 words, so 150 is still a ~2–3× reduction — while restoring room for the detail that was being cut. The sprite-safety override (constraints exempt from the cap) is unaffected. The `llm_complete` default of 1024 output tokens comfortably fits 150 words.

## Testing

- `bunx tsc --noEmit` clean
- `bun run test` — 2305 tests pass
- Not yet validated against live generations — worth re-generating a couple of race portraits to confirm the detail comes back