### PR TITLE
Save Layout: pin the zone map exactly as the builder drew it

### DIFF
--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -24,6 +24,7 @@ import { useAssetStore } from "@/stores/assetStore";
 import { useToastStore } from "@/stores/toastStore";
 import { zoneToGraph, GRAPH } from "@/lib/zoneToGraph";
 import { compassLayout, getLayoutBounds, type LayoutMeasurement } from "@/lib/dagreLayout";
+import { quantizeLayout, applyMapPins } from "@/lib/mapPins";
 import { addRoom, addExit, deleteExit, deleteRoom, generateRoomId } from "@/lib/zoneEdits";
 import { saveZone } from "@/lib/saveZone";
 import type { WorldFile } from "@/types/world";
@@ -479,6 +480,19 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
     [zoneId, updateZone],
   );
 
+  // ─── Save map layout ─────────────────────────────────────────────
+  // Quantize the current (possibly hand-dragged) node positions to integer
+  // grid cells and pin every room (mapX/mapY/mapZ). The change goes through
+  // the normal undo stack; Save then writes the pins into the zone YAML,
+  // where the server seats each room exactly where the builder left it.
+  const handleSaveLayout = useCallback(() => {
+    if (!zoneState) return;
+    const pins = quantizeLayout(nodes, zoneState.data);
+    if (pins.size === 0) return;
+    applyWorldChange(applyMapPins(zoneState.data, pins));
+    useToastStore.getState().show("Map layout pinned — Save writes it to the zone");
+  }, [zoneState, nodes, applyWorldChange]);
+
   // ─── Connection (exit creation) ──────────────────────────────────
   const onConnect = useCallback(
     (connection: Connection) => {
@@ -745,6 +759,15 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
               aria-label="Re-layout rooms"
             >
               Re-layout
+            </button>
+            <button
+              onClick={handleSaveLayout}
+              disabled={roomCount === 0}
+              className="h-6 rounded px-2 text-xs text-text-secondary transition-colors hover:bg-[var(--chrome-highlight)] hover:text-text-primary disabled:opacity-30 max-[1100px]:h-9"
+              title="Pin every room to its current map position (written to the zone on Save)"
+              aria-label="Save map layout"
+            >
+              Save Layout
             </button>
             <button
               onClick={() => setShowDuplicate(true)}

--- a/creator/src/lib/__tests__/dagreLayout.test.ts
+++ b/creator/src/lib/__tests__/dagreLayout.test.ts
@@ -248,3 +248,74 @@ describe("getLayoutBounds", () => {
     expect(bounds).toEqual({ x: 0, y: 0, width: 100, height: 50 });
   });
 });
+
+describe("compassLayout with map pins", () => {
+  it("seats pinned rooms in their authored arrangement, ignoring exit geometry", () => {
+    // The exit says "b is north of a", but the author pinned b two cells EAST.
+    // Pins win.
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { n: "b" }, mapX: 0, mapY: 0 },
+      b: { title: "B", description: "", exits: { s: "a" }, mapX: 2, mapY: 0 },
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+    const a = laid.find((n) => n.id === "a")!;
+    const b = laid.find((n) => n.id === "b")!;
+    expect(b.position.y).toBe(a.position.y);
+    expect(b.position.x).toBeGreaterThan(a.position.x);
+  });
+
+  it("BFS-places unpinned rooms relative to their pinned neighbours", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", exits: { e: "b" }, mapX: 4, mapY: 4 },
+      b: { title: "B", description: "", exits: { w: "a", e: "c" }, mapX: 5, mapY: 4 },
+      c: { title: "C", description: "", exits: { w: "b" } }, // unpinned
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+    const b = laid.find((n) => n.id === "b")!;
+    const c = laid.find((n) => n.id === "c")!;
+    // c flows out of pinned b, one cell east on the same row.
+    expect(c.position.y).toBe(b.position.y);
+    expect(c.position.x).toBeGreaterThan(b.position.x);
+  });
+
+  it("keeps pinned floors on separate islands and expands through stairs", () => {
+    const world = makeWorld({
+      ground: { title: "", description: "", exits: { u: "loft" }, mapX: 0, mapY: 0 },
+      loft: { title: "", description: "", exits: { d: "ground", e: "loft_east" }, mapX: 0, mapY: 0, mapZ: 1 },
+      loft_east: { title: "", description: "", exits: { w: "loft" } }, // unpinned
+    });
+    const { nodes } = zoneToGraph(world);
+    const laid = compassLayout(nodes, world);
+    const ground = laid.find((n) => n.id === "ground")!;
+    const loft = laid.find((n) => n.id === "loft")!;
+    const loftEast = laid.find((n) => n.id === "loft_east")!;
+    // Same authored cell, different floors → stacked islands, not a collision.
+    expect(loft.position.y).not.toBe(ground.position.y);
+    // The unpinned neighbour seats east of the pinned loft on its island.
+    expect(loftEast.position.y).toBe(loft.position.y);
+    expect(loftEast.position.x).toBeGreaterThan(loft.position.x);
+  });
+
+  it("recomputes the cached layout when only pins change", () => {
+    const rooms: WorldFile["rooms"] = {
+      a: { title: "A", description: "", exits: { e: "b" } },
+      b: { title: "B", description: "", exits: { w: "a" } },
+    };
+    const unpinned = makeWorld(structuredClone(rooms));
+    const { nodes: nodes1 } = zoneToGraph(unpinned);
+    const before = compassLayout(nodes1, unpinned);
+    const bBefore = before.find((n) => n.id === "b")!;
+
+    // Same exits, but b pinned far east — the layout cache must not serve
+    // the unpinned result.
+    const pinned = makeWorld(structuredClone(rooms));
+    pinned.rooms.a = { ...pinned.rooms.a!, mapX: 0, mapY: 0 };
+    pinned.rooms.b = { ...pinned.rooms.b!, mapX: 5, mapY: 0 };
+    const { nodes: nodes2 } = zoneToGraph(pinned);
+    const after = compassLayout(nodes2, pinned);
+    const bAfter = after.find((n) => n.id === "b")!;
+    expect(bAfter.position.x).toBeGreaterThan(bBefore.position.x);
+  });
+});

--- a/creator/src/lib/__tests__/mapPins.test.ts
+++ b/creator/src/lib/__tests__/mapPins.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import type { Node } from "@xyflow/react";
+import type { WorldFile } from "@/types/world";
+import {
+  CELL_H,
+  CELL_W,
+  applyMapPins,
+  quantizeLayout,
+  roomFloors,
+  roomMapPin,
+  zoneMapPins,
+} from "../mapPins";
+
+function makeWorld(rooms: WorldFile["rooms"], overrides?: Partial<WorldFile>): WorldFile {
+  return {
+    zone: "test_zone",
+    startRoom: Object.keys(rooms)[0] ?? "room1",
+    rooms,
+    ...overrides,
+  };
+}
+
+/** Minimal React Flow node at a pixel position (default 220x140 footprint). */
+function node(id: string, x: number, y: number): Node {
+  return { id, position: { x, y }, data: {} } as Node;
+}
+
+describe("roomMapPin / zoneMapPins", () => {
+  it("reads a full pin, defaulting mapZ to 0", () => {
+    expect(roomMapPin({ title: "", description: "", mapX: 3, mapY: 7 })).toEqual({
+      x: 3,
+      y: 7,
+      z: 0,
+    });
+    expect(roomMapPin({ title: "", description: "", mapX: 1, mapY: 2, mapZ: -1 })).toEqual({
+      x: 1,
+      y: 2,
+      z: -1,
+    });
+  });
+
+  it("treats half-specified pins as unpinned", () => {
+    expect(roomMapPin({ title: "", description: "", mapX: 3 })).toBeUndefined();
+    expect(roomMapPin({ title: "", description: "", mapY: 3 })).toBeUndefined();
+    const world = makeWorld({
+      a: { title: "A", description: "", mapX: 1, mapY: 1 },
+      b: { title: "B", description: "", mapX: 5 },
+      c: { title: "C", description: "" },
+    });
+    expect([...zoneMapPins(world).keys()]).toEqual(["a"]);
+  });
+});
+
+describe("roomFloors", () => {
+  it("assigns floors through stairs: u is +1, d is -1", () => {
+    const world = makeWorld({
+      ground: { title: "", description: "", exits: { u: "upstairs", d: "cellar" } },
+      upstairs: { title: "", description: "", exits: { d: "ground", e: "attic_hall" } },
+      attic_hall: { title: "", description: "", exits: { w: "upstairs" } },
+      cellar: { title: "", description: "", exits: { u: "ground" } },
+    });
+    const floors = roomFloors(world);
+    expect(floors.get("ground")).toBe(0);
+    expect(floors.get("upstairs")).toBe(1);
+    expect(floors.get("attic_hall")).toBe(1);
+    expect(floors.get("cellar")).toBe(-1);
+  });
+
+  it("anchors rooms with no inbound path through their own exits, reversed", () => {
+    // "hidden" has no exit leading to it, only an outgoing u to a placed room:
+    // my `u` leads above me, so I sit one floor below it.
+    const world = makeWorld({
+      start: { title: "", description: "" },
+      hidden: { title: "", description: "", exits: { u: "start" } },
+    });
+    const floors = roomFloors(world);
+    expect(floors.get("start")).toBe(0);
+    expect(floors.get("hidden")).toBe(-1);
+  });
+
+  it("puts fully disconnected rooms on the ground floor", () => {
+    const world = makeWorld({
+      start: { title: "", description: "" },
+      island: { title: "", description: "" },
+    });
+    expect(roomFloors(world).get("island")).toBe(0);
+  });
+
+  it("understands long-form direction names", () => {
+    const world = makeWorld({
+      start: { title: "", description: "", exits: { up: "loft" } },
+      loft: { title: "", description: "" },
+    });
+    expect(roomFloors(world).get("loft")).toBe(1);
+  });
+});
+
+describe("quantizeLayout", () => {
+  it("snaps node centers to the nearest grid cell, normalized per floor", () => {
+    const world = makeWorld({
+      a: { title: "", description: "", exits: { e: "b" } },
+      b: { title: "", description: "", exits: { w: "a" } },
+    });
+    // b dragged roughly one cell east and slightly off-grid.
+    const pins = quantizeLayout(
+      [node("a", 100, 100), node("b", 100 + CELL_W + 30, 100 - 20)],
+      world,
+    );
+    expect(pins.get("a")).toEqual({ x: 0, y: 0, z: 0 });
+    expect(pins.get("b")).toEqual({ x: 1, y: 0, z: 0 });
+  });
+
+  it("resolves two rooms snapping to the same cell onto distinct cells", () => {
+    const world = makeWorld({
+      a: { title: "", description: "" },
+      b: { title: "", description: "" },
+    });
+    const pins = quantizeLayout([node("a", 0, 0), node("b", 40, 30)], world);
+    const cells = new Set([...pins.values()].map((p) => `${p.x},${p.y},${p.z}`));
+    expect(cells.size).toBe(2);
+  });
+
+  it("quantizes each floor in its own frame, from graph-derived floors", () => {
+    const world = makeWorld({
+      ground: { title: "", description: "", exits: { u: "loft" } },
+      loft: { title: "", description: "", exits: { d: "ground", e: "loft_east" } },
+      loft_east: { title: "", description: "", exits: { w: "loft" } },
+    });
+    // The editor stacks the loft island far below the ground floor; per-floor
+    // normalization must strip that pixel offset out of the pins.
+    const pins = quantizeLayout(
+      [
+        node("ground", 0, 0),
+        node("loft", 0, 5 * CELL_H),
+        node("loft_east", CELL_W, 5 * CELL_H),
+      ],
+      world,
+    );
+    expect(pins.get("ground")).toEqual({ x: 0, y: 0, z: 0 });
+    expect(pins.get("loft")).toEqual({ x: 0, y: 0, z: 1 });
+    expect(pins.get("loft_east")).toEqual({ x: 1, y: 0, z: 1 });
+  });
+
+  it("ignores cross-zone nodes", () => {
+    const world = makeWorld({
+      a: { title: "", description: "", exits: { e: "other:room" } },
+    });
+    const pins = quantizeLayout(
+      [node("a", 0, 0), node("xzone:other:room", CELL_W, 0)],
+      world,
+    );
+    expect([...pins.keys()]).toEqual(["a"]);
+  });
+});
+
+describe("applyMapPins", () => {
+  it("writes pins onto rooms, omitting mapZ on the ground floor", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "desc", bank: true },
+      b: { title: "B", description: "" },
+    });
+    const next = applyMapPins(
+      world,
+      new Map([
+        ["a", { x: 2, y: 3, z: 0 }],
+        ["b", { x: 0, y: 0, z: 1 }],
+      ]),
+    );
+    expect(next.rooms.a).toMatchObject({ title: "A", description: "desc", bank: true, mapX: 2, mapY: 3 });
+    expect(next.rooms.a!.mapZ).toBeUndefined();
+    expect(next.rooms.b).toMatchObject({ mapX: 0, mapY: 0, mapZ: 1 });
+    // Input world untouched.
+    expect(world.rooms.a!.mapX).toBeUndefined();
+  });
+
+  it("leaves rooms without a pin entry unchanged", () => {
+    const world = makeWorld({
+      a: { title: "A", description: "", mapX: 9, mapY: 9 },
+      b: { title: "B", description: "" },
+    });
+    const next = applyMapPins(world, new Map([["b", { x: 1, y: 1, z: 0 }]]));
+    expect(next.rooms.a).toBe(world.rooms.a);
+    expect(next.rooms.b).toMatchObject({ mapX: 1, mapY: 1 });
+  });
+});

--- a/creator/src/lib/__tests__/validateZone.test.ts
+++ b/creator/src/lib/__tests__/validateZone.test.ts
@@ -971,6 +971,46 @@ describe("validateZone", () => {
     });
   });
 
+  // ─── Minimap pins (mapX/mapY/mapZ) ───────────────────────────
+  describe("map pins", () => {
+    it("accepts full pins on distinct cells, and the same cell across floors", () => {
+      const world = makeValidWorld();
+      world.rooms.room1 = { ...world.rooms.room1!, mapX: 0, mapY: 0 };
+      world.rooms.room2 = { ...world.rooms.room2!, mapX: 0, mapY: 0, mapZ: 1 };
+      const issues = validateZone(world).filter((i) => i.message.toLowerCase().includes("map"));
+      expect(issues).toHaveLength(0);
+    });
+
+    it("errors on a half-specified pin", () => {
+      const world = makeValidWorld();
+      world.rooms.room1 = { ...world.rooms.room1!, mapX: 3 };
+      const issues = errors(validateZone(world));
+      expect(issues.some((i) => i.message.includes("both mapX and mapY"))).toBe(true);
+    });
+
+    it("errors on mapZ without mapX/mapY", () => {
+      const world = makeValidWorld();
+      world.rooms.room1 = { ...world.rooms.room1!, mapZ: 1 };
+      const issues = errors(validateZone(world));
+      expect(issues.some((i) => i.message.includes("mapZ without mapX/mapY"))).toBe(true);
+    });
+
+    it("errors on non-integer pin coordinates", () => {
+      const world = makeValidWorld();
+      world.rooms.room1 = { ...world.rooms.room1!, mapX: 1.5, mapY: 0 };
+      const issues = errors(validateZone(world));
+      expect(issues.some((i) => i.message.includes("must be an integer"))).toBe(true);
+    });
+
+    it("errors when two rooms pin the same cell of the same floor", () => {
+      const world = makeValidWorld();
+      world.rooms.room1 = { ...world.rooms.room1!, mapX: 2, mapY: 2 };
+      world.rooms.room2 = { ...world.rooms.room2!, mapX: 2, mapY: 2 };
+      const issues = errors(validateZone(world));
+      expect(issues.some((i) => i.message.includes("duplicate pins"))).toBe(true);
+    });
+  });
+
   // ─── Boat docks (pins + routes) ──────────────────────────────
   describe("boat dock coordinates and routes", () => {
     it("accepts a boat dock with both coordinates in range and a valid local route", () => {

--- a/creator/src/lib/dagreLayout.ts
+++ b/creator/src/lib/dagreLayout.ts
@@ -2,34 +2,19 @@ import type { Node } from "@xyflow/react";
 import dagre from "@dagrejs/dagre";
 import type { WorldFile } from "@/types/world";
 import { exitTarget } from "@/lib/zoneEdits";
-
-const DEFAULT_NODE_WIDTH = 220;
-const DEFAULT_NODE_HEIGHT = 140;
-
-const COL_GUTTER = 80;
-const ROW_GUTTER = 60;
+import {
+  COL_GUTTER,
+  DEFAULT_NODE_HEIGHT,
+  DEFAULT_NODE_WIDTH,
+  DIR_OFFSET,
+  ROW_GUTTER,
+  findFreeCell,
+  zoneMapPins,
+  type MapPin,
+} from "@/lib/mapPins";
 
 /** Empty grid rows inserted between separate floor islands. */
 const ISLAND_GAP = 3;
-
-/**
- * Compass direction → grid offset (x, y). Y-axis is inverted: negative = up.
- *
- * u/d are omitted on purpose: they're vertical transitions (stairs, portals),
- * not 2D directions. BFS traverses through them for reachability but does not
- * let them dictate grid coordinates — otherwise a cave with n/u/s/w chains
- * explodes into a diagonal sprawl.
- */
-const DIR_OFFSET: Record<string, [number, number]> = {
-  n: [0, -1],
-  s: [0, 1],
-  e: [1, 0],
-  w: [-1, 0],
-  ne: [1, -1],
-  nw: [-1, -1],
-  se: [1, 1],
-  sw: [-1, 1],
-};
 
 /** Process cardinals first so they pin the grid before diagonals fill gaps. */
 const DIR_PRIORITY: Record<string, number> = {
@@ -101,7 +86,12 @@ function buildLayoutFingerprint(world: WorldFile): string {
       }
       exits = exitParts.join(";");
     }
-    parts.push(`r:${id}|${exits}`);
+    // Authored map pins shape the layout too, so they invalidate the cache.
+    const pin =
+      room.mapX != null && room.mapY != null
+        ? `|p${room.mapX},${room.mapY},${room.mapZ ?? 0}`
+        : "";
+    parts.push(`r:${id}|${exits}${pin}`);
   }
   return parts.join("\n");
 }
@@ -166,13 +156,16 @@ export function compassLayout(
   const allNodeIds = new Set(nodes.map((n) => n.id));
   const grid = new Map<string, string>();
   const pos = new Map<string, [number, number]>();
+  /** Rooms whose exits have already been walked — placed-but-unexpanded rooms
+   *  (author pins) still spread their neighbours when BFS reaches them. */
+  const expanded = new Set<string>();
   let collisions = 0;
 
   function place(id: string, gx: number, gy: number) {
     const key = `${gx},${gy}`;
     if (grid.has(key)) {
       collisions++;
-      [gx, gy] = findEmpty(gx, gy, grid);
+      [gx, gy] = findFreeCell(gx, gy, grid);
     }
     pos.set(id, [gx, gy]);
     grid.set(`${gx},${gy}`, id);
@@ -196,14 +189,18 @@ export function compassLayout(
   } {
     const placed: string[] = [];
     const nextSeeds: string[] = [];
-    if (pos.has(startId)) return { placed, nextFloorSeeds: nextSeeds };
+    if (expanded.has(startId)) return { placed, nextFloorSeeds: nextSeeds };
 
-    place(startId, ox, oy);
-    placed.push(startId);
+    // A pre-seated seed (author pin) keeps its cell and just expands in place.
+    if (!pos.has(startId)) {
+      place(startId, ox, oy);
+      placed.push(startId);
+    }
 
     const queue = [startId];
     while (queue.length > 0) {
       const cur = queue.shift()!;
+      if (!expanded.add(cur)) continue;
       const [cx, cy] = pos.get(cur)!;
 
       const room = world.rooms[cur];
@@ -215,22 +212,34 @@ export function compassLayout(
         const nodeId = raw.includes(":") ? `xzone:${raw}` : raw;
 
         if (!allNodeIds.has(nodeId)) continue;
-        if (pos.has(nodeId)) continue;
+        const isRoom = !raw.includes(":") && Boolean(world.rooms[raw]);
 
         const offset = DIR_OFFSET[dir];
         if (!offset) {
           // u/d: don't pull the target into this floor — it lives on its own
-          // island. Note the link so the caller can seed the next floor.
-          if (!raw.includes(":") && world.rooms[raw]) {
+          // island. Note the link so the caller can seed the next floor. A
+          // pinned partner is already seated; walk through it so its own
+          // unpinned neighbours seat around the authored cell.
+          if (!isRoom) continue;
+          if (pos.has(nodeId)) {
+            if (!expanded.has(nodeId)) queue.push(nodeId);
+          } else {
             nextSeeds.push(nodeId);
           }
+          continue;
+        }
+
+        if (pos.has(nodeId)) {
+          // Placed earlier (pin or previous pass) — keep its cell but keep
+          // flowing outward through it.
+          if (isRoom && !expanded.has(nodeId)) queue.push(nodeId);
           continue;
         }
 
         place(nodeId, cx + offset[0], cy + offset[1]);
         placed.push(nodeId);
 
-        if (!raw.includes(":") && world.rooms[raw]) {
+        if (isRoom) {
           queue.push(nodeId);
         }
       }
@@ -239,17 +248,59 @@ export function compassLayout(
     return { placed, nextFloorSeeds: nextSeeds };
   }
 
+  let maxY = 0;
+
+  // Phase 0: seat author pins (mapX/mapY/mapZ) exactly where they were placed,
+  // one island per pinned floor in ascending z order. This mirrors the server
+  // loader: pins are fixed anchors, BFS lays out only the unpinned remainder
+  // around them (flowing outward through pinned rooms via `expanded`).
+  const pins = zoneMapPins(world);
+  const pinnedIds: string[] = [];
+  if (pins.size > 0) {
+    const byFloor = new Map<number, Array<[string, MapPin]>>();
+    for (const [id, pin] of pins) {
+      if (!allNodeIds.has(id)) continue;
+      const list = byFloor.get(pin.z) ?? [];
+      list.push([id, pin]);
+      byFloor.set(pin.z, list);
+    }
+    const zs = [...byFloor.keys()].sort((a, b) => a - b);
+    for (const z of zs) {
+      const entries = byFloor.get(z)!;
+      let minX = Infinity;
+      let minY = Infinity;
+      for (const [, p] of entries) {
+        if (p.x < minX) minX = p.x;
+        if (p.y < minY) minY = p.y;
+      }
+      const islandY = pos.size === 0 ? 0 : maxY + ISLAND_GAP;
+      entries.sort(
+        (a, b) => a[1].y - b[1].y || a[1].x - b[1].x || a[0].localeCompare(b[0]),
+      );
+      for (const [id, p] of entries) {
+        place(id, p.x - minX, islandY + (p.y - minY));
+        pinnedIds.push(id);
+      }
+      for (const [, [, y]] of pos) {
+        if (y > maxY) maxY = y;
+      }
+    }
+    // Pin collisions are authoring errors (validateZone flags them); the
+    // spiral in place() keeps the editor usable, but they mustn't count
+    // toward the grid-embeddability heuristic below.
+    collisions = 0;
+  }
+
   // Place the start floor, then walk u/d links breadth-first to find sibling
   // floors and stack each one below the previous. Floors connected via stairs
   // end up in vertical reading order (start → upstairs → attic, etc.); fully
-  // disconnected pockets fall through to the orphan sweep below.
-  let maxY = 0;
-  const floorQueue: string[] = [world.startRoom];
+  // disconnected pockets fall through to the orphan sweep below. Pinned rooms
+  // queue too so their unpinned neighbours seat around the authored cells.
+  const floorQueue: string[] = [world.startRoom, ...pinnedIds];
 
   function placeAndAdvance(seedId: string) {
     const islandY = pos.size === 0 ? 0 : maxY + ISLAND_GAP;
     const result = placeFloor(seedId, 0, islandY);
-    if (result.placed.length === 0) return;
     for (const [, [, y]] of pos) {
       if (y > maxY) maxY = y;
     }
@@ -264,7 +315,7 @@ export function compassLayout(
   let mainPlaced = 0;
   while (floorQueue.length > 0) {
     const seed = floorQueue.shift()!;
-    if (pos.has(seed)) continue;
+    if (expanded.has(seed)) continue;
     const beforeCol = collisions;
     const beforeSize = pos.size;
     placeAndAdvance(seed);
@@ -285,8 +336,10 @@ export function compassLayout(
 
   // Heuristic: if many placements collided in the main BFS, the graph isn't
   // grid-embeddable. Throw it away and run a proper hierarchical layout.
+  // Never when the author pinned a layout — pins ARE the layout.
   let result: Node[];
   if (
+    pins.size === 0 &&
     mainPlaced >= 8 &&
     mainCollisions / Math.max(1, mainPlaced) > COLLISION_FALLBACK_RATIO
   ) {
@@ -488,21 +541,4 @@ export function getLayoutBounds(
   };
 }
 
-/** Spiral outward from (x, y) to find the nearest unoccupied grid cell. */
-function findEmpty(
-  x: number,
-  y: number,
-  grid: Map<string, string>,
-): [number, number] {
-  for (let r = 1; r <= 20; r++) {
-    for (let dx = -r; dx <= r; dx++) {
-      for (let dy = -r; dy <= r; dy++) {
-        if (Math.abs(dx) < r && Math.abs(dy) < r) continue;
-        const key = `${x + dx},${y + dy}`;
-        if (!grid.has(key)) return [x + dx, y + dy];
-      }
-    }
-  }
-  return [x + 1, y];
-}
 

--- a/creator/src/lib/mapPins.ts
+++ b/creator/src/lib/mapPins.ts
@@ -1,0 +1,242 @@
+import type { Node } from "@xyflow/react";
+import type { WorldFile } from "@/types/world";
+import { exitTarget, normalizeDir } from "@/lib/zoneEdits";
+
+/**
+ * Map-pin grid contract, shared with the AmbonMUD server (WorldLoader).
+ *
+ * Every room may carry an explicit minimap cell (`mapX`/`mapY`/`mapZ` in zone
+ * YAML). The server seats pinned rooms exactly where the author put them and
+ * BFS-places unpinned rooms around them. This module is Arcanum's side of the
+ * contract: it derives pins from the zone editor's dragged node positions
+ * ("Save Layout") and applies them back onto the WorldFile.
+ *
+ * Grid frame (matches the server): `+x` = east, `+y` = south, `z` = floor
+ * (0 = ground, `u` exits go up one floor, `d` down one). Absolute values are
+ * meaningless — only relative placement within a floor matters — so pins are
+ * normalized to a 0-based frame per floor.
+ */
+
+/** Node footprint + gutters — one layout grid cell in pixels. `dagreLayout`
+ *  builds pixel positions from these; quantization inverts them. */
+export const DEFAULT_NODE_WIDTH = 220;
+export const DEFAULT_NODE_HEIGHT = 140;
+export const COL_GUTTER = 80;
+export const ROW_GUTTER = 60;
+export const CELL_W = DEFAULT_NODE_WIDTH + COL_GUTTER;
+export const CELL_H = DEFAULT_NODE_HEIGHT + ROW_GUTTER;
+
+/**
+ * Compass direction → grid offset (x, y). Y-axis is inverted: negative = up
+ * (north). Mirrors the server's DIRECTION_OFFSETS. u/d are omitted on
+ * purpose: they're floor transitions, not 2D directions.
+ */
+export const DIR_OFFSET: Record<string, [number, number]> = {
+  n: [0, -1],
+  s: [0, 1],
+  e: [1, 0],
+  w: [-1, 0],
+  ne: [1, -1],
+  nw: [-1, -1],
+  se: [1, 1],
+  sw: [-1, 1],
+};
+
+export interface MapPin {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/**
+ * A room's authored pin, or undefined when it declares none. Half-specified
+ * pins (only one of mapX/mapY) are treated as unpinned here — `validateZone`
+ * flags them as errors, since the server refuses to load them.
+ */
+export function roomMapPin(room: WorldFile["rooms"][string]): MapPin | undefined {
+  if (room.mapX == null || room.mapY == null) return undefined;
+  return { x: room.mapX, y: room.mapY, z: room.mapZ ?? 0 };
+}
+
+/** All authored pins in a zone, keyed by room id. */
+export function zoneMapPins(world: WorldFile): Map<string, MapPin> {
+  const pins = new Map<string, MapPin>();
+  for (const [id, room] of Object.entries(world.rooms)) {
+    const pin = roomMapPin(room);
+    if (pin) pins.set(id, pin);
+  }
+  return pins;
+}
+
+/** Spiral outward from (x, y) to the nearest unoccupied grid cell. */
+export function findFreeCell(
+  x: number,
+  y: number,
+  grid: Map<string, string>,
+): [number, number] {
+  for (let r = 1; r <= 20; r++) {
+    for (let dx = -r; dx <= r; dx++) {
+      for (let dy = -r; dy <= r; dy++) {
+        if (Math.abs(dx) < r && Math.abs(dy) < r) continue;
+        const key = `${x + dx},${y + dy}`;
+        if (!grid.has(key)) return [x + dx, y + dy];
+      }
+    }
+  }
+  return [x + 1, y];
+}
+
+/**
+ * Assign each room a floor by walking the exit graph from the start room,
+ * mirroring the server's layout: horizontal exits stay on the current floor,
+ * `u` goes to floor+1, `d` to floor-1. Rooms with no static inbound path are
+ * anchored through their own outgoing exits (offset reversed); anything fully
+ * disconnected lands on the ground floor.
+ */
+export function roomFloors(world: WorldFile): Map<string, number> {
+  const floors = new Map<string, number>();
+  const queue: string[] = [];
+
+  const seed = (id: string, z: number) => {
+    if (!world.rooms[id] || floors.has(id)) return;
+    floors.set(id, z);
+    queue.push(id);
+  };
+
+  const drain = () => {
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      const z = floors.get(cur)!;
+      const exits = world.rooms[cur]?.exits;
+      if (!exits) continue;
+      for (const [rawDir, exitVal] of Object.entries(exits)) {
+        const target = exitTarget(exitVal);
+        if (target.includes(":")) continue; // cross-zone
+        const dir = normalizeDir(rawDir);
+        const dz = dir === "u" ? 1 : dir === "d" ? -1 : 0;
+        seed(target, z + dz);
+      }
+    }
+  };
+
+  if (world.rooms[world.startRoom]) seed(world.startRoom, 0);
+  drain();
+
+  // Rooms only reachable through dynamic exits (puzzles, etc.): anchor each
+  // through an outgoing exit back to a placed neighbour, repeating until
+  // stable so chains of hidden rooms resolve too.
+  let progressed = true;
+  while (progressed) {
+    progressed = false;
+    for (const [id, room] of Object.entries(world.rooms)) {
+      if (floors.has(id) || !room.exits) continue;
+      for (const [rawDir, exitVal] of Object.entries(room.exits)) {
+        const target = exitTarget(exitVal);
+        if (target.includes(":")) continue;
+        const zn = floors.get(target);
+        if (zn == null) continue;
+        const dir = normalizeDir(rawDir);
+        // Reversed: my `u` exit leads to a room above me, so I sit below it.
+        const z = dir === "u" ? zn - 1 : dir === "d" ? zn + 1 : zn;
+        seed(id, z);
+        progressed = true;
+        break;
+      }
+    }
+    drain();
+  }
+
+  for (const id of Object.keys(world.rooms)) {
+    if (!floors.has(id)) floors.set(id, 0);
+  }
+  return floors;
+}
+
+/**
+ * Quantize the zone editor's current node positions into map pins: nearest
+ * grid cell per room (from the node's pixel center), spiral-resolved on
+ * collision, normalized to a 0-based frame per floor. Floors come from the
+ * exit graph (see {@link roomFloors}), not from pixel positions, so they
+ * always agree with what the server would derive.
+ *
+ * Cross-zone nodes and nodes without a backing room are ignored.
+ */
+export function quantizeLayout(
+  nodes: Node[],
+  world: WorldFile,
+): Map<string, MapPin> {
+  const floors = roomFloors(world);
+  const byFloor = new Map<number, Array<{ id: string; cx: number; cy: number }>>();
+  for (const node of nodes) {
+    if (!world.rooms[node.id]) continue;
+    const w = node.measured?.width ?? node.width ?? DEFAULT_NODE_WIDTH;
+    const h = node.measured?.height ?? node.height ?? DEFAULT_NODE_HEIGHT;
+    const z = floors.get(node.id) ?? 0;
+    const list = byFloor.get(z) ?? [];
+    list.push({
+      id: node.id,
+      cx: (node.position?.x ?? 0) + w / 2,
+      cy: (node.position?.y ?? 0) + h / 2,
+    });
+    byFloor.set(z, list);
+  }
+
+  const pins = new Map<string, MapPin>();
+  for (const [z, rooms] of byFloor) {
+    let minCx = Infinity;
+    let minCy = Infinity;
+    for (const r of rooms) {
+      if (r.cx < minCx) minCx = r.cx;
+      if (r.cy < minCy) minCy = r.cy;
+    }
+
+    const provisional = rooms.map((r) => ({
+      id: r.id,
+      gx: Math.round((r.cx - minCx) / CELL_W),
+      gy: Math.round((r.cy - minCy) / CELL_H),
+    }));
+    // Reading order, then id — deterministic, and rooms keep their own cell
+    // over latecomers when two quantize to the same spot.
+    provisional.sort((a, b) => a.gy - b.gy || a.gx - b.gx || a.id.localeCompare(b.id));
+
+    const grid = new Map<string, string>();
+    const placed: Array<{ id: string; gx: number; gy: number }> = [];
+    for (const p of provisional) {
+      let gx = p.gx;
+      let gy = p.gy;
+      if (grid.has(`${gx},${gy}`)) [gx, gy] = findFreeCell(gx, gy, grid);
+      grid.set(`${gx},${gy}`, p.id);
+      placed.push({ id: p.id, gx, gy });
+    }
+
+    let minGx = Infinity;
+    let minGy = Infinity;
+    for (const p of placed) {
+      if (p.gx < minGx) minGx = p.gx;
+      if (p.gy < minGy) minGy = p.gy;
+    }
+    for (const p of placed) {
+      pins.set(p.id, { x: p.gx - minGx, y: p.gy - minGy, z });
+    }
+  }
+  return pins;
+}
+
+/**
+ * Write pins onto the zone. Rooms without an entry keep whatever they had;
+ * `mapZ: 0` is written as absent (the server default) to keep YAML diffs
+ * quiet for single-floor zones.
+ */
+export function applyMapPins(
+  world: WorldFile,
+  pins: Map<string, MapPin>,
+): WorldFile {
+  const rooms: WorldFile["rooms"] = {};
+  for (const [id, room] of Object.entries(world.rooms)) {
+    const pin = pins.get(id);
+    rooms[id] = pin
+      ? { ...room, mapX: pin.x, mapY: pin.y, mapZ: pin.z === 0 ? undefined : pin.z }
+      : room;
+  }
+  return { ...world, rooms };
+}

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -101,6 +101,45 @@ function validateFlightMapCoords(
 }
 
 /**
+ * Minimap pins must satisfy the server's load contract: `mapX`/`mapY` come as
+ * an integer pair, `mapZ` is only valid alongside them, and no two rooms in a
+ * zone may pin the same cell of the same floor. The loader refuses the whole
+ * zone on any of these, so they're all errors.
+ */
+function validateMapPin(
+  issues: ValidationIssue[],
+  entity: string,
+  roomId: string,
+  room: WorldFile["rooms"][string],
+  pinnedCells: Map<string, string>,
+): void {
+  const { mapX, mapY, mapZ } = room;
+  if (mapX == null && mapY == null) {
+    if (mapZ != null) {
+      addIssue(issues, "error", entity, "mapZ without mapX/mapY — a floor alone doesn't pin a map cell; the server will refuse to load this zone");
+    }
+    return;
+  }
+  if (mapX == null || mapY == null) {
+    addIssue(issues, "error", entity, "Map pin needs both mapX and mapY — the server refuses half-specified pins");
+    return;
+  }
+  for (const [axis, value] of [["mapX", mapX], ["mapY", mapY], ["mapZ", mapZ]] as const) {
+    if (value != null && !Number.isInteger(value)) {
+      addIssue(issues, "error", entity, `${axis} (${value}) must be an integer grid coordinate`);
+      return;
+    }
+  }
+  const cell = `${mapX},${mapY},${mapZ ?? 0}`;
+  const other = pinnedCells.get(cell);
+  if (other) {
+    addIssue(issues, "error", entity, `Pinned to map cell (${mapX},${mapY}) on floor ${mapZ ?? 0}, already taken by room "${other}" — the server refuses duplicate pins`);
+  } else {
+    pinnedCells.set(cell, roomId);
+  }
+}
+
+/**
  * Boat docks share the flight map's coordinate contract (each coord, if present,
  * is a number in 0..100, and the engine only seats a hotspot when both are set),
  * and additionally carry authored routes. Each route needs a non-negative fare
@@ -596,6 +635,7 @@ export function validateZone(
   }
   factionCheck("zone", world.faction, "Controlling faction");
 
+  const pinnedCells = new Map<string, string>();
   for (const [roomId, room] of Object.entries(world.rooms)) {
     const entity = `room:${roomId}`;
     if (!room.title?.trim()) addIssue(issues, "warning", entity, "Room has no title");
@@ -605,6 +645,7 @@ export function validateZone(
     }
 
     validateFlightMapCoords(issues, entity, room);
+    validateMapPin(issues, entity, roomId, room, pinnedCells);
     validateBoatDock(issues, entity, room, roomIds);
 
     for (const [dir, exit] of Object.entries(room.exits ?? {})) {

--- a/creator/src/lib/zoneToGraph.ts
+++ b/creator/src/lib/zoneToGraph.ts
@@ -160,7 +160,14 @@ function buildGraphFingerprint(world: WorldFile): string {
       }
       exits = exitParts.join(";");
     }
-    parts.push(`r:${id}|${room.title}|${room.image ?? ""}|${room.station ?? ""}|${flags}|${exits}`);
+    // Map pins don't feed node data, but compassLayout's fastest cache tier
+    // assumes "same nodes ref → same layout inputs" — so anything the layout
+    // reads must be part of this fingerprint too.
+    const pin =
+      room.mapX != null && room.mapY != null
+        ? `|p${room.mapX},${room.mapY},${room.mapZ ?? 0}`
+        : "";
+    parts.push(`r:${id}|${room.title}|${room.image ?? ""}|${room.station ?? ""}|${flags}|${exits}${pin}`);
   }
 
   for (const [id, mob] of Object.entries(world.mobs ?? {})) {

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -174,6 +174,18 @@ export interface RoomFile {
   /** A single song — present means the room has a music box (a free, player-scoped
    *  one-song miniature of the jukebox). */
   musicBox?: MusicBoxFile;
+  /** Explicit minimap grid pin (server contract, AmbonMUD #1401): integer grid
+   *  column within the zone's own frame, +x = east. Written for every room by
+   *  the zone editor's "Save Layout"; the server seats pinned rooms exactly
+   *  here and BFS-places unpinned rooms around them. Must be paired with
+   *  {@link mapY} — the server fails to load a half-specified pin, and fails if
+   *  two rooms in one zone share a cell on the same floor. */
+  mapX?: number;
+  /** Explicit minimap grid pin: integer grid row, +y = south. See {@link mapX}. */
+  mapY?: number;
+  /** Minimap floor for the pin: 0 = ground, positive = upstairs. Only valid
+   *  alongside {@link mapX}/{@link mapY}; defaults to 0 when omitted. */
+  mapZ?: number;
   /** Legacy Arcanum-only alias; stripped on output. */
   audio?: string;
 }


### PR DESCRIPTION
Arcanum counterpart to [AmbonMUD #1401](https://github.com/jnoecker/AmbonMUD/pull/1401) — the map-layout / persistent-exploration pass. The server now honors explicit per-room minimap pins (`mapX`/`mapY`/`mapZ` in zone YAML); this PR lets the builder author them visually.

## What's new

**"Save Layout" action in the zone editor toolbar** (next to Re-layout). It takes the current node positions — including anything hand-dragged — and pins every room:

- Nearest-cell snap of each node's pixel center to the integer layout grid, spiral collision resolution, normalized to a 0-based frame per floor (`creator/src/lib/mapPins.ts`).
- Floors are derived from the exit graph exactly like the server derives them (`u` = +1, `d` = −1 from the start room, hidden rooms anchored through reversed outgoing exits), so `mapZ` always agrees with what the loader would compute.
- The pin write goes through `applyWorldChange`, so it's undoable; the regular **Save** serializes the pins to zone YAML (`mapZ: 0` is omitted to keep single-floor diffs quiet).

**`compassLayout` honors authored pins**, mirroring the server loader: pinned rooms are seated first (one island per floor, ascending z), and BFS flows outward *through* pinned rooms so unpinned neighbours seat relative to the authored cells. The dagre fallback never discards a pinned layout, and pins participate in both layout-cache fingerprints — including `zoneToGraph`'s graph fingerprint, because `compassLayout`'s fastest cache tier assumes "same nodes ref → same layout inputs" (caught by a test: without this, pinning a room served the stale unpinned layout from cache).

**`validateZone` enforces the server's load contract** so Arcanum can't author a zone the server refuses: half-specified pins, `mapZ` without `mapX`/`mapY`, non-integer cells, and two rooms pinned to the same cell of the same floor are all errors.

## Round-trip

Save Layout → Save → server `WorldLoader` seats every room exactly where the builder left it → the MUD's fog-of-war full-screen map (AmbonMUD #1401) renders the authored layout. Re-opening the zone in Arcanum seeds the graph from the pins, so the layout survives editor restarts too.

## Testing

- `bunx tsc --noEmit` clean
- `bun run test`: 74 files, 2330 tests green — new coverage in `mapPins.test.ts` (extraction, floor derivation, quantization, collision resolution, apply), `dagreLayout.test.ts` (pin seating, BFS-through-pins, per-floor islands, cache invalidation on pin change), `validateZone.test.ts` (all four contract errors + happy path)