### PR TITLE
feat(creator): rework zones sidebar for usability

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,43 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Indie developers, writers, hobbyist worldbuilders, and small teams building MUD game worlds and worldbuilding projects. They range from technically comfortable to complete beginners. They use Arcanum for long creative sessions (hours at a time), switching between zone mapping, entity editing, config tuning, lore writing, and AI art generation. The tool has power-user features (command palette, keyboard shortcuts, dense editors) but must be approachable to someone opening it for the first time. Discoverability and guided onboarding matter as much as depth.
+
+## Product Purpose
+
+Arcanum is a Tauri 2 desktop worldbuilding tool that edits YAML world files for the AmbonMUD server (zones, mobs, items, quests), manages game configuration, generates AI art for every entity type, and publishes public lore showcases. Success means a builder can hold an entire world in their head through the tool — navigating between hundreds of rooms, mobs, items, and articles without friction — while the interface stays worthy of the act of creation.
+
+## Brand Personality
+
+**Cosmological. Precise. Ornate.**
+
+The Arcanum is the Creator's own instrument — a window into the architecture of a world. The interface should feel like it was carved into existence by the same force that shaped the land. Never a SaaS dashboard with a dark theme.
+
+Emotional goals: grandeur, creative confidence, unhurried focus. The cosmos does not rush.
+
+## Anti-references
+
+Generic AI-generated UIs: glassmorphism, gradient text, hero metrics, identical card grids, Inter/Geist fonts, teal-purple-pink palettes. Modern SaaS dashboards. Anything flat, corporate, or template-driven.
+
+## Design Principles
+
+1. **Ember against the deep** — Warm accent light appears only where something is alive, active, or important. A single ember highlight against midnight-teal carries enormous weight. Don't dilute it.
+2. **Density serves the builder** — This is a data-dense creative tool, not a marketing page. Small type (10px workhorse), tight spacing, and information-rich panels are appropriate. Progressive disclosure for secondary features, but never hide what power users need frequently.
+3. **Texture over flatness** — Every major surface has visual texture: background images, gradient overlays, subtle glow. Flat solid-color panels feel dead. Texture must be quiet (low opacity, `pointer-events-none`) — never competing with content.
+4. **Semantic tokens, not arbitrary values** — Colors, sizes, tracking, gradients, and shadows come from the token system in `creator/src/index.css`. Hard-coded values indicate a missing token, not a design choice.
+5. **Accessibility is structural** — Keyboard navigation, focus traps, ARIA labels, `prefers-reduced-motion`, and sufficient contrast are baseline requirements, not polish items.
+
+## Accessibility & Inclusion
+
+Keyboard-first navigation throughout; full-screen overlays must use dialog semantics with focus traps (see CLAUDE.md accessibility contract). All motion honors `prefers-reduced-motion`. Contrast targets WCAG AA against the midnight-teal palette. The app is themeable (dark and light anchor palettes) via semantic tokens — components must never hardcode palette hexes.
+
+## See also
+
+- `.impeccable.md` — condensed design context (palette, type scale, utilities, patterns)
+- `ARCANUM_STYLE_GUIDE.md` — full design system
+- `CLAUDE.md` — architecture, conventions, pitfalls

--- a/creator/src/components/sidebar/ZonesPanel.tsx
+++ b/creator/src/components/sidebar/ZonesPanel.tsx
@@ -276,10 +276,13 @@ function CategorySection({
             style={{ background: CATEGORY_COLORS[cat.key] }}
             aria-hidden="true"
           />
-          <span className="truncate font-display text-2xs font-semibold uppercase tracking-label text-text-secondary">
+          <span
+            className="truncate font-display text-2xs font-semibold uppercase tracking-label text-text-secondary"
+            title={cat.label}
+          >
             {cat.label}
           </span>
-          <span className="shrink-0 text-2xs text-text-muted">
+          <span className="ml-auto shrink-0 pl-1 text-2xs text-text-muted">
             {filtering && entries.length !== total ? `${entries.length}/${total}` : total}
           </span>
         </button>
@@ -311,7 +314,7 @@ function CategorySection({
                     ref={isSelected ? selectedRef : undefined}
                     onClick={() => onEntityClick(cat, row.id)}
                     aria-current={isSelected ? "true" : undefined}
-                    className={`flex w-full items-center gap-2 rounded-xl border px-2 py-1.5 text-left text-xs transition ${
+                    className={`focus-ring flex w-full items-center gap-2 rounded-xl border px-2 py-1.5 text-left text-xs transition ${
                       isSelected
                         ? "selected-pill text-text-primary"
                         : "border-transparent text-text-muted hover:bg-accent/8 hover:text-text-primary"

--- a/creator/src/components/sidebar/ZonesPanel.tsx
+++ b/creator/src/components/sidebar/ZonesPanel.tsx
@@ -1,7 +1,8 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useZoneStore, type ZoneState } from "@/stores/zoneStore";
-import { useProjectStore } from "@/stores/projectStore";
+import { useProjectStore, type ActiveSelection } from "@/stores/projectStore";
+import { useSidebarStore, catExpansionKey } from "@/stores/sidebarStore";
 import { useToastStore } from "@/stores/toastStore";
 import { saveZone } from "@/lib/saveZone";
 import type { WorldFile } from "@/types/world";
@@ -15,8 +16,10 @@ import {
   addMob,
   addItem,
   addShop,
+  addQuest,
   addGatheringNode,
   addRecipe,
+  addPuzzle,
   setDungeon,
   generateEntityId,
   generateRoomId,
@@ -25,8 +28,10 @@ import type {
   MobFile,
   ItemFile,
   ShopFile,
+  QuestFile,
   GatheringNodeFile,
   RecipeFile,
+  PuzzleFile,
 } from "@/types/world";
 
 interface CategoryDef {
@@ -47,6 +52,7 @@ const CATEGORY_COLORS: Record<string, string> = {
   quest: "var(--color-entity-quest)",
   gatheringNode: "var(--color-entity-gather)",
   recipe: "var(--color-entity-recipe)",
+  puzzle: "var(--color-entity-puzzle)",
   dungeon: "var(--color-entity-dungeon)",
 };
 
@@ -94,6 +100,17 @@ const CATEGORIES: CategoryDef[] = [
     },
   },
   {
+    key: "quest",
+    label: "Quests",
+    collection: "quests",
+    nameField: "name",
+    addFn: (world) => {
+      const id = generateEntityId(world, "quests");
+      const firstMob = Object.keys(world.mobs ?? {})[0] ?? "";
+      return addQuest(world, id, { name: id, giver: firstMob } as QuestFile);
+    },
+  },
+  {
     key: "gatheringNode",
     label: "Gathering Nodes",
     collection: "gatheringNodes",
@@ -125,6 +142,23 @@ const CATEGORIES: CategoryDef[] = [
     },
   },
   {
+    key: "puzzle",
+    label: "Puzzles",
+    collection: "puzzles",
+    nameField: "question",
+    addFn: (world) => {
+      const id = generateEntityId(world, "puzzles");
+      const firstRoom = Object.keys(world.rooms)[0] ?? "";
+      return addPuzzle(world, id, {
+        type: "riddle",
+        roomId: firstRoom,
+        question: "",
+        answer: "",
+        reward: { type: "give_gold", gold: 10 },
+      } as PuzzleFile);
+    },
+  },
+  {
     key: "dungeon",
     label: "Dungeon",
     collection: "dungeon",
@@ -140,10 +174,177 @@ const CATEGORIES: CategoryDef[] = [
   },
 ];
 
+interface EntityRow {
+  id: string;
+  name?: string;
+}
+
+interface CategoryView {
+  cat: CategoryDef;
+  /** Sorted rows; narrowed to matches when a query is active. */
+  entries: EntityRow[];
+  total: number;
+}
+
+function entityName(entity: unknown, nameField: string): string | undefined {
+  if (!entity || typeof entity !== "object") return undefined;
+  const value = (entity as Record<string, unknown>)[nameField];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function rowMatches(row: EntityRow, query: string): boolean {
+  return (
+    row.id.toLowerCase().includes(query) ||
+    (row.name !== undefined && row.name.toLowerCase().includes(query))
+  );
+}
+
+function buildCategoryViews(world: WorldFile, query: string): CategoryView[] {
+  return CATEGORIES.map((cat) => {
+    if (cat.singular) {
+      const data = world[cat.collection] as Record<string, unknown> | undefined;
+      const all: EntityRow[] = data ? [{ id: cat.key, name: entityName(data, cat.nameField) }] : [];
+      const entries = query ? all.filter((row) => rowMatches(row, query)) : all;
+      return { cat, entries, total: all.length };
+    }
+    const collection = world[cat.collection] as Record<string, Record<string, unknown>> | undefined;
+    const all: EntityRow[] = collection
+      ? Object.entries(collection).map(([id, entity]) => ({
+          id,
+          name: entityName(entity, cat.nameField),
+        }))
+      : [];
+    all.sort((a, b) =>
+      (a.name ?? a.id).localeCompare(b.name ?? b.id, undefined, { sensitivity: "base" }),
+    );
+    const entries = query ? all.filter((row) => rowMatches(row, query)) : all;
+    return { cat, entries, total: all.length };
+  });
+}
+
+function zoneMatchesQuery(zoneId: string, world: WorldFile, query: string): boolean {
+  if ((world.zone || zoneId).toLowerCase().includes(query)) return true;
+  if (zoneId.toLowerCase().includes(query)) return true;
+  return buildCategoryViews(world, query).some((view) => view.entries.length > 0);
+}
+
+function CategorySection({
+  zoneId,
+  view,
+  filtering,
+  selectedId,
+  startRoomId,
+  onEntityClick,
+  onAdd,
+}: {
+  zoneId: string;
+  view: CategoryView;
+  filtering: boolean;
+  selectedId: string | undefined;
+  startRoomId: string | undefined;
+  onEntityClick: (cat: CategoryDef, entityId: string) => void;
+  onAdd: (cat: CategoryDef) => void;
+}) {
+  const { cat, entries, total } = view;
+  const toggleCatExpanded = useSidebarStore((s) => s.toggleCatExpanded);
+  const storedOpen = useSidebarStore((s) => !!s.expandedCats[catExpansionKey(zoneId, cat.key)]);
+  const open = filtering || storedOpen;
+  const listId = `sidebar-cat-${zoneId}-${cat.key}`;
+
+  const selectedRef = useRef<HTMLButtonElement | null>(null);
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: "nearest" });
+  }, [selectedId]);
+
+  const canAdd = !!cat.addFn && !filtering && (!cat.singular || total === 0);
+
+  return (
+    <div className="border-t border-[var(--chrome-stroke)] pt-1 first:border-t-0 first:pt-0">
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => toggleCatExpanded(zoneId, cat.key)}
+          disabled={filtering}
+          aria-expanded={open}
+          aria-controls={listId}
+          className="focus-ring flex h-8 min-w-0 flex-1 items-center gap-2 rounded-xl px-1.5 text-left transition hover:bg-[var(--chrome-highlight)] disabled:cursor-default disabled:hover:bg-transparent"
+        >
+          <span aria-hidden="true" className="w-3 shrink-0 text-center text-3xs text-text-muted">
+            {open ? "▾" : "▸"}
+          </span>
+          <span
+            className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
+            style={{ background: CATEGORY_COLORS[cat.key] }}
+            aria-hidden="true"
+          />
+          <span className="truncate font-display text-2xs font-semibold uppercase tracking-label text-text-secondary">
+            {cat.label}
+          </span>
+          <span className="shrink-0 text-2xs text-text-muted">
+            {filtering && entries.length !== total ? `${entries.length}/${total}` : total}
+          </span>
+        </button>
+        {canAdd && (
+          <button
+            onClick={() => onAdd(cat)}
+            className="shrink-0 rounded-full border border-[var(--chrome-stroke)] px-2 py-1 text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
+            title={`Add ${cat.label.replace(/s$/, "").toLowerCase()}`}
+            aria-label={`Add ${cat.label.replace(/s$/, "").toLowerCase()}`}
+          >
+            Add
+          </button>
+        )}
+      </div>
+      {open && (
+        <ul id={listId} className="flex flex-col pb-1">
+          {entries.length === 0 ? (
+            <li className="px-6 py-1 text-2xs italic text-text-muted">
+              {filtering ? "No matches" : `No ${cat.label.toLowerCase()} yet`}
+            </li>
+          ) : (
+            entries.map((row) => {
+              const isSelected = selectedId !== undefined && selectedId === row.id;
+              const isStart = cat.key === "room" && startRoomId === row.id;
+              const showId = !cat.singular && row.name !== undefined && row.name !== row.id;
+              return (
+                <li key={row.id}>
+                  <button
+                    ref={isSelected ? selectedRef : undefined}
+                    onClick={() => onEntityClick(cat, row.id)}
+                    aria-current={isSelected ? "true" : undefined}
+                    className={`flex w-full items-center gap-2 rounded-xl border px-2 py-1.5 text-left text-xs transition ${
+                      isSelected
+                        ? "selected-pill text-text-primary"
+                        : "border-transparent text-text-muted hover:bg-accent/8 hover:text-text-primary"
+                    }`}
+                    title={row.name ? `${row.name} — ${row.id}` : row.id}
+                  >
+                    <span className="min-w-0 flex-1 truncate">{row.name || row.id}</span>
+                    {isStart && (
+                      <span className="shrink-0 text-3xs text-warm-pale" title="Start room">
+                        ✦ start
+                      </span>
+                    )}
+                    {showId && (
+                      <span className="max-w-[8rem] shrink-0 truncate text-3xs text-text-muted">
+                        {row.id}
+                      </span>
+                    )}
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 function ZoneTree({
   zoneId,
   zoneState,
   isActive,
+  query,
   onDelete,
   onRename,
   onDuplicate,
@@ -151,20 +352,58 @@ function ZoneTree({
   zoneId: string;
   zoneState: ZoneState;
   isActive: boolean;
+  query: string;
   onDelete: (zoneId: string) => void;
   onRename: (zoneId: string) => void;
   onDuplicate: (zoneId: string) => void;
 }) {
   const openTab = useProjectStore((s) => s.openTab);
   const navigateTo = useProjectStore((s) => s.navigateTo);
+  const activeSelection = useProjectStore((s) => s.activeSelection);
   const updateZone = useZoneStore((s) => s.updateZone);
-  const [expanded, setExpanded] = useState(false);
+  const storedExpanded = useSidebarStore((s) => !!s.expandedZones[zoneId]);
+  const toggleZoneExpanded = useSidebarStore((s) => s.toggleZoneExpanded);
+  const setZoneExpanded = useSidebarStore((s) => s.setZoneExpanded);
+  const setCatExpanded = useSidebarStore((s) => s.setCatExpanded);
   const [saving, setSaving] = useState(false);
 
   const world = zoneState.data;
+  const zoneName = world.zone || zoneId;
+
+  const zoneNameMatch =
+    query !== "" &&
+    (zoneName.toLowerCase().includes(query) || zoneId.toLowerCase().includes(query));
+  // When the zone itself matched, show its full contents rather than nothing.
+  const effectiveQuery = zoneNameMatch ? "" : query;
+  const filtering = effectiveQuery !== "";
+
+  const catViews = useMemo(
+    () => buildCategoryViews(world, effectiveQuery),
+    [world, effectiveQuery],
+  );
+  const entityMatches = filtering
+    ? catViews.reduce((n, view) => n + view.entries.length, 0)
+    : 0;
+
+  const expanded = filtering ? entityMatches > 0 || storedExpanded : storedExpanded;
+
+  const selection: ActiveSelection | null =
+    isActive && activeSelection?.zoneId === zoneId ? activeSelection : null;
+  const selectionCatKey = selection
+    ? (selection.entityKind ?? (selection.roomId ? "room" : null))
+    : null;
+  const selectionId = selection?.entityId ?? selection?.roomId ?? null;
+
+  // Reveal the selection in the tree whenever it changes in the editor.
+  useEffect(() => {
+    if (!selectionCatKey || !selectionId) return;
+    setZoneExpanded(zoneId, true);
+    setCatExpanded(zoneId, selectionCatKey, true);
+  }, [zoneId, selectionCatKey, selectionId, setZoneExpanded, setCatExpanded]);
 
   const handleZoneClick = () => {
     openTab({ id: `zone:${zoneId}`, kind: "zone", label: zoneId });
+    setZoneExpanded(zoneId, true);
   };
 
   const handleEntityClick = (cat: CategoryDef, entityId: string) => {
@@ -182,6 +421,7 @@ function ZoneTree({
     try {
       const next = cat.addFn(world, zoneId);
       updateZone(zoneId, next);
+      setCatExpanded(zoneId, cat.key, true);
       if (cat.singular) {
         if (cat.targetView) navigateTo({ zoneId, view: cat.targetView });
         return;
@@ -229,22 +469,24 @@ function ZoneTree({
     <li className="group/zone">
       <div className="flex items-center gap-1">
         <button
-          onClick={() => setExpanded((v) => !v)}
+          onClick={() => toggleZoneExpanded(zoneId)}
+          disabled={filtering}
           aria-expanded={expanded}
-          aria-label={expanded ? `Collapse ${zoneState.data.zone || zoneId}` : `Expand ${zoneState.data.zone || zoneId}`}
-          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
+          aria-label={expanded ? `Collapse ${zoneName}` : `Expand ${zoneName}`}
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary disabled:cursor-default disabled:hover:bg-transparent"
         >
           {expanded ? "▾" : "▸"}
         </button>
         <button
           onClick={handleZoneClick}
+          aria-current={isActive ? "true" : undefined}
           className={`flex min-w-0 flex-1 items-baseline gap-2 rounded-2xl border px-3 py-2 text-left text-sm transition ${
             isActive
               ? "border-border-active bg-gradient-active text-text-primary"
               : "border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] text-text-secondary hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
           }`}
         >
-          <span className="min-w-0 truncate font-medium" title={zoneState.data.zone || zoneId}>{zoneState.data.zone || zoneId}</span>
+          <span className="min-w-0 truncate font-medium" title={zoneName}>{zoneName}</span>
           <span className="shrink-0 text-2xs text-text-muted" title={zoneId}>{zoneId}</span>
         </button>
         {zoneState.dirty && (
@@ -252,8 +494,8 @@ function ZoneTree({
             onClick={handleSaveZone}
             disabled={saving}
             className="shrink-0 rounded-full border border-accent/50 bg-accent/12 px-2.5 py-1.5 text-2xs font-semibold uppercase tracking-label text-accent shadow-[0_0_12px_rgb(var(--accent-rgb)/0.25)] transition hover:border-accent hover:bg-accent/20 hover:shadow-[0_0_18px_rgb(var(--accent-rgb)/0.45)] disabled:opacity-60 animate-warm-breathe"
-            title={`Save ${zoneState.data.zone || zoneId}`}
-            aria-label={`Save ${zoneState.data.zone || zoneId}`}
+            title={`Save ${zoneName}`}
+            aria-label={`Save ${zoneName}`}
           >
             {saving ? "…" : "Save"}
           </button>
@@ -261,127 +503,53 @@ function ZoneTree({
       </div>
 
       {expanded && (
-        <div className="ml-10 mt-2 flex flex-col gap-2.5 border-l border-accent/15 pl-4">
-          <div className="flex items-center gap-1.5 pb-0.5">
-            <button
-              onClick={() => onRename(zoneId)}
-              className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted transition hover:border-accent/40 hover:text-accent"
-              title="Rename zone"
-              aria-label="Rename zone"
-            >
-              Rename
-            </button>
-            <button
-              onClick={() => onDuplicate(zoneId)}
-              className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted transition hover:border-accent/40 hover:text-accent"
-              title="Duplicate zone"
-              aria-label="Duplicate zone"
-            >
-              Duplicate
-            </button>
-            <button
-              onClick={() => onDelete(zoneId)}
-              className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted transition hover:border-status-danger/40 hover:text-status-danger"
-              title="Delete zone"
-              aria-label="Delete zone"
-            >
-              Remove
-            </button>
-          </div>
-          {CATEGORIES.map((cat) => {
-            if (cat.singular) {
-              const data = world[cat.collection] as Record<string, unknown> | undefined;
-              const present = !!data;
-              if (!present && !cat.addFn) return null;
-              const name = present && data ? (data[cat.nameField] as string | undefined) : undefined;
-              return (
-                <div key={cat.key} className="border-t border-[var(--chrome-stroke)] pt-2 first:border-t-0 first:pt-0">
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
-                      style={{ background: CATEGORY_COLORS[cat.key] }}
-                      aria-hidden="true"
-                    />
-                    <span className="font-display font-semibold text-2xs uppercase tracking-label text-text-secondary">
-                      {cat.label}
-                    </span>
-                    <span className="text-2xs text-text-muted">{present ? 1 : 0}</span>
-                    {!present && cat.addFn && (
-                      <button
-                        onClick={() => handleAdd(cat)}
-                        className="ml-auto rounded-full border border-[var(--chrome-stroke)] px-2 py-1 text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
-                        title={`Add ${cat.label.toLowerCase()}`}
-                        aria-label={`Add ${cat.label.toLowerCase()}`}
-                      >
-                        Add
-                      </button>
-                    )}
-                  </div>
-                  {present && (
-                    <ul className="flex flex-col">
-                      <li>
-                        <button
-                          onClick={() => handleEntityClick(cat, cat.key)}
-                          className="w-full truncate rounded-xl px-2 py-1.5 text-left text-xs text-text-muted transition hover:bg-accent/8 hover:text-text-primary"
-                          title={name || cat.label}
-                        >
-                          {name || cat.label}
-                        </button>
-                      </li>
-                    </ul>
-                  )}
-                </div>
-              );
-            }
-
-            const collection = world[cat.collection] as Record<string, Record<string, unknown>> | undefined;
-            const entries = collection ? Object.entries(collection) : [];
-            if (entries.length === 0 && !cat.addFn) return null;
-
+        <div className="ml-10 mt-2 flex flex-col gap-1.5 border-l border-accent/15 pl-4">
+          {!filtering && (
+            <div className="flex items-center gap-1.5 pb-1">
+              <button
+                onClick={() => onRename(zoneId)}
+                className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted transition hover:border-accent/40 hover:text-accent"
+                title="Rename zone"
+                aria-label="Rename zone"
+              >
+                Rename
+              </button>
+              <button
+                onClick={() => onDuplicate(zoneId)}
+                className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted transition hover:border-accent/40 hover:text-accent"
+                title="Duplicate zone"
+                aria-label="Duplicate zone"
+              >
+                Duplicate
+              </button>
+              <button
+                onClick={() => onDelete(zoneId)}
+                className="rounded-full border border-[var(--chrome-stroke)] px-2.5 py-1 text-2xs text-text-muted transition hover:border-status-danger/40 hover:text-status-danger"
+                title="Delete zone"
+                aria-label="Delete zone"
+              >
+                Remove
+              </button>
+            </div>
+          )}
+          {catViews.map((view) => {
+            if (filtering && view.entries.length === 0) return null;
+            if (view.total === 0 && !view.cat.addFn) return null;
             return (
-              <div key={cat.key} className="border-t border-[var(--chrome-stroke)] pt-2 first:border-t-0 first:pt-0">
-                <div className="flex items-center gap-2">
-                  <span
-                    className="inline-block h-1.5 w-1.5 shrink-0 rounded-full"
-                    style={{ background: CATEGORY_COLORS[cat.key] }}
-                    aria-hidden="true"
-                  />
-                  <span className="font-display font-semibold text-2xs uppercase tracking-label text-text-secondary">
-                    {cat.label}
-                  </span>
-                  <span className="text-2xs text-text-muted">
-                    {entries.length}
-                  </span>
-                  {cat.addFn && (
-                    <button
-                      onClick={() => handleAdd(cat)}
-                      className="ml-auto rounded-full border border-[var(--chrome-stroke)] px-2 py-1 text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
-                      title={`Add ${cat.label.replace(/s$/, "").toLowerCase()}`}
-                      aria-label={`Add ${cat.label.replace(/s$/, "").toLowerCase()}`}
-                    >
-                      Add
-                    </button>
-                  )}
-                </div>
-                {entries.length > 0 && (
-                  <ul className="flex flex-col">
-                    {entries.map(([id, entity]) => {
-                      const name = (entity as Record<string, unknown>)[cat.nameField] as string | undefined;
-                      return (
-                        <li key={id}>
-                          <button
-                            onClick={() => handleEntityClick(cat, id)}
-                            className="w-full truncate rounded-xl px-2 py-1.5 text-left text-xs text-text-muted transition hover:bg-accent/8 hover:text-text-primary"
-                            title={name || id}
-                          >
-                            {name || id}
-                          </button>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </div>
+              <CategorySection
+                key={view.cat.key}
+                zoneId={zoneId}
+                view={view}
+                filtering={filtering}
+                selectedId={
+                  selectionCatKey === view.cat.key && selectionId !== null
+                    ? selectionId
+                    : undefined
+                }
+                startRoomId={world.startRoom}
+                onEntityClick={handleEntityClick}
+                onAdd={handleAdd}
+              />
             );
           })}
         </div>
@@ -402,7 +570,9 @@ export function ZonesPanel() {
   const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const [duplicateTarget, setDuplicateTarget] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
   const hasProject = !!project;
+  const query = filter.trim().toLowerCase();
 
   const handleDeleteZone = useCallback(async (zoneId: string) => {
     const zoneState = zones.get(zoneId);
@@ -429,12 +599,24 @@ export function ZonesPanel() {
     [zones],
   );
 
+  const visibleZones = useMemo(
+    () =>
+      query === ""
+        ? sortedZones
+        : sortedZones.filter(([zoneId, zoneState]) =>
+            zoneMatchesQuery(zoneId, zoneState.data, query),
+          ),
+    [sortedZones, query],
+  );
+
   return (
     <section aria-label="Zones" className="flex min-h-0 flex-1 flex-col overflow-y-auto px-4 pb-4 pt-1">
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
         {hasProject ? (
           <span className="whitespace-nowrap text-2xs uppercase tracking-label text-text-muted">
-            {sortedZones.length} zone{sortedZones.length === 1 ? "" : "s"}
+            {query !== ""
+              ? `${visibleZones.length} of ${sortedZones.length} zone${sortedZones.length === 1 ? "" : "s"}`
+              : `${sortedZones.length} zone${sortedZones.length === 1 ? "" : "s"}`}
           </span>
         ) : (
           <span aria-hidden="true" />
@@ -457,6 +639,36 @@ export function ZonesPanel() {
           </button>
         </div>
       </div>
+
+      {hasProject && sortedZones.length > 0 && (
+        <div className="relative mb-3">
+          <input
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape" && filter) {
+                e.stopPropagation();
+                setFilter("");
+              }
+            }}
+            placeholder="Filter zones and entities…"
+            aria-label="Filter zones and entities"
+            className="focus-ring w-full rounded-full border border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] py-1.5 pl-3.5 pr-8 text-xs text-text-primary transition placeholder:text-text-muted focus:border-accent/40"
+          />
+          {filter && (
+            <button
+              onClick={() => setFilter("")}
+              className="absolute right-1.5 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full text-2xs text-text-muted transition hover:bg-[var(--chrome-highlight-strong)] hover:text-text-primary"
+              title="Clear filter"
+              aria-label="Clear filter"
+            >
+              ×
+            </button>
+          )}
+        </div>
+      )}
+
       {sortedZones.length === 0 ? (
         <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-5 text-sm text-text-muted">
           {hasProject ? (
@@ -475,14 +687,25 @@ export function ZonesPanel() {
             <p className="leading-relaxed">Open a world to begin shaping it.</p>
           )}
         </div>
+      ) : visibleZones.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-[var(--chrome-stroke)] bg-[var(--chrome-fill)] px-4 py-5 text-sm text-text-muted">
+          <p className="leading-relaxed">No zones or entities match “{filter.trim()}”.</p>
+          <button
+            onClick={() => setFilter("")}
+            className="focus-ring mt-2 rounded-full border border-[var(--chrome-stroke)] px-3 py-1 text-2xs text-text-muted transition hover:border-accent/40 hover:text-accent"
+          >
+            Clear filter
+          </button>
+        </div>
       ) : (
         <ul className="flex flex-col gap-0.5">
-          {sortedZones.map(([zoneId, zoneState]) => (
+          {visibleZones.map(([zoneId, zoneState]) => (
             <ZoneTree
               key={zoneId}
               zoneId={zoneId}
               zoneState={zoneState}
               isActive={activeTabId === `zone:${zoneId}`}
+              query={query}
               onDelete={(id) => setDeleteTarget(id)}
               onRename={(id) => setRenameTarget(id)}
               onDuplicate={(id) => setDuplicateTarget(id)}

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -274,6 +274,18 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
     }
   }, [zoneState, selectedEntity]);
 
+  // Mirror the current selection so the sidebar can highlight it
+  useEffect(() => {
+    const setActiveSelection = useProjectStore.getState().setActiveSelection;
+    if (selectedEntity) {
+      setActiveSelection({ zoneId, entityKind: selectedEntity.kind, entityId: selectedEntity.id });
+    } else if (selectedRoomId) {
+      setActiveSelection({ zoneId, roomId: selectedRoomId });
+    } else {
+      setActiveSelection({ zoneId });
+    }
+  }, [zoneId, selectedRoomId, selectedEntity]);
+
   // Consume pending navigation from sidebar
   const pendingNavigation = useProjectStore((s) => s.pendingNavigation);
   const consumeNavigation = useProjectStore((s) => s.consumeNavigation);

--- a/creator/src/index.css
+++ b/creator/src/index.css
@@ -183,6 +183,7 @@
   --color-entity-quest:    #d88c3a;  /* character-gold — adventure */
   --color-entity-gather:   #55aebe;  /* stormblade — natural */
   --color-entity-recipe:   #6e8d5a;  /* necromancer — earthy crafting */
+  --color-entity-puzzle:   #786eb2;  /* steel-violet — arcane */
   --color-entity-dungeon:  #d9756b;  /* danger — perilous */
 
   /* ─── Chart / Visualization ─── */

--- a/creator/src/stores/projectStore.ts
+++ b/creator/src/stores/projectStore.ts
@@ -26,6 +26,15 @@ export interface PendingNavigation {
   view?: string;
 }
 
+/** What the active zone editor currently has selected, mirrored so the
+ *  sidebar can highlight it. Only meaningful while that zone's tab is active. */
+export interface ActiveSelection {
+  zoneId: string;
+  roomId?: string;
+  entityKind?: string;
+  entityId?: string;
+}
+
 interface ProjectStore {
   project: Project | null;
   tabs: Tab[];
@@ -33,6 +42,7 @@ interface ProjectStore {
   adminSubView: AdminSubView;
   adminContentSubView: AdminContentSubView;
   pendingNavigation: PendingNavigation | null;
+  activeSelection: ActiveSelection | null;
   /** Global flag to show the MUD import wizard. Palette & sidebar both toggle this. */
   showMudImport: boolean;
   /** Global flag to show the zone YAML import dialog. */
@@ -59,6 +69,7 @@ interface ProjectStore {
   setAdminContentSubView: (subView: AdminContentSubView) => void;
   navigateTo: (nav: PendingNavigation) => void;
   consumeNavigation: () => PendingNavigation | null;
+  setActiveSelection: (selection: ActiveSelection | null) => void;
   setShowMudImport: (show: boolean) => void;
   setShowImportZone: (show: boolean) => void;
   /** Show the top-level world map (clears any open island detail). */
@@ -95,6 +106,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   adminSubView: "overview",
   adminContentSubView: "abilities",
   pendingNavigation: null,
+  activeSelection: null,
   showMudImport: false,
   showImportZone: false,
   mapView: "world",
@@ -115,6 +127,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
       adminSubView: "overview",
       adminContentSubView: "abilities",
       mapView: "world",
+      activeSelection: null,
     });
     // Tell the Rust backend which project is active so get_settings
     // automatically merges project-level settings (R2 credentials, etc.)
@@ -126,7 +139,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     clearRoomDataCache();
     clearLayoutCache();
     invoke("set_active_project_dir", { projectDir: null }).catch(() => {});
-    set({ project: null, tabs: [], activeTabId: null, mapView: "world" });
+    set({ project: null, tabs: [], activeTabId: null, mapView: "world", activeSelection: null });
   },
 
   openTab: (tab) => {
@@ -174,6 +187,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     if (nav) set({ pendingNavigation: null });
     return nav;
   },
+  setActiveSelection: (activeSelection) => set({ activeSelection }),
   setShowMudImport: (showMudImport) => set({ showMudImport }),
   setShowImportZone: (showImportZone) => set({ showImportZone }),
 

--- a/creator/src/stores/sidebarStore.ts
+++ b/creator/src/stores/sidebarStore.ts
@@ -6,11 +6,23 @@ export type DrillTarget = "articles" | "zones" | null;
 interface SidebarState {
   mode: SidebarMode;
   drillTarget: DrillTarget;
+  /** Zone tree rows the user has expanded in the Zones panel, by zone id. */
+  expandedZones: Record<string, boolean>;
+  /** Expanded entity categories, keyed `${zoneId}::${categoryKey}`. */
+  expandedCats: Record<string, boolean>;
   setMode: (mode: SidebarMode) => void;
   toggleMode: () => void;
   setDrillTarget: (target: DrillTarget) => void;
   drillInto: (target: Exclude<DrillTarget, null>) => void;
   goBack: () => void;
+  toggleZoneExpanded: (zoneId: string) => void;
+  setZoneExpanded: (zoneId: string, expanded: boolean) => void;
+  toggleCatExpanded: (zoneId: string, catKey: string) => void;
+  setCatExpanded: (zoneId: string, catKey: string, expanded: boolean) => void;
+}
+
+export function catExpansionKey(zoneId: string, catKey: string): string {
+  return `${zoneId}::${catKey}`;
 }
 
 const STORAGE_KEY = "arcanum.sidebar";
@@ -18,12 +30,23 @@ const STORAGE_KEY = "arcanum.sidebar";
 interface PersistedState {
   mode: SidebarMode;
   drillTarget: DrillTarget;
+  expandedZones?: string[];
+  expandedCats?: string[];
 }
 
 const VALID_DRILL_TARGETS = new Set<DrillTarget>(["articles", "zones"]);
 
 function coerceDrillTarget(value: unknown): DrillTarget {
   return VALID_DRILL_TARGETS.has(value as DrillTarget) ? (value as DrillTarget) : null;
+}
+
+function coerceKeySet(value: unknown): Record<string, boolean> {
+  if (!Array.isArray(value)) return {};
+  const out: Record<string, boolean> = {};
+  for (const key of value) {
+    if (typeof key === "string") out[key] = true;
+  }
+  return out;
 }
 
 function readPersisted(): PersistedState {
@@ -33,16 +56,27 @@ function readPersisted(): PersistedState {
     if (!raw) return { mode: "full", drillTarget: null };
     const parsed = JSON.parse(raw) as Partial<PersistedState>;
     const mode = parsed.mode === "rail" ? "rail" : "full";
-    return { mode, drillTarget: coerceDrillTarget(parsed.drillTarget) };
+    return {
+      mode,
+      drillTarget: coerceDrillTarget(parsed.drillTarget),
+      expandedZones: Array.isArray(parsed.expandedZones) ? parsed.expandedZones : [],
+      expandedCats: Array.isArray(parsed.expandedCats) ? parsed.expandedCats : [],
+    };
   } catch {
     return { mode: "full", drillTarget: null };
   }
 }
 
-function writePersisted(state: PersistedState) {
+function writePersisted(state: SidebarState) {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    const payload: PersistedState = {
+      mode: state.mode,
+      drillTarget: state.drillTarget,
+      expandedZones: Object.keys(state.expandedZones).filter((k) => state.expandedZones[k]),
+      expandedCats: Object.keys(state.expandedCats).filter((k) => state.expandedCats[k]),
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
   } catch {
     // ignore quota / privacy errors
   }
@@ -50,33 +84,50 @@ function writePersisted(state: PersistedState) {
 
 const initial = readPersisted();
 
-export const useSidebarStore = create<SidebarState>((set, get) => ({
-  mode: initial.mode,
-  drillTarget: initial.drillTarget,
+export const useSidebarStore = create<SidebarState>((set, get) => {
+  const apply = (partial: Partial<SidebarState>) => {
+    set(partial);
+    writePersisted(get());
+  };
 
-  setMode: (mode) => {
-    set({ mode });
-    writePersisted({ mode, drillTarget: get().drillTarget });
-  },
+  return {
+    mode: initial.mode,
+    drillTarget: initial.drillTarget,
+    expandedZones: coerceKeySet(initial.expandedZones),
+    expandedCats: coerceKeySet(initial.expandedCats),
 
-  toggleMode: () => {
-    const next: SidebarMode = get().mode === "full" ? "rail" : "full";
-    set({ mode: next });
-    writePersisted({ mode: next, drillTarget: get().drillTarget });
-  },
+    setMode: (mode) => apply({ mode }),
 
-  setDrillTarget: (target) => {
-    set({ drillTarget: target });
-    writePersisted({ mode: get().mode, drillTarget: target });
-  },
+    toggleMode: () => apply({ mode: get().mode === "full" ? "rail" : "full" }),
 
-  drillInto: (target) => {
-    set({ drillTarget: target, mode: "full" });
-    writePersisted({ mode: "full", drillTarget: target });
-  },
+    setDrillTarget: (target) => apply({ drillTarget: target }),
 
-  goBack: () => {
-    set({ drillTarget: null });
-    writePersisted({ mode: get().mode, drillTarget: null });
-  },
-}));
+    drillInto: (target) => apply({ drillTarget: target, mode: "full" }),
+
+    goBack: () => apply({ drillTarget: null }),
+
+    toggleZoneExpanded: (zoneId) => {
+      const { expandedZones } = get();
+      apply({ expandedZones: { ...expandedZones, [zoneId]: !expandedZones[zoneId] } });
+    },
+
+    setZoneExpanded: (zoneId, expanded) => {
+      const { expandedZones } = get();
+      if (!!expandedZones[zoneId] === expanded) return;
+      apply({ expandedZones: { ...expandedZones, [zoneId]: expanded } });
+    },
+
+    toggleCatExpanded: (zoneId, catKey) => {
+      const { expandedCats } = get();
+      const key = catExpansionKey(zoneId, catKey);
+      apply({ expandedCats: { ...expandedCats, [key]: !expandedCats[key] } });
+    },
+
+    setCatExpanded: (zoneId, catKey, expanded) => {
+      const { expandedCats } = get();
+      const key = catExpansionKey(zoneId, catKey);
+      if (!!expandedCats[key] === expanded) return;
+      apply({ expandedCats: { ...expandedCats, [key]: expanded } });
+    },
+  };
+});


### PR DESCRIPTION
## Summary

Reworks the left-side Zones panel (the tree listing zones → rooms/mobs/items/…) for usability:

- **Collapsible categories** — each entity category (Rooms, Mobs, Items, …) is now a disclosure section with a caret, color dot, and right-aligned count. Expansion state for both zones and categories persists across sessions (localStorage via `sidebarStore`).
- **Selection highlighting** — the room/entity currently open in the zone editor is highlighted in the tree (`selected-pill` ember treatment), its category auto-expands, and it scrolls into view. Works both when navigating from the sidebar and when selecting rooms/entities inside the editor. Implemented by mirroring the editor's selection into `projectStore.activeSelection`.
- **Filter box** — type to filter zones *and* entities by name or id across the whole tree; matching zones/categories force-expand and show match counts (`1/3`). A zone-name match shows the zone's full contents. Escape or × clears; "0 of N zones" empty state with a clear button.
- **Alphabetical sorting** — entities sort by display name (was YAML insertion order), with the muted id shown alongside when it differs.
- **Start-room marker** — the zone's `startRoom` gets a ✦ start badge.
- **Quests + Puzzles categories** — both collections existed in zone YAML and had editors, but were unreachable from the sidebar. Added with Add buttons and a new `--color-entity-puzzle` token (steel-violet).
- Zone action pills (Rename/Duplicate/Remove) hide while filtering to keep result lists quiet.
- A11y: `aria-expanded`/`aria-controls` on disclosure toggles, `aria-current` on the selected row and active zone, focus rings on all rows.

Also adds a root `PRODUCT.md` (design context distilled from `.impeccable.md` / the style guide) — happy to drop that commit if unwanted.

## Testing

- `bunx tsc --noEmit` clean; `bun run test` — 73 files, 2305 tests pass
- Verified live in a headless browser against the Vite dev build with seeded fixture zones:
  - expand/collapse persists, counts render, Add buttons show
  - clicking a mob in the tree opens its editor and highlights the row
  - editor-side selection auto-expands the right category and highlights (incl. ✦ start marker on the start room)
  - filter narrows to matching zones/entities, force-expands, shows `1/3`-style counts, and the no-match state renders