### PR TITLE
feat(config): akathavae unpledged/zone-completion knobs + shrine kiosk asset

### DIFF
--- a/creator/src/components/config/panels/AkathavaePanel.tsx
+++ b/creator/src/components/config/panels/AkathavaePanel.tsx
@@ -139,6 +139,21 @@ export function AkathavaePanel({ config, onChange }: ConfigPanelProps) {
           {num(a.unpledgedXpMultiplier, (v) => patch({ unpledgedXpMultiplier: v }), { min: 0, max: 1, step: 0.05 })}
         </FieldRow>
       </Section>
+
+      <Section title="Sketching">
+        <FieldRow label="Ms per combat round" hint="Sketch time per estimated melee round-to-kill — illumination takes about as long as the fight would. All-zero sketch knobs make it instant.">
+          {num(a.sketchMsPerEstimatedRound, (v) => patch({ sketchMsPerEstimatedRound: v }), { min: 0 })}
+        </FieldRow>
+        <FieldRow label="Min duration (ms)" hint="Lower clamp on sketch time for combat-capable subjects.">
+          {num(a.sketchMinMs, (v) => patch({ sketchMinMs: v }), { min: 0 })}
+        </FieldRow>
+        <FieldRow label="Max duration (ms)" hint="Upper clamp on sketch time for combat-capable subjects.">
+          {num(a.sketchMaxMs, (v) => patch({ sketchMaxMs: v }), { min: 0 })}
+        </FieldRow>
+        <FieldRow label="Observe duration (ms)" hint="Flat sketch time for observing a non-combat NPC.">
+          {num(a.observeSketchMs, (v) => patch({ observeSketchMs: v }), { min: 0 })}
+        </FieldRow>
+      </Section>
     </div>
   );
 }

--- a/creator/src/components/config/panels/AkathavaePanel.tsx
+++ b/creator/src/components/config/panels/AkathavaePanel.tsx
@@ -108,6 +108,9 @@ export function AkathavaePanel({ config, onChange }: ConfigPanelProps) {
         <FieldRow label="Room discovery XP" hint="XP for recording a never-before-visited room.">
           {num(a.roomDiscoveryXp, (v) => patch({ roomDiscoveryXp: v }), { min: 0 })}
         </FieldRow>
+        <FieldRow label="Room XP per zone level" hint="Extra room XP per average mob level of the zone — dangerous zones pay like the zone.">
+          {num(a.roomDiscoveryXpPerZoneLevel, (v) => patch({ roomDiscoveryXpPerZoneLevel: v }), { min: 0 })}
+        </FieldRow>
         <FieldRow label="Item discovery XP" hint="XP for recording a never-before-seen item.">
           {num(a.itemDiscoveryXp, (v) => patch({ itemDiscoveryXp: v }), { min: 0 })}
         </FieldRow>
@@ -116,6 +119,24 @@ export function AkathavaePanel({ config, onChange }: ConfigPanelProps) {
         </FieldRow>
         <FieldRow label="XP throttle" hint="Minimum milliseconds between discovery XP awards — anti-speedrun throttle.">
           {num(a.discoveryXpThrottleMs, (v) => patch({ discoveryXpThrottleMs: v }), { min: 0 })}
+        </FieldRow>
+      </Section>
+
+      <Section title="Zone Completion">
+        <FieldRow label="XP per room" hint="One-time XP per room in a zone, paid when its Arcanum record reaches 100%.">
+          {num(a.zoneCompletionXpPerRoom, (v) => patch({ zoneCompletionXpPerRoom: v }), { min: 0 })}
+        </FieldRow>
+        <FieldRow label="Completion gold" hint="One-time gold paid on zone completion — the Akathavae's gold faucet.">
+          {num(a.zoneCompletionGold, (v) => patch({ zoneCompletionGold: v }), { min: 0 })}
+        </FieldRow>
+      </Section>
+
+      <Section title="Unpledged Journaling">
+        <FieldRow label="Success multiplier" hint="Scales illumination odds for players who never pledged (0–1) — anyone may keep a field journal.">
+          {num(a.unpledgedSuccessMultiplier, (v) => patch({ unpledgedSuccessMultiplier: v }), { min: 0, max: 1, step: 0.05 })}
+        </FieldRow>
+        <FieldRow label="XP multiplier" hint="Scales discovery XP for unpledged players (0–1). 0 makes their journaling pure record-keeping.">
+          {num(a.unpledgedXpMultiplier, (v) => patch({ unpledgedXpMultiplier: v }), { min: 0, max: 1, step: 0.05 })}
         </FieldRow>
       </Section>
     </div>

--- a/creator/src/lib/__tests__/exportMud.test.ts
+++ b/creator/src/lib/__tests__/exportMud.test.ts
@@ -556,6 +556,28 @@ ambonmud:
     // Block re-parses cleanly with the change preserved.
     expect(parseAppConfigYaml(stringify({ ambonmud: runtime })).akathavae.renounceCostGold).toBe(5000);
   });
+
+  it("round-trips the unpledged journaling and zone-completion knobs", () => {
+    const base = parseAppConfigYaml(`
+ambonmud:
+  server: { telnetPort: 4000, webPort: 8080 }
+  world: { startRoom: hub:square, resources: [] }
+  engine: {}
+`);
+    const tuned: AppConfig = {
+      ...base,
+      akathavae: { ...base.akathavae, unpledgedSuccessMultiplier: 0.3, unpledgedXpMultiplier: 0, zoneCompletionGold: 1000 },
+    };
+    const runtime = buildMonolithicConfigObject(tuned) as any;
+    expect(runtime.engine.akathavae.unpledgedSuccessMultiplier).toBe(0.3);
+    const reparsed = parseAppConfigYaml(stringify({ ambonmud: runtime })).akathavae;
+    expect(reparsed.unpledgedSuccessMultiplier).toBe(0.3);
+    expect(reparsed.unpledgedXpMultiplier).toBe(0);
+    expect(reparsed.zoneCompletionGold).toBe(1000);
+    // Untouched new knobs fall back to canonical defaults.
+    expect(reparsed.roomDiscoveryXpPerZoneLevel).toBe(5);
+    expect(reparsed.zoneCompletionXpPerRoom).toBe(50);
+  });
 });
 
 describe("flight config", () => {

--- a/creator/src/lib/configDefaults.ts
+++ b/creator/src/lib/configDefaults.ts
@@ -47,6 +47,10 @@ export const DEFAULT_AKATHAVAE: AppConfig["akathavae"] = {
   zoneCompletionGold: 500,
   unpledgedSuccessMultiplier: 0.5,
   unpledgedXpMultiplier: 0.25,
+  sketchMsPerEstimatedRound: 1_000,
+  sketchMinMs: 2_000,
+  sketchMaxMs: 10_000,
+  observeSketchMs: 2_000,
 };
 
 /** Canonical defaults for flight masters (mirrors the server's FlightConfig).

--- a/creator/src/lib/configDefaults.ts
+++ b/creator/src/lib/configDefaults.ts
@@ -39,9 +39,14 @@ export const DEFAULT_AKATHAVAE: AppConfig["akathavae"] = {
   repeatXpFraction: 0.2,
   repeatXpCooldownMs: 300_000,
   roomDiscoveryXp: 15,
+  roomDiscoveryXpPerZoneLevel: 5,
   itemDiscoveryXp: 25,
   observeNpcXp: 10,
   discoveryXpThrottleMs: 1_500,
+  zoneCompletionXpPerRoom: 50,
+  zoneCompletionGold: 500,
+  unpledgedSuccessMultiplier: 0.5,
+  unpledgedXpMultiplier: 0.25,
 };
 
 /** Canonical defaults for flight masters (mirrors the server's FlightConfig).

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -234,6 +234,10 @@ export function normalizeAkathavaeConfig(config?: AppConfig["akathavae"]): AppCo
     zoneCompletionGold: c.zoneCompletionGold,
     unpledgedSuccessMultiplier: c.unpledgedSuccessMultiplier,
     unpledgedXpMultiplier: c.unpledgedXpMultiplier,
+    sketchMsPerEstimatedRound: c.sketchMsPerEstimatedRound,
+    sketchMinMs: c.sketchMinMs,
+    sketchMaxMs: c.sketchMaxMs,
+    observeSketchMs: c.observeSketchMs,
   };
   return JSON.stringify(ordered) === JSON.stringify(d) ? undefined : ordered;
 }

--- a/creator/src/lib/exportMud.ts
+++ b/creator/src/lib/exportMud.ts
@@ -226,9 +226,14 @@ export function normalizeAkathavaeConfig(config?: AppConfig["akathavae"]): AppCo
     repeatXpFraction: c.repeatXpFraction,
     repeatXpCooldownMs: c.repeatXpCooldownMs,
     roomDiscoveryXp: c.roomDiscoveryXp,
+    roomDiscoveryXpPerZoneLevel: c.roomDiscoveryXpPerZoneLevel,
     itemDiscoveryXp: c.itemDiscoveryXp,
     observeNpcXp: c.observeNpcXp,
     discoveryXpThrottleMs: c.discoveryXpThrottleMs,
+    zoneCompletionXpPerRoom: c.zoneCompletionXpPerRoom,
+    zoneCompletionGold: c.zoneCompletionGold,
+    unpledgedSuccessMultiplier: c.unpledgedSuccessMultiplier,
+    unpledgedXpMultiplier: c.unpledgedXpMultiplier,
   };
   return JSON.stringify(ordered) === JSON.stringify(d) ? undefined : ordered;
 }

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -761,6 +761,11 @@ function parseAkathavaeConfig(raw: unknown): AppConfig["akathavae"] {
     itemDiscoveryXp: asNumber(s.itemDiscoveryXp, d.itemDiscoveryXp),
     observeNpcXp: asNumber(s.observeNpcXp, d.observeNpcXp),
     discoveryXpThrottleMs: asNumber(s.discoveryXpThrottleMs, d.discoveryXpThrottleMs),
+    roomDiscoveryXpPerZoneLevel: asNumber(s.roomDiscoveryXpPerZoneLevel, d.roomDiscoveryXpPerZoneLevel),
+    zoneCompletionXpPerRoom: asNumber(s.zoneCompletionXpPerRoom, d.zoneCompletionXpPerRoom),
+    zoneCompletionGold: asNumber(s.zoneCompletionGold, d.zoneCompletionGold),
+    unpledgedSuccessMultiplier: asNumber(s.unpledgedSuccessMultiplier, d.unpledgedSuccessMultiplier),
+    unpledgedXpMultiplier: asNumber(s.unpledgedXpMultiplier, d.unpledgedXpMultiplier),
   };
 }
 

--- a/creator/src/lib/loader.ts
+++ b/creator/src/lib/loader.ts
@@ -766,6 +766,10 @@ function parseAkathavaeConfig(raw: unknown): AppConfig["akathavae"] {
     zoneCompletionGold: asNumber(s.zoneCompletionGold, d.zoneCompletionGold),
     unpledgedSuccessMultiplier: asNumber(s.unpledgedSuccessMultiplier, d.unpledgedSuccessMultiplier),
     unpledgedXpMultiplier: asNumber(s.unpledgedXpMultiplier, d.unpledgedXpMultiplier),
+    sketchMsPerEstimatedRound: asNumber(s.sketchMsPerEstimatedRound, d.sketchMsPerEstimatedRound),
+    sketchMinMs: asNumber(s.sketchMinMs, d.sketchMinMs),
+    sketchMaxMs: asNumber(s.sketchMaxMs, d.sketchMaxMs),
+    observeSketchMs: asNumber(s.observeSketchMs, d.observeSketchMs),
   };
 }
 

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -492,10 +492,21 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     key: "arcanum_widget",
     defaultFilename: "arcanum_widget.png",
     label: "Arcanum Kiosk",
-    description: "Action-dock button that opens the Akathavae's Arcanum journal. Shown to pledged players.",
+    description: "Action-dock button that opens the Arcanum journal — every player keeps a field journal now.",
     assetType: "ability_icon",
     defaultPrompt:
       "A single open illuminated codex with a quill resting across it and a faint candlelight glow, gilded page edges, centered, soft outline, transparent background.",
+    transparent: true,
+    optional: true,
+  },
+  {
+    key: "shrine_widget",
+    defaultFilename: "shrine_widget.png",
+    label: "Akathavae Shrine Kiosk",
+    description: "Action-dock button that opens the shrine panel for taking or renouncing the Akathavae pledge.",
+    assetType: "ability_icon",
+    defaultPrompt:
+      "A small stone shrine arch sheltering a single serene candle flame, faint motes of light rising, centered, soft outline, transparent background.",
     transparent: true,
     optional: true,
   },

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -1460,6 +1460,16 @@ export interface AkathavaeConfig {
   observeNpcXp: number;
   /** Minimum gap between discovery XP awards (ms) — anti-speedrun throttle. */
   discoveryXpThrottleMs: number;
+  /** Extra room-discovery XP per average mob level of the zone — dangerous zones pay like the zone. */
+  roomDiscoveryXpPerZoneLevel: number;
+  /** One-time XP per room in a zone, paid when its Arcanum record reaches 100%. */
+  zoneCompletionXpPerRoom: number;
+  /** One-time gold paid on zone completion — the Akathavae's gold faucet. */
+  zoneCompletionGold: number;
+  /** Multiplier (0..1) on illumination success odds for unpledged players — anyone may keep a field journal. */
+  unpledgedSuccessMultiplier: number;
+  /** Multiplier (0..1) on discovery XP for unpledged players. 0 turns their journaling into pure record-keeping. */
+  unpledgedXpMultiplier: number;
 }
 
 // ─── Flight masters (gold fast-travel) ─────────────────────────────

--- a/creator/src/types/config.ts
+++ b/creator/src/types/config.ts
@@ -1470,6 +1470,13 @@ export interface AkathavaeConfig {
   unpledgedSuccessMultiplier: number;
   /** Multiplier (0..1) on discovery XP for unpledged players. 0 turns their journaling into pure record-keeping. */
   unpledgedXpMultiplier: number;
+  /** Sketch time per estimated melee round-to-kill (ms) — illumination takes about as long as the fight would. */
+  sketchMsPerEstimatedRound: number;
+  /** Sketch duration clamp (ms). All-zero sketch knobs make illumination instant. */
+  sketchMinMs: number;
+  sketchMaxMs: number;
+  /** Flat sketch time for observing a non-combat NPC (ms). */
+  observeSketchMs: number;
 }
 
 // ─── Flight masters (gold fast-travel) ─────────────────────────────


### PR DESCRIPTION
## Summary

Mirrors the new server-side Akathavae tuning from AmbonMUD (#1416, #1417, and jnoecker/AmbonMUD#1418) so worldbuilders can configure it in the creator:

- **AkathavaeConfig knobs**: `roomDiscoveryXpPerZoneLevel`, `zoneCompletionXpPerRoom`, `zoneCompletionGold`, `unpledgedSuccessMultiplier`, `unpledgedXpMultiplier` — added to `types/config.ts`, `configDefaults.ts`, `loader.ts`, `exportMud.ts` (server declaration order preserved for the omit-when-default check), and the Akathavae config panel (new "Zone Completion" and "Unpledged Journaling" sections).
- **Global assets**: new `shrine_widget` entry (the web client's new pledge/renounce shrine kiosk button, AmbonMUD#1418) and a refreshed `arcanum_widget` description now that every player keeps a field journal.

## Testing
- `bunx tsc --noEmit` clean; `bun run test` 2331/2331 green, including a new round-trip test for the added knobs.

🤖 Generated with Claude Code