### PR TITLE
feat(creator): Optimize Library — migrate existing assets to runtime profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ All public functions exposed to the frontend are `#[tauri::command]` and return 
 - `assets.rs` — asset manifest (JSON) with content-addressed SHA-256 storage
 - `generation.rs` — image generation utilities (dimension capping to 1024px, format inference, resize pipeline)
 - `image_profiles.rs` — per-asset-type runtime image profiles + downscale helpers, shared by the ingest paths and the R2 optimizer. Always compiled (not behind the `ai` feature) because `assets.rs` and `r2.rs` use it in the Community Edition build
-- `asset_migration.rs` — one-shot library migration ("Optimize Library" in the Asset Gallery): downscales stored images that exceed their runtime profile, takes a project snapshot, updates the manifest, and rewrites every YAML reference via exact-token replacement (content-hash filenames are globally unique, so plain substitution is safe and format-preserving). Old files are deleted only after the manifest and all references point at the new names
+- `asset_migration.rs` — one-shot library migration ("Optimize Library" in the Asset Gallery): downscales stored images that exceed their runtime profile, takes a project snapshot, updates the manifest, and rewrites every YAML/JSON reference (zones, config, lore, story files) via exact-token replacement (content-hash filenames are globally unique, so plain substitution is safe and format-preserving). Old files are deleted only after the manifest and all references point at the new names
 - `deepinfra.rs` — DeepInfra API client (FLUX image generation)
 - `runware.rs` — Runware API client (alternative image provider)
 - `openai_images.rs` — OpenAI GPT Image provider

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ All public functions exposed to the frontend are `#[tauri::command]` and return 
 - `assets.rs` — asset manifest (JSON) with content-addressed SHA-256 storage
 - `generation.rs` — image generation utilities (dimension capping to 1024px, format inference, resize pipeline)
 - `image_profiles.rs` — per-asset-type runtime image profiles + downscale helpers, shared by the ingest paths and the R2 optimizer. Always compiled (not behind the `ai` feature) because `assets.rs` and `r2.rs` use it in the Community Edition build
+- `asset_migration.rs` — one-shot library migration ("Optimize Library" in the Asset Gallery): downscales stored images that exceed their runtime profile, takes a project snapshot, updates the manifest, and rewrites every YAML reference via exact-token replacement (content-hash filenames are globally unique, so plain substitution is safe and format-preserving). Old files are deleted only after the manifest and all references point at the new names
 - `deepinfra.rs` — DeepInfra API client (FLUX image generation)
 - `runware.rs` — Runware API client (alternative image provider)
 - `openai_images.rs` — OpenAI GPT Image provider

--- a/creator/src-tauri/src/asset_migration.rs
+++ b/creator/src-tauri/src/asset_migration.rs
@@ -1,0 +1,363 @@
+//! Migrates an existing asset library to the per-asset-type runtime image
+//! profiles. Files are content-addressed (`<sha256>.<ext>`), so re-encoding
+//! produces a new filename; the migration rewrites every YAML reference in
+//! the project via exact-token replacement — hash filenames are globally
+//! unique 64-hex strings, so plain string substitution cannot false-match
+//! and preserves formatting without re-serializing YAML.
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Emitter};
+
+/// Directories never scanned for references. `.arcanum` holds the manifest
+/// (updated separately) and snapshots; the rest are VCS/build output.
+const SKIP_DIRS: &[&str] = &[
+    ".arcanum",
+    ".git",
+    ".gradle",
+    "build",
+    "dist",
+    "node_modules",
+    "target",
+];
+
+#[derive(Debug, Default, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MigrationReport {
+    /// Image assets that have a runtime profile and were checked.
+    pub total_assets: usize,
+    /// Assets exceeding their profile (migrated, or would be in a dry run).
+    pub affected: usize,
+    pub bytes_before: u64,
+    /// Dry run: estimated from the area ratio. Real run: actual.
+    pub bytes_after: u64,
+    pub estimated: bool,
+    /// YAML files whose references were rewritten.
+    pub references_updated: usize,
+    pub errors: Vec<String>,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MigrationProgress {
+    stage: String,
+    current: usize,
+    total: usize,
+}
+
+fn emit_progress(app: &AppHandle, stage: &str, current: usize, total: usize) {
+    let _ = app.emit(
+        "asset-migration-progress",
+        MigrationProgress {
+            stage: stage.to_string(),
+            current,
+            total,
+        },
+    );
+}
+
+fn extension_of(file_name: &str) -> String {
+    file_name
+        .rsplit('.')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+}
+
+struct MigrationPlan {
+    /// Manifest indices sharing this file (historical duplicates).
+    indices: Vec<usize>,
+    old_name: String,
+    asset_type: String,
+    ext: String,
+    path: PathBuf,
+    file_size: u64,
+    width: u32,
+    height: u32,
+}
+
+/// Replace every mapped filename token in `content`. Returns `None` when
+/// nothing matched. Keys are full content-addressed filenames
+/// (`<64-hex>.<ext>`), so substitution is exact and order-independent.
+fn rewrite_content(content: &str, mapping: &HashMap<String, String>) -> Option<String> {
+    let mut result = content.to_string();
+    let mut changed = false;
+    for (old, new) in mapping {
+        if result.contains(old.as_str()) {
+            result = result.replace(old.as_str(), new);
+            changed = true;
+        }
+    }
+    changed.then_some(result)
+}
+
+/// Walk the project directory and rewrite references in every YAML file.
+/// Returns the number of files updated.
+fn rewrite_project_references(
+    root: &Path,
+    mapping: &HashMap<String, String>,
+) -> Result<usize, String> {
+    if mapping.is_empty() {
+        return Ok(0);
+    }
+    let mut updated = 0;
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .map_err(|e| format!("Failed to read {}: {e}", dir.display()))?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if path.is_dir() {
+                if !SKIP_DIRS.contains(&name.as_str()) {
+                    stack.push(path);
+                }
+                continue;
+            }
+            let is_yaml = matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("yaml") | Some("yml")
+            );
+            if !is_yaml {
+                continue;
+            }
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            if let Some(new_content) = rewrite_content(&content, mapping) {
+                std::fs::write(&path, new_content)
+                    .map_err(|e| format!("Failed to rewrite {}: {e}", path.display()))?;
+                updated += 1;
+            }
+        }
+    }
+    Ok(updated)
+}
+
+/// Downscale every stored image that exceeds its asset type's runtime
+/// profile, updating the manifest and rewriting project YAML references to
+/// the new content-addressed filenames. `dry_run` reports what would change
+/// without touching anything.
+#[tauri::command]
+pub async fn migrate_assets_to_profiles(
+    app: AppHandle,
+    dry_run: bool,
+) -> Result<MigrationReport, String> {
+    let Some(project_dir) = crate::settings::active_project_dir().await else {
+        return Err("Open a project first — migration rewrites project files.".to_string());
+    };
+
+    let images_dir = crate::assets::assets_dir(&app)?.join("images");
+
+    let _lock = crate::assets::MANIFEST_LOCK.lock().await;
+    let mut manifest = crate::assets::load_manifest(&app).await?;
+
+    let mut report = MigrationReport::default();
+    let mut plans: Vec<MigrationPlan> = Vec::new();
+    let mut planned: HashMap<String, usize> = HashMap::new();
+
+    for (idx, entry) in manifest.assets.iter().enumerate() {
+        let ext = extension_of(&entry.file_name);
+        if !matches!(ext.as_str(), "png" | "jpg" | "jpeg") {
+            continue;
+        }
+        if crate::image_profiles::runtime_image_profile(&entry.asset_type).is_none() {
+            continue;
+        }
+        let path = images_dir.join(&entry.file_name);
+        let Ok(meta) = std::fs::metadata(&path) else {
+            continue;
+        };
+        report.total_assets += 1;
+
+        if let Some(&plan_idx) = planned.get(&entry.file_name) {
+            plans[plan_idx].indices.push(idx);
+            continue;
+        }
+
+        let (width, height) = if entry.width > 0 && entry.height > 0 {
+            (entry.width, entry.height)
+        } else {
+            match imagesize::size(&path) {
+                Ok(size) => (size.width as u32, size.height as u32),
+                Err(_) => continue,
+            }
+        };
+        let (capped_w, capped_h) =
+            crate::image_profiles::cap_stored_dims(&entry.asset_type, width, height);
+        if (capped_w, capped_h) == (width, height) {
+            continue;
+        }
+
+        report.affected += 1;
+        report.bytes_before += meta.len();
+        if dry_run {
+            let ratio =
+                (capped_w as u64 * capped_h as u64) as f64 / (width as u64 * height as u64) as f64;
+            report.bytes_after += (meta.len() as f64 * ratio) as u64;
+        }
+
+        planned.insert(entry.file_name.clone(), plans.len());
+        plans.push(MigrationPlan {
+            indices: vec![idx],
+            old_name: entry.file_name.clone(),
+            asset_type: entry.asset_type.clone(),
+            ext,
+            path,
+            file_size: meta.len(),
+            width,
+            height,
+        });
+    }
+
+    if dry_run {
+        report.estimated = true;
+        return Ok(report);
+    }
+    if plans.is_empty() {
+        return Ok(report);
+    }
+
+    // Safety snapshot of the project (manifest + YAMLs) before any rewrite.
+    // The image bytes themselves are not snapshotted — originals are gone
+    // after migration, which is the point; R2/hub only ever served the
+    // optimized versions anyway.
+    crate::snapshots::snapshot_create(
+        project_dir.clone(),
+        "migration".to_string(),
+        Some("library-optimize".to_string()),
+        false,
+    )
+    .await?;
+
+    let total = plans.len();
+    let mut mapping: HashMap<String, String> = HashMap::new();
+
+    for (i, plan) in plans.iter().enumerate() {
+        emit_progress(&app, "encoding", i, total);
+
+        let bytes = match tokio::fs::read(&plan.path).await {
+            Ok(b) => b,
+            Err(e) => {
+                report.errors.push(format!("{}: read failed: {e}", plan.old_name));
+                report.bytes_after += plan.file_size;
+                continue;
+            }
+        };
+        let asset_type = plan.asset_type.clone();
+        let ext = plan.ext.clone();
+        let new_bytes =
+            tokio::task::spawn_blocking(move || {
+                crate::image_profiles::cap_image_bytes(&asset_type, &ext, &bytes)
+            })
+            .await
+            .map_err(|e| format!("encode task join failed: {e}"))?;
+
+        let mut hasher = Sha256::new();
+        hasher.update(&new_bytes);
+        let hash = format!("{:x}", hasher.finalize());
+        let new_name = format!("{hash}.{}", plan.ext);
+        if new_name == plan.old_name {
+            report.bytes_after += plan.file_size;
+            continue;
+        }
+
+        let (new_w, new_h) = match imagesize::blob_size(&new_bytes) {
+            Ok(size) => (size.width as u32, size.height as u32),
+            Err(_) => (
+                crate::image_profiles::cap_stored_dims(&plan.asset_type, plan.width, plan.height).0,
+                crate::image_profiles::cap_stored_dims(&plan.asset_type, plan.width, plan.height).1,
+            ),
+        };
+
+        let dest = images_dir.join(&new_name);
+        if !dest.exists() {
+            if let Err(e) = tokio::fs::write(&dest, &new_bytes).await {
+                report.errors.push(format!("{}: write failed: {e}", plan.old_name));
+                report.bytes_after += plan.file_size;
+                continue;
+            }
+        }
+
+        report.bytes_after += new_bytes.len() as u64;
+        for &idx in &plan.indices {
+            let entry = &mut manifest.assets[idx];
+            entry.hash = hash.clone();
+            entry.file_name = new_name.clone();
+            entry.width = new_w;
+            entry.height = new_h;
+            entry.sync_status = "local".to_string();
+        }
+        mapping.insert(plan.old_name.clone(), new_name);
+    }
+
+    emit_progress(&app, "rewriting", 0, 1);
+    let root = PathBuf::from(&project_dir);
+    let mapping_for_walk = mapping.clone();
+    report.references_updated =
+        tokio::task::spawn_blocking(move || rewrite_project_references(&root, &mapping_for_walk))
+            .await
+            .map_err(|e| format!("rewrite task join failed: {e}"))??;
+
+    crate::assets::save_manifest(&app, &manifest).await?;
+
+    // Old files go last, once the manifest and every reference point at the
+    // new names — a failure above leaves a working (just unmigrated) library.
+    for old_name in mapping.keys() {
+        let _ = tokio::fs::remove_file(images_dir.join(old_name)).await;
+    }
+
+    emit_progress(&app, "done", total, total);
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mapping(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(a, b)| (a.to_string(), b.to_string()))
+            .collect()
+    }
+
+    const OLD_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.png";
+    const NEW_A: &str = "1111111111111111111111111111111111111111111111111111111111111111.png";
+    const OLD_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.jpg";
+    const NEW_B: &str = "2222222222222222222222222222222222222222222222222222222222222222.jpg";
+
+    #[test]
+    fn rewrite_content_replaces_all_mapped_tokens() {
+        let content = format!("rooms:\n  start:\n    image: {OLD_A}\nmobs:\n  rat:\n    image: {OLD_B}\n  bat:\n    image: {OLD_A}\n");
+        let out = rewrite_content(&content, &mapping(&[(OLD_A, NEW_A), (OLD_B, NEW_B)])).unwrap();
+        assert!(!out.contains(OLD_A));
+        assert!(!out.contains(OLD_B));
+        assert_eq!(out.matches(NEW_A).count(), 2);
+        assert_eq!(out.matches(NEW_B).count(), 1);
+    }
+
+    #[test]
+    fn rewrite_content_returns_none_when_nothing_matches() {
+        let content = "zone: test\nrooms: {}\n";
+        assert!(rewrite_content(content, &mapping(&[(OLD_A, NEW_A)])).is_none());
+    }
+
+    #[test]
+    fn rewrite_content_preserves_surrounding_formatting() {
+        let content = format!("# comment stays\nimage: {OLD_A}   # trailing note\n");
+        let out = rewrite_content(&content, &mapping(&[(OLD_A, NEW_A)])).unwrap();
+        assert_eq!(
+            out,
+            format!("# comment stays\nimage: {NEW_A}   # trailing note\n")
+        );
+    }
+
+    #[test]
+    fn extension_of_lowercases() {
+        assert_eq!(extension_of("ABC.PNG"), "png");
+        assert_eq!(extension_of("x.jpg"), "jpg");
+    }
+}

--- a/creator/src-tauri/src/asset_migration.rs
+++ b/creator/src-tauri/src/asset_migration.rs
@@ -1,9 +1,10 @@
 //! Migrates an existing asset library to the per-asset-type runtime image
 //! profiles. Files are content-addressed (`<sha256>.<ext>`), so re-encoding
-//! produces a new filename; the migration rewrites every YAML reference in
-//! the project via exact-token replacement — hash filenames are globally
-//! unique 64-hex strings, so plain string substitution cannot false-match
-//! and preserves formatting without re-serializing YAML.
+//! produces a new filename; the migration rewrites every YAML and JSON
+//! reference in the project (zones, config, lore, story files) via
+//! exact-token replacement — hash filenames are globally unique 64-hex
+//! strings, so plain string substitution cannot false-match and preserves
+//! formatting without re-serializing.
 
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -34,7 +35,7 @@ pub struct MigrationReport {
     /// Dry run: estimated from the area ratio. Real run: actual.
     pub bytes_after: u64,
     pub estimated: bool,
-    /// YAML files whose references were rewritten.
+    /// Project files whose references were rewritten.
     pub references_updated: usize,
     pub errors: Vec<String>,
 }
@@ -93,8 +94,9 @@ fn rewrite_content(content: &str, mapping: &HashMap<String, String>) -> Option<S
     changed.then_some(result)
 }
 
-/// Walk the project directory and rewrite references in every YAML file.
-/// Returns the number of files updated.
+/// Walk the project directory and rewrite references in every YAML and JSON
+/// file (zone/config/lore YAML, story JSON). Returns the number of files
+/// updated.
 fn rewrite_project_references(
     root: &Path,
     mapping: &HashMap<String, String>,
@@ -108,19 +110,28 @@ fn rewrite_project_references(
         let entries = std::fs::read_dir(&dir)
             .map_err(|e| format!("Failed to read {}: {e}", dir.display()))?;
         for entry in entries.flatten() {
+            // Never follow symlinks — a linked directory could escape the
+            // project root (rewriting files the snapshot doesn't cover) or
+            // form a cycle.
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
             let path = entry.path();
             let name = entry.file_name().to_string_lossy().to_string();
-            if path.is_dir() {
+            if file_type.is_dir() {
                 if !SKIP_DIRS.contains(&name.as_str()) {
                     stack.push(path);
                 }
                 continue;
             }
-            let is_yaml = matches!(
+            let is_rewritable = matches!(
                 path.extension().and_then(|e| e.to_str()),
-                Some("yaml") | Some("yml")
+                Some("yaml") | Some("yml") | Some("json")
             );
-            if !is_yaml {
+            if !is_rewritable {
                 continue;
             }
             let Ok(content) = std::fs::read_to_string(&path) else {
@@ -266,10 +277,9 @@ pub async fn migrate_assets_to_profiles(
 
         let (new_w, new_h) = match imagesize::blob_size(&new_bytes) {
             Ok(size) => (size.width as u32, size.height as u32),
-            Err(_) => (
-                crate::image_profiles::cap_stored_dims(&plan.asset_type, plan.width, plan.height).0,
-                crate::image_profiles::cap_stored_dims(&plan.asset_type, plan.width, plan.height).1,
-            ),
+            Err(_) => {
+                crate::image_profiles::cap_stored_dims(&plan.asset_type, plan.width, plan.height)
+            }
         };
 
         let dest = images_dir.join(&new_name);
@@ -305,7 +315,15 @@ pub async fn migrate_assets_to_profiles(
 
     // Old files go last, once the manifest and every reference point at the
     // new names — a failure above leaves a working (just unmigrated) library.
+    // Skip any name the final manifest still references: an optimized output
+    // can hash to a file that already existed, and an entry whose asset type
+    // has no profile can share a file with a migrated entry.
+    let still_referenced: std::collections::HashSet<&str> =
+        manifest.assets.iter().map(|a| a.file_name.as_str()).collect();
     for old_name in mapping.keys() {
+        if still_referenced.contains(old_name.as_str()) {
+            continue;
+        }
         let _ = tokio::fs::remove_file(images_dir.join(old_name)).await;
     }
 
@@ -359,5 +377,75 @@ mod tests {
     fn extension_of_lowercases() {
         assert_eq!(extension_of("ABC.PNG"), "png");
         assert_eq!(extension_of("x.jpg"), "jpg");
+    }
+
+    #[test]
+    fn rewrite_project_references_covers_yaml_and_json_and_skips_excluded_dirs() {
+        let root = std::env::temp_dir().join(format!(
+            "arcanum-migration-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("stories")).unwrap();
+        std::fs::create_dir_all(root.join(".arcanum")).unwrap();
+
+        std::fs::write(
+            root.join("zone.yaml"),
+            format!("rooms:\n  start:\n    image: {OLD_A}\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("stories").join("intro.json"),
+            format!("{{\n  \"imageOverride\": \"{OLD_A}\"\n}}\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join(".arcanum").join("manifest.json"),
+            format!("{{\"fileName\": \"{OLD_A}\"}}"),
+        )
+        .unwrap();
+        std::fs::write(root.join("notes.txt"), OLD_A).unwrap();
+
+        let updated =
+            rewrite_project_references(&root, &mapping(&[(OLD_A, NEW_A)])).unwrap();
+        assert_eq!(updated, 2);
+
+        let zone = std::fs::read_to_string(root.join("zone.yaml")).unwrap();
+        assert!(zone.contains(NEW_A) && !zone.contains(OLD_A));
+        let story = std::fs::read_to_string(root.join("stories").join("intro.json")).unwrap();
+        assert!(story.contains(NEW_A) && !story.contains(OLD_A));
+        let manifest =
+            std::fs::read_to_string(root.join(".arcanum").join("manifest.json")).unwrap();
+        assert!(manifest.contains(OLD_A));
+        let notes = std::fs::read_to_string(root.join("notes.txt")).unwrap();
+        assert!(notes.contains(OLD_A));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rewrite_project_references_does_not_follow_symlinks() {
+        let base = std::env::temp_dir().join(format!(
+            "arcanum-migration-symlink-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&base);
+        let root = base.join("project");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+
+        std::fs::write(outside.join("external.yaml"), format!("image: {OLD_A}\n")).unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("linked")).unwrap();
+
+        let updated =
+            rewrite_project_references(&root, &mapping(&[(OLD_A, NEW_A)])).unwrap();
+        assert_eq!(updated, 0);
+
+        let external = std::fs::read_to_string(outside.join("external.yaml")).unwrap();
+        assert!(external.contains(OLD_A));
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -12,7 +12,7 @@ use tokio::sync::Mutex;
 const MANIFEST_FILE: &str = "manifest.json";
 
 /// Global mutex to prevent concurrent manifest read-modify-write corruption.
-static MANIFEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+pub(crate) static MANIFEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssetEntry {
@@ -67,11 +67,11 @@ pub struct AssetContext {
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
-struct Manifest {
-    assets: Vec<AssetEntry>,
+pub(crate) struct Manifest {
+    pub(crate) assets: Vec<AssetEntry>,
 }
 
-fn assets_dir(app: &AppHandle) -> Result<PathBuf, String> {
+pub(crate) fn assets_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = crate::fs_utils::app_data_dir(app)?;
     Ok(dir.join("assets"))
 }
@@ -92,7 +92,7 @@ async fn manifest_path(app: &AppHandle) -> Result<PathBuf, String> {
     global_manifest_path(app)
 }
 
-async fn load_manifest(app: &AppHandle) -> Result<Manifest, String> {
+pub(crate) async fn load_manifest(app: &AppHandle) -> Result<Manifest, String> {
     let path = manifest_path(app).await?;
     if !path.exists() {
         return Ok(Manifest::default());
@@ -103,7 +103,7 @@ async fn load_manifest(app: &AppHandle) -> Result<Manifest, String> {
     serde_json::from_str(&data).map_err(|e| format!("Failed to parse manifest: {e}"))
 }
 
-async fn save_manifest(app: &AppHandle, manifest: &Manifest) -> Result<(), String> {
+pub(crate) async fn save_manifest(app: &AppHandle, manifest: &Manifest) -> Result<(), String> {
     let path = manifest_path(app).await?;
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent)

--- a/creator/src-tauri/src/lib.rs
+++ b/creator/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod admin;
 #[cfg(feature = "ai")]
 mod anthropic;
 mod arcanum_meta;
+mod asset_migration;
 mod assets;
 mod audio_mix;
 mod cancellation;
@@ -103,6 +104,7 @@ macro_rules! base_handler {
             assets::migrate_sprite_tier,
             assets::expand_base_sprites,
             assets::flip_image,
+            asset_migration::migrate_assets_to_profiles,
             r2::import_from_r2,
             r2::sync_assets,
             r2::get_sync_status,

--- a/creator/src/components/AssetGallery.tsx
+++ b/creator/src/components/AssetGallery.tsx
@@ -5,6 +5,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { useAssetStore } from "@/stores/assetStore";
 import { useConfigStore } from "@/stores/configStore";
 import { useLoreStore } from "@/stores/loreStore";
+import { useStoryStore } from "@/stores/storyStore";
 import { useToastStore } from "@/stores/toastStore";
 import { useZoneStore } from "@/stores/zoneStore";
 import { useFocusTrap } from "@/lib/useFocusTrap";
@@ -161,7 +162,8 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
 
   const handleOptimizeCheck = async () => {
     const zonesDirty = Array.from(useZoneStore.getState().zones.values()).some((z) => z.dirty);
-    if (zonesDirty || useConfigStore.getState().dirty || useLoreStore.getState().dirty) {
+    const storiesDirty = Object.values(useStoryStore.getState().dirty).some(Boolean);
+    if (zonesDirty || storiesDirty || useConfigStore.getState().dirty || useLoreStore.getState().dirty) {
       useToastStore.getState().show("Save all changes first — optimizing rewrites project files", 4000);
       return;
     }
@@ -438,7 +440,7 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
             {migrationPlan && !migrating && (
               <>
                 <span className="text-text-secondary">
-                  {migrationPlan.affected} of {migrationPlan.totalAssets} images exceed their serving size — {formatMB(migrationPlan.bytesBefore)} → ~{formatMB(migrationPlan.bytesAfter)}. A project snapshot is taken first; filenames change and every zone/lore reference is updated. Downscaled images can't be restored to full size.
+                  {migrationPlan.affected} of {migrationPlan.totalAssets} images exceed their serving size — {formatMB(migrationPlan.bytesBefore)} → ~{formatMB(migrationPlan.bytesAfter)}. A project snapshot is taken first; filenames change and every zone, lore, and story reference is updated. Downscaled images can't be restored to full size.
                 </span>
                 <button
                   onClick={handleOptimizeRun}

--- a/creator/src/components/AssetGallery.tsx
+++ b/creator/src/components/AssetGallery.tsx
@@ -1,13 +1,17 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useAssetStore } from "@/stores/assetStore";
+import { useConfigStore } from "@/stores/configStore";
+import { useLoreStore } from "@/stores/loreStore";
 import { useToastStore } from "@/stores/toastStore";
+import { useZoneStore } from "@/stores/zoneStore";
 import { useFocusTrap } from "@/lib/useFocusTrap";
-import { useImageSrc, useImageSrcStatus } from "@/lib/useImageSrc";
+import { clearImageCache, useImageSrc, useImageSrcStatus } from "@/lib/useImageSrc";
 import { useMediaSrc } from "@/lib/useMediaSrc";
 import { removeBgAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
-import type { AssetEntry, AssetType, SyncProgress, SyncScope } from "@/types/assets";
+import type { AssetEntry, AssetType, MigrationProgress, MigrationReport, SyncProgress, SyncScope } from "@/types/assets";
 import { Spinner } from "@/components/ui/FormWidgets";
 
 type SortKey = "newest" | "oldest" | "type";
@@ -35,6 +39,10 @@ function shouldShowInCuratedView(asset: AssetEntry): boolean {
 
 function shouldSyncAsset(asset: AssetEntry, scope: SyncScope): boolean {
   return scope === "all" || shouldShowInCuratedView(asset);
+}
+
+function formatMB(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function localAssetPath(assetsDir: string, asset: AssetEntry): string {
@@ -136,6 +144,62 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
   const [removingBg, setRemovingBg] = useState(false);
   const [syncResult, setSyncResult] = useState<SyncProgress | null>(null);
   const [copiedField, setCopiedField] = useState<string | null>(null);
+  const [checkingMigration, setCheckingMigration] = useState(false);
+  const [migrating, setMigrating] = useState(false);
+  const [migrationPlan, setMigrationPlan] = useState<MigrationReport | null>(null);
+  const [migrationProgress, setMigrationProgress] = useState<MigrationProgress | null>(null);
+  const [migrationResult, setMigrationResult] = useState<MigrationReport | null>(null);
+
+  useEffect(() => {
+    const unlisten = listen<MigrationProgress>("asset-migration-progress", (event) => {
+      setMigrationProgress(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const handleOptimizeCheck = async () => {
+    const zonesDirty = Array.from(useZoneStore.getState().zones.values()).some((z) => z.dirty);
+    if (zonesDirty || useConfigStore.getState().dirty || useLoreStore.getState().dirty) {
+      useToastStore.getState().show("Save all changes first — optimizing rewrites project files", 4000);
+      return;
+    }
+    setCheckingMigration(true);
+    setMigrationResult(null);
+    try {
+      const plan = await invoke<MigrationReport>("migrate_assets_to_profiles", { dryRun: true });
+      if (plan.affected === 0) {
+        useToastStore.getState().show("Library already optimized — every image fits its serving size", 3000);
+      } else {
+        setMigrationPlan(plan);
+      }
+    } catch (err) {
+      useToastStore.getState().show(`Optimize check failed: ${err instanceof Error ? err.message : String(err)}`, 4000);
+    } finally {
+      setCheckingMigration(false);
+    }
+  };
+
+  const handleOptimizeRun = async () => {
+    setMigrationPlan(null);
+    setMigrating(true);
+    setMigrationProgress(null);
+    try {
+      const result = await invoke<MigrationReport>("migrate_assets_to_profiles", { dryRun: false });
+      if (result.errors.length > 0) {
+        console.error("Asset migration errors:", result.errors);
+      }
+      setMigrationResult(result);
+      clearImageCache();
+      await loadAssets();
+    } catch (err) {
+      useToastStore.getState().show(`Optimize failed: ${err instanceof Error ? err.message : String(err)}`, 5000);
+    } finally {
+      setMigrating(false);
+      setMigrationProgress(null);
+    }
+  };
 
   const copyText = (field: string, text: string) => {
     navigator.clipboard.writeText(text);
@@ -349,11 +413,67 @@ export function AssetGallery({ onClose }: { onClose: () => void }) {
                 )}
               </>
             )}
+            <button
+              onClick={handleOptimizeCheck}
+              disabled={checkingMigration || migrating}
+              title="Downscale stored images to the size the game actually serves"
+              className="rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-3 py-1.5 text-2xs font-medium text-text-secondary transition-colors hover:text-accent disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {checkingMigration ? (
+                <span className="flex items-center gap-1.5"><Spinner />Checking</span>
+              ) : migrating ? (
+                <span className="flex items-center gap-1.5"><Spinner />Optimizing</span>
+              ) : (
+                "Optimize Library"
+              )}
+            </button>
           </div>
           <button aria-label="Close" onClick={onClose} className="text-xs text-text-muted hover:text-text-primary">
             &times;
           </button>
         </div>
+
+        {(migrationPlan || migrating || migrationResult) && (
+          <div className="flex shrink-0 flex-wrap items-center gap-3 border-b border-border-default bg-bg-primary/40 px-5 py-2 text-2xs">
+            {migrationPlan && !migrating && (
+              <>
+                <span className="text-text-secondary">
+                  {migrationPlan.affected} of {migrationPlan.totalAssets} images exceed their serving size — {formatMB(migrationPlan.bytesBefore)} → ~{formatMB(migrationPlan.bytesAfter)}. A project snapshot is taken first; filenames change and every zone/lore reference is updated. Downscaled images can't be restored to full size.
+                </span>
+                <button
+                  onClick={handleOptimizeRun}
+                  className="rounded-full border border-[var(--chrome-stroke)] bg-accent/15 px-3 py-1 font-medium text-accent transition-colors hover:bg-accent/25"
+                >
+                  Optimize {migrationPlan.affected} images
+                </button>
+                <button
+                  onClick={() => setMigrationPlan(null)}
+                  className="rounded-full px-3 py-1 text-text-muted transition-colors hover:text-text-secondary"
+                >
+                  Cancel
+                </button>
+              </>
+            )}
+            {migrating && (
+              <span className="flex items-center gap-1.5 text-text-secondary">
+                <Spinner />
+                {migrationProgress?.stage === "rewriting"
+                  ? "Updating project references…"
+                  : migrationProgress
+                    ? `Re-encoding ${Math.min(migrationProgress.current + 1, migrationProgress.total)} of ${migrationProgress.total}…`
+                    : "Optimizing…"}
+              </span>
+            )}
+            {migrationResult && !migrating && (
+              <span className="text-text-secondary">
+                Optimized {migrationResult.affected} images — {formatMB(migrationResult.bytesBefore)} → {formatMB(migrationResult.bytesAfter)}, {migrationResult.referencesUpdated} project {migrationResult.referencesUpdated === 1 ? "file" : "files"} updated. Reload the project to refresh open editors.
+                {migrationResult.errors.length > 0 && (
+                  <span className="text-status-error"> {migrationResult.errors.length} failed — see console.</span>
+                )}
+              </span>
+            )}
+          </div>
+        )}
 
         <div className="flex min-h-[120px] max-h-[40vh] shrink flex-col gap-3 overflow-y-auto border-b border-border-default px-5 py-3">
           <div className="flex flex-wrap items-center justify-between gap-3">

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -187,6 +187,24 @@ export interface SyncProgress {
   errors: string[];
 }
 
+/** Mirrors the Rust MigrationReport struct */
+export interface MigrationReport {
+  totalAssets: number;
+  affected: number;
+  bytesBefore: number;
+  bytesAfter: number;
+  estimated: boolean;
+  referencesUpdated: number;
+  errors: string[];
+}
+
+/** Payload of the `asset-migration-progress` event */
+export interface MigrationProgress {
+  stage: string;
+  current: number;
+  total: number;
+}
+
 export interface ExportResult {
   total: number;
   copied: number;


### PR DESCRIPTION
## Why

The ingest caps (#341) only apply to newly generated/imported assets. Existing libraries still carry originals stored 2–4× larger than anything ever serves. Filenames are content hashes, so re-encoding in place isn't an option — this adds the proper migration.

## What

**Backend — `asset_migration.rs`, one command `migrate_assets_to_profiles(dry_run)`:**

- **Dry run**: scans the manifest for images whose type has a runtime profile and whose dimensions exceed it; reports affected count and current → estimated size (area-ratio estimate, flagged as such).
- **Real run**, ordered so any failure leaves a working (just unmigrated) library:
  1. Project snapshot (`snapshot_create`, kind `migration`) — covers the manifest and every YAML about to be rewritten
  2. Re-encode each oversized image via `image_profiles::cap_image_bytes` (spawn_blocking), write the new content-addressed file **alongside** the old one
  3. Update manifest entries: new hash/filename/dimensions, `sync_status: local` so the next R2 sync uploads the optimized objects
  4. Rewrite references: walk the project dir for `.yaml`/`.yml` (skipping `.git`, `.arcanum`, build dirs) and replace old→new filename tokens. **Content-hash filenames are globally unique 64-hex strings, so exact string replacement can't false-match and preserves YAML formatting/comments byte-for-byte** — no re-serialization. Covers zone files, lore.yaml (incl. showcase banner), config/application.yaml global assets, legacy layouts.
  5. Save the manifest, then — only now — delete the old files
- Progress streams via `asset-migration-progress` events (hub-publish pattern). Handles duplicate manifest entries sharing one file, entries with missing files, and 0×0 legacy dims (probed via imagesize).
- Old R2 objects are left in place deliberately (immutable-cached, content-addressed; deleting risks breaking published showcases).

**Frontend — "Optimize Library" button in the Asset Gallery:**

- Refuses to start while zones/config/lore have unsaved changes (migration rewrites those files on disk)
- Dry-run confirm strip: "N of M images exceed their serving size — X MB → ~Y MB", with an explicit note that downscaling is irreversible
- Live progress (re-encoding i/N → updating references), result strip with actual savings + files-updated count, and a "reload the project" note matching the snapshot-restore precedent; image cache cleared and manifest reloaded on completion

## Notes

- `assets.rs` manifest helpers (`MANIFEST_LOCK`, `load_manifest`, `save_manifest`, `assets_dir`, `Manifest`) exposed as `pub(crate)` for the migration module
- Originals are **not** backed up — reclaiming their disk is the point, and R2/hub only ever served the optimized sizes anyway. The confirm strip says so
- Module is ungated (works in Community Edition)

## Testing

- `cargo check` clean on default **and** `--no-default-features` (CE)
- `cargo test` — 4 new tests on the reference-rewrite pass (multi-token replacement, no-op detection, formatting preservation) + all existing pass
- `bunx tsc --noEmit` clean, `bun run test` 2305 pass
- **Not yet run against a real library** — recommend trying dry-run + real run on a copy/snapshot of your project first