### PR TITLE
Switch Runware background removal to BiRefNet General

### DIFF
--- a/creator/src-tauri/src/hub_ai.rs
+++ b/creator/src-tauri/src/hub_ai.rs
@@ -232,7 +232,7 @@ pub async fn generate_image(
     .await
 }
 
-/// Hub-proxied background removal (Bria RMBG v2.0 via Runware).
+/// Hub-proxied background removal (BiRefNet General via Runware).
 /// Returns the processed PNG bytes as base64.
 pub async fn remove_background(s: &Settings, image_data_url: &str) -> Result<String, String> {
     let body = HubRemoveBgRequest { image_data_url };

--- a/creator/src-tauri/src/runware.rs
+++ b/creator/src-tauri/src/runware.rs
@@ -287,33 +287,24 @@ pub async fn runware_generate_image(
     .await
 }
 
-// ─── Background Removal (Bria RMBG v2.0) ─────────────────────────────
+// ─── Background Removal (BiRefNet General) ───────────────────────────
 //
-// Server-side background removal via Runware's Bria model. An
-// alternative to the local @imgly/background-removal WASM pipeline for
-// users whose machines can't run onnxruntime reliably, or who prefer
-// the quality of the Bria model. In hub mode this short-circuits to
-// the hub proxy; otherwise it calls Runware directly with the user's
-// runware_api_key.
+// Server-side background removal via Runware's hosted BiRefNet General
+// model. An alternative to the local @imgly/background-removal WASM
+// pipeline for users whose machines can't run onnxruntime reliably, or
+// who need better handling of thin structures (antlers, wings, chains).
+// BiRefNet's high-resolution refinement branch preserves those where
+// the local ISNet model hedges with semi-transparent alpha — at ~1/30
+// the per-image cost of Bria RMBG v2.0 (same architecture family). In
+// hub mode this short-circuits to the hub proxy; otherwise it calls
+// Runware directly with the user's runware_api_key.
 //
 // The command takes a data URL (what the frontend has on hand after
 // image generation) and returns the PNG bytes as base64, matching the
 // shape the existing `removeBackground()` helper expects so all the
 // current call sites keep working unchanged.
 
-const BG_REMOVAL_MODEL: &str = "bria:2@1";
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct BriaProviderSettings {
-    preserve_alpha: bool,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct RemoveBgProviderSettings {
-    bria: BriaProviderSettings,
-}
+const BG_REMOVAL_MODEL: &str = "runware:112@5";
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -331,7 +322,6 @@ struct RunwareRemoveBgTask {
     output_type: String,
     output_format: String,
     inputs: RemoveBgInputs,
-    provider_settings: RemoveBgProviderSettings,
 }
 
 #[derive(Debug, Deserialize)]
@@ -354,7 +344,7 @@ struct RunwareRemoveBgError {
     message: Option<String>,
 }
 
-/// Server-side background removal via Runware Bria RMBG v2.0.
+/// Server-side background removal via Runware BiRefNet General.
 /// Takes a data URL and returns the processed PNG as base64.
 #[tauri::command]
 pub async fn runware_remove_background(
@@ -381,9 +371,6 @@ pub async fn runware_remove_background(
         output_type: "base64Data".to_string(),
         output_format: "PNG".to_string(),
         inputs: RemoveBgInputs { image: image_data_url },
-        provider_settings: RemoveBgProviderSettings {
-            bria: BriaProviderSettings { preserve_alpha: false },
-        },
     };
 
     let client = crate::http::shared_client();

--- a/creator/src/components/config/panels/ApiSettingsPanel.tsx
+++ b/creator/src/components/config/panels/ApiSettingsPanel.tsx
@@ -165,8 +165,8 @@ const BG_REMOVAL_PROVIDERS = [
   },
   {
     id: "runware" as const,
-    label: "Runware (Bria RMBG v2.0)",
-    description: "Server-side, high quality. ~$0.018/image when using direct Runware; billed against your hub image quota in hub mode.",
+    label: "Runware (BiRefNet General)",
+    description: "Server-side, high quality — much better with antlers, wings, and other fine structures. ~$0.0006/image when using direct Runware; billed against your hub image quota in hub mode.",
   },
 ];
 

--- a/creator/src/lib/useBackgroundRemoval.ts
+++ b/creator/src/lib/useBackgroundRemoval.ts
@@ -54,7 +54,7 @@ function getWorker(): Worker {
 /** Remove background from an image data URL.
  *  Dispatches based on the project's bg_removal_provider setting:
  *  - "local": runs the Imgly/ONNX model in a Web Worker.
- *  - "runware": calls Runware Bria RMBG v2.0 (direct or via hub). */
+ *  - "runware": calls Runware BiRefNet General (direct or via hub). */
 export async function removeBackground(imageDataUrl: string): Promise<Blob> {
   if (!AI_ENABLED) return removeBackgroundLocal(imageDataUrl);
   if (currentBgProvider() === "runware") {

--- a/creator/src/types/assets.ts
+++ b/creator/src/types/assets.ts
@@ -86,7 +86,7 @@ export type AssetType =
 export type SyncScope = "approved" | "all";
 
 /** Background removal backend. "local" runs Imgly/ONNX in a Web Worker;
- *  "runware" calls Bria RMBG v2.0 via Runware (or the hub proxy). */
+ *  "runware" calls BiRefNet General via Runware (or the hub proxy). */
 export type BgRemovalProvider = "local" | "runware";
 
 /** Mirrors the Rust Settings struct */

--- a/hub-worker/src/handlers/ai.ts
+++ b/hub-worker/src/handlers/ai.ts
@@ -6,7 +6,7 @@
 // GPT quality tier) so a single request can't blow through the budget.
 //
 //   POST /ai/image/generate            → Runware (FLUX.2 or GPT Image 2)
-//   POST /ai/image/remove-background   → Runware Bria RMBG v2.0
+//   POST /ai/image/remove-background   → Runware BiRefNet General
 //   POST /ai/llm/complete              → OpenRouter → DeepSeek V3.2
 //   POST /ai/llm/vision                → Anthropic Claude Sonnet 4.6
 //   POST /ai/embed                     → Voyage AI (voyage-3-lite)
@@ -37,9 +37,10 @@ const IMAGE_MODELS = new Set([
 ]);
 
 // Background removal is locked to a single model — no caller choice.
-// Bria RMBG v2.0 is fast, high quality, and priced at ~$0.018/image
-// which fits comfortably inside the same image quota.
-const BG_REMOVAL_MODEL = "bria:2@1";
+// BiRefNet General handles thin structures (antlers, wings, chains)
+// better than the local ISNet pipeline and costs ~$0.0006/image —
+// roughly 1/30 of Bria RMBG v2.0, which shares the same architecture.
+const BG_REMOVAL_MODEL = "runware:112@5";
 
 // Default Runware FLUX model matches creator/src-tauri/src/runware.rs.
 const DEFAULT_IMAGE_MODEL = "runware:400@2";
@@ -332,12 +333,12 @@ async function imageGenerate(req: Request, env: Env, user: UserRow): Promise<Res
   );
 }
 
-// ─── Background removal (Bria RMBG v2.0) ─────────────────────────────
+// ─── Background removal (BiRefNet General) ───────────────────────────
 //
-// Server-side background removal via Runware's Bria model. Bills
-// against the same `images_used` counter as image generation — it's
-// one upstream image API call — so quota-exhausted users can't farm
-// free bg-removal by switching modes.
+// Server-side background removal via Runware's hosted BiRefNet model.
+// Bills against the same `images_used` counter as image generation —
+// it's one upstream image API call — so quota-exhausted users can't
+// farm free bg-removal by switching modes.
 
 interface RemoveBgBody {
   imageDataUrl?: string;
@@ -350,7 +351,6 @@ interface RunwareRemoveBgTask {
   outputType: "base64Data";
   outputFormat: "PNG";
   inputs: { image: string };
-  providerSettings: { bria: { preserveAlpha: boolean } };
   includeCost: boolean;
 }
 
@@ -395,7 +395,6 @@ async function imageRemoveBackground(req: Request, env: Env, user: UserRow): Pro
     outputType: "base64Data",
     outputFormat: "PNG",
     inputs: { image },
-    providerSettings: { bria: { preserveAlpha: false } },
     includeCost: true,
   };
 


### PR DESCRIPTION
## Summary
- Replace `bria:2@1` with `runware:112@5` (BiRefNet General) as the pinned Runware background-removal model, in both the creator's direct-Runware path (`creator/src-tauri/src/runware.rs`) and the hub AI proxy (`hub-worker/src/handlers/ai.ts`).
- Drop the Bria-specific `providerSettings: { bria: { preserveAlpha } }` block from both request shapes — BiRefNet takes no provider settings.
- Update the provider label/description in the API settings panel and the related doc comments (`assets.ts`, `useBackgroundRemoval.ts`, `hub_ai.rs`).

## Why
Bria RMBG v2.0 costs ~$0.018/image — about 3× the cost of the FLUX generation it cleans up. BiRefNet General is the same architecture family (Bria RMBG 2.0 is BiRefNet-based), hosted by Runware at ~$0.0006/image, and its high-resolution refinement branch is specifically strong on the thin structures (antlers, wings, chains) where the local ISNet/imgly pipeline hedges with semi-transparent alpha.

## Notes for deploy
- The hub-worker change takes effect on the next `npm run deploy` from `hub-worker/`.
- Worth an A/B spot-check on a few antlered/winged renders before deploying the hub, though quality is expected to be at or near Bria parity.

## Testing
- `cargo check` (creator/src-tauri) ✓
- `bunx tsc --noEmit` (creator) ✓
- `bun run test` — 2344 passed ✓
- `npm run typecheck` (hub-worker) ✓