### PR TITLE
feat(creator): variant lightbox — preview before setting the primary image

### DIFF
--- a/creator/src/components/AbilityStudio.tsx
+++ b/creator/src/components/AbilityStudio.tsx
@@ -3,6 +3,7 @@ import { AI_ENABLED } from "@/lib/featureFlags";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useAssetStore } from "@/stores/assetStore";
 import { Spinner, InlineError } from "@/components/ui/FormWidgets";
+import { VariantLightbox } from "@/components/ui/VariantLightbox";
 import { useConfigStore } from "@/stores/configStore";
 import { useImageSrc } from "@/lib/useImageSrc";
 import { composePrompt, type ArtStyle } from "@/lib/arcanumPrompts";
@@ -131,6 +132,7 @@ export function AbilityStudio() {
   const [selectedKey, setSelectedKey] = useState<TargetKey | null>(null);
   const [promptDraft, setPromptDraft] = useState("");
   const [variants, setVariants] = useState<AssetEntry[]>([]);
+  const [variantPreview, setVariantPreview] = useState<number | null>(null);
   const [previewEntry, setPreviewEntry] = useState<AssetEntry | null>(null);
   const [promptGeneratedByLlm, setPromptGeneratedByLlm] = useState(false);
   const [generatingPrompt, setGeneratingPrompt] = useState(false);
@@ -752,8 +754,8 @@ export function AbilityStudio() {
                     <div className="mt-3">
                       <div className="mb-1.5 text-2xs uppercase tracking-ui text-text-muted">Variants</div>
                       <div className="flex gap-2 overflow-x-auto pb-1">
-                        {variants.map((entry) => (
-                          <VariantCard key={entry.id} entry={entry} assetsDir={assetsDir} onClick={() => handleVariantSelect(entry)} />
+                        {variants.map((entry, i) => (
+                          <VariantCard key={entry.id} entry={entry} assetsDir={assetsDir} onClick={() => setVariantPreview(i)} />
                         ))}
                       </div>
                     </div>
@@ -849,6 +851,16 @@ export function AbilityStudio() {
             </div>
           </div>
         </div>
+      )}
+
+      {variantPreview !== null && (
+        <VariantLightbox
+          variants={variants}
+          initialIndex={variantPreview}
+          assetsDir={assetsDir}
+          onSetPrimary={handleVariantSelect}
+          onClose={() => setVariantPreview(null)}
+        />
       )}
     </section>
   );

--- a/creator/src/components/CustomAssetStudio.tsx
+++ b/creator/src/components/CustomAssetStudio.tsx
@@ -16,6 +16,7 @@ import {
 import { resolveImageModel, type AssetEntry, type AssetType } from "@/types/assets";
 import { generateAssetImage } from "@/lib/imageGen";
 import { InlineError, Spinner } from "@/components/ui/FormWidgets";
+import { VariantLightbox } from "@/components/ui/VariantLightbox";
 
 const CUSTOM_ASSET_TYPES: AssetType[] = [
   "background",
@@ -114,6 +115,7 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
   const [globalAssetKey, setGlobalAssetKey] = useState("");
   const [promptDraft, setPromptDraft] = useState("");
   const [variants, setVariants] = useState<AssetEntry[]>([]);
+  const [variantPreview, setVariantPreview] = useState<number | null>(null);
   const [previewEntry, setPreviewEntry] = useState<AssetEntry | null>(null);
   const [promptGeneratedByLlm, setPromptGeneratedByLlm] = useState(false);
   const [generatingPrompt, setGeneratingPrompt] = useState(false);
@@ -510,14 +512,24 @@ export function CustomAssetStudio({ selectedZoneId }: { selectedZoneId: string |
             <div className="mt-4">
               <div className="mb-2 text-2xs uppercase tracking-ui text-text-muted">Variant strip</div>
               <div className="flex gap-2 overflow-x-auto pb-1">
-                {variants.map((entry) => (
-                  <VariantCard key={entry.id} entry={entry} assetsDir={assetsDir} onClick={() => handleVariantSelect(entry)} />
+                {variants.map((entry, i) => (
+                  <VariantCard key={entry.id} entry={entry} assetsDir={assetsDir} onClick={() => setVariantPreview(i)} />
                 ))}
               </div>
             </div>
           )}
         </div>
       </div>
+
+      {variantPreview !== null && (
+        <VariantLightbox
+          variants={variants}
+          initialIndex={variantPreview}
+          assetsDir={assetsDir}
+          onSetPrimary={handleVariantSelect}
+          onClose={() => setVariantPreview(null)}
+        />
+      )}
     </section>
   );
 }

--- a/creator/src/components/PortraitStudio.tsx
+++ b/creator/src/components/PortraitStudio.tsx
@@ -13,6 +13,7 @@ import {
 import { resolveImageModel, type AssetEntry } from "@/types/assets";
 import { generateAssetImage } from "@/lib/imageGen";
 import { InlineError, Spinner } from "@/components/ui/FormWidgets";
+import { VariantLightbox } from "@/components/ui/VariantLightbox";
 
 type PortraitKind = "race" | "class";
 type PortraitKey = `${PortraitKind}:${string}`;
@@ -88,6 +89,7 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
   const [promptDraft, setPromptDraft] = useState("");
   const [template, setTemplate] = useState<PortraitPromptTemplate | null>(null);
   const [variants, setVariants] = useState<AssetEntry[]>([]);
+  const [variantPreview, setVariantPreview] = useState<number | null>(null);
   const [previewEntry, setPreviewEntry] = useState<AssetEntry | null>(null);
   const [generatingTemplate, setGeneratingTemplate] = useState(false);
   const [generatingImage, setGeneratingImage] = useState(false);
@@ -418,8 +420,8 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
                     <div className="mt-3">
                       <div className="mb-1.5 text-2xs uppercase tracking-ui text-text-muted">Variants</div>
                       <div className="flex gap-2 overflow-x-auto pb-1">
-                        {variants.map((entry) => (
-                          <VariantCard key={entry.id} entry={entry} assetsDir={assetsDir} onClick={() => handleVariantSelect(entry)} />
+                        {variants.map((entry, i) => (
+                          <VariantCard key={entry.id} entry={entry} assetsDir={assetsDir} onClick={() => setVariantPreview(i)} />
                         ))}
                       </div>
                     </div>
@@ -479,6 +481,16 @@ export function PortraitStudio({ selectedZoneId }: { selectedZoneId: string | nu
             </div>
           </div>
         </div>
+      )}
+
+      {variantPreview !== null && (
+        <VariantLightbox
+          variants={variants}
+          initialIndex={variantPreview}
+          assetsDir={assetsDir}
+          onSetPrimary={handleVariantSelect}
+          onClose={() => setVariantPreview(null)}
+        />
       )}
     </section>
   );

--- a/creator/src/components/ui/EntityArtGenerator.css
+++ b/creator/src/components/ui/EntityArtGenerator.css
@@ -1049,6 +1049,64 @@
   padding: 0 6px;
 }
 
+.art-lightbox__caption {
+  padding: 0 8px;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+
+.art-lightbox__btn--primary {
+  color: var(--color-accent);
+  border-color: var(--border-accent-subtle);
+}
+
+.art-lightbox__btn--primary:disabled {
+  color: var(--color-warm-pale);
+  border-color: transparent;
+  background: rgb(var(--accent-rgb) / 0.10);
+  cursor: default;
+}
+
+.art-lightbox__nav {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 48px;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--chrome-stroke-strong);
+  border-radius: 16px;
+  background: rgb(var(--bg-rgb) / 0.82);
+  backdrop-filter: blur(10px);
+  color: var(--color-text-secondary);
+  font-size: 30px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 160ms var(--ease-cosmic), border-color 160ms var(--ease-cosmic), background 160ms var(--ease-cosmic);
+}
+
+.art-lightbox__nav:hover {
+  color: var(--color-warm-pale);
+  border-color: var(--border-accent-subtle);
+  background: rgb(var(--accent-rgb) / 0.12);
+}
+
+.art-lightbox__nav--prev {
+  left: 20px;
+}
+
+.art-lightbox__nav--next {
+  right: 20px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .art-lightbox {
+    animation: none;
+  }
+}
+
 /* Compact faction-emblem forge used inside the fixed Allegiances workbench. */
 .faction-emblem-generator .art-panel,
 .faction-emblem-generator .art-panel__hero-col,

--- a/creator/src/components/ui/EntityArtGenerator.tsx
+++ b/creator/src/components/ui/EntityArtGenerator.tsx
@@ -22,6 +22,7 @@ import { removeBgAndSave, shouldRemoveBg } from "@/lib/useBackgroundRemoval";
 import { InlineError } from "./FormWidgets";
 import { SketchDialog } from "./SketchDialog";
 import { ImageLightbox } from "./ImageLightbox";
+import { VariantLightbox } from "./VariantLightbox";
 
 type Stage = "idle" | "generating" | "preview";
 
@@ -153,6 +154,7 @@ export function EntityArtGenerator({
   const [showSketch, setShowSketch] = useState(false);
   const [variants, setVariants] = useState<AssetEntry[]>([]);
   const [lightbox, setLightbox] = useState<string | null>(null);
+  const [variantPreview, setVariantPreview] = useState<number | null>(null);
 
   // Refs to track pending results across unmount — auto-accept if user navigates away
   const pendingResultRef = useRef<GeneratedImage | null>(null);
@@ -567,7 +569,7 @@ export function EntityArtGenerator({
               variants={variants}
               currentImage={currentImage}
               assetsDir={assetsDir}
-              onSelect={handleSelectVariant}
+              onPreview={setVariantPreview}
               onReroll={AI_ENABLED && hasApiKey ? handleGenerate : undefined}
               rerollDisabled={removingBg}
             />
@@ -855,6 +857,17 @@ export function EntityArtGenerator({
       {lightbox && (
         <ImageLightbox src={lightbox} onClose={() => setLightbox(null)} />
       )}
+
+      {variantPreview !== null && (
+        <VariantLightbox
+          variants={variants}
+          initialIndex={variantPreview}
+          assetsDir={assetsDir}
+          isPrimary={(v) => v.is_active || v.file_name === currentImage}
+          onSetPrimary={handleSelectVariant}
+          onClose={() => setVariantPreview(null)}
+        />
+      )}
     </section>
   );
 }
@@ -985,14 +998,14 @@ function VariantsRail({
   variants,
   currentImage,
   assetsDir,
-  onSelect,
+  onPreview,
   onReroll,
   rerollDisabled,
 }: {
   variants: AssetEntry[];
   currentImage?: string;
   assetsDir: string;
-  onSelect: (entry: AssetEntry) => void;
+  onPreview: (index: number) => void;
   onReroll?: () => void;
   rerollDisabled?: boolean;
 }) {
@@ -1003,13 +1016,13 @@ function VariantsRail({
         <span className="art-rail__count">{variants.length}</span>
       </div>
       <div className="art-rail__strip">
-        {variants.map((v) => (
+        {variants.map((v, i) => (
           <VariantThumb
             key={v.id}
             entry={v}
             assetsDir={assetsDir}
             isPrimary={v.is_active || v.file_name === currentImage}
-            onClick={() => onSelect(v)}
+            onClick={() => onPreview(i)}
           />
         ))}
         {onReroll && (
@@ -1047,7 +1060,7 @@ function VariantThumb({
       className="art-thumb"
       data-primary={isPrimary}
       onClick={onClick}
-      title={isPrimary ? "Primary" : "Set as primary"}
+      title={isPrimary ? "Primary — click to preview" : "Preview"}
     >
       {src ? (
         <img src={src} alt="" loading="lazy" />
@@ -1056,7 +1069,7 @@ function VariantThumb({
       )}
       {isPrimary && <span className="art-thumb__star">✦</span>}
       {!isPrimary && (
-        <div className="art-thumb__hover">Set primary</div>
+        <div className="art-thumb__hover">Preview</div>
       )}
     </button>
   );

--- a/creator/src/components/ui/ImageLightbox.tsx
+++ b/creator/src/components/ui/ImageLightbox.tsx
@@ -1,14 +1,23 @@
 import "./EntityArtGenerator.css";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 
 interface ImageLightboxProps {
   src: string;
   onClose: () => void;
+  /** Extra buttons rendered in the HUD, before the Close button. */
+  actions?: ReactNode;
+  /** Short status text rendered in the HUD (e.g. a "3 / 7" counter). */
+  caption?: ReactNode;
+  /** When provided, shows a ◀ chevron and binds ArrowLeft. */
+  onPrev?: () => void;
+  /** When provided, shows a ▶ chevron and binds ArrowRight. */
+  onNext?: () => void;
 }
 
 /** Click-to-zoom modal with scroll-zoom and drag-pan. Click outside or Esc closes. */
-export function ImageLightbox({ src, onClose }: ImageLightboxProps) {
+export function ImageLightbox({ src, onClose, actions, caption, onPrev, onNext }: ImageLightboxProps) {
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [dragging, setDragging] = useState(false);
@@ -26,7 +35,19 @@ export function ImageLightbox({ src, onClose }: ImageLightboxProps) {
     closeBtnRef.current?.focus();
   }, []);
 
-  // Keyboard zoom shortcuts (Escape is handled by the focus trap).
+  // Reset the view when navigating between images.
+  useEffect(() => {
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+  }, [src]);
+
+  // Keep the latest nav callbacks readable from the stable key handler.
+  const onPrevRef = useRef(onPrev);
+  const onNextRef = useRef(onNext);
+  onPrevRef.current = onPrev;
+  onNextRef.current = onNext;
+
+  // Keyboard zoom + navigation shortcuts (Escape is handled by the focus trap).
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "0") {
@@ -36,6 +57,10 @@ export function ImageLightbox({ src, onClose }: ImageLightboxProps) {
         setZoom((z) => Math.min(8, z * 1.2));
       } else if (e.key === "-" || e.key === "_") {
         setZoom((z) => Math.max(0.5, z / 1.2));
+      } else if (e.key === "ArrowLeft") {
+        onPrevRef.current?.();
+      } else if (e.key === "ArrowRight") {
+        onNextRef.current?.();
       }
     };
     window.addEventListener("keydown", handleKey);
@@ -79,7 +104,9 @@ export function ImageLightbox({ src, onClose }: ImageLightboxProps) {
   };
   const onMouseLeave = () => setDragging(false);
 
-  return (
+  // Portal to <body>: ancestor stacking contexts (app shell chrome, panel
+  // columns) otherwise paint the sidebar and toolbar above this overlay.
+  return createPortal(
     <div
       ref={rootRef}
       className="art-lightbox"
@@ -106,7 +133,29 @@ export function ImageLightbox({ src, onClose }: ImageLightboxProps) {
           }}
         />
       </div>
+      {onPrev && (
+        <button
+          className="art-lightbox__nav art-lightbox__nav--prev"
+          onClick={(e) => { e.stopPropagation(); onPrev(); }}
+          title="Previous (←)"
+          aria-label="Previous image"
+        >
+          ‹
+        </button>
+      )}
+      {onNext && (
+        <button
+          className="art-lightbox__nav art-lightbox__nav--next"
+          onClick={(e) => { e.stopPropagation(); onNext(); }}
+          title="Next (→)"
+          aria-label="Next image"
+        >
+          ›
+        </button>
+      )}
       <div className="art-lightbox__hud" onClick={(e) => e.stopPropagation()}>
+        {caption && <span className="art-lightbox__caption">{caption}</span>}
+        {actions}
         <button
           className="art-lightbox__btn"
           onClick={() => setZoom((z) => Math.max(0.5, z / 1.2))}
@@ -138,6 +187,7 @@ export function ImageLightbox({ src, onClose }: ImageLightboxProps) {
           Close · Esc
         </button>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/creator/src/components/ui/VariantLightbox.tsx
+++ b/creator/src/components/ui/VariantLightbox.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import type { AssetEntry } from "@/types/assets";
+import { useImageSrc } from "@/lib/useImageSrc";
+import { ImageLightbox } from "./ImageLightbox";
+
+interface VariantLightboxProps {
+  variants: AssetEntry[];
+  initialIndex: number;
+  assetsDir: string;
+  onSetPrimary: (entry: AssetEntry) => void | Promise<void>;
+  onClose: () => void;
+  /** Overrides the default `entry.is_active` primary check. */
+  isPrimary?: (entry: AssetEntry) => boolean;
+}
+
+/**
+ * Full-screen preview for an asset's variant group: pan/zoom via
+ * ImageLightbox, ◀ ▶ / arrow-key navigation between variants, and an
+ * explicit "Set as primary" action so browsing never commits a change.
+ */
+export function VariantLightbox({
+  variants,
+  initialIndex,
+  assetsDir,
+  onSetPrimary,
+  onClose,
+  isPrimary,
+}: VariantLightboxProps) {
+  const [index, setIndex] = useState(initialIndex);
+  const [setting, setSetting] = useState(false);
+
+  const count = variants.length;
+  const clamped = count === 0 ? 0 : Math.min(Math.max(index, 0), count - 1);
+  const entry = variants[clamped];
+  const src = useImageSrc(entry ? `${assetsDir}\\images\\${entry.file_name}` : undefined);
+
+  useEffect(() => {
+    if (count === 0) onClose();
+  }, [count, onClose]);
+
+  if (!entry) return null;
+
+  const primary = isPrimary ? isPrimary(entry) : entry.is_active;
+  const multi = count > 1;
+
+  const handleSetPrimary = async () => {
+    if (primary || setting) return;
+    setSetting(true);
+    try {
+      await onSetPrimary(entry);
+    } finally {
+      setSetting(false);
+    }
+  };
+
+  return (
+    <ImageLightbox
+      src={src ?? ""}
+      onClose={onClose}
+      caption={multi ? `${clamped + 1} / ${count}` : undefined}
+      onPrev={multi ? () => setIndex((i) => (i - 1 + count) % count) : undefined}
+      onNext={multi ? () => setIndex((i) => (i + 1) % count) : undefined}
+      actions={
+        <button
+          className="art-lightbox__btn art-lightbox__btn--primary"
+          onClick={handleSetPrimary}
+          disabled={primary || setting}
+        >
+          {primary ? "✦ Primary" : setting ? "Setting…" : "✦ Set as primary"}
+        </button>
+      }
+    />
+  );
+}

--- a/creator/src/components/zone/AssetBrowser.tsx
+++ b/creator/src/components/zone/AssetBrowser.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useAssetStore } from "@/stores/assetStore";
 import { useImageSrc } from "@/lib/useImageSrc";
+import { VariantLightbox } from "@/components/ui/VariantLightbox";
 import type { WorldFile } from "@/types/world";
 import type { AssetEntry } from "@/types/assets";
 import { MISC_NO_IMAGE } from "@/assets/ui";
@@ -271,6 +272,7 @@ function PreviewPanel({
   const assetsDir = useAssetStore((s) => s.assetsDir);
   const assetCount = useAssetStore((s) => s.assets.length);
   const [variants, setVariants] = useState<AssetEntry[]>([]);
+  const [variantPreview, setVariantPreview] = useState<number | null>(null);
 
   const loadVariants = useCallback(async () => {
     try {
@@ -364,17 +366,27 @@ function PreviewPanel({
               {variants.length} variant{variants.length !== 1 ? "s" : ""}
             </span>
             <div className="flex gap-1.5 overflow-x-auto pb-0.5">
-              {variants.map((v) => (
+              {variants.map((v, i) => (
                 <VariantThumb
                   key={v.id}
                   entry={v}
                   assetsDir={assetsDir}
-                  onSelect={() => handleSelectVariant(v)}
+                  onSelect={() => setVariantPreview(i)}
                 />
               ))}
             </div>
           </div>
         </div>
+      )}
+
+      {variantPreview !== null && (
+        <VariantLightbox
+          variants={variants}
+          initialIndex={variantPreview}
+          assetsDir={assetsDir}
+          onSetPrimary={handleSelectVariant}
+          onClose={() => setVariantPreview(null)}
+        />
       )}
     </div>
   );
@@ -397,7 +409,7 @@ function VariantThumb({
   return (
     <button
       onClick={onSelect}
-      title={entry.created_at}
+      title={`Preview — ${entry.created_at}`}
       className={`relative h-14 w-14 shrink-0 overflow-hidden rounded border-2 transition-[border-color,box-shadow] ${
         entry.is_active
           ? "border-accent shadow-[0_0_6px_var(--color-accent)]"

--- a/creator/src/components/zone/ZoneAssetWorkbench.tsx
+++ b/creator/src/components/zone/ZoneAssetWorkbench.tsx
@@ -15,6 +15,7 @@ import {
 import { getEnhanceSystemPrompt, getNegativePrompt } from "@/lib/arcanumPrompts";
 import { imageGenerateCommand, resolveImageModel, requestsTransparentBackground, type AssetContext, type AssetEntry, type GeneratedImage } from "@/types/assets";
 import { InlineError, Spinner } from "@/components/ui/FormWidgets";
+import { VariantLightbox } from "@/components/ui/VariantLightbox";
 import {
   loadCollapsedZoneAssetSections,
   saveCollapsedZoneAssetSections,
@@ -191,6 +192,7 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
   const [promptDraft, setPromptDraft] = useState("");
   const [promptGeneratedByLlm, setPromptGeneratedByLlm] = useState(false);
   const [variants, setVariants] = useState<AssetEntry[]>([]);
+  const [variantPreview, setVariantPreview] = useState<number | null>(null);
   const [previewEntry, setPreviewEntry] = useState<AssetEntry | null>(null);
   const [generatingPrompt, setGeneratingPrompt] = useState(false);
   const [generatingImage, setGeneratingImage] = useState(false);
@@ -696,8 +698,8 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
                     <div className="mt-3">
                       <div className="mb-1.5 text-2xs uppercase tracking-ui text-text-muted">Variants</div>
                       <div className="flex gap-2 overflow-x-auto pb-1">
-                        {variants.map((entry) => (
-                          <VariantCard key={entry.id} entry={entry} assetsDir={assetsDir} onClick={() => handleVariantSelect(entry)} />
+                        {variants.map((entry, i) => (
+                          <VariantCard key={entry.id} entry={entry} assetsDir={assetsDir} onClick={() => setVariantPreview(i)} />
                         ))}
                       </div>
                     </div>
@@ -826,6 +828,16 @@ export function ZoneAssetWorkbench({ zoneId, world, onWorldChange }: ZoneAssetWo
             </div>
           </div>
         </div>
+      )}
+
+      {variantPreview !== null && (
+        <VariantLightbox
+          variants={variants}
+          initialIndex={variantPreview}
+          assetsDir={assetsDir}
+          onSetPrimary={handleVariantSelect}
+          onClose={() => setVariantPreview(null)}
+        />
       )}
     </section>
   );


### PR DESCRIPTION
## Summary

Clicking a variant thumbnail used to instantly swap the primary image — there was no way to actually look at a variant first. Now every variant strip opens a full-screen lightbox preview, and changing the primary image is an explicit action inside it.

- **New shared `VariantLightbox`** (`creator/src/components/ui/VariantLightbox.tsx`): pan/zoom preview (reuses `ImageLightbox` mechanics), ◀ ▶ chevrons + arrow-key navigation with wrap-around, a `3 / 5` counter, and an ember **✦ Set as primary** button. On the already-active variant the button reads **✦ Primary** and is disabled. Esc / click-outside closes without changing anything.
- **`ImageLightbox` extended** with optional `actions` / `caption` / `onPrev` / `onNext` props, zoom+pan reset when navigating between images, and — the important fix — **rendering via a portal to `<body>`**: ancestor stacking contexts previously painted the sidebar, toolbar, and status bar *over* the overlay (this also fixes the pre-existing hero-image lightbox).
- **All six variant surfaces wired**: `EntityArtGenerator` (entity editors' art panel), zone `AssetBrowser`, `PortraitStudio`, `AbilityStudio`, `ZoneAssetWorkbench`, and `CustomAssetStudio`. Thumb click opens the preview; each surface's existing set-active handler (which also updates zone/config YAML references) runs only from the lightbox action.
- Thumb tooltips/hover chips updated from "Set primary" to "Preview". Reduced-motion users get the lightbox without the fade animation.

## Testing

- `bunx tsc --noEmit` clean; `bun run test` — 73 files, 2305 tests pass
- Verified live in a headless browser against the Vite dev build with a mocked Tauri IPC layer (fixture variants + placeholder images):
  - thumb click opens the preview instead of switching the image
  - arrow keys / chevrons cycle variants with the counter updating; view resets per image
  - the active variant shows a disabled "✦ Primary" state
  - "Set as primary" updates the manifest active flag **and** the mob's `image` field in zone data (zone marked dirty), the rail's ✦ star moves, and Esc closes
  - overlay now covers the entire app shell (sidebar/toolbar dimmed beneath it)