### PR TITLE
Persist mob/item editor subtab across entity switches

### DIFF
--- a/creator/src/components/editors/ItemEditor.tsx
+++ b/creator/src/components/editors/ItemEditor.tsx
@@ -38,9 +38,11 @@ interface ItemEditorProps {
   onDelete: () => void;
   onDuplicate?: () => void;
   zoneId?: string;
+  activeTab?: ItemTab;
+  onTabChange?: (tab: ItemTab) => void;
 }
 
-type ItemTab = "item" | "media";
+export type ItemTab = "item" | "media";
 const ITEM_TABS: readonly { value: ItemTab; label: string }[] = [
   { value: "item", label: "Item" },
   { value: "media", label: "Media" },
@@ -83,8 +85,12 @@ function ItemEditorContent({
   patch,
   handleDelete,
   rooms,
+  activeTab: controlledTab,
+  onTabChange,
 }: ItemEditorContentProps) {
-  const [activeTab, setActiveTab] = useState<ItemTab>("item");
+  const [localTab, setLocalTab] = useState<ItemTab>("item");
+  const activeTab = controlledTab ?? localTab;
+  const setActiveTab = onTabChange ?? setLocalTab;
   const equipmentSlots = useConfigStore((s) => s.config?.equipmentSlots);
   const slotOptions = useConfigOptions(equipmentSlots, [
     { value: "head", label: "Head" },

--- a/creator/src/components/editors/MobEditor.tsx
+++ b/creator/src/components/editors/MobEditor.tsx
@@ -56,6 +56,8 @@ interface MobEditorProps {
   onDelete: () => void;
   onDuplicate?: () => void;
   zoneId?: string;
+  activeTab?: MobTab;
+  onTabChange?: (tab: MobTab) => void;
 }
 
 const TIER_OPTIONS = [
@@ -136,7 +138,7 @@ const TEMPLATES_WITH_WANDER_DISTANCE = new Set(["wander", "wander_aggro", "cowar
 const TEMPLATES_WITH_AGGRO_MSG = new Set(["aggro_guard", "patrol_aggro", "wander_aggro"]);
 const TEMPLATES_WITH_FLEE = new Set(["coward"]);
 
-type MobTab = "mob" | "rewards" | "dialogue" | "media";
+export type MobTab = "mob" | "rewards" | "dialogue" | "media";
 const MOB_TABS: readonly { value: MobTab; label: string }[] = [
   { value: "mob", label: "Mob" },
   { value: "rewards", label: "Rewards" },
@@ -183,8 +185,12 @@ function MobEditorContent({
   patch,
   handleDelete,
   rooms,
+  activeTab: controlledTab,
+  onTabChange,
 }: MobEditorContentProps) {
-  const [activeTab, setActiveTab] = useState<MobTab>("mob");
+  const [localTab, setLocalTab] = useState<MobTab>("mob");
+  const activeTab = controlledTab ?? localTab;
+  const setActiveTab = onTabChange ?? setLocalTab;
 
   const role: MobRole = mob.role ?? "combat";
   const isCombatant = role === "combat";
@@ -473,7 +479,7 @@ function MobEditorContent({
         </div>
       </EntityHeader>
 
-      <TabBar tabs={visibleTabs} active={activeTab} onChange={setActiveTab} />
+      <TabBar tabs={visibleTabs} active={effectiveTab} onChange={setActiveTab} />
 
       {effectiveTab === "mob" && (
         <>

--- a/creator/src/components/zone/EntityPanel.tsx
+++ b/creator/src/components/zone/EntityPanel.tsx
@@ -3,8 +3,8 @@ import type { WorldFile } from "@/types/world";
 import { duplicateMob, duplicateItem } from "@/lib/zoneEdits";
 import { useToastStore } from "@/stores/toastStore";
 import type { EntitySelection } from "./RoomPanel";
-import { MobEditor } from "@/components/editors/MobEditor";
-import { ItemEditor } from "@/components/editors/ItemEditor";
+import { MobEditor, type MobTab } from "@/components/editors/MobEditor";
+import { ItemEditor, type ItemTab } from "@/components/editors/ItemEditor";
 import { ShopEditor } from "@/components/editors/ShopEditor";
 import { QuestEditor } from "@/components/editors/QuestEditor";
 import { GatheringNodeEditor } from "@/components/editors/GatheringNodeEditor";
@@ -31,6 +31,10 @@ interface EntityPanelProps {
   onClose: () => void;
   onRename?: (newId: string) => void;
   zoneId?: string;
+  mobTab?: MobTab;
+  onMobTabChange?: (tab: MobTab) => void;
+  itemTab?: ItemTab;
+  onItemTabChange?: (tab: ItemTab) => void;
 }
 
 export function EntityPanel({
@@ -40,6 +44,10 @@ export function EntityPanel({
   onClose,
   onRename,
   zoneId,
+  mobTab,
+  onMobTabChange,
+  itemTab,
+  onItemTabChange,
 }: EntityPanelProps) {
   const [showYaml, setShowYaml] = useState(false);
   const [renaming, setRenaming] = useState(false);
@@ -165,6 +173,8 @@ export function EntityPanel({
           onDelete={handleDelete}
           onDuplicate={onRename ? handleDuplicateMob : undefined}
           zoneId={zoneId}
+          activeTab={mobTab}
+          onTabChange={onMobTabChange}
         />
       )}
       {selection.kind === "item" && (
@@ -175,6 +185,8 @@ export function EntityPanel({
           onDelete={handleDelete}
           onDuplicate={onRename ? handleDuplicateItem : undefined}
           zoneId={zoneId}
+          activeTab={itemTab}
+          onTabChange={onItemTabChange}
         />
       )}
       {selection.kind === "shop" && (

--- a/creator/src/components/zone/ZoneEditor.tsx
+++ b/creator/src/components/zone/ZoneEditor.tsx
@@ -33,6 +33,8 @@ import { CrossZoneNode } from "./CrossZoneNode";
 import { ExitEdge, ExitDeleteContext } from "./ExitEdge";
 import { RoomPanel, type EntitySelection } from "./RoomPanel";
 import { EntityPanel } from "./EntityPanel";
+import type { MobTab } from "@/components/editors/MobEditor";
+import type { ItemTab } from "@/components/editors/ItemEditor";
 import { DirectionPicker } from "./DirectionPicker";
 import { useBatchArtStore } from "@/stores/batchArtStore";
 import { RethemeDialog } from "./RethemeDialog";
@@ -179,6 +181,8 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const [selectedEntity, setSelectedEntity] = useState<EntitySelection | null>(null);
   const [roomPanelTab, setRoomPanelTab] = useState<"room" | "entities" | "media">("room");
+  const [mobPanelTab, setMobPanelTab] = useState<MobTab>("mob");
+  const [itemPanelTab, setItemPanelTab] = useState<ItemTab>("item");
   const [showAddRoom, setShowAddRoom] = useState(false);
   const [newRoomId, setNewRoomId] = useState("");
   const addRoomInputRef = useRef<HTMLInputElement>(null);
@@ -1242,6 +1246,10 @@ function ZoneEditorInner({ zoneId }: ZoneEditorProps) {
                   )
                 }
                 zoneId={zoneId}
+                mobTab={mobPanelTab}
+                onMobTabChange={setMobPanelTab}
+                itemTab={itemPanelTab}
+                onItemTabChange={setItemPanelTab}
               />
             </SpringPanel>
           ) : selectedRoomId ? (


### PR DESCRIPTION
## Summary
- Mob and item editor subtabs (Mob/Rewards/Dialogue/Media, Item/Media) now persist when switching between entities, matching how the room panel already remembers its tab.
- Tab state is hoisted into `ZoneEditor` (`mobPanelTab` / `itemPanelTab`, mirroring `roomPanelTab`) and threaded through `EntityPanel` into `MobEditor` / `ItemEditor` as optional controlled props with a local-state fallback for uncontrolled use.
- `MobEditor`'s TabBar now highlights `effectiveTab`, so a persisted **Rewards** selection visibly falls back to **Mob** when you click a non-combatant mob (whose Rewards tab is hidden) instead of leaving no tab highlighted.

## Why
Clicking through mobs to do media or dialogue work reset the editor to the first tab on every selection, because `EntityPanel` is remounted per entity (`key={kind:id}`) and the tab state lived inside the editors.

## Testing
- `bunx tsc --noEmit` clean
- `bun run test` — 74 files, 2331 tests pass