### PR TITLE
perf(creator): make "Set as primary" O(group) instead of O(library)

### DIFF
--- a/creator/src-tauri/src/assets.rs
+++ b/creator/src-tauri/src/assets.rs
@@ -66,10 +66,24 @@ pub struct AssetContext {
     pub entity_id: String,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct Manifest {
     pub(crate) assets: Vec<AssetEntry>,
 }
+
+/// Parsed-manifest cache. Large libraries make the manifest file multi-MB, and
+/// nearly every asset command starts with a full read+parse of it; caching the
+/// parsed form turns those into a stat + clone. Validated against (path, mtime,
+/// len) so external writes — git checkout, snapshot restore, hand edits — are
+/// still picked up.
+struct CachedManifest {
+    path: PathBuf,
+    mtime: Option<std::time::SystemTime>,
+    len: u64,
+    manifest: Manifest,
+}
+
+static MANIFEST_CACHE: LazyLock<Mutex<Option<CachedManifest>>> = LazyLock::new(|| Mutex::new(None));
 
 pub(crate) fn assets_dir(app: &AppHandle) -> Result<PathBuf, String> {
     let dir = crate::fs_utils::app_data_dir(app)?;
@@ -94,13 +108,35 @@ async fn manifest_path(app: &AppHandle) -> Result<PathBuf, String> {
 
 pub(crate) async fn load_manifest(app: &AppHandle) -> Result<Manifest, String> {
     let path = manifest_path(app).await?;
-    if !path.exists() {
+    let Ok(meta) = tokio::fs::metadata(&path).await else {
         return Ok(Manifest::default());
+    };
+    let mtime = meta.modified().ok();
+    let len = meta.len();
+
+    {
+        let cache = MANIFEST_CACHE.lock().await;
+        if let Some(c) = cache.as_ref() {
+            if c.path == path && c.mtime == mtime && c.len == len {
+                return Ok(c.manifest.clone());
+            }
+        }
     }
+
     let data = tokio::fs::read_to_string(&path)
         .await
         .map_err(|e| format!("Failed to read manifest: {e}"))?;
-    serde_json::from_str(&data).map_err(|e| format!("Failed to parse manifest: {e}"))
+    let manifest: Manifest =
+        serde_json::from_str(&data).map_err(|e| format!("Failed to parse manifest: {e}"))?;
+
+    let mut cache = MANIFEST_CACHE.lock().await;
+    *cache = Some(CachedManifest {
+        path,
+        mtime,
+        len,
+        manifest: manifest.clone(),
+    });
+    Ok(manifest)
 }
 
 pub(crate) async fn save_manifest(app: &AppHandle, manifest: &Manifest) -> Result<(), String> {
@@ -110,7 +146,19 @@ pub(crate) async fn save_manifest(app: &AppHandle, manifest: &Manifest) -> Resul
             .await
             .map_err(|e| format!("Failed to create assets dir: {e}"))?;
     }
-    crate::fs_utils::write_json_file(&path, manifest, "manifest").await
+    crate::fs_utils::write_json_file(&path, manifest, "manifest").await?;
+
+    // Stat after the write so the cached (mtime, len) matches what a later
+    // load_manifest sees; a failed stat degrades to a cache miss, never staleness.
+    let meta = tokio::fs::metadata(&path).await.ok();
+    let mut cache = MANIFEST_CACHE.lock().await;
+    *cache = Some(CachedManifest {
+        mtime: meta.as_ref().and_then(|m| m.modified().ok()),
+        len: meta.map(|m| m.len()).unwrap_or(0),
+        path,
+        manifest: manifest.clone(),
+    });
+    Ok(())
 }
 
 #[tauri::command]

--- a/creator/src/stores/assetStore.ts
+++ b/creator/src/stores/assetStore.ts
@@ -225,7 +225,14 @@ export const useAssetStore = create<AssetState>((set, get) => ({
 
   setActiveVariant: async (variantGroup, assetId) => {
     await invoke("set_active_variant", { variantGroup, assetId });
-    await get().loadAssets();
+    // The outcome is fully known here, so flip the flags locally instead of
+    // re-marshalling the entire AssetEntry[] over IPC (O(library) per click).
+    // Untouched entries keep their identity so memoized rows skip re-rendering.
+    set((state) => ({
+      assets: state.assets.map((a) =>
+        a.variant_group === variantGroup ? { ...a, is_active: a.id === assetId } : a,
+      ),
+    }));
   },
 
   listVariants: async (variantGroup) => {


### PR DESCRIPTION
## Summary

Setting an image as the primary/active variant took ~5 s on a large library. One click performed **three full manifest reads + one full pretty-printed rewrite + a full-library IPC round-trip**, all serialized before the spinner cleared:

1. `set_active_variant` — read + parse the entire `manifest.json`, flip two booleans, rewrite the whole file
2. `loadAssets()` — Rust re-reads and re-parses the full manifest **again** (`list_assets`), then ships every `AssetEntry` (every prompt + enhanced prompt in the library, ~20 MB at 10k assets) across IPC into the WebView, which `JSON.parse`s it and replaces the whole store array
3. `refreshVariants()` / `loadVariants()` — `list_variants` parses the full manifest a **third** time

Two surgical changes:

- **`assetStore.setActiveVariant`** no longer calls `loadAssets()`. The outcome is fully known client-side, so after the backend write succeeds it flips `is_active` locally with a map over the existing array. This removes the full-library IPC + WebView parse entirely; untouched entries keep object identity so memoized rows skip re-rendering. (Same treatment `acceptAsset` already documents for batch runs.)
- **Rust parsed-manifest cache** in `assets.rs`: `load_manifest` validates a module-level cache against `(path, mtime, len)` — a hit is a stat + clone instead of a multi-MB read + parse. `save_manifest` refreshes the cache after the atomic write. The stat-based fingerprint means external writes (git checkout, snapshot restore, hand edits) still invalidate, and project switches miss naturally on the path key. `asset_migration.rs` goes through the same helpers, so it stays coherent; the `hub.rs` "manifest" is the unrelated showcase manifest.

Net effect per click: one tiny IPC + one manifest write + a local array map — the remaining O(library) cost is the durability rewrite of `manifest.json` itself. Every other asset command (accept, gallery open, the per-entity-card `list_variants` storm when the zone Asset Browser mounts) also benefits from the cache.

## Testing

- `bunx tsc --noEmit` clean
- `bun run test` — 73 files, 2305 tests pass
- `cargo check` clean