### PR TITLE
Mount authoring: mount item type + mount sprite category

### DIFF
--- a/creator/src/components/PlayerSpriteHelpers.tsx
+++ b/creator/src/components/PlayerSpriteHelpers.tsx
@@ -20,6 +20,7 @@ function emptyRequirement(type: RequirementType): SpriteRequirement {
     case "class": return { type: "class", playerClass: "" };
     case "achievement": return { type: "achievement", achievementId: "" };
     case "staff": return { type: "staff" };
+    case "mount": return { type: "mount", mountId: "" };
   }
 }
 
@@ -30,6 +31,7 @@ export function requirementLabel(req: SpriteRequirement): string {
     case "class": return `Class: ${req.playerClass || "?"}`;
     case "achievement": return `Achievement: ${req.achievementId || "?"}`;
     case "staff": return "Staff";
+    case "mount": return `Mount: ${req.mountId || "?"}`;
   }
 }
 
@@ -39,6 +41,7 @@ const REQUIREMENT_TYPES: { value: RequirementType; label: string }[] = [
   { value: "class", label: "Class" },
   { value: "achievement", label: "Achievement" },
   { value: "staff", label: "Staff" },
+  { value: "mount", label: "Mount" },
 ];
 
 // ─── Thumbnail ──────────────────────────────────────────────────────
@@ -226,6 +229,15 @@ export function RequirementRow({
         <span className="text-2xs text-text-muted">Player must be staff</span>
       )}
 
+      {req.type === "mount" && (
+        <input
+          value={req.mountId}
+          onChange={(e) => onChange(index, { type: "mount", mountId: e.target.value })}
+          className="ornate-input min-h-11 flex-1 rounded-2xl px-3 py-3 text-sm text-text-primary"
+          placeholder="mount id — matches the shop item's mountId"
+        />
+      )}
+
       <ActionButton
         onClick={() => onRemove(index)}
         className="ml-auto shrink-0"
@@ -304,10 +316,11 @@ export function SpriteDetailEditor({
             <select
               className="ornate-input min-h-11 rounded-2xl px-4 py-3 text-sm text-text-primary"
               value={def.category}
-              onChange={(e) => onPatch({ category: e.target.value as "general" | "staff" })}
+              onChange={(e) => onPatch({ category: e.target.value as SpriteDefinition["category"] })}
             >
               <option value="general">General</option>
               <option value="staff">Staff</option>
+              <option value="mount">Mount</option>
             </select>
           </label>
           <label className="flex flex-col gap-1 text-xs text-text-secondary">

--- a/creator/src/components/PlayerSpriteManager.tsx
+++ b/creator/src/components/PlayerSpriteManager.tsx
@@ -106,7 +106,7 @@ const SpriteListRow = memo(function SpriteListRow({
           )}
         </div>
         <span className="shrink-0 text-2xs text-text-muted">
-          {def.category === "staff" ? "S" : def.sortOrder}
+          {def.category === "staff" ? "S" : def.category === "mount" ? "M" : def.sortOrder}
         </span>
       </button>
     </div>
@@ -135,7 +135,7 @@ export function PlayerSpriteManager() {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [newId, setNewId] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
-  const [filterCategory, setFilterCategory] = useState<"all" | "general" | "staff">("all");
+  const [filterCategory, setFilterCategory] = useState<"all" | "general" | "staff" | "mount">("all");
   const [filterRace, setFilterRace] = useState<string>("all");
   const [filterClass, setFilterClass] = useState<string>("all");
   const [filterGender, setFilterGender] = useState<string>("all");
@@ -627,12 +627,13 @@ export function PlayerSpriteManager() {
               <select
                 className="ornate-input min-h-7 rounded-xl px-2 py-1 text-2xs text-text-primary"
                 value={filterCategory}
-                onChange={(e) => setFilterCategory(e.target.value as "all" | "general" | "staff")}
+                onChange={(e) => setFilterCategory(e.target.value as "all" | "general" | "staff" | "mount")}
                 title="Category"
               >
                 <option value="all">All categories</option>
                 <option value="general">General</option>
                 <option value="staff">Staff</option>
+                <option value="mount">Mount</option>
               </select>
               <select
                 className="ornate-input min-h-7 rounded-xl px-2 py-1 text-2xs text-text-primary"

--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -445,17 +445,35 @@ function ItemEditorContent({
                 hint={
                   item.itemType === "keepsake"
                     ? "Keepsakes are soulbound souvenirs — locked like a quest item, but shelved under their own Keepsakes heading in the inventory."
-                    : undefined
+                    : item.itemType === "mount"
+                      ? "Mounts sold in shops never enter the inventory — buying one permanently unlocks its sprite and map fast travel."
+                      : undefined
                 }
               >
                 <SelectInput
                   value={item.itemType ?? ""}
                   options={itemTypeOptions}
-                  onCommit={(v) => patch({ itemType: (v || undefined) as ItemType | undefined })}
+                  onCommit={(v) => {
+                    const next = (v || undefined) as ItemType | undefined;
+                    // mountId is only valid on mount items; the server refuses it elsewhere.
+                    patch(next === "mount" ? { itemType: next } : { itemType: next, mountId: undefined });
+                  }}
                   allowEmpty
                   placeholder="— auto —"
                 />
               </FieldRow>
+              {item.itemType === "mount" && (
+                <FieldRow
+                  label="Mount ID"
+                  hint="Must match the {type: mount, mountId} requirement on a mount sprite (Player Sprites manager). Required for mount items."
+                >
+                  <TextInput
+                    value={item.mountId ?? ""}
+                    onCommit={(v) => patch({ mountId: v.trim() || undefined })}
+                    placeholder="e.g. dappled_pony"
+                  />
+                </FieldRow>
+              )}
               <FieldRow label="Quest Item">
                 <CheckboxInput
                   checked={item.questItem ?? false}

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -769,6 +769,7 @@ export function generateSpritesYaml(): string {
             case "class": return { type: "class", playerClass: req.playerClass };
             case "achievement": return { type: "achievement", achievementId: req.achievementId };
             case "staff": return { type: "staff" };
+            case "mount": return { type: "mount", mountId: req.mountId };
           }
         })
       : [{ type: "minLevel", level: 0 }];

--- a/creator/src/lib/spritePromptGen.ts
+++ b/creator/src/lib/spritePromptGen.ts
@@ -23,6 +23,8 @@ export interface SpriteDimensions {
   race?: string;
   playerClass?: string;
   gender?: string;
+  /** True for mount sprites — the subject is the rideable creature, not an adventurer. */
+  mount?: boolean;
 }
 
 export interface SpritePromptArgs {
@@ -81,6 +83,7 @@ export function resolveSpriteDimensions(def: SpriteDefinition): SpriteDimensions
     race: findReq(def.requirements, "race")?.race || undefined,
     playerClass: findReq(def.requirements, "class")?.playerClass || undefined,
     gender: def.gender || undefined,
+    mount: def.category === "mount" || undefined,
   };
 }
 
@@ -93,6 +96,9 @@ export function spritePromptNotes(def: SpriteDefinition): string | undefined {
 // ─── Prompt assembly ─────────────────────────────────────────────────
 
 function spriteSubject(dimensions: SpriteDimensions): string {
+  if (dimensions.mount) {
+    return "rideable fantasy mount, saddled and bridled, with a small hooded rider seated in the saddle";
+  }
   const parts: string[] = [];
   if (dimensions.gender) parts.push(dimensions.gender);
   if (dimensions.race) {
@@ -119,26 +125,30 @@ export function spriteContext(
   notes?: string,
 ): string {
   const parts = [
-    `Player character sprite "${displayName}" — a full-body standing figure used as a "player is standing here" marker composited into room scenes at small sizes.`,
+    dimensions.mount
+      ? `Mount sprite "${displayName}" — a full-body saddled rideable creature carrying a small rider, shown while a player fast-travels; composited into room scenes at small sizes in place of the usual standing figure.`
+      : `Player character sprite "${displayName}" — a full-body standing figure used as a "player is standing here" marker composited into room scenes at small sizes.`,
   ];
-  if (dimensions.gender) parts.push(`Gender: ${dimensions.gender}`);
-  if (dimensions.race) {
-    const desc = getRaceBodyDescription(dimensions.race);
-    parts.push(desc !== dimensions.race ? `Race: ${dimensions.race} — ${desc}` : `Race: ${dimensions.race}`);
-  }
-  if (dimensions.playerClass) {
-    const desc = getClassOutfitDescription(dimensions.playerClass);
-    parts.push(
-      desc !== dimensions.playerClass
-        ? `Class: ${dimensions.playerClass} — outfit: ${desc}`
-        : `Class: ${dimensions.playerClass}`,
-    );
-  } else {
-    parts.push("No class — wearing simple traveler's clothing");
-  }
-  const directive = getRaceImagePromptDirective(dimensions.race);
-  if (directive) {
-    parts.push(`Hard constraint for this race (must never be contradicted): ${directive}`);
+  if (!dimensions.mount) {
+    if (dimensions.gender) parts.push(`Gender: ${dimensions.gender}`);
+    if (dimensions.race) {
+      const desc = getRaceBodyDescription(dimensions.race);
+      parts.push(desc !== dimensions.race ? `Race: ${dimensions.race} — ${desc}` : `Race: ${dimensions.race}`);
+    }
+    if (dimensions.playerClass) {
+      const desc = getClassOutfitDescription(dimensions.playerClass);
+      parts.push(
+        desc !== dimensions.playerClass
+          ? `Class: ${dimensions.playerClass} — outfit: ${desc}`
+          : `Class: ${dimensions.playerClass}`,
+      );
+    } else {
+      parts.push("No class — wearing simple traveler's clothing");
+    }
+    const directive = getRaceImagePromptDirective(dimensions.race);
+    if (directive) {
+      parts.push(`Hard constraint for this race (must never be contradicted): ${directive}`);
+    }
   }
   if (notes?.trim()) parts.push(`Art direction: ${notes.trim()}`);
   return parts.join("\n");

--- a/creator/src/lib/validateZone.ts
+++ b/creator/src/lib/validateZone.ts
@@ -943,6 +943,14 @@ export function validateZone(
         `itemType "${item.itemType}" is not a known type. Valid: ${ITEM_TYPES.join(", ")}`,
       );
     }
+    // Mirrors the server's WorldLoader rules: mount items must carry a mountId,
+    // and mountId is meaningless (rejected) on any other item type.
+    if (item.itemType === "mount" && !item.mountId?.trim()) {
+      addIssue(issues, "error", entity, "Mount items must set a mountId (matches a mount sprite's requirement)");
+    }
+    if (item.itemType !== "mount" && item.mountId?.trim()) {
+      addIssue(issues, "error", entity, 'mountId is only valid when itemType is "mount"');
+    }
     if (item.classes && item.classes.length > 0) {
       for (const cls of item.classes) {
         if (!VALID_CLASSES.has(cls.toUpperCase())) {

--- a/creator/src/stores/spriteDefinitionStore.ts
+++ b/creator/src/stores/spriteDefinitionStore.ts
@@ -23,6 +23,8 @@ function parseRequirement(raw: Record<string, unknown>): SpriteRequirement | nul
       return { type: "achievement", achievementId: String(raw.achievementId ?? "") };
     case "staff":
       return { type: "staff" };
+    case "mount":
+      return { type: "mount", mountId: String(raw.mountId ?? "") };
     default:
       return null;
   }
@@ -100,7 +102,7 @@ function parseDefinition(id: string, entry: Record<string, unknown>): SpriteDefi
     displayName: String(entry.displayName ?? id),
     description: entry.description ? String(entry.description) : undefined,
     artDirection: entry.artDirection ? String(entry.artDirection) : undefined,
-    category: entry.category === "staff" ? "staff" : "general",
+    category: entry.category === "staff" ? "staff" : entry.category === "mount" ? "mount" : "general",
     gender: entry.gender ? String(entry.gender) : undefined,
     sortOrder: Number(entry.sortOrder) || 0,
     requirements,
@@ -122,6 +124,8 @@ function requirementToPlain(req: SpriteRequirement): Record<string, unknown> {
       return { type: "achievement", achievementId: req.achievementId };
     case "staff":
       return { type: "staff" };
+    case "mount":
+      return { type: "mount", mountId: req.mountId };
   }
 }
 

--- a/creator/src/types/sprites.ts
+++ b/creator/src/types/sprites.ts
@@ -39,12 +39,19 @@ export interface StaffRequirement {
   type: "staff";
 }
 
+/** Player must have bought the mount with this id (a shop item's `mountId`). */
+export interface MountRequirement {
+  type: "mount";
+  mountId: string;
+}
+
 export type SpriteRequirement =
   | MinLevelRequirement
   | RaceRequirement
   | ClassRequirement
   | AchievementRequirement
-  | StaffRequirement;
+  | StaffRequirement
+  | MountRequirement;
 
 export type RequirementType = SpriteRequirement["type"];
 
@@ -55,7 +62,7 @@ export interface SpriteDefinition {
   description?: string;
   /** Visual prompt guidance for AI image generation — separate from player-facing description. */
   artDirection?: string;
-  category: "general" | "staff";
+  category: "general" | "staff" | "mount";
   gender?: string;
   sortOrder: number;
   requirements: SpriteRequirement[];

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -545,7 +545,7 @@ export interface BtNodeFile {
  * these automatically — e.g. a lyric sheet on the first play of a music-box
  * song — but they can also be authored by hand here.
  */
-export type ItemType = "equipment" | "consumable" | "quest" | "treasure" | "keepsake" | "misc";
+export type ItemType = "equipment" | "consumable" | "quest" | "treasure" | "keepsake" | "mount" | "misc";
 
 export const ITEM_TYPES: readonly ItemType[] = [
   "equipment",
@@ -553,6 +553,7 @@ export const ITEM_TYPES: readonly ItemType[] = [
   "quest",
   "treasure",
   "keepsake",
+  "mount",
   "misc",
 ] as const;
 
@@ -591,6 +592,14 @@ export interface ItemFile {
    * other fields. Values are lowercase to match the server's `ItemType.label()`.
    */
   itemType?: ItemType;
+  /**
+   * Mount unlock id, required when `itemType` is "mount" and forbidden
+   * otherwise. Buying the item never enters the inventory: the server records
+   * this id on the character permanently, which unlocks the mount sprite
+   * whose `{type: "mount", mountId}` requirement matches and enables map
+   * fast travel.
+   */
+  mountId?: string;
   /**
    * Soulbound flag: quest items cannot be dropped, sold, traded, given, or
    * stored in containers. Always resolves to the "quest" category server-side.


### PR DESCRIPTION
## Summary
Arcanum-side authoring support for AmbonMUD's new mount fast-travel system (jnoecker/AmbonMUD#1403):

- **Item editor** — new `mount` item type with a **Mount ID** field. Buying such an item on the server permanently unlocks the mount (never enters inventory). `mountId` is required on mount items and refused on any other type, matching the server's `WorldLoader` validation; zone validation surfaces both mistakes.
- **Player Sprites manager** — new `mount` sprite category and `{type: mount, mountId}` unlock requirement, with editor row, list badge (`M`), and category filter. `spriteDefinitionStore` and `exportMud` round-trip the new fields through `sprites.yaml`.
- **Art generation** — mount sprites prompt as a saddled rideable creature carrying a small rider, instead of the standing-adventurer template; race/class context lines are suppressed for mounts.

## Testing
- `bunx tsc --noEmit` clean
- `bun run test` — 2330 tests pass