### PR TITLE
Publish Map overlay placements to zone YAML for the game's World Map tab

### DIFF
--- a/creator/src/components/zone/WorldOverlayView.tsx
+++ b/creator/src/components/zone/WorldOverlayView.tsx
@@ -276,6 +276,7 @@ function MapBackdrop({
 
 function WorldOverlay() {
   const zones = useZoneStore((s) => s.zones);
+  const updateZone = useZoneStore((s) => s.updateZone);
   const maps = useLoreStore(selectMaps);
   const openTab = useProjectStore((s) => s.openTab);
   const projectPath = useProjectStore((s) => s.project?.mudDir ?? "");
@@ -352,6 +353,59 @@ function WorldOverlay() {
     },
     [openTab],
   );
+
+  const [publishNote, setPublishNote] = useState<string | null>(null);
+
+  // Write the selected map's placements into each zone's YAML as a percent
+  // rectangle (`worldMap`), which the MUD forwards to the web client's World
+  // Map atlas tab via `World.Areas`. Zones absent from this map get their
+  // stale `worldMap` cleared so the game and the overlay stay in agreement.
+  const publishToGame = useCallback(() => {
+    const round = (v: number) => Math.round(v * 100) / 100;
+    let published = 0;
+    let cleared = 0;
+    let skipped = 0;
+    for (const [zoneId, state] of zones.entries()) {
+      const pl = placements[zoneId];
+      if (pl) {
+        // Intersect with the map so the game never sees out-of-bounds rects.
+        const x1 = round(Math.max(0, Math.min(100, (pl.x / mapW) * 100)));
+        const y1 = round(Math.max(0, Math.min(100, (pl.y / mapH) * 100)));
+        const x2 = round(Math.max(0, Math.min(100, ((pl.x + pl.w) / mapW) * 100)));
+        const y2 = round(Math.max(0, Math.min(100, ((pl.y + pl.h) / mapH) * 100)));
+        const rect = { x: x1, y: y1, w: round(x2 - x1), h: round(y2 - y1) };
+        if (rect.w < 0.1 || rect.h < 0.1) {
+          skipped++;
+          continue;
+        }
+        const prev = state.data.worldMap;
+        if (prev && prev.x === rect.x && prev.y === rect.y && prev.w === rect.w && prev.h === rect.h) {
+          continue;
+        }
+        updateZone(zoneId, { ...state.data, worldMap: rect });
+        published++;
+      } else if (state.data.worldMap) {
+        const next = { ...state.data };
+        delete next.worldMap;
+        updateZone(zoneId, next);
+        cleared++;
+      }
+    }
+    if (published + cleared === 0) {
+      setPublishNote(skipped > 0 ? "Nothing published — every placed zone sits off the map" : "Zone YAML already matches this map");
+      return;
+    }
+    const parts = [`${published} placed`];
+    if (cleared > 0) parts.push(`${cleared} cleared`);
+    if (skipped > 0) parts.push(`${skipped} off-map skipped`);
+    setPublishNote(`Published to zone YAML (${parts.join(", ")}) — save zones to write to disk`);
+  }, [zones, placements, mapW, mapH, updateZone]);
+
+  useEffect(() => {
+    if (!publishNote) return;
+    const t = setTimeout(() => setPublishNote(null), 6000);
+    return () => clearTimeout(t);
+  }, [publishNote]);
 
   // ── Per-zone geometry (footprint + connector anchors) ─────────────
   const zoneMeta = useMemo(() => {
@@ -648,12 +702,31 @@ function WorldOverlay() {
               Clear Placements
             </button>
           )}
+          {placedCount > 0 && (
+            <button
+              type="button"
+              onClick={publishToGame}
+              className="pointer-events-auto rounded-full border border-accent/50 bg-bg-abyss/80 px-2.5 py-1 uppercase tracking-wider text-accent backdrop-blur transition-colors hover:border-accent hover:bg-accent/10"
+              title="Write this map's placements into each zone's YAML (worldMap) — powers the game's World Map atlas tab"
+            >
+              Publish to Game
+            </button>
+          )}
+          {publishNote && (
+            <span
+              role="status"
+              className="pointer-events-none rounded-full border border-border-muted bg-bg-abyss/85 px-2.5 py-1 text-text-secondary backdrop-blur"
+            >
+              {publishNote}
+            </span>
+          )}
         </div>
 
         <div className="pointer-events-none absolute bottom-4 left-4 z-10 max-w-md rounded-lg border border-border-muted bg-bg-abyss/85 px-3 py-2 text-2xs italic text-text-muted backdrop-blur">
           Drag a zone from the tray onto the map, then drag to move and pull the handles to
           stretch it into place. Lines mark cross-zone connections — line up the endpoints
-          where zones meet. Double-click a zone to open it.
+          where zones meet. Double-click a zone to open it. Publish to Game writes the
+          placements into each zone&apos;s YAML for the game&apos;s World Map tab.
         </div>
       </div>
 

--- a/creator/src/lib/__tests__/sanitizeZone.test.ts
+++ b/creator/src/lib/__tests__/sanitizeZone.test.ts
@@ -205,6 +205,29 @@ describe("sanitizeZone — ID remapping", () => {
   });
 });
 
+// ─── sanitizeZone — worldMap placement ────────────────────────────
+
+describe("sanitizeZone — worldMap placement", () => {
+  it("preserves a valid worldMap rectangle", () => {
+    const world = makeWorld({ worldMap: { x: 12.5, y: 30, w: 22, h: 18.25 } });
+    expect(sanitizeZone(world).worldMap).toEqual({ x: 12.5, y: 30, w: 22, h: 18.25 });
+  });
+
+  it("drops a worldMap that extends past the map edge", () => {
+    const world = makeWorld({ worldMap: { x: 90, y: 30, w: 22, h: 18 } });
+    expect(sanitizeZone(world).worldMap).toBeUndefined();
+  });
+
+  it("drops a worldMap with non-positive size", () => {
+    const world = makeWorld({ worldMap: { x: 10, y: 10, w: 0, h: 18 } });
+    expect(sanitizeZone(world).worldMap).toBeUndefined();
+  });
+
+  it("omits worldMap when absent", () => {
+    expect(sanitizeZone(makeWorld()).worldMap).toBeUndefined();
+  });
+});
+
 // ─── sanitizeZone — invalid entity stripping ──────────────────────
 
 describe("sanitizeZone — invalid entity stripping", () => {

--- a/creator/src/lib/requiredGlobalAssets.ts
+++ b/creator/src/lib/requiredGlobalAssets.ts
@@ -445,6 +445,19 @@ export const REQUIRED_GLOBAL_ASSETS: readonly RequiredGlobalAsset[] = [
     transparent: true,
     optional: true,
   },
+  {
+    key: "world_map",
+    defaultFilename: "flight_map.png",
+    label: "World Map — Atlas",
+    description:
+      "Painted world map behind the game's World Map atlas tab. Zones published from the Map overlay (zone YAML worldMap) are seated onto it as glowing regions with their name and level range. Defaults to the same art as the Flight Map so every world-map surface shares one coastline — only assign this if the atlas should use different art. Optional — the tab falls back to a parchment backdrop when absent.",
+    assetType: "background",
+    defaultPrompt:
+      "A painted antique cartographer's map of the fantasy land of Ambon, full-bleed edge to edge, weathered vellum with hand-inked coastlines, mountains, forests, and rivers, warm sepia and muted jewel tones, soft ambient candlelight, no grid, no pins, no markers, no readable text, no labels, suitable as a backdrop for overlaid travel hotspots.",
+    transparent: false,
+    aspect: "landscape",
+    optional: true,
+  },
   // Persistent player-UI navigation buttons rendered down the left edge of
   // every room canvas (unlike the room-feature badges above, which only
   // appear on rooms that host the corresponding feature).

--- a/creator/src/lib/sanitizeZone.ts
+++ b/creator/src/lib/sanitizeZone.ts
@@ -915,6 +915,19 @@ function cleanOutput(world: WorldFile): WorldFile {
   ) {
     result.difficultyHint = world.difficultyHint;
   }
+  if (
+    world.worldMap &&
+    [world.worldMap.x, world.worldMap.y, world.worldMap.w, world.worldMap.h].every(Number.isFinite) &&
+    world.worldMap.x >= 0 &&
+    world.worldMap.y >= 0 &&
+    world.worldMap.w > 0 &&
+    world.worldMap.h > 0 &&
+    world.worldMap.x + world.worldMap.w <= 100 &&
+    world.worldMap.y + world.worldMap.h <= 100
+  ) {
+    const { x, y, w, h } = world.worldMap;
+    result.worldMap = { x, y, w, h };
+  }
   if (world.faction?.trim()) result.faction = world.faction.trim();
   if (world.image) {
     // Strip zoneMap — it's Arcanum-only; the MUD server's ZoneImageDefaults

--- a/creator/src/types/world.ts
+++ b/creator/src/types/world.ts
@@ -62,6 +62,13 @@ export interface WorldFile {
   levelBand?: { min: number; max: number };
   /** Intended difficulty profile — informs rebalance stat targets. */
   difficultyHint?: "casual" | "standard" | "challenging";
+  /**
+   * The zone's rectangle on the painted world map, in percent (0–100) of the
+   * image from its top-left corner. Written by the Map overlay's "Publish to
+   * Game" action; the MUD serves it to the web client's World Map atlas tab
+   * via `World.Areas`.
+   */
+  worldMap?: { x: number; y: number; w: number; h: number };
   /** Controlling faction ID (references FactionConfig.definitions). Drives "hostile territory" reactions. */
   faction?: string;
   puzzles?: Record<string, PuzzleFile>;


### PR DESCRIPTION
## Summary
Counterpart to AmbonMUD PR jnoecker/AmbonMUD#1429. The Map overlay gains a **Publish to Game** action that writes the selected lore map's zone placements into each zone's YAML as a percent rectangle:

```yaml
worldMap:
  x: 12.5   # left edge, % of map width
  y: 30     # top edge, % of map height
  w: 22
  h: 18.25
```

The MUD validates the block, forwards it on `World.Areas`, and seats each zone onto the painted `world_map` art in its new World Map atlas tab.

## Changes
- `types/world.ts`: `worldMap` field on `WorldFile`
- `WorldOverlayView.tsx`: Publish to Game button — converts the selected map's pixel placements to percent (intersected with the map bounds, 2-decimal rounding), writes them via `zoneStore.updateZone` (dirty + undo-aware), clears stale `worldMap` from zones removed from the map, and reports a status note
- `sanitizeZone.ts`: preserve a valid `worldMap` on save (whitelist), drop out-of-bounds/degenerate rects
- `requiredGlobalAssets.ts`: new optional `world_map` background key (defaults to the Flight Map art so all world-map surfaces share one coastline)

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run test` (2339 passing, incl. new sanitizeZone worldMap cases)