### PR TITLE
Run Runware background removals concurrently

### DIFF
--- a/creator/src/components/ui/BulkBgRemoval.tsx
+++ b/creator/src/components/ui/BulkBgRemoval.tsx
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { DialogShell, ActionButton, Spinner } from "@/components/ui/FormWidgets";
 import { useFocusTrap } from "@/lib/useFocusTrap";
 import { useAssetStore } from "@/stores/assetStore";
-import { removeBgAndSave } from "@/lib/useBackgroundRemoval";
+import { removeBgAndSave, bgRemovalConcurrency } from "@/lib/useBackgroundRemoval";
 import type { AssetContext, AssetEntry } from "@/types/assets";
 
 // ─── Types ─────────────────────────────────────────────────────────
@@ -93,44 +93,60 @@ export function BulkBgRemoval({
 
     const processed: { target: BulkBgTarget; fileName: string }[] = [];
 
-    for (const { item, idx } of toProcess) {
-      if (abortRef.current) break;
+    // Worker pool sized to the provider's concurrency (1 for local, more
+    // for Runware) so bulk runs overlap HTTP round trips instead of paying
+    // full per-image latency serially. Abort stops workers between items;
+    // in-flight removals finish and land normally.
+    let nextJob = 0;
+    const worker = async () => {
+      while (!abortRef.current) {
+        const job = toProcess[nextJob++];
+        if (!job) return;
+        const { item, idx } = job;
 
-      setItems((prev) =>
-        prev.map((t, i) => (i === idx ? { ...t, status: "processing" } : t)),
-      );
-
-      try {
-        // Get data URL from the resolved path. This fails for newly
-        // generated images when the DB path format has drifted — the
-        // thrown error is surfaced into the row below.
-        const dataUrl = await invoke<string>("read_image_data_url", {
-          path: item.resolvedPath,
-        });
-
-        const entry = await removeBgAndSave(
-          dataUrl,
-          item.assetType,
-          item.context,
-          item.variantGroup,
-        );
-
-        // Record the bg-free result so the caller can repoint the entity's
-        // image field. removeBgAndSave flips the active variant server-side,
-        // but the entity keeps referencing its original background image until
-        // we rewrite it via onComplete below.
-        processed.push({ target: item, fileName: entry.file_name });
         setItems((prev) =>
-          prev.map((t, i) => (i === idx ? { ...t, status: "done", error: undefined } : t)),
+          prev.map((t, i) => (i === idx ? { ...t, status: "processing" } : t)),
         );
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error(`[bulk bg removal] ${item.label} failed:`, err);
-        setItems((prev) =>
-          prev.map((t, i) => (i === idx ? { ...t, status: "error", error: message } : t)),
-        );
+
+        try {
+          // Get data URL from the resolved path. This fails for newly
+          // generated images when the DB path format has drifted — the
+          // thrown error is surfaced into the row below.
+          const dataUrl = await invoke<string>("read_image_data_url", {
+            path: item.resolvedPath,
+          });
+
+          const entry = await removeBgAndSave(
+            dataUrl,
+            item.assetType,
+            item.context,
+            item.variantGroup,
+          );
+
+          // Record the bg-free result so the caller can repoint the entity's
+          // image field. removeBgAndSave flips the active variant server-side,
+          // but the entity keeps referencing its original background image until
+          // we rewrite it via onComplete below.
+          processed.push({ target: item, fileName: entry.file_name });
+          setItems((prev) =>
+            prev.map((t, i) => (i === idx ? { ...t, status: "done", error: undefined } : t)),
+          );
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`[bulk bg removal] ${item.label} failed:`, err);
+          setItems((prev) =>
+            prev.map((t, i) => (i === idx ? { ...t, status: "error", error: message } : t)),
+          );
+        }
       }
-    }
+    };
+
+    await Promise.all(
+      Array.from(
+        { length: Math.min(bgRemovalConcurrency(), toProcess.length) },
+        () => worker(),
+      ),
+    );
 
     await loadAssets();
     if (processed.length > 0) onComplete?.(processed);

--- a/creator/src/lib/useBackgroundRemoval.ts
+++ b/creator/src/lib/useBackgroundRemoval.ts
@@ -85,14 +85,24 @@ async function removeBackgroundRunware(imageDataUrl: string): Promise<Blob> {
   return new Blob([bytes], { type: "image/png" });
 }
 
-// ─── Sequential queue ─────────────────────────────────────────────
-// Serialize requests so we don't send multiple large data URLs
-// to the worker at once (memory pressure).
+// ─── Bounded-concurrency queue ────────────────────────────────────
+// The local provider stays strictly serial: there's a single WASM
+// worker, and holding multiple large data URLs at once creates memory
+// pressure. The Runware provider is just an HTTP round trip, so several
+// removals run in flight at once — the per-image latency is upstream
+// inference, and parallel requests are how you buy it back.
 //
-// NOTE: the queue runner must never let a task throw out of the while
-// loop, because that would leave `bgQueueRunning = true` and wedge the
-// whole queue for the rest of the session. Per-task errors are surfaced
-// through the per-task promise (reject), not through the runner.
+// NOTE: a runner must never let a task throw out of its loop — that
+// would leak an `activeBgRunners` slot and shrink the pool for the rest
+// of the session. Per-task errors are surfaced through the per-task
+// promise (reject), not through the runner.
+
+const RUNWARE_BG_CONCURRENCY = 4;
+
+/** How many bg-removal tasks may run at once for the current provider. */
+export function bgRemovalConcurrency(): number {
+  return currentBgProvider() === "runware" ? RUNWARE_BG_CONCURRENCY : 1;
+}
 
 interface QueueEntry<T> {
   run: () => Promise<T>;
@@ -101,11 +111,10 @@ interface QueueEntry<T> {
 }
 
 const bgQueue: QueueEntry<unknown>[] = [];
-let bgQueueRunning = false;
+let activeBgRunners = 0;
 
-async function processBgQueue() {
-  if (bgQueueRunning) return;
-  bgQueueRunning = true;
+async function runBgWorker() {
+  activeBgRunners++;
   try {
     while (bgQueue.length > 0) {
       const entry = bgQueue.shift()!;
@@ -117,7 +126,17 @@ async function processBgQueue() {
       }
     }
   } finally {
-    bgQueueRunning = false;
+    activeBgRunners--;
+  }
+}
+
+function processBgQueue() {
+  // Re-read the limit on every pump: the provider can switch mid-session,
+  // and extra runners drain naturally when their loop finds an empty queue.
+  // Each spawned worker synchronously shifts its first task, so this loop
+  // can't spawn more workers than there are waiting tasks.
+  while (activeBgRunners < bgRemovalConcurrency() && bgQueue.length > 0) {
+    runBgWorker();
   }
 }
 


### PR DESCRIPTION
## Summary
- The global bg-removal queue in `useBackgroundRemoval.ts` now runs a bounded worker pool instead of strict serialization: concurrency 1 for the local provider (single WASM worker, memory pressure), 4 for the Runware provider (each removal is an independent HTTP round trip — direct or via the hub proxy).
- `BulkBgRemoval.tsx` previously awaited each item sequentially in its own loop, so it never would have benefited from queue concurrency; it now runs a caller-side worker pool at the same provider-aware size (`bgRemovalConcurrency()`), preserving per-row status updates and abort behavior (abort stops between items; in-flight removals finish).
- Zone batch art generation (`batchArt.ts`) needs no changes — it already enqueues all removals up front and awaits them at the end, so it gets the ~4× overlap for free.

## Why
With BiRefNet on Runware (#361), per-image cost is negligible but the queue still processed one removal per HTTP round trip. A zone batch with dozens of sprites spent most of its bg-removal phase waiting serially. Parallel requests overlap upstream inference latency.

## Safety
- Concurrent `save_bytes_as_asset` calls are safe: manifest mutations are serialized behind the global `MANIFEST_LOCK` in `creator/src-tauri/src/assets.rs`.
- The pool re-reads the concurrency limit on every pump, so switching provider mid-session takes effect naturally; extra runners drain when the queue empties.
- Local provider behavior is unchanged (still strictly serial).

## Testing
- `bunx tsc --noEmit` ✓
- `bun run test` — 74 files, 2344 tests passed ✓