### PR TITLE
Stop the zone validator crying wolf (cross-zone quests + graduated zones)

### DIFF
--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { validateZone, type ValidationIssue } from "../validateZone";
+import { validateZone, validateAllZones, type ValidationIssue } from "../validateZone";
 import type { WorldFile } from "@/types/world";
 
 const TEST_MOB_TIERS = {
@@ -557,6 +557,62 @@ describe("validateZone", () => {
     expect(issues.some((i) => i.message.includes("at least one objective"))).toBe(false);
   });
 
+  it("warns on a zone-qualified turn-in reference when no cross-zone registry is available and it is unresolvable", () => {
+    // Standalone validateZone can't see other zones, so a qualified reference
+    // is taken on trust (the author explicitly pointed at another zone).
+    const world = makeValidWorld();
+    world.quests = {
+      q1: {
+        name: "Deliver the letter",
+        giver: "rat",
+        turnInMob: "other_zone:elder",
+        completionType: "NPC_TURN_IN",
+      },
+    };
+    const issues = warnings(validateZone(world));
+    expect(issues.some((i) => i.message.includes("other_zone:elder"))).toBe(false);
+  });
+
+  it("resolves a cross-zone turn-in reference against the whole-world registry", () => {
+    const home: { data: WorldFile } = { data: makeValidWorld() };
+    home.data.zone = "home";
+    home.data.quests = {
+      q1: {
+        name: "Deliver the letter",
+        giver: "rat",
+        turnInMob: "town:elder",
+        completionType: "NPC_TURN_IN",
+      },
+    };
+    const town: { data: WorldFile } = { data: makeValidWorld() };
+    town.data.zone = "town";
+    town.data.mobs = { elder: { name: "Elder", spawns: [{ room: "room1" }] } };
+
+    const results = validateAllZones(new Map([["home", home], ["town", town]]));
+    const homeIssues = results.get("home") ?? [];
+    expect(homeIssues.some((i) => i.message.includes("town:elder"))).toBe(false);
+  });
+
+  it("warns on a cross-zone turn-in reference that resolves to nothing", () => {
+    const home: { data: WorldFile } = { data: makeValidWorld() };
+    home.data.zone = "home";
+    home.data.quests = {
+      q1: {
+        name: "Deliver the letter",
+        giver: "rat",
+        turnInMob: "town:ghost",
+        completionType: "NPC_TURN_IN",
+      },
+    };
+    const town: { data: WorldFile } = { data: makeValidWorld() };
+    town.data.zone = "town";
+    town.data.mobs = { elder: { name: "Elder", spawns: [{ room: "room1" }] } };
+
+    const results = validateAllZones(new Map([["home", home], ["town", town]]));
+    const homeIssues = results.get("home") ?? [];
+    expect(homeIssues.some((i) => i.message.includes("town:ghost") && i.message.includes("does not resolve"))).toBe(true);
+  });
+
   // ─── Gathering node checks ────────────────────────────────
   it("errors if gathering node room does not exist", () => {
     const world = makeValidWorld();
@@ -808,15 +864,30 @@ describe("validateZone", () => {
   });
 
   describe("zone rebalance targets", () => {
-    it("warns when a mob level drifts outside the zone target band", () => {
+    it("warns when a mob level escapes the zone level band", () => {
       const world = makeValidWorld();
       world.levelBand = { min: 3, max: 7 };
       world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], tier: "weak", level: 12 };
 
       const issues = warnings(validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS));
 
-      expect(issues.some((i) => i.entity === "mob:rat" && i.message.includes("outside the zone target"))).toBe(true);
-      expect(issues.some((i) => i.entity === "mob:rat" && i.message.includes("Expected level 3"))).toBe(true);
+      expect(issues.some((i) => i.entity === "mob:rat" && i.message.includes("outside the zone level band"))).toBe(true);
+      expect(issues.some((i) => i.entity === "mob:rat" && i.message.includes("3-7"))).toBe(true);
+    });
+
+    it("stays quiet for a level within the band even if it is off the tier's canonical level", () => {
+      // Graduated zones spread tiers across the band on purpose: a standard-tier
+      // mob at the entrance can sit at band-min while another sits at mid. Only a
+      // level that escapes the band is worth flagging.
+      const world = makeValidWorld();
+      world.levelBand = { min: 1, max: 5 };
+      // standard tier's canonical target for band 1-5 is level 3; level 1 is
+      // still inside the band and must not warn.
+      world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], tier: "standard", level: 1 };
+
+      const issues = validateZone(world, undefined, undefined, undefined, undefined, TEST_MOB_TIERS);
+
+      expect(issues.filter((i) => i.entity === "mob:rat")).toHaveLength(0);
     });
 
     // (Override-divergence warnings were removed when the rebalance flow
@@ -834,7 +905,7 @@ describe("validateZone", () => {
       expect(issues.some((i) => i.entity === "mob:rat" && i.message.includes("cannot be validated"))).toBe(true);
     });
 
-    it("stays quiet when the mob already matches the zone target", () => {
+    it("stays quiet when the mob sits within the band", () => {
       const world = makeValidWorld();
       world.levelBand = { min: 3, max: 7 };
       world.mobs!.rat = { name: "Rat", spawns: [{ room: "room1" }], tier: "weak", level: 3 };

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -12,7 +12,7 @@ import { ITEM_TYPES, ARCHETYPAL_STATS, isArchetypalStat } from "@/types/world";
 import type { EquipmentSlotDefinition, MobTiersConfig } from "@/types/config";
 import { resolveDoorKeyId, resolveDoorState } from "./doorHelpers";
 import { mobMaxDamageAtLevel, mobMinDamageAtLevel } from "./tuning/formulas";
-import { classifyMob, inferLevelBand, targetLevelForTier } from "./zoneRebalance";
+import { classifyMob, inferLevelBand } from "./zoneRebalance";
 import { exitTarget } from "./zoneEdits";
 import { getTrainerClasses } from "./trainers";
 import { resolveMobStats } from "./resolveMobStats";
@@ -225,7 +225,6 @@ function validateZoneBalanceTargets(
   if (!hasBoundedRange && !world.levelBand) return;
 
   const band = inferLevelBand(world);
-  const difficulty = world.difficultyHint ?? "standard";
   const zoneTargetLabel = formatZoneTargetLabel(band, world.difficultyHint);
 
   for (const [mobId, mob] of Object.entries(world.mobs)) {
@@ -242,13 +241,18 @@ function validateZoneBalanceTargets(
       continue;
     }
 
-    const expectedLevel = targetLevelForTier(tierKey, band, difficulty);
-    if (mob.level != null && mob.level !== expectedLevel) {
+    // Flag a mob only when its level escapes the zone's level band entirely.
+    // Within the band, authored placement is legitimate — graduated zones
+    // intentionally spread tiers across their range (weak near the entrance,
+    // bosses in the deep), so pinning every tier to a single canonical level
+    // produced warnings authors could only ignore. "Rebalance to tier" is
+    // still available to snap a mob to its tier's target inside the band.
+    if (mob.level != null && (mob.level < band.min || mob.level > band.max)) {
       addIssue(
         issues,
         "warning",
         `mob:${mobId}`,
-        `Mob level ${mob.level} is outside the zone target for tier "${tierKey}". Expected level ${expectedLevel} for zone ${zoneTargetLabel}. Run "Rebalance to tier" to fix.`,
+        `Mob level ${mob.level} falls outside the zone level band ${zoneTargetLabel}. Bring it within the band, widen the zone's level band, or run "Rebalance to tier".`,
       );
     }
   }
@@ -514,8 +518,13 @@ export function validateZone(
    *  archetypal stat slot that no class fills (the bonus would silently drop). */
   classStatPriorities?: Record<string, string[]>,
   /** `jukeboxOutput` enables the server's strict title/duration checks, which
-   *  only hold after save-time enrichment — in-editor songs are bare file refs. */
-  opts?: { jukeboxOutput?: boolean },
+   *  only hold after save-time enrichment — in-editor songs are bare file refs.
+   *  `knownQualifiedMobIds` is the set of every `zone:mobKey` across all zones,
+   *  supplied by `validateAllZones`. When present, a zone-qualified quest
+   *  giver/turn-in reference is resolved against it instead of blindly warned;
+   *  cross-zone references are a first-class feature (turn a letter in at
+   *  another town), so they should only warn when they resolve to nothing. */
+  opts?: { jukeboxOutput?: boolean; knownQualifiedMobIds?: ReadonlySet<string> },
 ): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const roomIds = new Set(Object.keys(world.rooms));
@@ -976,43 +985,54 @@ export function validateZone(
     }
   }
 
+  // Validate a quest giver/turn-in reference. Bare keywords are qualified with
+  // this zone by the loader, so they must resolve locally. A zone-qualified
+  // `zone:mob` reference is an intentional cross-zone link (e.g. accept a
+  // letter here, deliver it in another town) — resolve it against the whole-
+  // world registry when we have one, and only warn when it resolves to nothing.
+  const knownQualifiedMobIds = opts?.knownQualifiedMobIds;
+  const checkQuestNpc = (entity: string, ref: string, label: string, uniqueNoun: string): void => {
+    if (ref.includes(":")) {
+      if (knownQualifiedMobIds && !knownQualifiedMobIds.has(ref)) {
+        addIssue(
+          issues,
+          "warning",
+          entity,
+          `${label} mob "${ref}" does not resolve to any mob in any zone — check the zone id and mob key.`,
+        );
+      }
+      return;
+    }
+    if (!mobIds.has(ref)) {
+      addIssue(
+        issues,
+        "warning",
+        entity,
+        `${label} mob "${ref}" is not a known mob in this zone. Use a bare keyword for a local NPC, or "zone:mob" to point at an NPC in another zone.`,
+      );
+      return;
+    }
+    const mob = world.mobs?.[ref];
+    if (mob && !isUniqueSpawn(mob)) {
+      addIssue(
+        issues,
+        "error",
+        entity,
+        `${label} mob "${ref}" must have exactly one spawn with count 1 — ${uniqueNoun} are unique NPCs`,
+      );
+    }
+  };
+
   for (const [questId, quest] of Object.entries(world.quests ?? {})) {
     const entity = `quest:${questId}`;
     if (!quest.name?.trim()) addIssue(issues, "warning", entity, "Quest has no name");
     if (!quest.giver) {
       addIssue(issues, "warning", entity, "Quest has no giver");
-    } else if (!mobIds.has(quest.giver)) {
-      addIssue(issues, "warning", entity, `Giver mob "${quest.giver}" is not a known mob in this zone`);
     } else {
-      const giverMob = world.mobs?.[quest.giver];
-      if (giverMob && !isUniqueSpawn(giverMob)) {
-        addIssue(
-          issues,
-          "error",
-          entity,
-          `Giver mob "${quest.giver}" must have exactly one spawn with count 1 — quest givers are unique NPCs`,
-        );
-      }
+      checkQuestNpc(entity, quest.giver, "Giver", "quest givers");
     }
     if (quest.turnInMob) {
-      if (!mobIds.has(quest.turnInMob)) {
-        addIssue(
-          issues,
-          "warning",
-          entity,
-          `Turn-in mob "${quest.turnInMob}" is not a known mob in this zone — the engine still qualifies it with the zone id, so this is only valid if the mob lives elsewhere`,
-        );
-      } else {
-        const turnInMob = world.mobs?.[quest.turnInMob];
-        if (turnInMob && !isUniqueSpawn(turnInMob)) {
-          addIssue(
-            issues,
-            "error",
-            entity,
-            `Turn-in mob "${quest.turnInMob}" must have exactly one spawn with count 1 — turn-in NPCs are unique`,
-          );
-        }
-      }
+      checkQuestNpc(entity, quest.turnInMob, "Turn-in", "turn-in NPCs");
     }
     // Objective-less quests are valid for the npc_turn_in completion type
     // (use case: "go visit this other NPC"). Auto-completion needs at least
@@ -1161,9 +1181,19 @@ export function validateAllZones(
   questXpConfig?: QuestXpConfig,
   classStatPriorities?: Record<string, string[]>,
 ): Map<string, ValidationIssue[]> {
+  // Registry of every `zone:mobKey` across all loaded zones, so per-zone
+  // validation can resolve intentional cross-zone quest references (turn-in
+  // NPCs, remote givers) instead of warning on every one of them.
+  const knownQualifiedMobIds = new Set<string>();
+  for (const [zoneId, zone] of zones) {
+    for (const mobKey of Object.keys(zone.data.mobs ?? {})) {
+      knownQualifiedMobIds.add(`${zoneId}:${mobKey}`);
+    }
+  }
+
   const results = new Map<string, ValidationIssue[]>();
   for (const [zoneId, zone] of zones) {
-    const issues = validateZone(zone.data, equipmentSlots, validClasses, knownFactions, knownAchievements, mobTiers, questXpConfig, classStatPriorities);
+    const issues = validateZone(zone.data, equipmentSlots, validClasses, knownFactions, knownAchievements, mobTiers, questXpConfig, classStatPriorities, { knownQualifiedMobIds });
     if (issues.length > 0) {
       results.set(zoneId, issues);
     }


### PR DESCRIPTION
## Why

The validation panel was ~150 warnings on the Ambon world, and virtually all of them fired on **intentional, correct** authoring. When a panel is that noisy, authors stop reading it — and real problems hide in the flood. Two checks accounted for nearly all of it:

| Category | Count (Ambon) | Was it a real problem? |
|---|---|---|
| `Turn-in mob "zone:mob" is not a known mob in this zone` | 75 | No — every one resolved to a real NPC in the named zone |
| `Mob level N is outside the zone target for tier … Expected level N` | 68 | No — every one sat inside the zone's level band |
| Stat-override / true out-of-band | 3 | **Yes** — kept |

This PR fixes the two noisy checks so the panel shows **only relevant warnings**. On the Ambon world the panel goes from **145 warnings → 3**, and all 3 that remain are genuine (two deliberately hand-tuned mobs, one boss authored above its zone band).

## Changes

### 1. Resolve cross-zone quest references instead of blind-warning
Cross-zone turn-ins are a real feature — you accept a letter in one town and deliver it in another (`turnInMob: "eqreon:eq_corral_groom"`). But `validateZone` only sees one zone, so it warned on every qualified reference with a hedge ("only valid if the mob lives elsewhere").

`validateAllZones` (the path that populates the panel) *does* have every zone. It now builds a registry of every `zone:mobKey` and threads it into `validateZone` via `opts.knownQualifiedMobIds`. A qualified reference is resolved against that registry and only warns when it genuinely dangles. Bare references keep the existing local-resolution check, with a clearer message explaining the bare-vs-`zone:mob` distinction. Standalone `validateZone` (e.g. `saveZone`) passes no registry and takes qualified references on trust, exactly as before.

### 2. Tier-band check: flag out-of-band, not off-canonical-level
The check computed one canonical level per tier (`weak→min`, `standard→mid`, `boss→max`) and warned on any deviation. That's wrong for graduated zones, which spread a tier across the band on purpose (a level-1 tutorial void ramping to a level-5 boss; a dungeon shallow-to-deep). Nearly every mob warned despite being perfectly in range.

It now warns only when a mob's level **escapes the zone's level band entirely** — the genuinely notable case (e.g. a level-33 boss in a 30-30 zone). "Rebalance to tier" still snaps a mob to its tier's canonical level within the band for authors who want that. (The existing test's own name — "drifts outside the zone target *band*" — already described this intended behavior; the implementation was just stricter than the name.)

## What deliberately still warns

The 3 remaining Ambon warnings are all real signals and are left intact:
- `practice_dummy` and `the_final_lesson` — deliberate off-tier-curve stat overrides (a human should confirm a 0-damage mob / softened boss is intentional).
- `ct_kirot_aethiryn` — level 33 in a 30-30 zone; a genuine out-of-band capstone superboss, now the *only* level warning instead of one-of-68.

## Testing
- Full `creator` Vitest suite green: **2309 passed**. Updated the tier-band tests to the band semantics and added coverage for within-band placement; added `validateAllZones` tests for cross-zone resolution (resolves → silent, dangles → warns).
- `tsc --noEmit` clean (0 errors).
- Verified end-to-end by running the patched `validateAllZones` over the real Ambon world: 145W → 3W, no new errors.

Companion data-side cleanup (the handful of genuinely-broken items this validator was correctly flagging — an undefined `offhand` slot, a prop offering a quest, etc.) is Ambon PR #112.