### PR TITLE
Ground feature backdrop art context in sign text, room, and zone vibe

### DIFF
--- a/creator/src/components/zone/FeatureBackgroundEditor.tsx
+++ b/creator/src/components/zone/FeatureBackgroundEditor.tsx
@@ -2,7 +2,9 @@ import type { FeatureFile, WorldFile } from "@/types/world";
 import { EntityArtGenerator } from "@/components/ui/EntityArtGenerator";
 import { useImageSrc } from "@/lib/useImageSrc";
 import type { ArtStyle } from "@/lib/arcanumPrompts";
+import { featureBackgroundContext } from "@/lib/entityPrompts";
 import { useConfigStore } from "@/stores/configStore";
+import { useVibeStore } from "@/stores/vibeStore";
 import type { FeatureType } from "@/lib/zoneEdits";
 
 interface FeatureBackgroundEditorProps {
@@ -21,29 +23,14 @@ const GLOBAL_KEY: Record<FeatureType, string> = {
   LEVER: "lever_bg",
 };
 
-/** Base prompt + composition guidance per feature type. */
-const BACKDROP_SPEC: Record<
-  FeatureType,
-  { framing: string; brief: (label: string) => string }
-> = {
-  CONTAINER: {
-    framing:
-      "Wide landscape backdrop, the open interior cavity occupying the lower ~55% as a clear flat area for an items list to overlay on top, no items inside, no readable text.",
-    brief: (label) =>
-      `A backdrop for ${label} — an open chest or container viewed head-on, lid/back up top, a deep open interior in the lower half where the contents list overlays. Centered, cover-friendly.`,
-  },
-  SIGN: {
-    framing:
-      "Wide landscape backdrop with a clean flat central writable area for sign text to overlay, decorative frame around the edges, blank face, no readable text, no letters.",
-    brief: (label) =>
-      `A backdrop for ${label} — a carved sign board or placard with a clear central text-safe area and a decorative frame. The sign text renders over the center.`,
-  },
-  LEVER: {
-    framing:
-      "Portrait backdrop box with an open uncluttered center where the lever mechanism mounts on top, ornate framing around the edges, no lever, no handle, no readable text.",
-    brief: (label) =>
-      `A backdrop box for ${label} — the decorative recessed alcove the lever sits inside. Leave the center open; the plate and handle render on top.`,
-  },
+/** Composition guidance per feature type. */
+const BACKDROP_FRAMING: Record<FeatureType, string> = {
+  CONTAINER:
+    "Wide landscape backdrop, the open interior cavity occupying the lower ~55% as a clear flat area for an items list to overlay on top, no items inside, no readable text.",
+  SIGN:
+    "Wide landscape backdrop with a clean flat central writable area for sign text to overlay, decorative frame around the edges, blank face, no readable text, no letters.",
+  LEVER:
+    "Portrait backdrop box with an open uncluttered center where the lever mechanism mounts on top, ornate framing around the edges, no lever, no handle, no readable text.",
 };
 
 /**
@@ -61,13 +48,13 @@ export function FeatureBackgroundEditor({
   onPatch,
 }: FeatureBackgroundEditorProps) {
   const globalAssets = useConfigStore((s) => s.config?.globalAssets);
+  const vibe = useVibeStore((s) => s.getVibe(world.zone));
   const globalKey = GLOBAL_KEY[type];
   const resolved = feature.backgroundImage || globalAssets?.[globalKey] || undefined;
   const usingDefault = !feature.backgroundImage && !!resolved;
   const previewSrc = useImageSrc(resolved);
 
-  const spec = BACKDROP_SPEC[type];
-  const label = feature.displayName || labelForType(type);
+  const framing = BACKDROP_FRAMING[type];
   const entityKey = globalKey; // drives generation dimensions (landscape/portrait)
 
   return (
@@ -108,9 +95,9 @@ export function FeatureBackgroundEditor({
           surface="worldbuilding"
           currentImage={feature.backgroundImage}
           onAccept={(fileName) => onPatch({ backgroundImage: fileName })}
-          getPrompt={(_style: ArtStyle) => spec.framing}
-          entityContext={spec.brief(label)}
-          framingHint={spec.framing}
+          getPrompt={(_style: ArtStyle) => framing}
+          entityContext={featureBackgroundContext(world, roomId, type, feature, vibe)}
+          framingHint={framing}
           context={{
             zone: world.zone,
             entity_type: entityKey,
@@ -120,10 +107,4 @@ export function FeatureBackgroundEditor({
       </div>
     </details>
   );
-}
-
-function labelForType(type: FeatureType): string {
-  if (type === "CONTAINER") return "container";
-  if (type === "LEVER") return "lever";
-  return "sign";
 }

--- a/creator/src/lib/__tests__/entityPrompts.test.ts
+++ b/creator/src/lib/__tests__/entityPrompts.test.ts
@@ -1,5 +1,75 @@
 import { describe, expect, it } from "vitest";
-import { musicBoxKeepsakeContext } from "@/lib/entityPrompts";
+import { featureBackgroundContext, musicBoxKeepsakeContext } from "@/lib/entityPrompts";
+import type { FeatureFile, WorldFile } from "@/types/world";
+
+function makeWorld(): WorldFile {
+  return {
+    zone: "harbor",
+    startRoom: "parlor",
+    rooms: {
+      parlor: {
+        title: "The Velvet Parlor",
+        description: "A candlelit parlor where a brass music box turns slowly on the mantel.",
+        exits: {},
+      },
+    },
+    mobs: {},
+    items: {
+      locket: { displayName: "a silver locket" },
+      shell: { displayName: "a spiraled shell" },
+    },
+    shops: {},
+  };
+}
+
+function makeSign(): FeatureFile {
+  return {
+    type: "SIGN",
+    displayName: "a small lacquered placard beside the music box",
+    keyword: "placard",
+    text: "Wind me gently, and I will sing you the tide's own lullaby.",
+  };
+}
+
+describe("featureBackgroundContext", () => {
+  it("grounds a sign in its text, room, and zone vibe", () => {
+    const ctx = featureBackgroundContext(makeWorld(), "parlor", "SIGN", makeSign(), "Sleepy seaside town, warm lantern light");
+    expect(ctx).toContain("a small lacquered placard beside the music box");
+    expect(ctx).toContain("the tide's own lullaby");
+    expect(ctx).toMatch(/do NOT render it/i);
+    expect(ctx).toContain('"The Velvet Parlor"');
+    expect(ctx).toContain("brass music box turns slowly");
+    expect(ctx).toContain("Sleepy seaside town, warm lantern light");
+  });
+
+  it("omits blank sign text and vibe", () => {
+    const sign = { ...makeSign(), text: "   " };
+    const ctx = featureBackgroundContext(makeWorld(), "parlor", "SIGN", sign, "  ");
+    expect(ctx).not.toContain("will display this text");
+    expect(ctx).not.toContain("Zone atmosphere");
+  });
+
+  it("survives an unknown room and falls back to the type label", () => {
+    const sign = { ...makeSign(), displayName: "" };
+    const ctx = featureBackgroundContext(makeWorld(), "nowhere", "SIGN", sign);
+    expect(ctx).toContain("A backdrop for sign");
+    expect(ctx).not.toContain("It stands in the room");
+  });
+
+  it("resolves container contents to display names", () => {
+    const chest: FeatureFile = {
+      type: "CONTAINER",
+      displayName: "a barnacled sea chest",
+      keyword: "chest",
+      items: ["locket", "shell", "unknown_id"],
+    };
+    const ctx = featureBackgroundContext(makeWorld(), "parlor", "CONTAINER", chest);
+    expect(ctx).toContain("a silver locket");
+    expect(ctx).toContain("a spiraled shell");
+    expect(ctx).toContain("unknown_id");
+    expect(ctx).toMatch(/do NOT draw the items/i);
+  });
+});
 
 describe("musicBoxKeepsakeContext", () => {
   it("names the song and artist", () => {

--- a/creator/src/lib/entityPrompts.ts
+++ b/creator/src/lib/entityPrompts.ts
@@ -1,5 +1,6 @@
-import type { RoomFile, MobFile, ItemFile, ShopFile, GatheringNodeFile, WorldFile, DungeonFile, DungeonRoomTemplate } from "@/types/world";
+import type { RoomFile, MobFile, ItemFile, ShopFile, FeatureFile, GatheringNodeFile, WorldFile, DungeonFile, DungeonRoomTemplate } from "@/types/world";
 import type { GuildHallRoomTemplate, HousingTemplateDefinition } from "@/types/config";
+import type { FeatureType } from "./zoneEdits";
 import { getTrainerPrimaryClass } from "@/lib/trainers";
 import {
   type ArtStyle,
@@ -73,6 +74,65 @@ export function shopContext(shopId: string, shop: ShopFile): string {
   }
   parts.push("Composition: wide landscape, an empty marketplace interior — storefront, shelves, wares, and architecture only");
   parts.push(EMPTY_SCENE_DIRECTIVE);
+  return parts.join("\n");
+}
+
+const FEATURE_BACKDROP_BRIEF: Record<FeatureType, (label: string) => string> = {
+  CONTAINER: (label) =>
+    `A backdrop for ${label} — an open chest or container viewed head-on, lid/back up top, a deep open interior in the lower half where the contents list overlays. Centered, cover-friendly.`,
+  SIGN: (label) =>
+    `A backdrop for ${label} — a carved sign board or placard with a clear central text-safe area and a decorative frame. The sign text renders over the center.`,
+  LEVER: (label) =>
+    `A backdrop box for ${label} — the decorative recessed alcove the lever sits inside. Leave the center open; the plate and handle render on top.`,
+};
+
+/**
+ * Build a context description for a feature's full-card backdrop
+ * (CONTAINER / SIGN / LEVER). Grounds the backdrop in what the feature
+ * actually says or holds, the room it stands in, and the zone's atmosphere —
+ * a bare display name gives the enhancer nothing to design from.
+ */
+export function featureBackgroundContext(
+  world: WorldFile,
+  roomId: string,
+  type: FeatureType,
+  feature: FeatureFile,
+  zoneVibe?: string,
+): string {
+  const label = feature.displayName || type.toLowerCase();
+  const parts = [FEATURE_BACKDROP_BRIEF[type](label)];
+
+  if (type === "SIGN") {
+    const text = feature.text?.trim();
+    if (text) {
+      parts.push(
+        `The sign will display this text (do NOT render it — it overlays at runtime; let its meaning, tone, and imagery shape the board's materials, ornament, and palette):\n${text}`,
+      );
+    }
+  }
+  if (type === "CONTAINER") {
+    const contents = (feature.items ?? [])
+      .map((id) => world.items?.[id]?.displayName || id)
+      .filter(Boolean);
+    if (contents.length > 0) {
+      parts.push(
+        `It holds: ${contents.join(", ")} — let the contents suggest the container's character and materials (do NOT draw the items; they overlay as a list).`,
+      );
+    }
+  }
+
+  const room = world.rooms[roomId];
+  if (room) {
+    const where = [`It stands in the room "${room.title}"`];
+    if (room.description) where.push(`described as: ${room.description}`);
+    parts.push(
+      `${where.join(", ")}\nUse the room only to inform the backdrop's setting, materials, and mood — the image is a close-up of the ${type.toLowerCase()} itself, not the room.`,
+    );
+  }
+
+  const vibe = zoneVibe?.trim();
+  if (vibe) parts.push(`Zone atmosphere:\n${vibe}`);
+
   return parts.join("\n");
 }
 


### PR DESCRIPTION
## Problem

Sign (and container/lever) background generation gives the prompt enhancer almost no context — just the feature's display name wrapped in a one-line brief. A sign described as *"a small lacquered placard beside the music box"* generates a generic ornate frame with no connection to what the sign says, the room it hangs in, or the zone's mood.

## Fix

New `featureBackgroundContext()` in `entityPrompts.ts` (following the existing context-builder convention) that the enhance/generation flow in `FeatureBackgroundEditor` now uses. The context includes:

- **SIGN**: the sign's `text` — flagged as overlay-only so the model uses its meaning/tone/imagery to shape materials, ornament, and palette without rendering it
- **CONTAINER**: resolved display names of the contents, as character/material guidance (items overlay as a list, never drawn)
- **Room grounding**: the room's title + description, scoped so the image stays a close-up of the feature rather than a room scene
- **Zone vibe**: from `vibeStore`, same as other zone-entity art paths

The framing hints (text-safe zone, blank face, no letters) are unchanged. Because `EntityArtGenerator` hashes `entityContext` for staleness, edits to sign text / room description / vibe now correctly mark existing art as out of date.

## Testing

- `bunx tsc --noEmit` clean
- `bun run test` — 2335 tests pass, including 4 new `featureBackgroundContext` tests